### PR TITLE
fix(deps): remove stale tree-sitter codegraph dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,8 +149,6 @@ docs = [
 codegraph = [
     "fastembed<=0.8.0 ; python_version < '3.14'",
     "transformers>=4.46.3,<5",
-    "tree-sitter>=0.24.0,<0.25",
-    "tree-sitter-python>=0.23.6,<0.24",
 ]
 evals = [
     "plotly>=6.0.0,<7",
@@ -241,11 +239,6 @@ packages = ["cognee", "cognee_db_workers", "kuzu"]
 [tool.uv]
 # Note: exclude newer packages that are less than 2 days old
 exclude-newer = "2 days"
-# docling-full needs docling-core[chunking]>=2.86 (tree-sitter>=0.25) while
-# codegraph pins tree-sitter<0.25, so the two extras cannot be co-installed.
-conflicts = [
-    [{ extra = "docling-full" }, { extra = "codegraph" }],
-]
 constraint-dependencies = [
     "protobuf>=5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.1, !=6.33.2, !=6.33.3, !=6.33.4", # protobuf 6.33.5 and higher versions + version 5.29.6
     "pyasn1>=0.6.2",

--- a/uv.lock
+++ b/uv.lock
@@ -2,53 +2,25 @@ version = 1
 revision = 3
 requires-python = ">=3.10, <3.15"
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
-conflicts = [[
-    { package = "cognee", extra = "codegraph" },
-    { package = "cognee", extra = "docling-full" },
-]]
 
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
@@ -70,14 +42,14 @@ version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8d/75/94cd5d389649578aca399e5aa822637eec18319a1dadc400ffe2f9a7493f/accelerate-1.14.0.tar.gz", hash = "sha256:41b9c4377a54e0b460a959b0defa1b736e4ca0a2373252d9a539964c2afe3c8d", size = 412167, upload-time = "2026-06-11T13:45:52.326Z" }
 wheels = [
@@ -132,12 +104,12 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
     { name = "aiosignal" },
-    { name = "async-timeout", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "async-timeout", marker = "python_full_version < '3.11'" },
     { name = "attrs" },
     { name = "frozenlist" },
     { name = "multidict" },
     { name = "propcache" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "yarl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
@@ -286,7 +258,7 @@ version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -309,7 +281,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
@@ -365,9 +337,9 @@ name = "anyio"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
 wheels = [
@@ -479,7 +451,7 @@ name = "async-lru"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
 wheels = [
@@ -500,7 +472,7 @@ name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "async-timeout", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
 wheels = [
@@ -758,8 +730,8 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
     { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
 wheels = [
@@ -822,7 +794,7 @@ name = "blis"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/d0/d8cc8c9a4488a787e7fa430f6055e5bd1ddb22c340a751d9e901b82e2efe/blis-1.3.3.tar.gz", hash = "sha256:034d4560ff3cc43e8aa37e188451b0440e3261d989bb8a42ceee865607715ecd", size = 2644873, upload-time = "2025-11-17T12:28:30.511Z" }
 wheels = [
@@ -1028,7 +1000,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1224,7 +1196,7 @@ name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
@@ -1262,17 +1234,17 @@ dependencies = [
     { name = "gunicorn" },
     { name = "instructor" },
     { name = "jinja2" },
-    { name = "ladybug", version = "0.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(platform_release < '24.' and sys_platform == 'darwin') or (platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "ladybug", version = "0.18.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_release >= '24.' or (platform_release < '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform != 'darwin'" },
+    { name = "ladybug", version = "0.17.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_release < '24.' and sys_platform == 'darwin'" },
+    { name = "ladybug", version = "0.18.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_release >= '24.' or sys_platform != 'darwin'" },
     { name = "lancedb" },
     { name = "langdetect" },
     { name = "limits" },
     { name = "litellm" },
     { name = "nbformat" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1280,7 +1252,7 @@ dependencies = [
     { name = "pympler" },
     { name = "pypdf" },
     { name = "python-dotenv" },
-    { name = "python-magic-bin", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "python-magic-bin", marker = "sys_platform == 'win32'" },
     { name = "python-multipart" },
     { name = "rdflib" },
     { name = "sqlalchemy" },
@@ -1310,8 +1282,6 @@ baml = [
 codegraph = [
     { name = "fastembed", marker = "python_full_version < '3.14'" },
     { name = "transformers" },
-    { name = "tree-sitter", version = "0.24.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "tree-sitter-python" },
 ]
 debug = [
     { name = "debugpy" },
@@ -1348,27 +1318,27 @@ docling-full = [
     { name = "transformers" },
 ]
 docs = [
-    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
+    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "nltk" },
-    { name = "unstructured", version = "0.18.32", source = { registry = "https://pypi.org/simple" }, extra = ["csv", "doc", "docx", "epub", "md", "odt", "org", "pdf", "ppt", "pptx", "rst", "rtf", "tsv", "xlsx"], marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "unstructured", version = "0.21.5", source = { registry = "https://pypi.org/simple" }, extra = ["csv", "doc", "docx", "epub", "md", "odt", "org", "pdf", "ppt", "pptx", "rst", "rtf", "tsv", "xlsx"], marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "unstructured", version = "0.18.32", source = { registry = "https://pypi.org/simple" }, extra = ["csv", "doc", "docx", "epub", "md", "odt", "org", "pdf", "ppt", "pptx", "rst", "rtf", "tsv", "xlsx"], marker = "python_full_version < '3.13'" },
+    { name = "unstructured", version = "0.21.5", source = { registry = "https://pypi.org/simple" }, extra = ["csv", "doc", "docx", "epub", "md", "odt", "org", "pdf", "ppt", "pptx", "rst", "rtf", "tsv", "xlsx"], marker = "python_full_version >= '3.13'" },
 ]
 evals = [
     { name = "gdown" },
     { name = "locust" },
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas" },
     { name = "plotly" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 fastembed = [
     { name = "fastembed" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 graphiti = [
     { name = "graphiti-core" },
@@ -1391,8 +1361,8 @@ llama-index = [
     { name = "llama-index-core" },
 ]
 mistral = [
-    { name = "mistral-common", version = "1.9.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "mistral-common", version = "1.11.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "mistral-common", version = "1.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "mistral-common", version = "1.11.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "mistralai" },
 ]
 neo4j = [
@@ -1429,9 +1399,9 @@ redis = [
 scraping = [
     { name = "apscheduler" },
     { name = "beautifulsoup4" },
-    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
+    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "playwright" },
     { name = "protego" },
     { name = "tavily-python" },
@@ -1574,8 +1544,6 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'docling-full'", specifier = ">=4.55" },
     { name = "transformers", marker = "extra == 'huggingface'", specifier = ">=4.46.3,<5" },
     { name = "transformers", marker = "extra == 'ollama'", specifier = ">=4.46.3,<5" },
-    { name = "tree-sitter", marker = "extra == 'codegraph'", specifier = ">=0.24.0,<0.25" },
-    { name = "tree-sitter-python", marker = "extra == 'codegraph'", specifier = ">=0.23.6,<0.24" },
     { name = "tweepy", marker = "extra == 'dev'", specifier = ">=4.14.0,<5.0.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.31,<0.1.0" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5.0.0" },
@@ -1610,7 +1578,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly", marker = "python_full_version < '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "humanfriendly" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -1661,16 +1629,12 @@ name = "contourpy"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -1737,44 +1701,24 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1966,7 +1910,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -1974,8 +1918,8 @@ name = "cryptography"
 version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
@@ -2037,35 +1981,19 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/31/bfcc870f69c6a017c4ad5c42316207fc7551940db6f3639aa4466ec5faf3/cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a022c96b8bd847e8dc0675523431149a4c3e872f440e3002213dbb9e08f0331a", size = 11800959, upload-time = "2025-10-21T14:51:26.458Z" },
     { url = "https://files.pythonhosted.org/packages/7a/d8/b546104b8da3f562c1ff8ab36d130c8fe1dd6a045ced80b4f6ad74f7d4e1/cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d3c842c2a4303b2a580fe955018e31aea30278be19795ae05226235268032e5", size = 12148218, upload-time = "2025-10-21T14:51:28.855Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/1e/9c8ed3f3dbed7b7d038805fdc65cbc65fda9983e84437778a9571e7092bc/cuda_bindings-12.9.4-cp310-cp310-win_amd64.whl", hash = "sha256:f69107389e6b9948969bfd0a20c4f571fd1aefcfb1d2e1b72cc8ba5ecb7918ab", size = 11464568, upload-time = "2025-10-21T14:51:31.454Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/2b/ebcbb60aa6dba830474cd360c42e10282f7a343c0a1f58d24fbd3b7c2d77/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6a429dc6c13148ff1e27c44f40a3dd23203823e637b87fd0854205195988306", size = 11840604, upload-time = "2025-10-21T14:51:34.565Z" },
     { url = "https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9", size = 12210593, upload-time = "2025-10-21T14:51:36.574Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/be/90d32049e06abcfba4b2e7df1dbcb5e16215c8852eef0cd8b25f38a66bd4/cuda_bindings-12.9.4-cp311-cp311-win_amd64.whl", hash = "sha256:443b0875916879c2e4c3722941e25e42d5ab9bcbf34c9e83404fb100fa1f6913", size = 11490933, upload-time = "2025-10-21T14:51:38.792Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/c2/65bfd79292b8ff18be4dd7f7442cea37bcbc1a228c1886f1dea515c45b67/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694ba35023846625ef471257e6b5a4bc8af690f961d197d77d34b1d1db393f56", size = 11760260, upload-time = "2025-10-21T14:51:40.79Z" },
     { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
-    { url = "https://files.pythonhosted.org/packages/df/6b/9c1b1a6c01392bfdd758e9486f52a1a72bc8f49e98f9355774ef98b5fb4e/cuda_bindings-12.9.4-cp312-cp312-win_amd64.whl", hash = "sha256:696ca75d249ddf287d01b9a698b8e2d8a05046495a9c051ca15659dc52d17615", size = 11586961, upload-time = "2025-10-21T14:51:45.394Z" },
-    { url = "https://files.pythonhosted.org/packages/05/8b/b4b2d1c7775fa403b64333e720cfcfccef8dcb9cdeb99947061ca5a77628/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf8bfaedc238f3b115d957d1fd6562b7e8435ba57f6d0e2f87d0e7149ccb2da5", size = 11570071, upload-time = "2025-10-21T14:51:47.472Z" },
     { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
-    { url = "https://files.pythonhosted.org/packages/05/d0/d0e4e2e047d8e899f023fa15ad5e9894ce951253f4c894f1cd68490fdb14/cuda_bindings-12.9.4-cp313-cp313-win_amd64.whl", hash = "sha256:a2e82c8985948f953c2be51df45c3fe11c812a928fca525154fb9503190b3e64", size = 11556719, upload-time = "2025-10-21T14:51:52.248Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/07/6aff13bc1e977e35aaa6b22f52b172e2890c608c6db22438cf7ed2bf43a6/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3adf4958dcf68ae7801a59b73fb00a8b37f8d0595060d66ceae111b1002de38d", size = 11566797, upload-time = "2025-10-21T14:51:54.581Z" },
     { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/3c/972edfddb4ae8a9fccd3c3766ed47453b6f805b6026b32f10209dd4b8ad4/cuda_bindings-12.9.4-cp313-cp313t-win_amd64.whl", hash = "sha256:b32d8b685f0e66f5658bcf4601ef034e89fc2843582886f0a58784a4302da06c", size = 11894363, upload-time = "2025-10-21T14:51:58.633Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/b5/96a6696e20c4ffd2b327f54c7d0fde2259bdb998d045c25d5dedbbe30290/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f53a7f453d4b2643d8663d036bafe29b5ba89eb904c133180f295df6dc151e5", size = 11624530, upload-time = "2025-10-21T14:52:01.539Z" },
     { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703, upload-time = "2025-10-21T14:52:03.585Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/87/652796522cc1a7af559460e1ce59b642e05c1468b9c08522a9a096b4cf04/cuda_bindings-12.9.4-cp314-cp314-win_amd64.whl", hash = "sha256:53a10c71fdbdb743e0268d07964e5a996dd00b4e43831cbfce9804515d97d575", size = 11517716, upload-time = "2025-10-21T14:52:06.013Z" },
-    { url = "https://files.pythonhosted.org/packages/39/73/d2fc40c043bac699c3880bf88d3cebe9d88410cd043795382826c93a89f0/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20f2699d61d724de3eb3f3369d57e2b245f93085cab44fd37c3bea036cea1a6f", size = 11565056, upload-time = "2025-10-21T14:52:08.338Z" },
     { url = "https://files.pythonhosted.org/packages/6c/19/90ac264acc00f6df8a49378eedec9fd2db3061bf9263bf9f39fd3d8377c3/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee", size = 11924658, upload-time = "2025-10-21T14:52:10.411Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/52/a30f46e822bfa6b4a659d1e8de8c4a4adf908ea075dac568b55362541bd8/cuda_bindings-12.9.4-cp314-cp314t-win_amd64.whl", hash = "sha256:53e11991a92ff6f26a0c8a98554cd5d6721c308a6b7bfb08bebac9201e039e43", size = 12055608, upload-time = "2025-10-21T14:52:12.335Z" },
 ]
 
 [[package]]
@@ -2073,44 +2001,28 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
     { url = "https://files.pythonhosted.org/packages/a8/1f/5ef51f5fbaa5d4d3201bb3d7555af028ec1aa4416275ccbf73c9e34e3d2d/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9851b0caa8bfd3bc6fa054eaf57bea7c8e9c3a62db2d2621224677f49f3c53d0", size = 6675244, upload-time = "2026-05-29T23:11:38.664Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/64/bb17e4d168569ef7be05c44474fe3dc19278d60a69ba228e45a431c86444/cuda_bindings-13.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:c0c4b1a995098c46695c24257a342dc97d6e6d3f3050b944c9f43bd26d734051", size = 5625597, upload-time = "2026-05-29T23:11:40.808Z" },
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
     { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
-    { url = "https://files.pythonhosted.org/packages/93/f7/0e35987a21914f84068061dcf4b61466ccbce1c62ddc9727596d5ed0c26f/cuda_bindings-13.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:507b0e19e7f934c5e30f30f0244ad70a75812619a7d3a0d742543caae1bd50f1", size = 5664286, upload-time = "2026-05-29T23:11:47.719Z" },
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
     { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/95/872a0392122f1fb43fcb06869790ef3171f37beee9f7db8f441739113570/cuda_bindings-13.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:b134dd8c5c66ae4c4ad814f7aee88fd215353c077010cbc47e3b55ed35ec9eff", size = 5875099, upload-time = "2026-05-29T23:11:54.635Z" },
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
     { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/2f/6a0dd496550c6fafbf6aeb1bf40242eeabb2fd138a43892aabb4be8224c2/cuda_bindings-13.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:18c8c167c8907b8f02531ca810534315c458dabef31f7965095619bf647b9202", size = 5830027, upload-time = "2026-05-29T23:12:01.205Z" },
     { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
     { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
-    { url = "https://files.pythonhosted.org/packages/48/45/2734be44dbc80ac082ec23a86b41c8294992dcb90033645ed1bc50aafe4c/cuda_bindings-13.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:8de12ef60bf40756852cb62bbb40460609269f6ece522903d1cc93d73a3ececb", size = 5961055, upload-time = "2026-05-29T23:12:07.971Z" },
     { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
     { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
-    { url = "https://files.pythonhosted.org/packages/27/2a/b59bcac016ab9985d6b48a5d05b0d698461a159ca03ee11c4abd54da2ac4/cuda_bindings-13.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:61120b5e4f4a63f67efd7e7396914cb9ef871bb1f0021e990fb70277be240a4d", size = 6740329, upload-time = "2026-05-29T23:12:15.153Z" },
 ]
 
 [[package]]
@@ -2131,34 +2043,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'win32') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'win32') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'win32') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'win32') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'win32') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'win32') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'win32') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'win32') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'win32') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -2253,14 +2165,14 @@ version = "0.64.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
-    { name = "black", marker = "sys_platform != 'emscripten' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "black", marker = "sys_platform != 'emscripten'" },
     { name = "genson" },
     { name = "inflect" },
-    { name = "isort", marker = "sys_platform != 'emscripten' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "isort", marker = "sys_platform != 'emscripten'" },
     { name = "jinja2" },
     { name = "pydantic" },
     { name = "pyyaml" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9c/d2/86c94a2836ed42231653a7ddaefa0a5bc23418167a876bba7376c96b3a35/datamodel_code_generator-0.64.0.tar.gz", hash = "sha256:9c592900a00b20e416494273c22435f5a9aef6ea8c7b9190747522a60497a1cb", size = 1316440, upload-time = "2026-06-14T17:24:50.528Z" }
 wheels = [
@@ -2332,8 +2244,8 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "sentry-sdk" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
     { name = "tabulate" },
     { name = "tenacity" },
     { name = "tqdm" },
@@ -2384,8 +2296,8 @@ version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/9e/7a976d923d3ae18d7dc4ace8e0c83e20a847828196e7f4b13a4bf6b03b50/deptry-0.20.0.tar.gz", hash = "sha256:62e9aaf3aea9e2ca66c85da98a0ba0290b4d3daea4e1d0ad937d447bd3c36402", size = 129936, upload-time = "2024-08-27T12:18:45.743Z" }
 wheels = [
@@ -2458,27 +2370,27 @@ dependencies = [
     { name = "giturlparse" },
     { name = "humanize" },
     { name = "jsonpath-ng" },
-    { name = "orjson", marker = "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version < '3.14' and platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten') or (platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "orjson", marker = "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten') or (platform_python_implementation != 'PyPy' and sys_platform != 'emscripten')" },
     { name = "packaging" },
     { name = "pathvalidate" },
     { name = "pendulum" },
     { name = "pluggy" },
     { name = "pytz" },
-    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "requirements-parser" },
     { name = "rich-argparse" },
     { name = "semver" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
     { name = "simplejson" },
     { name = "sqlglot" },
     { name = "tenacity" },
     { name = "tomlkit" },
     { name = "typing-extensions" },
     { name = "tzdata" },
-    { name = "win-precise-time", marker = "(python_full_version < '3.13' and os_name == 'nt' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (python_full_version < '3.13' and os_name == 'nt' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.13' and os_name == 'nt' and sys_platform != 'darwin') or (python_full_version >= '3.13' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (os_name != 'nt' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "win-precise-time", marker = "python_full_version < '3.13' and os_name == 'nt' and sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/e9/45803a93a15e901ecb29c9ecbb63e346166b6c485df123f0fa9ff482b042/dlt-1.28.0.tar.gz", hash = "sha256:8fad65ca4c2a7c74b0b78d87ebed3f974cf9ed635e6f662bf4e8dec4be14f53f", size = 1085533, upload-time = "2026-06-15T16:14:52.893Z" }
 wheels = [
@@ -2505,9 +2417,9 @@ name = "doclang"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
+    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "typer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/3a/005e4856ad8e9b9879414a4df4dbc56dc3663b96f9d8c920ef210e8931cf/doclang-0.7.3.tar.gz", hash = "sha256:ca50615357e46ebf9597bb9065b9112367103ec24bd539f8ae12649224cf50b0", size = 31569, upload-time = "2026-07-15T08:11:02.917Z" }
@@ -2520,7 +2432,7 @@ name = "docling"
 version = "2.118.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docling-slim", extra = ["standard"], marker = "extra == 'extra-6-cognee-docling-full'" },
+    { name = "docling-slim", extra = ["standard"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/80/7b/1678d6e1190190687b59376e7870e3c9426a3dd1b2280f05d2a7fd35e467/docling-2.118.0.tar.gz", hash = "sha256:9c144f5f77c65680e2a4f6e7ad0f2971889bc9c514c69a11711624a7d5d58c9f", size = 9015, upload-time = "2026-08-03T15:32:39.262Z" }
 wheels = [
@@ -2555,7 +2467,7 @@ wheels = [
 chunking = [
     { name = "semchunk" },
     { name = "transformers" },
-    { name = "tree-sitter", version = "0.26.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "tree-sitter" },
     { name = "tree-sitter-c" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
@@ -2571,16 +2483,16 @@ dependencies = [
     { name = "docling-core" },
     { name = "huggingface-hub" },
     { name = "jsonlines" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-6-cognee-docling-full') or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-6-cognee-docling-full') or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
     { name = "pydantic" },
     { name = "rtree" },
-    { name = "safetensors", extra = ["torch"], marker = "extra == 'extra-6-cognee-docling-full'" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torchvision", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torchvision", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "safetensors", extra = ["torch"] },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
+    { name = "torchvision", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "torchvision", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
     { name = "tqdm" },
     { name = "transformers" },
 ]
@@ -2597,7 +2509,7 @@ dependencies = [
     { name = "docling-core" },
     { name = "pillow" },
     { name = "pydantic" },
-    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/35/f4a325e29bcd2f4dce9e4b389be92a9a417b662eb3b47ec5642354a60119/docling_parse-7.10.0.tar.gz", hash = "sha256:14cc71e031fa7c5f3ad360eb1d605dca359e754ae0c8558efb7e4626e8adc4ed", size = 6771754, upload-time = "2026-08-05T12:10:47.575Z" }
 wheels = [
@@ -2649,12 +2561,12 @@ wheels = [
 
 [package.optional-dependencies]
 convert-core = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
     { name = "rtree" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 format-email = [
     { name = "beautifulsoup4" },
@@ -2682,15 +2594,15 @@ standard = [
     { name = "accelerate" },
     { name = "beautifulsoup4" },
     { name = "defusedxml" },
-    { name = "docling-core", extra = ["chunking"], marker = "extra == 'extra-6-cognee-docling-full'" },
+    { name = "docling-core", extra = ["chunking"] },
     { name = "docling-ibm-models" },
     { name = "docling-parse" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "mail-parser" },
     { name = "marko" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-6-cognee-docling-full') or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-6-cognee-docling-full') or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openpyxl" },
     { name = "pillow" },
     { name = "polyfactory" },
@@ -2702,12 +2614,12 @@ standard = [
     { name = "rapidocr" },
     { name = "rich" },
     { name = "rtree" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-6-cognee-docling-full') or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-6-cognee-docling-full') or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torchvision", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torchvision", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
+    { name = "torchvision", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "torchvision", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
     { name = "typer" },
     { name = "websockets" },
 ]
@@ -2726,11 +2638,11 @@ name = "effdet"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "omegaconf", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pycocotools", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "timm", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torchvision", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "omegaconf" },
+    { name = "pycocotools" },
+    { name = "timm" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "torchvision", version = "0.27.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/c3/12d45167ec36f7f9a5ed80bc2128392b3f6207f760d437287d32a0e43f41/effdet-0.4.1.tar.gz", hash = "sha256:ac5589fd304a5650c201986b2ef5f8e10c111093a71b1c49fa6b8817710812b5", size = 110134, upload-time = "2023-05-21T22:18:01.039Z" }
 wheels = [
@@ -2782,7 +2694,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2826,7 +2738,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "redis" },
     { name = "sortedcontainers" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/ed/86ed74d8829c3bc565025c1c9efaf8518c9165fbf8c9cc2c026c8ed21bd9/fakeredis-2.36.2.tar.gz", hash = "sha256:c37a0b307fae3f27ec7c19e59519e57b8c52782e00303df9075361b5ba441be6", size = 213336, upload-time = "2026-06-17T13:25:38.934Z" }
 wheels = [
@@ -2897,10 +2809,10 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "loguru" },
     { name = "mmh3" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pillow" },
     { name = "py-rust-stemmers" },
     { name = "requests" },
@@ -3025,7 +2937,7 @@ version = "6.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "werkzeug" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/47/03/4e464a50860f9adf08b5c1d3479cb8ea1f12af2aa69535c7042c6e628135/flask_cors-6.0.5.tar.gz", hash = "sha256:30c5031552cd59f620ac0c8211dac45b345d3b2df310e7721879e4f46ef9c601", size = 101386, upload-time = "2026-06-08T20:20:17.765Z" }
@@ -3279,8 +3191,8 @@ name = "gevent"
 version = "25.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "(platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_python_implementation != 'CPython' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "greenlet", marker = "platform_python_implementation == 'CPython' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "cffi", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
+    { name = "greenlet", marker = "platform_python_implementation == 'CPython'" },
     { name = "zope-event" },
     { name = "zope-interface" },
 ]
@@ -3542,8 +3454,8 @@ version = "0.29.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "neo4j" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "posthog" },
     { name = "pydantic" },
@@ -3857,7 +3769,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -3874,7 +3786,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "(python_full_version < '3.14' and sys_platform == 'win32') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -3987,11 +3899,11 @@ name = "ipykernel"
 version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
-    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "ipython", version = "9.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "matplotlib-inline" },
@@ -4012,26 +3924,22 @@ name = "ipython"
 version = "8.39.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "colorama", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "decorator", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "jedi", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pexpect", marker = "(python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version >= '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pygments", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "stack-data", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "traitlets", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -4043,55 +3951,35 @@ name = "ipython"
 version = "9.14.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "colorama", marker = "(python_full_version >= '3.11' and sys_platform == 'win32') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "decorator", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "jedi", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pexpect", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "psutil", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "stack-data", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "traitlets", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
 wheels = [
@@ -4103,7 +3991,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -4365,8 +4253,8 @@ dependencies = [
     { name = "attrs" },
     { name = "jsonschema-specifications" },
     { name = "referencing" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "rpds-py", version = "2026.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "rpds-py", version = "2026.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -4473,10 +4361,10 @@ dependencies = [
     { name = "jupyter-server-terminals" },
     { name = "nbconvert" },
     { name = "nbformat" },
-    { name = "overrides", marker = "python_full_version < '3.12' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "overrides", marker = "python_full_version < '3.12'" },
     { name = "packaging" },
     { name = "prometheus-client" },
-    { name = "pywinpty", marker = "(os_name == 'nt' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (os_name == 'nt' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (os_name == 'nt' and sys_platform != 'darwin') or (os_name != 'nt' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pywinpty", marker = "os_name == 'nt' and sys_platform != 'darwin'" },
     { name = "pyzmq" },
     { name = "send2trash" },
     { name = "terminado" },
@@ -4494,7 +4382,7 @@ name = "jupyter-server-terminals"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywinpty", marker = "(os_name == 'nt' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (os_name == 'nt' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (os_name == 'nt' and sys_platform != 'darwin') or (os_name != 'nt' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pywinpty", marker = "os_name == 'nt' and sys_platform != 'darwin'" },
     { name = "terminado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
@@ -4517,9 +4405,9 @@ dependencies = [
     { name = "jupyterlab-server" },
     { name = "notebook-shim" },
     { name = "packaging" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tornado" },
     { name = "traitlets" },
 ]
@@ -4695,44 +4583,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/7e/f6/1511d2ab4391af8a4
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/60/b87c4d017caf35b50c839299b6698a1bf79ab1a6486e4e935a73332bffd2/ladybug-0.17.1-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:faf616d55f8a1269346c66913cabb32a88f9459878adadd7befb5e7adb206ea2", size = 4183667, upload-time = "2026-06-02T20:07:20.659Z" },
     { url = "https://files.pythonhosted.org/packages/a5/fb/7e2c6bc3950a60250cfa87fb20146f26df3888049490168f4b1d8924bab6/ladybug-0.17.1-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:6b93d3dc7eb3827bfec82368d1196f78aa529dcddab848a06015a51d05ec622d", size = 4666415, upload-time = "2026-06-02T20:07:22.826Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/03/4489ab0d7a65d82fe945c31abe5c0007f396b4040c1fabed512800ecad84/ladybug-0.17.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0624025078a120b4e397d0e84a4de2a931a8a40434fa0594c49da5beee093ce", size = 7066895, upload-time = "2026-06-02T20:07:24.537Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/b8/f84cd5c39ad471c332272ae54df83b533df208305d28857dc70bb9eee526/ladybug-0.17.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b69c79fafd7fbd2eaa2fa5ee7b891aa5ddf91f913b1d252a983175c1b8c4563", size = 7922849, upload-time = "2026-06-02T20:07:26.465Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/6a/37856a75d1ff1d7f0a6bfb15fe4fea30aed037c31c852bab77300915d91b/ladybug-0.17.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0ed7445e6bf200cc585f7e71e0d3a79b4a78718c1bf3fdcdee99dfadc0ce73c1", size = 7898267, upload-time = "2026-06-02T20:07:28.554Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2e/26ce9528a96911ca11d875013504287d722b46aebacd25626ac107579c5f/ladybug-0.17.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:99a76128828245e39996c44ba693a754132b785c5db5e70f0e469e73ec24d103", size = 8783469, upload-time = "2026-06-02T20:07:30.652Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/8e/ead3989595cf2e2df0829b3064b073f379a0bcdcba99bcd620d175e8ff1f/ladybug-0.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:2748b1bb9e13c6af465f8089eb20e72fb4f1871603b1031eeb3390ab5b9f9baa", size = 5289323, upload-time = "2026-06-02T20:07:33.089Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/4c/585f3b98ebf50a9fb5ad090e4deb04ad5a0080fc91c54da4ce1aad741fa0/ladybug-0.17.1-cp310-cp310-win_arm64.whl", hash = "sha256:0a7cea07905e7bdfb8a45bd80f3491ff6624ec34d0395d1887be0e4e0e2259d3", size = 5257509, upload-time = "2026-06-02T20:07:34.904Z" },
     { url = "https://files.pythonhosted.org/packages/df/9d/d2993494ecd3a6aa2d12a027a9f6adf365a702c720d99cd1fa8a9d9142bf/ladybug-0.17.1-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b21e9101855a852c8f810e591d078adc0d28639c45bfaae4f20c20ad07164162", size = 4185136, upload-time = "2026-06-02T20:07:36.714Z" },
     { url = "https://files.pythonhosted.org/packages/62/00/a42fdb3eef04e60819525f8bcccd785d7ea8d8bdcc0336b587e8742a2c8f/ladybug-0.17.1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:d6ed21cc33d636d9e69c9126a0e55142000faa3f402cc8f30a79f03f9c9c997b", size = 4667711, upload-time = "2026-06-02T20:07:38.573Z" },
-    { url = "https://files.pythonhosted.org/packages/28/fa/f27d01ea2a14fbf03a8d38d254ac39e36954f1ee6dfd0cf2f0f0aa34bbe6/ladybug-0.17.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:afbf3096d18ab6300a29df15c2a77c936434d11bf9ef2b370076e13450592907", size = 7069633, upload-time = "2026-06-02T20:07:40.586Z" },
-    { url = "https://files.pythonhosted.org/packages/58/97/6eac02e95ed5cf31eb3336ac2f95b4db3a98c775593a91f183a291f4a9e1/ladybug-0.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3cffc7023414c890f8be7841df8f41a9b3d489715ada9ab7426f943701e64eb6", size = 7923999, upload-time = "2026-06-02T20:07:42.631Z" },
-    { url = "https://files.pythonhosted.org/packages/75/0f/0887c7e6fe74245569f572a9a8d1011dead4367e9fce72b318acff544930/ladybug-0.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7eb77583aee8618bcb8d174ec834950b821f44feb21655d502fda415d51e1194", size = 7900586, upload-time = "2026-06-02T20:07:44.716Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/88/151439e993103788c112f7dc547596329ddd9e89abc439a629f79475d953/ladybug-0.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8eb26cb7508541facc38e4d4282583469ef3927fbb99900eb4ae66632a55e215", size = 8784396, upload-time = "2026-06-02T20:07:46.941Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/9f/f35cd80041209f93f47b6a60bc17d0fa73fa1b2c80467c788a10a6188bab/ladybug-0.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:b2fd0e4e8948e15e567e8dcdfa38709906f6f1a66552cd44eea873a8ff664df9", size = 5289990, upload-time = "2026-06-02T20:07:49.211Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/82/f66966cebb674dd9f995cb981c9d79284d84259dc482453edbd963a53a00/ladybug-0.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:e1b881433e6623daa5c84eb80a9c1d6d5b4a16618c022fa028aa16b9de7a7dd8", size = 5258334, upload-time = "2026-06-02T20:07:51.145Z" },
     { url = "https://files.pythonhosted.org/packages/75/0b/76ba668df9fe004c80bc2ee0cd46e76924467fa4d96853125962947d9c33/ladybug-0.17.1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:1a5fd5f324df8c5659a8cd6a0c08c58b2f6efbf0319cde6ec7cdcc3480343129", size = 4185245, upload-time = "2026-06-02T20:07:52.826Z" },
     { url = "https://files.pythonhosted.org/packages/25/54/11855f62e55a9b47e64c3c45c9d312e9830e5fc253c1f1b6d860f12faf74/ladybug-0.17.1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:17e540cedd30816fad248e4d3cc6444bbc139a4b79e43af5f471acbe790a707a", size = 4668570, upload-time = "2026-06-02T20:07:55.132Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/94/1e8796e91ec8d741a2bcd10bfa99cd96f0a30f26fe55ca910a993e6bcb9f/ladybug-0.17.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:067e183bd3fb2094a040cc4e69269fdcc5a770579a89f2d9f5dd8c93da6c08bc", size = 7065841, upload-time = "2026-06-02T20:07:57.147Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/1a/12796133dd933b59a441eb39145ff604a36d1fa3b9c08deb90048233b38b/ladybug-0.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c11887032a14ca49941cbb5e9ac94adcba804c17fc7f823f598c8cceb5438612", size = 7921694, upload-time = "2026-06-02T20:07:59.278Z" },
-    { url = "https://files.pythonhosted.org/packages/11/59/24f4dfbebc4298ca05ace1755abda6fe096e37db19a019239ca08828ee4c/ladybug-0.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5a3e906981abb4a92f3c2add315ae44419b1c5487bbedfa50eb03a0e2040dc38", size = 7897206, upload-time = "2026-06-02T20:08:01.334Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/4b/5dbe3d4193866ae54b210f75552a11a9c0f5fd6408ea78e01332347d7422/ladybug-0.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bc0d0276b6181c26434f33eb675a304d33ce183fe6f90d04c91e7c001468b407", size = 8781956, upload-time = "2026-06-02T20:08:03.322Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/77/c71612d69c41c4813a7687ee547145d1787bea96cd5530a23cc67eb8d5d8/ladybug-0.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:4efc3f1117c16d7e9728afe9a0a87b89d4d3fb98c480d16d7f22c64be963a43b", size = 5290750, upload-time = "2026-06-02T20:08:05.597Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/78/a6c1d9fe146216fb92dc6dfc8c289a818db0d8563333aca751679329ad26/ladybug-0.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:4c50a9e3e288cb57ede865b16e84bb4fd0471c572a641481e548cd70c4e82973", size = 5258304, upload-time = "2026-06-02T20:08:07.441Z" },
     { url = "https://files.pythonhosted.org/packages/13/4a/8a5a208b5a53384c576870c49a940a178083b1740f1b20332f2433f9a846/ladybug-0.17.1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:785c95d595754be8d16b2e35defc44a906ccbef329c180e97e47ac7df17776bf", size = 4185250, upload-time = "2026-06-02T20:08:09.137Z" },
     { url = "https://files.pythonhosted.org/packages/8c/1d/c4c2815475571c9eb32f44ae435957049e20ce7474fa5fc04aa74ac2b12e/ladybug-0.17.1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:a168cdeea1f239b698ca222d680faa9b9b01b5ff96a1087b6235be23533d05e0", size = 4668500, upload-time = "2026-06-02T20:08:11.013Z" },
-    { url = "https://files.pythonhosted.org/packages/92/64/6233cb455e327f752b7938cdcbbc693cd9584a154723be429272b9fa694c/ladybug-0.17.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb2d88b4852689d73437c7c31057345fc95540e242c25e71999d541ad104f390", size = 7065427, upload-time = "2026-06-02T20:08:12.979Z" },
-    { url = "https://files.pythonhosted.org/packages/37/31/18875d6e46e29081d7c0b0072c60df3e20090d46de00d481eaecf71cf0ab/ladybug-0.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf0ec0e0c0cb06be60ef83e3d95a3f5c02e3df6fe0270fee576b5688d0e70d28", size = 7921542, upload-time = "2026-06-02T20:08:15.167Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/ce/89eeaf428595146c790d7ebf982bdb53fa51b678daded5f09152a1454435/ladybug-0.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8fd79f020c5b2db9d2b2b689ac2616f86d43ebc5d36063a001ee1ce158f50bf8", size = 7898139, upload-time = "2026-06-02T20:08:17.308Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/44/b4c80147c547c380d35b9904245de01def0224342254b4fa36d8815210de/ladybug-0.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a9706c6a65365955ac3b18688a582c82ac3388362fdccab13a18e66b2c864e6b", size = 8782280, upload-time = "2026-06-02T20:08:19.49Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/39/f09366d5fe6d2f2c75a22d368e7c09f2e0194d1d80a4dfa7ece5b2deaa83/ladybug-0.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:616d5017ee21ac99c4e1251f75c569053b709f73e207bd2d97f7742169680286", size = 5291337, upload-time = "2026-06-02T20:08:21.538Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/d4/e64ae350b011c0cacde3df87e47cc6ec59564366cd364fc13698d6d774ca/ladybug-0.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5e84e5329f74e833828eeddd468ac881323fbfdb54a8610ae9f2bbe7bc02f952", size = 5258364, upload-time = "2026-06-02T20:08:23.504Z" },
     { url = "https://files.pythonhosted.org/packages/a9/e6/94dff21a9ef485fba3a933d76735197e8ced13184edd862361319ee2e253/ladybug-0.17.1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:c8a71f90f2fe16396c98380aadd5519ed72346aed4d7872b06e2450e9470ac77", size = 4186197, upload-time = "2026-06-02T20:08:25.443Z" },
     { url = "https://files.pythonhosted.org/packages/c6/7c/a9fd639408629e8a33d014d482355eab272edfe525aea1c7a5305d32662e/ladybug-0.17.1-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:08934e417214ca03836934ed7bd1f6ebedf6959db3b4405541aa4389f60800a6", size = 4668982, upload-time = "2026-06-02T20:08:27.451Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/aa/ccd37c07d38e7305212ddd8d05dbfadd61a07ad5e56aebaf92fe4c6c23cb/ladybug-0.17.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2dbca5d77c309b6c992f5ab9f5d18b2a8002d4766f09ab7fa6ff9510df304b74", size = 7066952, upload-time = "2026-06-02T20:08:29.43Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/a1/e9e987fdf72ec8c67bf57223295abba78489c7629bc126e851249cd4c24e/ladybug-0.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f206b635840a26dd76e0b2f74e00e25e33fad1eb4e913bcce98cd5e5cf0146d", size = 7921609, upload-time = "2026-06-02T20:08:31.751Z" },
-    { url = "https://files.pythonhosted.org/packages/56/0b/8267a09d1589e9f19756c1118d406da88d9370fb04ede0285ae75b9b0d04/ladybug-0.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4c6701f0abce984e7820f8242754682b7e6ed82787b1316b614c192458bac99", size = 7898765, upload-time = "2026-06-02T20:08:33.864Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/06/5214d7ed85e3a302a855af067475234d44d45dbf220f5773bd9f476c7ee8/ladybug-0.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c53cf98ae5b414af6f6f2025ccbb06dcd368eb1142e9a675ab24ccc4b936ed5", size = 8782260, upload-time = "2026-06-02T20:08:36.309Z" },
-    { url = "https://files.pythonhosted.org/packages/45/d7/5ad430ad61b7db1b409fd3086f32fb1b64300c9a2f1d455dd0ca7b39adf0/ladybug-0.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:48efb95673096a7524a1f16943a1885ad016944ea8a5a000746d9939cf2a039b", size = 5455451, upload-time = "2026-06-02T20:08:39.118Z" },
-    { url = "https://files.pythonhosted.org/packages/af/da/75ca2ef8911bd554e997793c767f6e77892c8cb4761939f3abd225532ebc/ladybug-0.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:2ad869f14b0307c7eb2f91639da7ab887c666c2f93260c46a055c7969e082a09", size = 5400801, upload-time = "2026-06-02T20:08:41.114Z" },
 ]
 
 [[package]]
@@ -4740,30 +4598,18 @@ name = "ladybug"
 version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/8f/f598687c2d6a56f7465ffeaf3a1f32681102b137c1af221803f40a8186b5/ladybug-0.18.1.tar.gz", hash = "sha256:f9566e4b09a1d8d1a2860bf87daa81d9063abe59ab6c814f45c6190ce3cb5ea8", size = 10273916, upload-time = "2026-07-10T02:46:33.663Z" }
 wheels = [
@@ -4843,9 +4689,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecation" },
     { name = "lance-namespace" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "overrides", marker = "python_full_version < '3.12' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "overrides", marker = "python_full_version < '3.12'" },
     { name = "packaging" },
     { name = "pyarrow" },
     { name = "pydantic" },
@@ -4867,8 +4713,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "langchain-core" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/1d/bb306951b1c394b7a27effb8eb6c9ee65dd77fcc4be7c20f76e3299a9e1e/langchain_aws-1.1.0.tar.gz", hash = "sha256:1e2f8570328eae4907c3cf7e900dc68d8034ddc865d9dc96823c9f9d8cccb901", size = 393899, upload-time = "2025-11-24T14:35:24.216Z" }
@@ -4935,7 +4781,7 @@ version = "0.8.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
-    { name = "orjson", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
     { name = "packaging" },
     { name = "pydantic" },
     { name = "requests" },
@@ -5034,8 +4880,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diskcache" },
     { name = "jinja2" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1e/45/2bca210df9ab2403efbd20316b6f53a2c322fd71a313d8bf090e2ee148e4/llama_cpp_python-0.3.30.tar.gz", hash = "sha256:798c9b42652d2e0bff5fe81e7e762089f425a99e67f66ffe5ae156957876e0d1", size = 70191382, upload-time = "2026-06-16T07:51:16.654Z" }
@@ -5066,18 +4912,18 @@ dependencies = [
     { name = "httpx" },
     { name = "llama-index-workflows" },
     { name = "nest-asyncio" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "nltk" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
     { name = "platformdirs" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "tenacity" },
     { name = "tiktoken" },
@@ -5167,13 +5013,13 @@ dependencies = [
     { name = "psutil" },
     { name = "python-engineio" },
     { name = "python-socketio", extra = ["client"] },
-    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "pyzmq" },
     { name = "requests" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "werkzeug" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/c8/10aa5445c404eed389b56877e6714c1787190cc09dd70059ce3765979ec5/locust-2.39.1.tar.gz", hash = "sha256:6bdd19e27edf9a1c84391d6cf6e9a737dfb832be7dfbf39053191ae31b9cc498", size = 1409902, upload-time = "2025-08-29T17:41:01.544Z" }
@@ -5191,7 +5037,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-engineio" },
     { name = "python-socketio", extra = ["client"] },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8d/86/cd6b611f008387ffce5bcb6132ba7431aec7d1b09d8ce27e152e96d94315/locust_cloud-1.30.0.tar.gz", hash = "sha256:324ae23754d49816df96d3f7472357a61cd10e56cebcb26e2def836675cb3c68", size = 457297, upload-time = "2025-12-15T13:35:50.342Z" }
 wheels = [
@@ -5203,8 +5049,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -5279,27 +5125,15 @@ name = "lxml"
 version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/14/c2070b5e37c650198de8328467dd3d1681e80986f81ba0fea04fc4ec9883/lxml-4.9.4.tar.gz", hash = "sha256:b1541e50b78e15fa06a2670157a1962ef06591d4c998b998047fff5e3236880e", size = 3576664, upload-time = "2023-12-19T19:37:24.296Z" }
 wheels = [
@@ -5339,13 +5173,9 @@ name = "lxml"
 version = "5.4.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/3d/14e82fc7c8fb1b7761f7e748fd47e2ec8276d137b6acfe5a4bb73853e08f/lxml-5.4.0.tar.gz", hash = "sha256:d12832e1dbea4be280b22fd0ea7c9b87f0d8fc51ba06e92dc62d52f804f78ebd", size = 3679479, upload-time = "2025-04-23T01:50:29.322Z" }
 wheels = [
@@ -5430,20 +5260,12 @@ name = "lxml"
 version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
 wheels = [
@@ -5721,24 +5543,20 @@ name = "matplotlib"
 version = "3.10.9"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "cycler", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "fonttools", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "kiwisolver", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "packaging", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pillow", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pyparsing", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -5803,52 +5621,32 @@ name = "matplotlib"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "cycler", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "fonttools", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "packaging", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pillow", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
 wheels = [
@@ -5934,30 +5732,22 @@ name = "mistral-common"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "jsonschema", marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pillow", marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pydantic", marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "requests", marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "tiktoken", marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typing-extensions", marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "jsonschema" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "pydantic-extra-types", extra = ["pycountry"] },
+    { name = "requests" },
+    { name = "tiktoken" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/ce/685b8127a326478e05501cb4c9ca23d1cd9f37e16c465a1e832c75aea709/mistral_common-1.9.1.tar.gz", hash = "sha256:550583d70a395c3586cfb748ffab53bd1d7c3409507f0efc0118bff30ffb26e9", size = 6338922, upload-time = "2026-02-12T10:53:41.639Z" }
 wheels = [
@@ -5969,45 +5759,29 @@ name = "mistral-common"
 version = "1.11.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "jsonschema", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pillow", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pydantic", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "python_full_version < '3.11' or python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "requests", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "tiktoken", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "jsonschema" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "pydantic-extra-types", extra = ["pycountry"] },
+    { name = "requests" },
+    { name = "tiktoken" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/03/3c5d4c9430da406f8444f9a7b058a6aa89c525fb068a57fe2ab8b04a6d08/mistral_common-1.11.3.tar.gz", hash = "sha256:6437e128fc8a307318440839ca14ddf2e8060056b062233ec0db10352651374c", size = 6360629, upload-time = "2026-06-04T09:01:11.131Z" }
 wheels = [
@@ -6040,7 +5814,7 @@ name = "mistune"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
 wheels = [
@@ -6053,7 +5827,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -6188,8 +5962,8 @@ name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
 wheels = [
@@ -6506,7 +6280,7 @@ name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
 wheels = [
@@ -6834,13 +6608,9 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -6852,41 +6622,21 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
@@ -6951,8 +6701,8 @@ version = "0.65.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llvmlite" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
 wheels = [
@@ -6987,13 +6737,9 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -7058,41 +6804,21 @@ name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
@@ -7174,12 +6900,11 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
     { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
-    { url = "https://files.pythonhosted.org/packages/45/9e/2f562daf80eb8f7a685fb7bea4fda71f6048e4f359d6fdd1b6e70206cb2f/nvidia_cublas-13.1.1.3-py3-none-win_amd64.whl", hash = "sha256:b6cdce694e47ff6aadf0a69df1cab6628d696f5ff56e8d16af50309d855fa20f", size = 404358158, upload-time = "2026-04-08T18:47:26.987Z" },
 ]
 
 [[package]]
@@ -7187,9 +6912,7 @@ name = "nvidia-cublas-cu12"
 version = "12.8.4.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/99/db44d685f0e257ff0e213ade1964fc459b4a690a73293220e98feb3307cf/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0", size = 590537124, upload-time = "2025-03-07T01:43:53.556Z" },
     { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
-    { url = "https://files.pythonhosted.org/packages/70/61/7d7b3c70186fb651d0fbd35b01dbfc8e755f69fd58f817f3d0f642df20c3/nvidia_cublas_cu12-12.8.4.1-py3-none-win_amd64.whl", hash = "sha256:47e9b82132fa8d2b4944e708049229601448aaad7e6f296f630f2d1a32de35af", size = 567544208, upload-time = "2025-03-07T01:53:30.535Z" },
 ]
 
 [[package]]
@@ -7199,7 +6922,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
     { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/df/b74b10025c1205695c5676373f2edd3e87a7202cc62ead0dfbc373b0f6ea/nvidia_cuda_cupti-13.0.85-py3-none-win_amd64.whl", hash = "sha256:683f58d301548deeefcb8f6fac1b8d907691b9d8b18eccab417f51e362102f00", size = 7736776, upload-time = "2025-09-04T08:38:08.38Z" },
 ]
 
 [[package]]
@@ -7207,9 +6929,7 @@ name = "nvidia-cuda-cupti-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/1f/b3bd73445e5cb342727fd24fe1f7b748f690b460acadc27ea22f904502c8/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed", size = 9533318, upload-time = "2025-03-07T01:40:10.421Z" },
     { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
-    { url = "https://files.pythonhosted.org/packages/41/bc/83f5426095d93694ae39fe1311431b5d5a9bb82e48bf0dd8e19be2765942/nvidia_cuda_cupti_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:bb479dcdf7e6d4f8b0b01b115260399bf34154a1a2e9fe11c85c517d87efd98e", size = 7015759, upload-time = "2025-03-07T01:51:11.355Z" },
 ]
 
 [[package]]
@@ -7219,7 +6939,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
     { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/af/345fedb9f4c76c84ab4fa445b36bd4048a4d9db60e6bc76b4f913ff4b852/nvidia_cuda_nvrtc-13.0.88-py3-none-win_amd64.whl", hash = "sha256:6bcd4e7f8e205cbe644f5a98f2f799bef9556fefc89dd786e79a16312ce49872", size = 76807835, upload-time = "2025-09-04T08:39:15.274Z" },
 ]
 
 [[package]]
@@ -7228,8 +6947,6 @@ version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d1/e50d0acaab360482034b84b6e27ee83c6738f7d32182b987f9c7a4e32962/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8", size = 43106076, upload-time = "2025-03-07T01:41:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/45/51/52a3d84baa2136cc8df15500ad731d74d3a1114d4c123e043cb608d4a32b/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:7a4b6b2904850fe78e0bd179c4b655c404d4bb799ef03ddc60804247099ae909", size = 73586838, upload-time = "2025-03-07T01:52:13.483Z" },
 ]
 
 [[package]]
@@ -7239,7 +6956,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
     { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/94/6b867483bec07da24ffa32736c79fabb94ef3a7af4d787a9d4a974868576/nvidia_cuda_runtime-13.0.96-py3-none-win_amd64.whl", hash = "sha256:f79298c8a098cec150a597c8eba58ecdab96e3bdc4b9bc4f9983635031740492", size = 2927037, upload-time = "2025-10-09T09:04:23.782Z" },
 ]
 
 [[package]]
@@ -7247,9 +6963,7 @@ name = "nvidia-cuda-runtime-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/75/f865a3b236e4647605ea34cc450900854ba123834a5f1598e160b9530c3a/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d", size = 965265, upload-time = "2025-03-07T01:39:43.533Z" },
     { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
-    { url = "https://files.pythonhosted.org/packages/30/a5/a515b7600ad361ea14bfa13fb4d6687abf500adc270f19e89849c0590492/nvidia_cuda_runtime_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:c0c6027f01505bfed6c3b21ec546f69c687689aad5f1a377554bc6ca4aa993a8", size = 944318, upload-time = "2025-03-07T01:51:01.794Z" },
 ]
 
 [[package]]
@@ -7257,12 +6971,10 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/90/0bd6e586701b3a890fd38aa71c387dab4883d619d6e5ad912ccbd05bfd67/nvidia_cudnn_cu12-9.10.2.21-py3-none-win_amd64.whl", hash = "sha256:c6288de7d63e6cf62988f0923f96dc339cea362decb1bf5b3141883392a7d65e", size = 692992268, upload-time = "2025-06-06T21:55:18.114Z" },
 ]
 
 [[package]]
@@ -7270,12 +6982,11 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
     { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
-    { url = "https://files.pythonhosted.org/packages/78/39/21507455b1bca8b5702a9e9fc6ce73735f216f558dac2c9ede58e4d456b8/nvidia_cudnn_cu13-9.20.0.48-py3-none-win_amd64.whl", hash = "sha256:af8139732b99c0118be65ea5aac97f0d46018f8c552889e49d2fb0c6261a4a24", size = 350712614, upload-time = "2026-03-09T19:31:11.398Z" },
 ]
 
 [[package]]
@@ -7283,12 +6994,11 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
     { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b2/f8af21a2ed1beed337a6a02c5a28aeb85441f4d578ec3d529543c775ea4b/nvidia_cufft-12.0.0.61-py3-none-win_amd64.whl", hash = "sha256:2abce5b39d2f5ae12730fb7e5db6696533e36c26e2d3e8fd1750bdd2853364eb", size = 213342123, upload-time = "2025-09-04T08:40:51.145Z" },
 ]
 
 [[package]]
@@ -7296,12 +7006,10 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/ec/ce1629f1e478bb5ccd208986b5f9e0316a78538dd6ab1d0484f012f8e2a1/nvidia_cufft_cu12-11.3.3.83-py3-none-win_amd64.whl", hash = "sha256:7a64a98ef2a7c47f905aaf8931b69a3a43f27c55530c698bb2ed7c75c0b42cb7", size = 192216559, upload-time = "2025-03-07T01:53:57.106Z" },
 ]
 
 [[package]]
@@ -7319,7 +7027,6 @@ version = "1.13.1.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f5/5607710447a6fe9fd9b3283956fceeee8a06cda1d2f56ce31371f595db2a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a", size = 1120705, upload-time = "2025-03-07T01:45:41.434Z" },
 ]
 
 [[package]]
@@ -7329,7 +7036,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
     { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
-    { url = "https://files.pythonhosted.org/packages/99/27/72103153b1ffc00e09fdc40ac970235343dcd1ea8bd762e84d2d73219ffa/nvidia_curand-10.4.0.35-py3-none-win_amd64.whl", hash = "sha256:65b1710aa6961d326b411e314b374290904c5ddf41dc3f766ebc3f1d7d4ca69f", size = 55242481, upload-time = "2025-08-04T10:30:41.831Z" },
 ]
 
 [[package]]
@@ -7337,9 +7043,7 @@ name = "nvidia-curand-cu12"
 version = "10.3.9.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/5e/92aa15eca622a388b80fbf8375d4760738df6285b1e92c43d37390a33a9a/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd", size = 63625754, upload-time = "2025-03-07T01:46:10.735Z" },
     { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/75/70c05b2f3ed5be3bb30b7102b6eb78e100da4bbf6944fd6725c012831cab/nvidia_curand_cu12-10.3.9.90-py3-none-win_amd64.whl", hash = "sha256:f149a8ca457277da854f89cf282d6ef43176861926c7ac85b2a0fbd237c587ec", size = 62765309, upload-time = "2025-03-07T01:54:20.478Z" },
 ]
 
 [[package]]
@@ -7347,14 +7051,13 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "nvidia-cusparse", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
     { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ef/332a0101260ca78a1daef046bf0b06199e8ed4dac1d2aa698289c358169c/nvidia_cusolver-12.0.4.66-py3-none-win_amd64.whl", hash = "sha256:16515bd33a8e76bb54d024cfa068fa68d30e80fc34b9e1090813ea9362e0cb65", size = 193551444, upload-time = "2025-09-04T08:41:46.813Z" },
 ]
 
 [[package]]
@@ -7362,14 +7065,12 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cusparse-cu12", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
-    { url = "https://files.pythonhosted.org/packages/13/c0/76ca8551b8a84146ffa189fec81c26d04adba4bc0dbe09cd6e6fd9b7de04/nvidia_cusolver_cu12-11.7.3.90-py3-none-win_amd64.whl", hash = "sha256:4a550db115fcabc4d495eb7d39ac8b58d4ab5d8e63274d3754df1c0ad6a22d34", size = 256720438, upload-time = "2025-03-07T01:54:39.898Z" },
 ]
 
 [[package]]
@@ -7377,12 +7078,11 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
     { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
-    { url = "https://files.pythonhosted.org/packages/02/b0/b043d6f3480f102f885cf87fc3ffd3edcb5e23b855025a50e2ef4d059185/nvidia_cusparse-12.6.3.3-py3-none-win_amd64.whl", hash = "sha256:cbcf42feb737bd7ec15b4c0a63e62351886bd3f975027b8815d7f720a2b5ea79", size = 143783033, upload-time = "2025-09-04T08:42:12.391Z" },
 ]
 
 [[package]]
@@ -7390,12 +7090,10 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
-    { url = "https://files.pythonhosted.org/packages/62/07/f3b2ad63f8e3d257a599f422ae34eb565e70c41031aecefa3d18b62cabd1/nvidia_cusparse_cu12-12.5.8.93-py3-none-win_amd64.whl", hash = "sha256:9a33604331cb2cac199f2e7f5104dfbb8a5a898c367a53dfda9ff2acb6b6b4dd", size = 284937404, upload-time = "2025-03-07T01:55:07.742Z" },
 ]
 
 [[package]]
@@ -7403,9 +7101,7 @@ name = "nvidia-cusparselt-cu12"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/b9/598f6ff36faaece4b3c50d26f50e38661499ff34346f00e057760b35cc9d/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5", size = 283835557, upload-time = "2025-02-26T00:16:54.265Z" },
     { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/d8/a6b0d0d0c2435e9310f3e2bb0d9c9dd4c33daef86aa5f30b3681defd37ea/nvidia_cusparselt_cu12-0.7.1-py3-none-win_amd64.whl", hash = "sha256:f67fbb5831940ec829c9117b7f33807db9f9678dc2a617fbe781cac17b4e1075", size = 271020911, upload-time = "2025-02-26T00:14:47.204Z" },
 ]
 
 [[package]]
@@ -7415,7 +7111,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
     { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
-    { url = "https://files.pythonhosted.org/packages/31/83/f3647ce26916c94a6ca4ff1810623e2c405cff2dea6e78d29516b2514df9/nvidia_cusparselt_cu13-0.8.1-py3-none-win_amd64.whl", hash = "sha256:dccbd362f91a7b9024d1f55ee9f548ac065027ff15d8c8b0db889ab3a8f31215", size = 156885108, upload-time = "2025-09-05T18:51:35.958Z" },
 ]
 
 [[package]]
@@ -7423,7 +7118,6 @@ name = "nvidia-nccl-cu12"
 version = "2.27.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/1c/857979db0ef194ca5e21478a0612bcdbbe59458d7694361882279947b349/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a", size = 322400625, upload-time = "2025-06-26T04:11:04.496Z" },
     { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
 ]
 
@@ -7443,7 +7137,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
     { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/01/07530b0e37546231052e30234540289c42eaffa486f1a34a87fed340157b/nvidia_nvjitlink-13.0.88-py3-none-win_amd64.whl", hash = "sha256:634e96e3da9ef845ae744097a1f289238ecf946ce0b82e93cdce14b9782e682f", size = 36035115, upload-time = "2025-09-04T08:43:03.001Z" },
 ]
 
 [[package]]
@@ -7452,8 +7145,6 @@ version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/a2/8cee5da30d13430e87bf99bb33455d2724d0a4a9cb5d7926d80ccb96d008/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7", size = 38386204, upload-time = "2025-03-07T01:49:43.612Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/d7/34f02dad2e30c31b10a51f6b04e025e5dd60e5f936af9045a9b858a05383/nvidia_nvjitlink_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:bd93fbeeee850917903583587f4fc3a4eafa022e34572251368238ab5e6bd67f", size = 268553710, upload-time = "2025-03-07T01:56:24.13Z" },
 ]
 
 [[package]]
@@ -7461,7 +7152,6 @@ name = "nvidia-nvshmem-cu12"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/6a/03aa43cc9bd3ad91553a88b5f6fb25ed6a3752ae86ce2180221962bc2aa5/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b48363fc6964dede448029434c6abed6c5e37f823cb43c3bcde7ecfc0457e15", size = 138936938, upload-time = "2025-09-06T00:32:05.589Z" },
     { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
 ]
 
@@ -7481,7 +7171,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/50/0e2220f8620a177de994211186ffc5bfa9f2ce1e1282797f8f90096f9f88/nvidia_nvtx-13.0.85-py3-none-win_amd64.whl", hash = "sha256:d66ea44254dd3c6eacc300047af6e1288d2269dd072b417e0adffbf479e18519", size = 137066, upload-time = "2025-09-04T08:39:25.649Z" },
 ]
 
 [[package]]
@@ -7489,9 +7178,7 @@ name = "nvidia-nvtx-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
     { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/99/4c9c0c329bf9fc125008c3b54c7c94c0023518d06fc025ae36431375e1fe/nvidia_nvtx_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:619c8304aedc69f02ea82dd244541a83c3d9d40993381b3b590f1adaed3db41e", size = 56492, upload-time = "2025-03-07T01:52:24.69Z" },
 ]
 
 [[package]]
@@ -7530,8 +7217,8 @@ name = "omegaconf"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime", marker = "python_full_version < '3.13' or extra == 'extra-6-cognee-docling-full'" },
-    { name = "pyyaml", marker = "python_full_version < '3.13' or extra == 'extra-6-cognee-docling-full'" },
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/3d/e4b57b8d9008c6ebe0d5eff901f91d5700cf7bdb8c8863df817463a7fd5e/omegaconf-2.3.1.tar.gz", hash = "sha256:e5e7de64aeebeddaf8e6d3f7a783b32ac2a01c0fbd9c878012caecb891a1f42a", size = 3298472, upload-time = "2026-06-11T05:05:12.885Z" }
 wheels = [
@@ -7544,8 +7231,8 @@ version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml-dtypes" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "protobuf" },
     { name = "typing-extensions" },
 ]
@@ -7581,43 +7268,27 @@ name = "onnxruntime"
 version = "1.23.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "coloredlogs", marker = "python_full_version < '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "flatbuffers", marker = "python_full_version < '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "packaging", marker = "python_full_version < '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "protobuf", marker = "python_full_version < '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "sympy", marker = "python_full_version < '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
@@ -7649,26 +7320,18 @@ name = "onnxruntime"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "flatbuffers", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "packaging", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "protobuf", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "protobuf" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
@@ -7721,8 +7384,8 @@ name = "opencv-python"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052, upload-time = "2026-02-05T07:01:25.046Z" },
@@ -7959,8 +7622,8 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -8163,8 +7826,8 @@ name = "pgvector"
 version = "0.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/d8/fd6009cee3e03214667df488cdcf9609461d729968da94e4f95d6359d304/pgvector-0.3.6.tar.gz", hash = "sha256:31d01690e6ea26cea8a633cde5f0f55f5b246d9c8292d68efdef8c22ec994ade", size = 25421, upload-time = "2024-10-27T00:15:09.632Z" }
 wheels = [
@@ -8234,9 +7897,9 @@ name = "pikepdf"
 version = "10.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
+    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "packaging" },
     { name = "pillow" },
 ]
@@ -8465,7 +8128,7 @@ name = "portalocker"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
 wheels = [
@@ -8510,8 +8173,8 @@ name = "preshed"
 version = "3.0.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cymem", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "murmurhash", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "cymem" },
+    { name = "murmurhash" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/75/fe6b7bbd0dea530a001b0e24c331b21a0be2786e402abf3c57f5dce43d4b/preshed-3.0.13.tar.gz", hash = "sha256:d75f718bbfd97e992f7827e0fa7faf6a91bdd9c922d5baa4b50d62731396cb89", size = 18338, upload-time = "2026-03-23T08:57:31.378Z" }
 wheels = [
@@ -9077,8 +8740,8 @@ name = "pycocotools"
 version = "2.0.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/df/32354b5dda963ffdfc8f75c9acf8828ef7890723a4ed57bb3ff2dc1d6f7e/pycocotools-2.0.11.tar.gz", hash = "sha256:34254d76da85576fcaf5c1f3aa9aae16b8cb15418334ba4283b800796bd1993d", size = 25381, upload-time = "2025-12-15T22:31:46.148Z" }
 wheels = [
@@ -9335,7 +8998,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
@@ -9352,8 +9015,8 @@ name = "pylance"
 version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyarrow" },
 ]
 wheels = [
@@ -9390,7 +9053,7 @@ name = "pympler"
 version = "1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/37/c384631908029676d8e7213dd956bb686af303a80db7afbc9be36bc49495/pympler-1.1.tar.gz", hash = "sha256:1eaa867cb8992c218430f1708fdaccda53df064144d1c5656b1e6f1ee6000424", size = 179954, upload-time = "2024-06-28T19:56:06.563Z" }
 wheels = [
@@ -9417,7 +9080,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/7f/1e5612b52900ebe590862dabeadf546f739b27527dcd8bfd632f8adac1be/pypandoc_binary-1.17-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ada156cb980cd54fd6534231788e668c00dbb591cbd24f0be0bd86812eb8788", size = 36867598, upload-time = "2026-03-14T22:38:56.351Z" },
     { url = "https://files.pythonhosted.org/packages/3b/31/a5a867159c4080e5d368f4a53540a727501a2f31affc297dc8e0fced96a7/pypandoc_binary-1.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2f439dcd211183bb3460253ca4511101df6e1acf4a01f45f5617e1fa2ad24279", size = 36867584, upload-time = "2026-03-14T22:38:59.087Z" },
     { url = "https://files.pythonhosted.org/packages/0d/2d/6a51cd4e54bdf132c19416801077c34bd40ba182e85d843360d36ae03a2d/pypandoc_binary-1.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f6e6d3e4cfafbe23189a08db3d41f8def260bacd6e7e382bceadab7ba1f17da6", size = 34460949, upload-time = "2026-03-14T22:39:01.71Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/b9/f47b77ba75ed5d47ec85fcc2ecfbf7f78e3a73347f3a09836634d930de98/pypandoc_binary-1.17-py3-none-win_amd64.whl", hash = "sha256:76fae066cd2d7e78fb97f0ec8e9e36f437b07187b689b0b415ca18216f8f898a", size = 40891661, upload-time = "2026-03-14T22:39:04.782Z" },
 ]
 
 [[package]]
@@ -9434,7 +9096,7 @@ name = "pypdf"
 version = "6.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/18/9947cc201af9ccf76720fd3347bf4f70eb882ce3fcf4cb05f7443e4cf871/pypdf-6.13.3.tar.gz", hash = "sha256:f3cb822769725f1bac658c406cfc9460399043f3750c2d3e4650e0a85eacabd7", size = 6484063, upload-time = "2026-06-17T15:22:00.898Z" }
 wheels = [
@@ -9493,12 +9155,12 @@ name = "pytest"
 version = "7.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
 wheels = [
@@ -9623,9 +9285,9 @@ name = "python-docx"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
+    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
@@ -9686,7 +9348,6 @@ name = "python-magic-bin"
 version = "0.4.14"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/2c/bbe8ad26591745da2c4692ea571145fb027c8ee1a0540407aa327684c4ce/python_magic_bin-0.4.14-py2.py3-none-macosx_10_6_intel.whl", hash = "sha256:7b1743b3dbf16601d6eedf4e7c2c9a637901b0faaf24ad4df4d4527e7d8f66a4", size = 334318, upload-time = "2017-10-02T16:30:13.6Z" },
     { url = "https://files.pythonhosted.org/packages/5a/5d/10b9ac745d9fd2f7151a2ab901e6bb6983dbd70e87c71111f54859d1ca2e/python_magic_bin-0.4.14-py2.py3-none-win32.whl", hash = "sha256:34a788c03adde7608028203e2dbb208f1f62225ad91518787ae26d603ae68892", size = 397784, upload-time = "2017-10-02T16:30:15.806Z" },
     { url = "https://files.pythonhosted.org/packages/07/c2/094e3d62b906d952537196603a23aec4bcd7c6126bf80eb14e6f9f4be3a2/python_magic_bin-0.4.14-py2.py3-none-win_amd64.whl", hash = "sha256:90be6206ad31071a36065a2fc169c5afb5e0355cbe6030e87641c6c62edc2b69", size = 409299, upload-time = "2017-10-02T16:30:18.545Z" },
 ]
@@ -9719,9 +9380,9 @@ name = "python-pptx"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
+    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pillow" },
     { name = "typing-extensions" },
     { name = "xlsxwriter" },
@@ -9923,7 +9584,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -10087,8 +9748,8 @@ version = "3.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorlog" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-6-cognee-docling-full') or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-6-cognee-docling-full') or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "omegaconf" },
     { name = "opencv-python" },
     { name = "pillow" },
@@ -10108,10 +9769,10 @@ name = "rapidocr-onnxruntime"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "pyclipper" },
@@ -10129,7 +9790,7 @@ name = "rdflib"
 version = "7.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "isodate", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "isodate", marker = "python_full_version < '3.11'" },
     { name = "pyparsing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e8/7e/cb2d74466bd8495051ebe2d241b1cb1d4acf9740d481126aef19ef2697f5/rdflib-7.1.4.tar.gz", hash = "sha256:fed46e24f26a788e2ab8e445f7077f00edcf95abb73bcef4b86cefa8b62dd174", size = 4692745, upload-time = "2025-03-29T02:23:02.386Z" }
@@ -10142,7 +9803,7 @@ name = "redis"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11.3' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
     { name = "pyjwt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
@@ -10156,9 +9817,9 @@ version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "rpds-py", version = "2026.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "rpds-py", version = "2026.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -10406,13 +10067,9 @@ name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
 wheels = [
@@ -10537,41 +10194,21 @@ name = "rpds-py"
 version = "2026.5.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
 wheels = [
@@ -10775,10 +10412,10 @@ wheels = [
 
 [package.optional-dependencies]
 torch = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-6-cognee-docling-full') or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-6-cognee-docling-full') or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
 ]
 
 [[package]]
@@ -10786,19 +10423,15 @@ name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -10839,48 +10472,28 @@ name = "scikit-learn"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "narwhals", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
@@ -10921,16 +10534,12 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -10986,44 +10595,24 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -11094,7 +10683,7 @@ name = "semchunk"
 version = "2.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpire", extra = ["dill"], marker = "extra == 'extra-6-cognee-docling-full'" },
+    { name = "mpire", extra = ["dill"] },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/62/96/c418c322730b385e81d4ab462e68dd48bb2dbda4d8efa17cad2ca468d9ac/semchunk-2.2.2.tar.gz", hash = "sha256:940e89896e64eeb01de97ba60f51c8c7b96c6a3951dfcf574f25ce2146752f52", size = 12271, upload-time = "2024-12-17T22:54:30.332Z" }
@@ -11138,41 +10727,21 @@ name = "setuptools"
 version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
@@ -11184,13 +10753,9 @@ name = "setuptools"
 version = "82.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
 wheels = [
@@ -11202,8 +10767,8 @@ name = "shapely"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
 wheels = [
@@ -11375,7 +10940,7 @@ name = "smart-open"
 version = "7.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/65/3ada667d32675399001bf022ad3d9f3989b57101351ebc71d6fbe2384634/smart_open-7.6.1.tar.gz", hash = "sha256:4347996e7ba21db7cd1e059632e0b30395407e4f6c660d2ddffc8f2a9ae5f990", size = 54754, upload-time = "2026-05-09T06:23:37.06Z" }
 wheels = [
@@ -11423,26 +10988,26 @@ name = "spacy"
 version = "3.8.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "catalogue", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "confection", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "cymem", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "jinja2", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "murmurhash", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "packaging", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "preshed", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pydantic", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "requests", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.13' and platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and sys_platform == 'emscripten') or (platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "spacy-legacy", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "spacy-loggers", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "srsly", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "thinc", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "tqdm", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typer", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "wasabi", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "weasel", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "jinja2" },
+    { name = "murmurhash" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "spacy-legacy" },
+    { name = "spacy-loggers" },
+    { name = "srsly" },
+    { name = "thinc" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "wasabi" },
+    { name = "weasel" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/d7/1924f32272f50d2f13275f16d6f869fcec47b2b676b64f91fa206bd30ef4/spacy-3.8.13.tar.gz", hash = "sha256:eb7c03c2bb16593c34d4c91974118f0931c6e6969dbfe895b1a026c6714176cf", size = 1328016, upload-time = "2026-03-23T17:44:32.042Z" }
 wheels = [
@@ -11510,7 +11075,7 @@ name = "sqlalchemy"
 version = "2.0.51"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/f1/a7a892f18d4d224e6b26f706531eafccc41e37594d37d304786969ee13cb/sqlalchemy-2.0.51.tar.gz", hash = "sha256:804dccd8a4a6242c4e30ad961e540e18a588f6527202f2d6791b01845d59fdc9", size = 9912201, upload-time = "2026-06-15T15:41:20.012Z" }
@@ -11579,7 +11144,7 @@ name = "srsly"
 version = "2.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "catalogue", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "catalogue" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/db/f794f219a6c788b881252d2536a8c4a97d2bdaadc690391e1cb53d123d71/srsly-2.5.3.tar.gz", hash = "sha256:08f98dbecbff3a31466c4ae7c833131f59d3655a0ad8ac749e6e2c149e2b0680", size = 490881, upload-time = "2026-03-23T11:56:59.865Z" }
 wheels = [
@@ -11666,7 +11231,7 @@ version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
@@ -11690,7 +11255,7 @@ name = "structlog"
 version = "25.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
@@ -11746,8 +11311,8 @@ name = "terminado"
 version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "os_name != 'nt' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pywinpty", marker = "(os_name == 'nt' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph') or (os_name == 'nt' and platform_release >= '24.' and extra != 'extra-6-cognee-docling-full') or (os_name == 'nt' and sys_platform != 'darwin') or (os_name != 'nt' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "ptyprocess", marker = "os_name != 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt' and sys_platform != 'darwin'" },
     { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
@@ -11760,19 +11325,19 @@ name = "thinc"
 version = "8.3.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "blis", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "catalogue", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "confection", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "cymem", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "murmurhash", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "packaging", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "preshed", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pydantic", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.13' and platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and sys_platform == 'emscripten') or (platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "srsly", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "wasabi", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "blis" },
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "murmurhash" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "srsly" },
+    { name = "wasabi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/46/76df95f2c327f9a9cef30c1523bf285627897097163584dcf5f77b2ebce2/thinc-8.3.13.tar.gz", hash = "sha256:68e658549fc1eb3ff92aed5147fcbb9c15d6e9cc0e623b4d0998d16522ffb4f9", size = 194640, upload-time = "2026-03-23T07:22:36.41Z" }
 wheels = [
@@ -11895,10 +11460,10 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "torchvision", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torchvision", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "torchvision", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "torchvision", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/54/ece85b0eef3700c90db8271a43669b05a0ebbe2edb1962329c34374a297e/timm-1.0.27.tar.gz", hash = "sha256:315dfe63186ca9fb7ff941268941231fd5be259f2b4bb4afa28560ae1015cb9a", size = 2439861, upload-time = "2026-05-08T19:38:36.844Z" }
 wheels = [
@@ -12024,39 +11589,35 @@ name = "torch"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "filelock", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "fsspec", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "jinja2", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cublas-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cudnn-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cufft-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cufile-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-curand-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cusolver-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cusparse-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cusparselt-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-nccl-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-nvshmem-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-nvtx-cu12", marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "sympy", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "triton", version = "3.6.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_machine != 'x86_64' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typing-extensions", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "sympy" },
+    { name = "triton", version = "3.6.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/30/bfebdd8ec77db9a79775121789992d6b3b75ee5494971294d7b4b7c999bc/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:2b980edd8d7c0a68c4e951ee1856334a43193f98730d97408fbd148c1a933313", size = 79411457, upload-time = "2026-02-10T21:44:59.189Z" },
@@ -12105,59 +11666,39 @@ name = "torch"
 version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "13.3.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "filelock", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "fsspec", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "jinja2", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_python_implementation != 'PyPy') or (python_full_version >= '3.11' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cublas", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cudnn-cu13", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-cusparselt-cu13", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-nccl-cu13", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nvidia-nvshmem-cu13", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "sympy", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "triton", version = "3.7.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version < '3.14' and sys_platform == 'linux') or (platform_python_implementation == 'PyPy' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
+    { name = "cuda-bindings", version = "13.3.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_python_implementation != 'PyPy') or (python_full_version >= '3.11' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.11' and sys_platform == 'emscripten')" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "sympy" },
+    { name = "triton", version = "3.7.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/ed/ff0c4f8cef63977a646dc80e40c05cae873f4097b12dc87e1cd7e1cecf42/torch-2.12.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:ec56e82be6a8b0c036771a77f7d32ad3c299770571af9815b3dafe61434389d5", size = 87967927, upload-time = "2026-06-17T21:08:43.16Z" },
@@ -12191,18 +11732,14 @@ name = "torchvision"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pillow", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "pillow" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/ae/cbf727421eb73f1cf907fbe5788326a08f111b3f6b6ddca15426b53fec9a/torchvision-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a95c47abb817d4e90ea1a8e57bd0d728e3e6b533b3495ae77d84d883c4d11f56", size = 1874919, upload-time = "2026-01-21T16:27:47.617Z" },
@@ -12240,47 +11777,27 @@ name = "torchvision"
 version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_python_implementation != 'PyPy') or (python_full_version >= '3.11' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pillow", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or (platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or sys_platform == 'emscripten'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_python_implementation != 'PyPy') or (python_full_version >= '3.11' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.11' and sys_platform == 'emscripten')" },
+    { name = "pillow" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/10/8e3e5a70dded1f86368bc987d93fa0436e73a79060aead75a8783b040ebd/torchvision-0.27.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:68ba63b48af92f06db995adb23d8411993dba1dee705a4e92411b83a00930b7f", size = 1852109, upload-time = "2026-06-17T21:09:34.966Z" },
@@ -12331,7 +11848,7 @@ name = "tqdm"
 version = "4.68.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
@@ -12354,8 +11871,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "huggingface-hub" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
@@ -12371,78 +11888,8 @@ wheels = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.') or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
-    "(python_full_version < '3.11' and platform_release >= '24.') or (python_full_version < '3.11' and sys_platform != 'darwin')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a2/698b9d31d08ad5558f8bfbfe3a0781bd4b1f284e89bde3ad18e05101a892/tree-sitter-0.24.0.tar.gz", hash = "sha256:abd95af65ca2f4f7eca356343391ed669e764f37748b5352946f00f7fc78e734", size = 168304, upload-time = "2025-01-17T05:06:38.115Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/9a/bd627a02e41671af73222316e1fcf87772c7804dc2fba99405275eb1f3eb/tree_sitter-0.24.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f3f00feff1fc47a8e4863561b8da8f5e023d382dd31ed3e43cd11d4cae445445", size = 140890, upload-time = "2025-01-17T05:05:42.659Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/9b/b1ccfb187f8be78e2116176a091a2f2abfd043a06d78f80c97c97f315b37/tree_sitter-0.24.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f9691be48d98c49ef8f498460278884c666b44129222ed6217477dffad5d4831", size = 134413, upload-time = "2025-01-17T05:05:45.241Z" },
-    { url = "https://files.pythonhosted.org/packages/01/39/e25b0042a049eb27e991133a7aa7c49bb8e49a8a7b44ca34e7e6353ba7ac/tree_sitter-0.24.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:098a81df9f89cf254d92c1cd0660a838593f85d7505b28249216661d87adde4a", size = 560427, upload-time = "2025-01-17T05:05:46.479Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/59/4d132f1388da5242151b90acf32cc56af779bfba063923699ab28b276b62/tree_sitter-0.24.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b26bf9e958da6eb7e74a081aab9d9c7d05f9baeaa830dbb67481898fd16f1f5", size = 574327, upload-time = "2025-01-17T05:05:48.93Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/97/3914e45ab9e0ff0f157e493caa91791372508488b97ff0961a0640a37d25/tree_sitter-0.24.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2a84ff87a2f2a008867a1064aba510ab3bd608e3e0cd6e8fef0379efee266c73", size = 577171, upload-time = "2025-01-17T05:05:51.588Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b0/266a529c3eef171137b73cde8ad7aa282734354609a8b2f5564428e8f12d/tree_sitter-0.24.0-cp310-cp310-win_amd64.whl", hash = "sha256:c012e4c345c57a95d92ab5a890c637aaa51ab3b7ff25ed7069834b1087361c95", size = 120260, upload-time = "2025-01-17T05:05:53.994Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/c3/07bfaa345e0037ff75d98b7a643cf940146e4092a1fd54eed0359836be03/tree_sitter-0.24.0-cp310-cp310-win_arm64.whl", hash = "sha256:033506c1bc2ba7bd559b23a6bdbeaf1127cee3c68a094b82396718596dfe98bc", size = 108416, upload-time = "2025-01-17T05:05:55.056Z" },
-    { url = "https://files.pythonhosted.org/packages/66/08/82aaf7cbea7286ee2a0b43e9b75cb93ac6ac132991b7d3c26ebe5e5235a3/tree_sitter-0.24.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:de0fb7c18c6068cacff46250c0a0473e8fc74d673e3e86555f131c2c1346fb13", size = 140733, upload-time = "2025-01-17T05:05:56.307Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bd/1a84574911c40734d80327495e6e218e8f17ef318dd62bb66b55c1e969f5/tree_sitter-0.24.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a7c9c89666dea2ce2b2bf98e75f429d2876c569fab966afefdcd71974c6d8538", size = 134243, upload-time = "2025-01-17T05:05:58.706Z" },
-    { url = "https://files.pythonhosted.org/packages/46/c1/c2037af2c44996d7bde84eb1c9e42308cc84b547dd6da7f8a8bea33007e1/tree_sitter-0.24.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ddb113e6b8b3e3b199695b1492a47d87d06c538e63050823d90ef13cac585fd", size = 562030, upload-time = "2025-01-17T05:05:59.825Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/aa/2fb4d81886df958e6ec7e370895f7106d46d0bbdcc531768326124dc8972/tree_sitter-0.24.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01ea01a7003b88b92f7f875da6ba9d5d741e0c84bb1bd92c503c0eecd0ee6409", size = 575585, upload-time = "2025-01-17T05:06:01.045Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/3c/5f997ce34c0d1b744e0f0c0757113bdfc173a2e3dadda92c751685cfcbd1/tree_sitter-0.24.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:464fa5b2cac63608915a9de8a6efd67a4da1929e603ea86abaeae2cb1fe89921", size = 578203, upload-time = "2025-01-17T05:06:02.255Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/1f/f2bc7fa7c3081653ea4f2639e06ff0af4616c47105dbcc0746137da7620d/tree_sitter-0.24.0-cp311-cp311-win_amd64.whl", hash = "sha256:3b1f3cbd9700e1fba0be2e7d801527e37c49fc02dc140714669144ef6ab58dce", size = 120147, upload-time = "2025-01-17T05:06:05.233Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/4c/9add771772c4d72a328e656367ca948e389432548696a3819b69cdd6f41e/tree_sitter-0.24.0-cp311-cp311-win_arm64.whl", hash = "sha256:f3f08a2ca9f600b3758792ba2406971665ffbad810847398d180c48cee174ee2", size = 108302, upload-time = "2025-01-17T05:06:07.487Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/57/3a590f287b5aa60c07d5545953912be3d252481bf5e178f750db75572bff/tree_sitter-0.24.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14beeff5f11e223c37be7d5d119819880601a80d0399abe8c738ae2288804afc", size = 140788, upload-time = "2025-01-17T05:06:08.492Z" },
-    { url = "https://files.pythonhosted.org/packages/61/0b/fc289e0cba7dbe77c6655a4dd949cd23c663fd62a8b4d8f02f97e28d7fe5/tree_sitter-0.24.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26a5b130f70d5925d67b47db314da209063664585a2fd36fa69e0717738efaf4", size = 133945, upload-time = "2025-01-17T05:06:12.39Z" },
-    { url = "https://files.pythonhosted.org/packages/86/d7/80767238308a137e0b5b5c947aa243e3c1e3e430e6d0d5ae94b9a9ffd1a2/tree_sitter-0.24.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fc5c3c26d83c9d0ecb4fc4304fba35f034b7761d35286b936c1db1217558b4e", size = 564819, upload-time = "2025-01-17T05:06:13.549Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/b3/6c5574f4b937b836601f5fb556b24804b0a6341f2eb42f40c0e6464339f4/tree_sitter-0.24.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:772e1bd8c0931c866b848d0369b32218ac97c24b04790ec4b0e409901945dd8e", size = 579303, upload-time = "2025-01-17T05:06:16.685Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/f4/bd0ddf9abe242ea67cca18a64810f8af230fc1ea74b28bb702e838ccd874/tree_sitter-0.24.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:24a8dd03b0d6b8812425f3b84d2f4763322684e38baf74e5bb766128b5633dc7", size = 581054, upload-time = "2025-01-17T05:06:19.439Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/1c/ff23fa4931b6ef1bbeac461b904ca7e49eaec7e7e5398584e3eef836ec96/tree_sitter-0.24.0-cp312-cp312-win_amd64.whl", hash = "sha256:f9e8b1605ab60ed43803100f067eed71b0b0e6c1fb9860a262727dbfbbb74751", size = 120221, upload-time = "2025-01-17T05:06:20.654Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/2a/9979c626f303177b7612a802237d0533155bf1e425ff6f73cc40f25453e2/tree_sitter-0.24.0-cp312-cp312-win_arm64.whl", hash = "sha256:f733a83d8355fc95561582b66bbea92ffd365c5d7a665bc9ebd25e049c2b2abb", size = 108234, upload-time = "2025-01-17T05:06:21.713Z" },
-    { url = "https://files.pythonhosted.org/packages/61/cd/2348339c85803330ce38cee1c6cbbfa78a656b34ff58606ebaf5c9e83bd0/tree_sitter-0.24.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d4a6416ed421c4210f0ca405a4834d5ccfbb8ad6692d4d74f7773ef68f92071", size = 140781, upload-time = "2025-01-17T05:06:22.82Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/a3/1ea9d8b64e8dcfcc0051028a9c84a630301290995cd6e947bf88267ef7b1/tree_sitter-0.24.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0992d483677e71d5c5d37f30dfb2e3afec2f932a9c53eec4fca13869b788c6c", size = 133928, upload-time = "2025-01-17T05:06:25.146Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/ae/55c1055609c9428a4aedf4b164400ab9adb0b1bf1538b51f4b3748a6c983/tree_sitter-0.24.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57277a12fbcefb1c8b206186068d456c600dbfbc3fd6c76968ee22614c5cd5ad", size = 564497, upload-time = "2025-01-17T05:06:27.53Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/d0/f2ffcd04882c5aa28d205a787353130cbf84b2b8a977fd211bdc3b399ae3/tree_sitter-0.24.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d25fa22766d63f73716c6fec1a31ee5cf904aa429484256bd5fdf5259051ed74", size = 578917, upload-time = "2025-01-17T05:06:31.057Z" },
-    { url = "https://files.pythonhosted.org/packages/af/82/aebe78ea23a2b3a79324993d4915f3093ad1af43d7c2208ee90be9273273/tree_sitter-0.24.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d5d9537507e1c8c5fa9935b34f320bfec4114d675e028f3ad94f11cf9db37b9", size = 581148, upload-time = "2025-01-17T05:06:32.409Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/b4/6b0291a590c2b0417cfdb64ccb8ea242f270a46ed429c641fbc2bfab77e0/tree_sitter-0.24.0-cp313-cp313-win_amd64.whl", hash = "sha256:f58bb4956917715ec4d5a28681829a8dad5c342cafd4aea269f9132a83ca9b34", size = 120207, upload-time = "2025-01-17T05:06:34.841Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/18/542fd844b75272630229c9939b03f7db232c71a9d82aadc59c596319ea6a/tree_sitter-0.24.0-cp313-cp313-win_arm64.whl", hash = "sha256:23641bd25dcd4bb0b6fa91b8fb3f46cc9f1c9f475efe4d536d3f1f688d1b84c8", size = 108232, upload-time = "2025-01-17T05:06:35.831Z" },
-]
-
-[[package]]
-name = "tree-sitter"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/03/5600b84aff2e6c4fe80cfebb4063fe2f50299521befe5f6092ab8c082f4a/tree_sitter-0.26.0.tar.gz", hash = "sha256:b40c219edccc4564530c96f8f1556f6202b37cda964d1cbd7bd2b7e68b40a245", size = 191423, upload-time = "2026-06-30T12:14:27.933Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/2f/201c33ea65875d8e4ec73e4d1949718ec49780d84c0adf19793ef75d99a2/tree_sitter-0.26.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ff527388df14cb5009f9274faf78cc69a7393ae6acf3b04784b8acca249519c5", size = 148676, upload-time = "2026-06-30T12:13:42.718Z" },
@@ -12552,24 +11999,15 @@ name = "triton"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/ba/b1b04f4b291a3205d95ebd24465de0e5bf010a2df27a4e58a9b5f039d8f2/triton-3.6.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c723cfb12f6842a0ae94ac307dba7e7a44741d720a40cf0e270ed4a4e3be781", size = 175972180, upload-time = "2026-01-20T16:15:53.664Z" },
     { url = "https://files.pythonhosted.org/packages/8c/f7/f1c9d3424ab199ac53c2da567b859bcddbb9c9e7154805119f8bd95ec36f/triton-3.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6550fae429e0667e397e5de64b332d1e5695b73650ee75a6146e2e902770bea", size = 188105201, upload-time = "2026-01-20T16:00:29.272Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/2c/96f92f3c60387e14cc45aed49487f3486f89ea27106c1b1376913c62abe4/triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49df5ef37379c0c2b5c0012286f80174fcf0e073e5ade1ca9a86c36814553651", size = 176081190, upload-time = "2026-01-20T16:16:00.523Z" },
     { url = "https://files.pythonhosted.org/packages/e0/12/b05ba554d2c623bffa59922b94b0775673de251f468a9609bc9e45de95e9/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3", size = 188214640, upload-time = "2026-01-20T16:00:35.869Z" },
-    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
     { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
     { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
-    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
-    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
 ]
 
@@ -12578,21 +12016,11 @@ name = "triton"
 version = "3.7.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ea/629cc37436ca5df93ce98956d09cd2ca1498bfee8ef4972d2fe48b9f958c/triton-3.7.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3daf64305d6cea88d3334c65ebc9bcd0c64c9564a977084366aa768d57cbcf64", size = 184551013, upload-time = "2026-06-17T20:03:37.551Z" },
@@ -12723,7 +12151,7 @@ name = "tzlocal"
 version = "5.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/55/15e2340963d2bfedcc6042da3911438fd336f8ae96b65bdbe3a29766da0c/tzlocal-5.4.3.tar.gz", hash = "sha256:3a8c9bc18cf47e1dcde252ea0e6a72a6cde320a400b6ac6db1f1f8cccd553c00", size = 30873, upload-time = "2026-06-17T04:17:41.764Z" }
 wheels = [
@@ -12735,53 +12163,41 @@ name = "unstructured"
 version = "0.18.32"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "backoff", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "beautifulsoup4", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "charset-normalizer", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "dataclasses-json", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "emoji", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "filetype", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "html5lib", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "langdetect", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "nltk", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numba", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "psutil", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "python-iso639", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "python-magic", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "python-oxmsg", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "rapidfuzz", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "requests", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "tqdm", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "unstructured-client", version = "0.42.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "unstructured-client", version = "0.45.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "wrapt", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "backoff" },
+    { name = "beautifulsoup4" },
+    { name = "charset-normalizer" },
+    { name = "dataclasses-json" },
+    { name = "emoji" },
+    { name = "filetype" },
+    { name = "html5lib" },
+    { name = "langdetect" },
+    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "nltk" },
+    { name = "numba" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "psutil" },
+    { name = "python-iso639" },
+    { name = "python-magic" },
+    { name = "python-oxmsg" },
+    { name = "rapidfuzz" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "unstructured-client", version = "0.42.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "unstructured-client", version = "0.45.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/65/b73d84ede08fc2defe9c59d85ebf91f78210a424986586c6e39784890c8e/unstructured-0.18.32.tar.gz", hash = "sha256:40a7cf4a4a7590350bedb8a447e37029d6e74b924692576627b4edb92d70e39d", size = 1707730, upload-time = "2026-02-10T22:28:22.332Z" }
 wheels = [
@@ -12790,63 +12206,63 @@ wheels = [
 
 [package.optional-dependencies]
 csv = [
-    { name = "pandas", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pandas" },
 ]
 doc = [
-    { name = "python-docx", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "python-docx" },
 ]
 docx = [
-    { name = "python-docx", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "python-docx" },
 ]
 epub = [
-    { name = "pypandoc", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pypandoc" },
 ]
 md = [
-    { name = "markdown", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "markdown" },
 ]
 odt = [
-    { name = "pypandoc", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "python-docx", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pypandoc" },
+    { name = "python-docx" },
 ]
 org = [
-    { name = "pypandoc", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pypandoc" },
 ]
 pdf = [
-    { name = "effdet", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "google-cloud-vision", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnx", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pdf2image", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pdfminer-six", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pi-heif", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pikepdf", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pypdf", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "unstructured-inference", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "unstructured-inference", version = "1.6.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "unstructured-pytesseract", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "effdet" },
+    { name = "google-cloud-vision" },
+    { name = "onnx" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "pdf2image" },
+    { name = "pdfminer-six" },
+    { name = "pi-heif" },
+    { name = "pikepdf" },
+    { name = "pypdf" },
+    { name = "unstructured-inference", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "unstructured-inference", version = "1.6.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "unstructured-pytesseract" },
 ]
 ppt = [
-    { name = "python-pptx", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "python-pptx" },
 ]
 pptx = [
-    { name = "python-pptx", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "python-pptx" },
 ]
 rst = [
-    { name = "pypandoc", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pypandoc" },
 ]
 rtf = [
-    { name = "pypandoc", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pypandoc" },
 ]
 tsv = [
-    { name = "pandas", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pandas" },
 ]
 xlsx = [
-    { name = "msoffcrypto-tool", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.13') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "openpyxl", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pandas", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "xlrd", marker = "python_full_version < '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "msoffcrypto-tool" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "openpyxl" },
+    { name = "pandas" },
+    { name = "xlrd" },
 ]
 
 [[package]]
@@ -12854,53 +12270,41 @@ name = "unstructured"
 version = "0.21.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "beautifulsoup4", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "charset-normalizer", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "emoji", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "filelock", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "filetype", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "html5lib", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "installer", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "langdetect", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numba", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "psutil", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "python-iso639", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "python-magic", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "python-oxmsg", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "rapidfuzz", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "regex", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "requests", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "spacy", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "tqdm", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "unstructured-client", version = "0.45.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "wrapt", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "beautifulsoup4" },
+    { name = "charset-normalizer" },
+    { name = "emoji" },
+    { name = "filelock" },
+    { name = "filetype" },
+    { name = "html5lib" },
+    { name = "installer" },
+    { name = "langdetect" },
+    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numba" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "psutil" },
+    { name = "python-iso639" },
+    { name = "python-magic" },
+    { name = "python-oxmsg" },
+    { name = "rapidfuzz" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "spacy" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "unstructured-client", version = "0.45.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/e6/fbef61517d130af1def3b81681e253a5679f19de2f04e439afbbf1f021e0/unstructured-0.21.5.tar.gz", hash = "sha256:3e220d0c2b9c8ec12c99767162b95ab0acfca75e979b82c66c15ca15caa60139", size = 1501811, upload-time = "2026-02-24T15:29:27.84Z" }
 wheels = [
@@ -12909,59 +12313,59 @@ wheels = [
 
 [package.optional-dependencies]
 csv = [
-    { name = "pandas", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pandas" },
 ]
 doc = [
-    { name = "python-docx", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "python-docx" },
 ]
 docx = [
-    { name = "python-docx", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "python-docx" },
 ]
 epub = [
-    { name = "pypandoc-binary", marker = "(python_full_version >= '3.13' and sys_platform != 'win32') or (python_full_version < '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
 ]
 md = [
-    { name = "markdown", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "markdown" },
 ]
 odt = [
-    { name = "pypandoc-binary", marker = "(python_full_version >= '3.13' and sys_platform != 'win32') or (python_full_version < '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "python-docx", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
+    { name = "python-docx" },
 ]
 org = [
-    { name = "pypandoc-binary", marker = "(python_full_version >= '3.13' and sys_platform != 'win32') or (python_full_version < '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
 ]
 pdf = [
-    { name = "google-cloud-vision", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pdf2image", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pdfminer-six", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pi-heif", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pikepdf", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pypdf", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "unstructured-inference", version = "1.6.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.13.*' and sys_platform != 'win32') or (python_full_version != '3.13.*' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "unstructured-inference", version = "1.6.13", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and sys_platform != 'win32') or (python_full_version < '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "unstructured-pytesseract", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "google-cloud-vision" },
+    { name = "pdf2image" },
+    { name = "pdfminer-six" },
+    { name = "pi-heif" },
+    { name = "pikepdf" },
+    { name = "pypdf" },
+    { name = "unstructured-inference", version = "1.6.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
+    { name = "unstructured-inference", version = "1.6.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "unstructured-pytesseract" },
 ]
 ppt = [
-    { name = "python-pptx", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "python-pptx" },
 ]
 pptx = [
-    { name = "python-pptx", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "python-pptx" },
 ]
 rst = [
-    { name = "pypandoc-binary", marker = "(python_full_version >= '3.13' and sys_platform != 'win32') or (python_full_version < '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
 ]
 rtf = [
-    { name = "pypandoc-binary", marker = "(python_full_version >= '3.13' and sys_platform != 'win32') or (python_full_version < '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
 ]
 tsv = [
-    { name = "pandas", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "pandas" },
 ]
 xlsx = [
-    { name = "msoffcrypto-tool", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "openpyxl", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pandas", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "xlrd", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "msoffcrypto-tool" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "openpyxl" },
+    { name = "pandas" },
+    { name = "xlrd" },
 ]
 
 [[package]]
@@ -12969,23 +12373,19 @@ name = "unstructured-client"
 version = "0.42.12"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "aiofiles", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "cryptography", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "httpcore", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "httpx", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pydantic", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pypdf", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pypdfium2", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "requests-toolbelt", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "aiofiles" },
+    { name = "cryptography" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pypdf" },
+    { name = "pypdfium2" },
+    { name = "requests-toolbelt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/ca/73904d53e486af2f1d9d8baaf43d2a74b3d67e5f533834f5d51056471339/unstructured_client-0.42.12.tar.gz", hash = "sha256:50eb6717d8c6513b14b309fce8d6551354e433da982b7a9161a889d8e6a11166", size = 94714, upload-time = "2026-03-25T20:24:21.528Z" }
 wheels = [
@@ -12997,50 +12397,30 @@ name = "unstructured-client"
 version = "0.45.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "aiofiles", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "httpcore", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "httpx", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pydantic", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pypdf", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pypdfium2", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "requests-toolbelt", marker = "python_full_version >= '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "aiofiles" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pypdf" },
+    { name = "pypdfium2" },
+    { name = "requests-toolbelt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/c6/bbc79efa9365fa8aecf353794a1253355eccf17468be3e6fb45a050e30d7/unstructured_client-0.45.0.tar.gz", hash = "sha256:3ffdaebdc27d2f043712dfeaee49cd38b990b480bed72e96255bf6245c0cc790", size = 94490, upload-time = "2026-06-05T21:36:51.635Z" }
 wheels = [
@@ -13052,31 +12432,27 @@ name = "unstructured-inference"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version < '3.11' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version < '3.11' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version < '3.11' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "accelerate", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "huggingface-hub", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnx", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "opencv-python", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pandas", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pdfminer-six", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pypdfium2", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "python-multipart", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "rapidfuzz", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "timm", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "transformers", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "accelerate" },
+    { name = "huggingface-hub" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "onnx" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "opencv-python" },
+    { name = "pandas" },
+    { name = "pdfminer-six" },
+    { name = "pypdfium2" },
+    { name = "python-multipart" },
+    { name = "rapidfuzz" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "timm" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/10/8f3bccfa9f1e0101a402ae1f529e07876541c6b18004747f0e793ed41f9e/unstructured_inference-1.2.0.tar.gz", hash = "sha256:19ca28512f3649c70a759cf2a4e98663e942a1b83c1acdb9506b0445f4862f23", size = 45732, upload-time = "2026-01-30T20:57:58.019Z" }
 wheels = [
@@ -13088,43 +12464,31 @@ name = "unstructured-inference"
 version = "1.6.9"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.13.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.12.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version == '3.11.*' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version == '3.13.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "accelerate", marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "huggingface-hub", marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnx", marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "opencv-python", marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pandas", marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pypdfium2", marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "rapidfuzz", marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "timm", marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "transformers", marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version < '3.11' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "accelerate" },
+    { name = "huggingface-hub" },
+    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "onnx" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "opencv-python" },
+    { name = "pandas" },
+    { name = "pypdfium2" },
+    { name = "rapidfuzz" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "timm" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/95/f5f629b6423bda2322de272366444acaeb07f0a02819638a2f19de07077e/unstructured_inference-1.6.9.tar.gz", hash = "sha256:7accd441c78033c6dce9a5f8020098daa44d75e65d95b100f3a5779866c27bc2", size = 47863, upload-time = "2026-04-26T19:03:29.998Z" }
 wheels = [
@@ -13136,38 +12500,30 @@ name = "unstructured-inference"
 version = "1.6.13"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra == 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full')",
-    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin' and extra != 'extra-6-cognee-codegraph' and extra != 'extra-6-cognee-docling-full'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release >= '24.' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and platform_release < '24.' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "accelerate", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "huggingface-hub", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnx", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "opencv-python", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pandas", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pdfminer-six", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pypdfium2", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "rapidfuzz", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "timm", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version < '3.14' and platform_python_implementation == 'PyPy' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (python_full_version >= '3.14' and sys_platform == 'emscripten') or (platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform == 'emscripten' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "transformers", marker = "python_full_version >= '3.14' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "accelerate" },
+    { name = "huggingface-hub" },
+    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "onnx" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "opencv-python" },
+    { name = "pandas" },
+    { name = "pdfminer-six" },
+    { name = "pypdfium2" },
+    { name = "rapidfuzz" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "timm" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/ce/1e58008b8416884edfa6d18d65b635cde892189512d2e7531f91553b34d0/unstructured_inference-1.6.13.tar.gz", hash = "sha256:4efa2f3f517370aa09166c669cdc1addee71531e95bfbec7e6e3be66be90c147", size = 50137, upload-time = "2026-06-11T22:27:33.146Z" }
 wheels = [
@@ -13312,7 +12668,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
@@ -13328,7 +12684,7 @@ dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
     { name = "python-discovery" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
 wheels = [
@@ -13340,7 +12696,7 @@ name = "wasabi"
 version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "(python_full_version >= '3.13' and sys_platform == 'win32') or (python_full_version < '3.13' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full') or (sys_platform != 'win32' and extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/054e6e2f1071e963b5e746b48d1e3727470b2a490834d18ad92364929db3/wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878", size = 30391, upload-time = "2024-05-31T16:56:18.99Z" }
 wheels = [
@@ -13393,15 +12749,15 @@ name = "weasel"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cloudpathlib", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "confection", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "httpx", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "packaging", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "pydantic", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "smart-open", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "srsly", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "typer", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
-    { name = "wasabi", marker = "python_full_version >= '3.13' or (extra == 'extra-6-cognee-codegraph' and extra == 'extra-6-cognee-docling-full')" },
+    { name = "cloudpathlib" },
+    { name = "confection" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "smart-open" },
+    { name = "srsly" },
+    { name = "typer" },
+    { name = "wasabi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/e5/e272bb9a045105a1fdf4b798d8086f5932a178f4d738f17a74f5c9e0ae9a/weasel-1.0.0.tar.gz", hash = "sha256:7b129b44c90cc543b760532974ca1e4eb30dad2aa2026f57bdce66354ae610fc", size = 38682, upload-time = "2026-03-20T08:10:25.266Z" }
 wheels = [


### PR DESCRIPTION
## Description

### Background

While setting up the local development environment by following `AGENTS.md`, I ran:

```bash
uv sync --dev --all-extras --reinstall
```

The command failed with the following dependency resolution error:

```text
Using CPython 3.11.15 interpreter at: /opt/homebrew/opt/python@3.11/bin/python3.11
Creating virtual environment at: .venv
Resolved 541 packages in 12ms
error: Extras `codegraph` and `docling-full` are incompatible with the declared conflicts: {`cognee[codegraph]`, `cognee[docling-full]`}
```

`AGENTS.md` instructs contributors to install all extras, while `pyproject.toml` declares `codegraph` and `docling-full` as mutually exclusive. As a result, the documented development setup command cannot complete.

### Root cause

The `codegraph` extra still declares these dependencies:

```toml
"tree-sitter>=0.24.0,<0.25"
"tree-sitter-python>=0.23.6,<0.24"
```

At the same time, `docling-full` requires `tree-sitter>=0.25` through `docling-core[chunking]`. The two extras were therefore declared incompatible.

The current Code Graph implementation does not directly import `tree-sitter` or `tree-sitter-python`. These dependencies were left behind by the removed Python AST-based Code Graph implementation.

### Relevant commit history

- [`f9e6dcf83`](https://github.com/topoteretes/cognee/commit/f9e6dcf83) introduced the legacy Code Graph parser. At that time, `repo_processor/get_local_dependencies.py` used Tree-sitter directly, so these dependencies were required.
- [`3cd49ae9dd`](https://github.com/topoteretes/cognee/commit/3cd49ae9dd) added the `--all-extras` development setup command to `AGENTS.md`.
- [`18e4bb48f`](https://github.com/topoteretes/cognee/commit/18e4bb48f) removed the Python AST-based Code Graph implementation, but its Tree-sitter dependencies remained in the `codegraph` extra.
- [`be35e6b13`](https://github.com/topoteretes/cognee/commit/be35e6b13) introduced the current Code Graph implementation based on the external Enola binary. The current implementation no longer uses these Python packages directly.
- [`5f622e6ee`](https://github.com/topoteretes/cognee/commit/5f622e6ee) added the conflict between `docling-full` and `codegraph` to work around their incompatible Tree-sitter version requirements.

Based on this history, the direct Tree-sitter dependencies in `codegraph` are leftovers from the removed implementation. Once they are removed, the two extras no longer need to be mutually exclusive.

### Changes

- Remove the unused `tree-sitter` and `tree-sitter-python` direct dependencies from the `codegraph` extra.
- Remove the UV conflict declaration between `codegraph` and `docling-full`.
- Regenerate `uv.lock` to remove the obsolete conflict and simplify the affected resolution markers.

This PR does not change `AGENTS.md`. After correcting the dependency configuration, its existing setup command can continue to be used.

## Acceptance Criteria

- `codegraph` and `docling-full` can participate in the same dependency resolution.
- The development setup command documented in `AGENTS.md` resolves successfully.
- The lockfile is consistent with `pyproject.toml`.
- Existing Code Graph unit tests continue to pass.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<img width="1052" height="256" alt="Dependency resolution" src="https://github.com/user-attachments/assets/9e02adb5-c004-47ef-83f1-cd277e63dee9" />
<img width="5112" height="1302" alt="Code Graph unit tests" src="https://github.com/user-attachments/assets/e3234771-776c-4725-9ff8-a224e0b3fd80" />

## Verification

```bash
uv lock --check
uv sync --dev --all-extras --reinstall --dry-run
uv run pytest cognee/tests/unit/tasks/code_graph/ -q -rs --tb=short
uv run ruff check .
uv run ruff format --check .
uv run ty check .
uv run pre-commit run --files pyproject.toml uv.lock
```

Results:

```text
uv sync: resolved 540 packages successfully
pytest: 80 passed, 1 skipped
```

The skipped test is the Enola integration test because the Enola binary is not installed locally.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing relevant tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
