### PR TITLE
feat: Add TELEMETRY_ORIGIN to telemetry events

### DIFF
--- a/cognee/shared/utils.py
+++ b/cognee/shared/utils.py
@@ -266,6 +266,10 @@ def send_telemetry(event_name: str, user_id: str | UUID, additional_properties: 
     anonymous_id = str(get_anonymous_id())
     persistent_id = str(get_persistent_id())
     api_key_tracking_id = _get_api_key_tracking_id()
+    # Where this telemetry event originates. Defaults to "sdk"; deployments such
+    # as the managed cloud set TELEMETRY_ORIGIN (e.g. "cloud") so events can be
+    # segmented by origin.
+    telemetry_origin = os.getenv("TELEMETRY_ORIGIN", "sdk")
     current_time = datetime.now(timezone.utc)
     payload = {
         "anonymous_id": anonymous_id,
@@ -283,6 +287,7 @@ def send_telemetry(event_name: str, user_id: str | UUID, additional_properties: 
             "persistent_id": persistent_id,
             "api_key_tracking_id": api_key_tracking_id,
             "api_key_hash": api_key_tracking_id,
+            "telemetry_origin": telemetry_origin,
             **additional_properties,
         },
     }

--- a/cognee/tests/unit/shared/test_telemetry_tracking.py
+++ b/cognee/tests/unit/shared/test_telemetry_tracking.py
@@ -80,6 +80,46 @@ def test_send_telemetry_includes_api_key_tracking_id(monkeypatch):
     assert "provider-prefix-secret" not in str(payload)
 
 
+def test_send_telemetry_includes_origin_from_env(monkeypatch):
+    """telemetry_origin defaults to "sdk" when TELEMETRY_ORIGIN is unset and is
+    honored (e.g. "cloud") when set, so events can be segmented by origin."""
+    payloads: list[dict[str, Any]] = []
+
+    def capture_payload(payload: dict[str, Any]) -> Coroutine[Any, Any, None]:
+        payloads.append(payload)
+
+        async def noop() -> None:
+            return None
+
+        return noop()
+
+    class FakeTask:
+        def add_done_callback(self, callback) -> None:
+            callback(self)
+
+    class CapturingLoop:
+        def create_task(self, coroutine: Coroutine[Any, Any, None]) -> "FakeTask":
+            coroutine.close()
+            return FakeTask()
+
+    monkeypatch.setenv("ENV", "prod")
+    monkeypatch.delenv("TELEMETRY_DISABLED", raising=False)
+    monkeypatch.setattr(utils, "get_anonymous_id", lambda: "anonymous-test-id")
+    monkeypatch.setattr(utils, "get_persistent_id", lambda: "persistent-test-id")
+    monkeypatch.setattr(utils, "_send_telemetry_request", capture_payload)
+    monkeypatch.setattr(utils.asyncio, "get_running_loop", lambda: CapturingLoop())
+
+    # Unset -> defaults to "sdk".
+    monkeypatch.delenv("TELEMETRY_ORIGIN", raising=False)
+    send_telemetry("test_event", "user-123")
+    assert payloads[-1]["properties"]["telemetry_origin"] == "sdk"
+
+    # Set -> honored (the managed cloud sets this to "cloud").
+    monkeypatch.setenv("TELEMETRY_ORIGIN", "cloud")
+    send_telemetry("test_event", "user-123")
+    assert payloads[-1]["properties"]["telemetry_origin"] == "cloud"
+
+
 @pytest.mark.asyncio
 async def test_send_telemetry_anchors_task_against_gc(monkeypatch):
     """The fire-and-forget telemetry task must be strongly referenced until


### PR DESCRIPTION
## What

Every telemetry event now carries a `telemetry_origin` property, read from the
`TELEMETRY_ORIGIN` env var and defaulting to `"sdk"` when unset.

```python
telemetry_origin = os.getenv("TELEMETRY_ORIGIN", "sdk")
# added to the event `properties` payload in send_telemetry()
```

## Why

So telemetry can be segmented by where it originates. Managed deployments (the
cloud) set `TELEMETRY_ORIGIN=cloud`; everything else (local SDK usage) reports
the default `"sdk"`. Makes tracking telemetry origin straightforward.

## Notes
- Read directly via `os.getenv`, matching how `send_telemetry` already reads
  `TELEMETRY_DISABLED` / `ENV`. No config-schema change, no new required setup.
- Placed before `**additional_properties`, so a per-call override remains possible.
- Test added: defaults to `"sdk"` when unset, honored as `"cloud"` when set.

## Verification
ruff clean; `cognee/tests/unit/shared/test_telemetry_tracking.py` passes (5 passed).