### PR TITLE
feat(permissions): read which principals have access to a dataset (COG-6140)

### DIFF
--- a/cognee/api/v1/permissions/routers/get_permissions_router.py
+++ b/cognee/api/v1/permissions/routers/get_permissions_router.py
@@ -140,6 +140,48 @@ def get_permissions_router() -> APIRouter:
             status_code=200, content={"message": "Permission revoked from principal"}
         )
 
+    @permissions_router.get("/datasets/{dataset_id}/principals")
+    async def get_principals_with_dataset_permission(
+        dataset_id: UUID,
+        user: User = Depends(get_authenticated_user),
+    ):
+        """
+        List the principals (users, roles, tenants) with permission on a dataset.
+
+        The inverse of the grant/revoke endpoints above: those write access, this
+        one reads back who holds it. The authenticated user must have "share"
+        permission on the dataset — a caller who cannot share it cannot
+        enumerate who it is shared with either.
+
+        ## Path Parameters
+        - **dataset_id** (UUID): The UUID of the dataset (list yours via GET /api/v1/datasets)
+
+        ## Response
+        Returns a JSON list: [{"principal_id", "kind", "name", "permissions"}],
+        where kind is "user", "role" or "tenant", name is the user's email or the
+        role/tenant name, and permissions lists what that principal holds
+        (e.g. ["read", "write"]). A dataset shared with the whole workspace
+        appears once as a "tenant" entry, not once per member.
+
+        ## Error Codes
+        - **403 Forbidden**: Caller lacks share permission on the dataset
+        """
+        send_telemetry(
+            "Permissions API Endpoint Invoked",
+            user.id,
+            additional_properties={
+                "endpoint": f"GET /v1/permissions/datasets/{str(dataset_id)}/principals",
+                "dataset_id": str(dataset_id),
+                "cognee_version": cognee_version,
+            },
+        )
+
+        from cognee.modules.users.permissions.methods import get_dataset_principals
+
+        principals = await get_dataset_principals(dataset_id, user.id)
+
+        return JSONResponse(status_code=200, content=principals)
+
     @permissions_router.post("/roles")
     async def create_role(
         role_name: str = Query(

--- a/cognee/modules/users/permissions/methods/__init__.py
+++ b/cognee/modules/users/permissions/methods/__init__.py
@@ -2,6 +2,7 @@ from .get_role import get_role
 from .get_tenant import get_tenant
 from .get_principal import get_principal
 from .get_principal_datasets import get_principal_datasets
+from .get_dataset_principals import get_dataset_principals
 from .get_all_user_permission_datasets import get_all_user_permission_datasets
 from .get_specific_user_permission_datasets import get_specific_user_permission_datasets
 from .check_permission_on_dataset import check_permission_on_dataset

--- a/cognee/modules/users/permissions/methods/get_dataset_principals.py
+++ b/cognee/modules/users/permissions/methods/get_dataset_principals.py
@@ -1,0 +1,77 @@
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.users.permissions.methods.get_specific_user_permission_datasets import (
+    get_specific_user_permission_datasets,
+)
+
+from ...models.ACL import ACL
+
+
+def _display_name(principal) -> str:
+    """Users are known by their email, roles and tenants by their name."""
+    if principal.type == "user":
+        return principal.email or ""
+    return getattr(principal, "name", "") or ""
+
+
+async def get_dataset_principals(dataset_id: UUID, user_id: UUID) -> list[dict]:
+    """
+        Return the principals holding a permission on a dataset, with the
+        permissions each of them holds.
+
+        The inverse of get_principal_datasets: that one answers "which datasets
+        can this principal reach", this one "who can reach this dataset".
+
+        Authorization matches the grant side — the caller must hold "share" on
+        the dataset, which raises PermissionDeniedError otherwise, so a caller
+        who cannot share it cannot enumerate who it is shared with either.
+
+        A tenant is itself a principal: a dataset shared workspace-wide appears
+        as one "tenant" entry rather than one entry per member.
+    Args:
+        dataset_id: Id of the dataset
+        user_id: Id of the request owner
+
+    Returns:
+        list[dict]: [{"principal_id", "kind", "name", "permissions": [str]}],
+        one entry per principal, permissions sorted for a stable response.
+    """
+    # Raises PermissionDeniedError when the caller cannot share this dataset.
+    await get_specific_user_permission_datasets(user_id, "share", [dataset_id])
+
+    db_engine = get_relational_engine()
+
+    async with db_engine.get_async_session() as session:
+        result = await session.execute(
+            select(ACL)
+            .options(joinedload(ACL.principal), joinedload(ACL.permission))
+            .where(ACL.dataset_id == dataset_id)
+        )
+        acls = result.unique().scalars().all()
+
+    # One row per principal, its permissions collected — the table stores a row
+    # per (principal, permission), which would otherwise repeat the principal.
+    principals: dict[UUID, dict] = {}
+
+    for acl in acls:
+        if acl.principal is None or acl.permission is None:
+            continue
+
+        entry = principals.get(acl.principal_id)
+        if entry is None:
+            entry = {
+                "principal_id": str(acl.principal_id),
+                # The polymorphic discriminator: "user", "role" or "tenant".
+                "kind": acl.principal.type,
+                "name": _display_name(acl.principal),
+                "permissions": set(),
+            }
+            principals[acl.principal_id] = entry
+
+        entry["permissions"].add(acl.permission.name)
+
+    return [{**entry, "permissions": sorted(entry["permissions"])} for entry in principals.values()]

--- a/cognee/tests/unit/users/permissions/test_get_dataset_principals.py
+++ b/cognee/tests/unit/users/permissions/test_get_dataset_principals.py
@@ -1,0 +1,163 @@
+"""Reading back who has access to a dataset.
+
+The inverse of get_principal_datasets: permissions could be granted and revoked
+but never enumerated, so the UI had no way to show which teams hold access.
+"""
+
+import importlib
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.permissions.methods.get_dataset_principals import (
+    get_dataset_principals,
+)
+
+_module = importlib.import_module("cognee.modules.users.permissions.methods.get_dataset_principals")
+
+
+class FakePermission:
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeACL:
+    def __init__(self, principal, permission_name):
+        self.principal = principal
+        self.principal_id = principal.id
+        self.permission = FakePermission(permission_name)
+
+
+class FakeResult:
+    def __init__(self, value):
+        self._value = value
+
+    def unique(self):
+        return self
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._value
+
+
+class FakeSession:
+    def __init__(self, acls):
+        self._acls = acls
+
+    async def execute(self, _query):
+        return FakeResult(self._acls)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        return False
+
+
+class FakeEngine:
+    def __init__(self, session):
+        self._session = session
+
+    def get_async_session(self):
+        return self._session
+
+
+def _patch(monkeypatch, acls, *, authorized=True):
+    monkeypatch.setattr(_module, "get_relational_engine", lambda: FakeEngine(FakeSession(acls)))
+
+    async def fake_authorize(_user_id, _permission, _dataset_ids):
+        if not authorized:
+            raise PermissionDeniedError(
+                "Request owner does not have necessary permission: [share] for all datasets requested."
+            )
+        return []
+
+    monkeypatch.setattr(_module, "get_specific_user_permission_datasets", fake_authorize)
+
+
+class FakePrincipal:
+    """Stands in for a User/Role/Tenant row — `type` is the discriminator column."""
+
+    def __init__(self, kind, *, email=None, name=None):
+        self.id = uuid4()
+        self.type = kind
+        self.email = email
+        self.name = name
+
+
+def _fake_user(email="member@example.com"):
+    return FakePrincipal("user", email=email)
+
+
+def _fake_role(name="engineering"):
+    return FakePrincipal("role", name=name)
+
+
+def _fake_tenant(name="acme"):
+    return FakePrincipal("tenant", name=name)
+
+
+@pytest.mark.asyncio
+async def test_returns_each_kind_of_principal(monkeypatch):
+    """Users, roles and the tenant principal are all reported, each labelled."""
+    user, role, tenant = _fake_user(), _fake_role(), _fake_tenant()
+    _patch(
+        monkeypatch,
+        [FakeACL(user, "read"), FakeACL(role, "write"), FakeACL(tenant, "read")],
+    )
+
+    result = await get_dataset_principals(uuid4(), uuid4())
+
+    by_kind = {entry["kind"]: entry for entry in result}
+    assert set(by_kind) == {"user", "role", "tenant"}
+    assert by_kind["user"]["name"] == "member@example.com"
+    assert by_kind["role"]["name"] == "engineering"
+    assert by_kind["tenant"]["name"] == "acme"
+
+
+@pytest.mark.asyncio
+async def test_collects_permissions_per_principal(monkeypatch):
+    """The ACL table stores a row per permission — one entry comes back, not three."""
+    role = _fake_role()
+    _patch(
+        monkeypatch,
+        [FakeACL(role, "read"), FakeACL(role, "write"), FakeACL(role, "share")],
+    )
+
+    result = await get_dataset_principals(uuid4(), uuid4())
+
+    assert len(result) == 1
+    assert result[0]["principal_id"] == str(role.id)
+    assert result[0]["permissions"] == ["read", "share", "write"]
+
+
+@pytest.mark.asyncio
+async def test_requires_share_permission(monkeypatch):
+    """A caller who cannot share the dataset cannot enumerate its principals."""
+    _patch(monkeypatch, [FakeACL(_fake_user(), "read")], authorized=False)
+
+    with pytest.raises(PermissionDeniedError):
+        await get_dataset_principals(uuid4(), uuid4())
+
+
+@pytest.mark.asyncio
+async def test_skips_rows_with_a_missing_side(monkeypatch):
+    """A dangling ACL row is dropped rather than crashing the listing."""
+    dangling = FakeACL(_fake_user(), "read")
+    dangling.principal = None
+    _patch(monkeypatch, [dangling, FakeACL(_fake_role(), "read")])
+
+    result = await get_dataset_principals(uuid4(), uuid4())
+
+    assert [entry["kind"] for entry in result] == ["role"]
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_nobody_has_access(monkeypatch):
+    """A dataset only its owner reaches lists no shared principals."""
+    _patch(monkeypatch, [])
+
+    assert await get_dataset_principals(uuid4(), uuid4()) == []


### PR DESCRIPTION
## Summary

Dataset permissions can be written but never read. `POST` and `DELETE /permissions/datasets/{principal_id}` both exist, and `get_principal_datasets` answers *"which datasets can this principal reach"* — but nothing answers the reverse, so a client that shares a dataset has no way to show who it is already shared with.

This adds the missing direction:

```
GET /v1/permissions/datasets/{dataset_id}/principals
```

```json
[
  {"principal_id": "…", "kind": "role",   "name": "engineering",        "permissions": ["read", "write"]},
  {"principal_id": "…", "kind": "user",   "name": "member@example.com", "permissions": ["read"]},
  {"principal_id": "…", "kind": "tenant", "name": "acme",               "permissions": ["read", "write"]}
]
```

No new tables and no new permission types. `acls` is already a plain `(principal_id, permission_id, dataset_id)` join table, so the inverse is one query — rows are collapsed per principal, since the table stores a row per permission and would otherwise repeat the principal once per grant.

## Design notes

- **Authorization mirrors the grant side.** The caller must hold `share` on the dataset (`get_specific_user_permission_datasets`, which raises `PermissionDeniedError`), so someone who cannot share a dataset cannot enumerate who it is shared with either.
- **`kind` comes from the polymorphic discriminator** on `principals`, not an `isinstance` ladder — so a dataset shared workspace-wide reads as a single `tenant` entry rather than one row per member, which is what a "who has access" list wants to show.
- **Dangling rows are skipped**, not fatal: an ACL whose principal or permission has gone is dropped from the listing.

## Testing

5 unit tests in `cognee/tests/unit/users/permissions/test_get_dataset_principals.py`: all three principal kinds are labelled correctly, permissions collapse per principal, the unauthorized caller is refused, a dangling ACL row is skipped, and a dataset nobody shares returns `[]`.

- `cognee/tests/unit/users` — 21 passed
- `ruff check .` and `ruff format --check .` — clean repo-wide

## Open question

`share` is the strict reading, and it matches the grant side. It does mean a plain member holding only `read` on a brain cannot see which teams it is shared with — so a UI listing teams-with-access would come back empty for them.

If this should instead follow the philosophy of #4336 (you can see what you are part of), `read` is the one-line alternative. Happy to switch before this leaves draft.

## Context

Needed by the cloud dashboard's brains page, where the Teams column currently lists every visible team rather than the ones with access, and the share modal forgets existing shares on reopen. Both track the missing read back to COG-6140.