### PR TITLE
feat: Add per-file upload labels to add/remember

### DIFF
--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -50,7 +50,7 @@ async def add(
     dataset_id: Optional[UUID] = None,
     preferred_loaders: Optional[List[Union[str, dict[str, dict[str, Any]]]]] = None,
     incremental_loading: bool = True,
-    data_per_batch: Optional[int] = 20,
+    data_per_batch: Optional[int] = 2000,
     importance_weight: Optional[float] = 0.5,
     run_in_background: bool = False,
     llm_config: Optional[LLMConfig] = None,

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -48,12 +48,13 @@ def get_add_router() -> APIRouter:
             default=None,
             examples=[""],
             description=(
-                'JSON array of per-file labels, e.g. ["finance", "people", ""]. Paired '
-                "positionally: the Nth label applies to the Nth uploaded file, so provide "
-                "one entry per file (an empty entry skips that file). Sent as a single "
-                "JSON string because multipart clients — Swagger UI included — cannot "
-                "reliably repeat array form fields. Stored on each file's data record "
-                "and returned when listing dataset data."
+                'Per-file labels, e.g. ["finance", "people", ""] — the Nth label applies '
+                "to the Nth uploaded file, one entry per file, an empty entry skips that "
+                'file. The comma-separated form "finance,people," is accepted '
+                "equivalently (it is what Swagger UI sends when you type a JSON array "
+                "here), so labels cannot contain commas unless the client sends real "
+                "JSON. Stored on each file's data record and returned when listing "
+                "dataset data."
             ),
         ),
         external_metadata: Optional[str] = Form(

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -45,6 +45,16 @@ def get_add_router() -> APIRouter:
     @log_usage(function_name="POST /v1/add", log_type="api_endpoint")
     async def add(
         data: List[UploadFile] = File(default=None),
+        label: Optional[List[EmptyExampleStr]] = Form(
+            default=None,
+            examples=[[]],
+            description=(
+                "Per-file labels, paired positionally: the Nth label applies to the Nth "
+                "uploaded file, so provide one entry per file (leave an entry empty to "
+                "skip labeling that file). Stored on each file's data record and returned "
+                "when listing dataset data."
+            ),
+        ),
         datasetName: Optional[str] = Form(
             default=None,
             examples=["default_dataset"],
@@ -62,16 +72,6 @@ def get_add_router() -> APIRouter:
             ),
         ),
         node_set: Optional[List[str]] = Form(default=[""], example=[""]),
-        label: Optional[List[EmptyExampleStr]] = Form(
-            default=None,
-            examples=[[]],
-            description=(
-                "Per-file labels, paired positionally: the Nth label applies to the Nth "
-                "uploaded file, so provide one entry per file (leave an entry empty to "
-                "skip labeling that file). Stored on each file's data record and returned "
-                "when listing dataset data."
-            ),
-        ),
         run_in_background: Optional[bool] = Form(default=False),
         user: User = Depends(get_authenticated_user),
     ):
@@ -87,13 +87,13 @@ def get_add_router() -> APIRouter:
           - HTTP URLs (if ALLOW_HTTP_REQUESTS is enabled)
           - GitHub repository URLs (will be cloned and processed)
           - Regular file uploads
+        - **label** (Optional[List[str]]): Per-file labels, paired positionally with the
+                 uploaded files (one entry per file; an empty entry skips that file).
+                 Stored on each file's data record.
         - **datasetName** (Optional[str]): Name of the dataset to add data to
         - **datasetId** (Optional[UUID]): UUID of an already existing dataset
         - **node_set** Optional[list[str]]: List of node identifiers for graph organization and access control.
                  Used for grouping related data points in the knowledge graph.
-        - **label** (Optional[List[str]]): Per-file labels, paired positionally with the
-                 uploaded files (one entry per file; an empty entry skips that file).
-                 Stored on each file's data record.
         - **run_in_background** (Optional[bool]): Run add pipeline asynchronously (default: False).
 
         Either datasetName or datasetId must be provided.

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -8,7 +8,7 @@ from pydantic import WithJsonSchema
 
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
-from cognee.tasks.ingestion.data_item import DataItem
+from cognee.tasks.ingestion.data_item import pair_labels_with_data
 from cognee.shared.utils import send_telemetry
 from cognee.modules.pipelines.models import PipelineRunErrored
 from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunInfo
@@ -133,22 +133,15 @@ def get_add_router() -> APIRouter:
                 ).model_dump(),
             )
 
-        # Swagger UI submits untouched array entries as "" — normalize to None.
-        labels = [(entry or None) for entry in (label or [])]
-        if any(labels):
-            if len(labels) != len(data or []):
-                return JSONResponse(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    content=ErrorResponse(
-                        error=(
-                            f"Provide one label per uploaded file: got {len(labels)} labels "
-                            f"for {len(data or [])} files."
-                        ),
-                    ).model_dump(),
-                )
-            # Labels ride on DataItems, which ingestion unwraps to store each
-            # label on its file's Data record.
-            data = [DataItem(data=item, label=lab) for item, lab in zip(data, labels)]
+        # Labels ride on DataItems, which ingestion unwraps to store each
+        # label on its file's Data record.
+        try:
+            data = pair_labels_with_data(data, label)
+        except ValueError as error:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content=ErrorResponse(error=str(error)).model_dump(),
+            )
 
         try:
             add_run = await cognee_add(

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -8,7 +8,11 @@ from pydantic import WithJsonSchema
 
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
-from cognee.tasks.ingestion.data_item import pair_labels_with_data, parse_labels
+from cognee.tasks.ingestion.data_item import (
+    pair_labels_with_data,
+    parse_external_metadata,
+    parse_labels,
+)
 from cognee.shared.utils import send_telemetry
 from cognee.modules.pipelines.models import PipelineRunErrored
 from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunInfo
@@ -52,6 +56,18 @@ def get_add_router() -> APIRouter:
                 "and returned when listing dataset data."
             ),
         ),
+        external_metadata: Optional[str] = Form(
+            default=None,
+            examples=[""],
+            description=(
+                "JSON array of per-file metadata objects, e.g. "
+                '[{"source": "crm", "ticket": 42}, null]. Paired positionally like labels: '
+                "the Nth entry applies to the Nth uploaded file (null or {} skips that "
+                "file), and one entry per file is required when any is given. Merged into "
+                "the file's stored external_metadata (your keys win over loader-derived "
+                "ones; 'node_set' is reserved) and returned when listing dataset data."
+            ),
+        ),
         datasetName: Optional[str] = Form(
             default=None,
             examples=["default_dataset"],
@@ -88,6 +104,10 @@ def get_add_router() -> APIRouter:
                  ["finance", "people", ""], paired positionally with the uploaded files
                  (one entry per file; an empty entry skips that file). Stored on each
                  file's data record.
+        - **external_metadata** (Optional[str]): JSON array of per-file metadata objects,
+                 e.g. [{"source": "crm"}, null], paired positionally with the uploaded
+                 files (one entry per file; null or {} skips that file). Merged into each
+                 file's stored external_metadata.
         - **datasetName** (Optional[str]): Name of the dataset to add data to
         - **datasetId** (Optional[UUID]): UUID of an already existing dataset
         - **node_set** Optional[list[str]]: List of node identifiers for graph organization and access control.
@@ -131,10 +151,12 @@ def get_add_router() -> APIRouter:
                 ).model_dump(),
             )
 
-        # Labels ride on DataItems, which ingestion unwraps to store each
-        # label on its file's Data record. Invalid JSON or a count mismatch
-        # raises a CogneeApiError (400), returned by the global handler.
-        data = pair_labels_with_data(data, parse_labels(labels))
+        # Labels and metadata ride on DataItems, which ingestion unwraps to
+        # store them on each file's Data record. Invalid JSON or a count
+        # mismatch raises a CogneeApiError (400), returned by the global handler.
+        data = pair_labels_with_data(
+            data, parse_labels(labels), parse_external_metadata(external_metadata)
+        )
 
         try:
             add_run = await cognee_add(

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -134,14 +134,9 @@ def get_add_router() -> APIRouter:
             )
 
         # Labels ride on DataItems, which ingestion unwraps to store each
-        # label on its file's Data record.
-        try:
-            data = pair_labels_with_data(data, label)
-        except ValueError as error:
-            return JSONResponse(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                content=ErrorResponse(error=str(error)).model_dump(),
-            )
+        # label on its file's Data record. A count mismatch raises
+        # LabelCountMismatchError (400), returned by the global handler.
+        data = pair_labels_with_data(data, label)
 
         try:
             add_run = await cognee_add(

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -8,6 +8,7 @@ from pydantic import WithJsonSchema
 
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
+from cognee.tasks.ingestion.data_item import DataItem
 from cognee.shared.utils import send_telemetry
 from cognee.modules.pipelines.models import PipelineRunErrored
 from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunInfo
@@ -56,6 +57,15 @@ def get_add_router() -> APIRouter:
             ),
         ),
         node_set: Optional[List[str]] = Form(default=[""], example=[""]),
+        label: Optional[str] = Form(
+            default=None,
+            examples=[""],
+            description=(
+                "Label to attach to every item uploaded in this request. Stored on each "
+                "item's data record and returned when listing dataset data. Leave empty "
+                "for no label."
+            ),
+        ),
         run_in_background: Optional[bool] = Form(default=False),
         user: User = Depends(get_authenticated_user),
     ):
@@ -75,6 +85,8 @@ def get_add_router() -> APIRouter:
         - **datasetId** (Optional[UUID]): UUID of an already existing dataset
         - **node_set** Optional[list[str]]: List of node identifiers for graph organization and access control.
                  Used for grouping related data points in the knowledge graph.
+        - **label** (Optional[str]): Label attached to every item uploaded in this request,
+                 stored on each item's data record.
         - **run_in_background** (Optional[bool]): Run add pipeline asynchronously (default: False).
 
         Either datasetName or datasetId must be provided.
@@ -113,6 +125,12 @@ def get_add_router() -> APIRouter:
                     error="Either datasetId or datasetName must be provided.",
                 ).model_dump(),
             )
+
+        # Swagger UI submits untouched optional fields as "" — treat that as no
+        # label. A label wraps each upload in a DataItem, which ingestion unwraps
+        # to store the label on the item's Data record.
+        if label and data:
+            data = [DataItem(data=item, label=label) for item in data]
 
         try:
             add_run = await cognee_add(

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -8,7 +8,7 @@ from pydantic import WithJsonSchema
 
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
-from cognee.tasks.ingestion.data_item import pair_labels_with_data
+from cognee.tasks.ingestion.data_item import pair_labels_with_data, parse_labels
 from cognee.shared.utils import send_telemetry
 from cognee.modules.pipelines.models import PipelineRunErrored
 from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunInfo
@@ -22,11 +22,6 @@ logger = get_logger()
 # NOTE: Needed because of: https://github.com/fastapi/fastapi/discussions/14975
 #       Once issue is resolved on Swagger side it can be removed.
 UploadFile = Annotated[UF, WithJsonSchema({"type": "string", "format": "binary"})]
-
-# Swagger UI prefills newly added array items from the ITEM-level example;
-# without one it inserts the literal "string". An empty item example keeps
-# "Add item" runnable (empty entries mean "no label for this file").
-EmptyExampleStr = Annotated[str, WithJsonSchema({"type": "string", "example": ""})]
 
 
 def get_add_router() -> APIRouter:
@@ -45,14 +40,16 @@ def get_add_router() -> APIRouter:
     @log_usage(function_name="POST /v1/add", log_type="api_endpoint")
     async def add(
         data: List[UploadFile] = File(default=None),
-        label: Optional[List[EmptyExampleStr]] = Form(
+        labels: Optional[str] = Form(
             default=None,
-            examples=[[]],
+            examples=[""],
             description=(
-                "Per-file labels, paired positionally: the Nth label applies to the Nth "
-                "uploaded file, so provide one entry per file (leave an entry empty to "
-                "skip labeling that file). Stored on each file's data record and returned "
-                "when listing dataset data."
+                'JSON array of per-file labels, e.g. ["finance", "people", ""]. Paired '
+                "positionally: the Nth label applies to the Nth uploaded file, so provide "
+                "one entry per file (an empty entry skips that file). Sent as a single "
+                "JSON string because multipart clients — Swagger UI included — cannot "
+                "reliably repeat array form fields. Stored on each file's data record "
+                "and returned when listing dataset data."
             ),
         ),
         datasetName: Optional[str] = Form(
@@ -87,9 +84,10 @@ def get_add_router() -> APIRouter:
           - HTTP URLs (if ALLOW_HTTP_REQUESTS is enabled)
           - GitHub repository URLs (will be cloned and processed)
           - Regular file uploads
-        - **label** (Optional[List[str]]): Per-file labels, paired positionally with the
-                 uploaded files (one entry per file; an empty entry skips that file).
-                 Stored on each file's data record.
+        - **labels** (Optional[str]): JSON array of per-file labels, e.g.
+                 ["finance", "people", ""], paired positionally with the uploaded files
+                 (one entry per file; an empty entry skips that file). Stored on each
+                 file's data record.
         - **datasetName** (Optional[str]): Name of the dataset to add data to
         - **datasetId** (Optional[UUID]): UUID of an already existing dataset
         - **node_set** Optional[list[str]]: List of node identifiers for graph organization and access control.
@@ -134,9 +132,9 @@ def get_add_router() -> APIRouter:
             )
 
         # Labels ride on DataItems, which ingestion unwraps to store each
-        # label on its file's Data record. A count mismatch raises
-        # LabelCountMismatchError (400), returned by the global handler.
-        data = pair_labels_with_data(data, label)
+        # label on its file's Data record. Invalid JSON or a count mismatch
+        # raises a CogneeApiError (400), returned by the global handler.
+        data = pair_labels_with_data(data, parse_labels(labels))
 
         try:
             add_run = await cognee_add(

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -23,6 +23,11 @@ logger = get_logger()
 #       Once issue is resolved on Swagger side it can be removed.
 UploadFile = Annotated[UF, WithJsonSchema({"type": "string", "format": "binary"})]
 
+# Swagger UI prefills newly added array items from the ITEM-level example;
+# without one it inserts the literal "string". An empty item example keeps
+# "Add item" runnable (empty entries mean "no label for this file").
+EmptyExampleStr = Annotated[str, WithJsonSchema({"type": "string", "example": ""})]
+
 
 def get_add_router() -> APIRouter:
     router = APIRouter()
@@ -57,13 +62,14 @@ def get_add_router() -> APIRouter:
             ),
         ),
         node_set: Optional[List[str]] = Form(default=[""], example=[""]),
-        label: Optional[str] = Form(
+        label: Optional[List[EmptyExampleStr]] = Form(
             default=None,
-            examples=[""],
+            examples=[[]],
             description=(
-                "Label to attach to every item uploaded in this request. Stored on each "
-                "item's data record and returned when listing dataset data. Leave empty "
-                "for no label."
+                "Per-file labels, paired positionally: the Nth label applies to the Nth "
+                "uploaded file, so provide one entry per file (leave an entry empty to "
+                "skip labeling that file). Stored on each file's data record and returned "
+                "when listing dataset data."
             ),
         ),
         run_in_background: Optional[bool] = Form(default=False),
@@ -85,8 +91,9 @@ def get_add_router() -> APIRouter:
         - **datasetId** (Optional[UUID]): UUID of an already existing dataset
         - **node_set** Optional[list[str]]: List of node identifiers for graph organization and access control.
                  Used for grouping related data points in the knowledge graph.
-        - **label** (Optional[str]): Label attached to every item uploaded in this request,
-                 stored on each item's data record.
+        - **label** (Optional[List[str]]): Per-file labels, paired positionally with the
+                 uploaded files (one entry per file; an empty entry skips that file).
+                 Stored on each file's data record.
         - **run_in_background** (Optional[bool]): Run add pipeline asynchronously (default: False).
 
         Either datasetName or datasetId must be provided.
@@ -126,11 +133,22 @@ def get_add_router() -> APIRouter:
                 ).model_dump(),
             )
 
-        # Swagger UI submits untouched optional fields as "" — treat that as no
-        # label. A label wraps each upload in a DataItem, which ingestion unwraps
-        # to store the label on the item's Data record.
-        if label and data:
-            data = [DataItem(data=item, label=label) for item in data]
+        # Swagger UI submits untouched array entries as "" — normalize to None.
+        labels = [(entry or None) for entry in (label or [])]
+        if any(labels):
+            if len(labels) != len(data or []):
+                return JSONResponse(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    content=ErrorResponse(
+                        error=(
+                            f"Provide one label per uploaded file: got {len(labels)} labels "
+                            f"for {len(data or [])} files."
+                        ),
+                    ).model_dump(),
+                )
+            # Labels ride on DataItems, which ingestion unwraps to store each
+            # label on its file's Data record.
+            data = [DataItem(data=item, label=lab) for item, lab in zip(data, labels)]
 
         try:
             add_run = await cognee_add(

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -62,7 +62,7 @@ async def cognify(
     custom_prompt: Optional[str] = None,
     temporal_cognify: bool = False,
     functional_relationships: Optional[Collection[str]] = None,
-    data_per_batch: int = 20,
+    data_per_batch: int = 2000,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
     data_cache: bool = True,

--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -110,8 +110,8 @@ class CognifyPayloadDTO(InDTO):
         ),
     )
     data_per_batch: Optional[int] = Field(
-        default=20,
-        examples=[20],
+        default=2000,
+        examples=[2000],
         description="Maximum number of data items to process concurrently within a dataset.",
     )
 
@@ -157,7 +157,7 @@ def get_cognify_router() -> APIRouter:
           a size from the configured LLM and embedding limits.
         - **ontology_key** (Optional[List[str]]): Reference to one or more previously uploaded ontology files to use for knowledge graph construction.
         - **chunks_per_batch** (Optional[int]): Number of chunks to process per task batch in Cognify. Uses the pipeline default when omitted.
-        - **data_per_batch** (Optional[int]): Maximum number of data items to process concurrently within a dataset. Defaults to 20.
+        - **data_per_batch** (Optional[int]): Maximum number of data items to process concurrently within a dataset. Defaults to 2000.
 
         ## Response
         - **Blocking execution**: Complete pipeline run information with entity counts, processing duration, and success/failure status

--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -52,6 +52,7 @@ class DataDTO(OutDTO):
     mime_type: str
     raw_data_location: str
     dataset_id: UUID
+    label: Optional[str] = None
 
 
 class DatasetGraphSummaryDTO(OutDTO):
@@ -360,6 +361,7 @@ def get_datasets_router() -> APIRouter:
         - **mime_type**: MIME type of the data
         - **raw_data_location**: Storage location of the raw data
         - **dataset_id**: ID of the containing dataset
+        - **label**: Label attached to the data item at upload, if any
 
         ## Error Codes
         - **404 Not Found**: Dataset doesn't exist or user doesn't have access

--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -53,6 +53,7 @@ class DataDTO(OutDTO):
     raw_data_location: str
     dataset_id: UUID
     label: Optional[str] = None
+    external_metadata: Optional[dict] = None
 
 
 class DatasetGraphSummaryDTO(OutDTO):
@@ -362,6 +363,8 @@ def get_datasets_router() -> APIRouter:
         - **raw_data_location**: Storage location of the raw data
         - **dataset_id**: ID of the containing dataset
         - **label**: Label attached to the data item at upload, if any
+        - **external_metadata**: Stored metadata dict (upload-provided keys merged over
+          loader-derived ones), if any
 
         ## Error Codes
         - **404 Not Found**: Dataset doesn't exist or user doesn't have access

--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -1190,10 +1190,6 @@ async def _remember_inner(
     if remaining:
         raise TypeError(f"Unexpected keyword arguments: {', '.join(remaining)}")
 
-    # Cap on concurrently processed data items for both the add and cognify
-    # phases; without this the callees' own (lower) defaults would apply.
-    shared_kwargs.setdefault("data_per_batch", 2000)
-
     # Ensure database is initialized (same as add() does internally).
     # Must run before get_default_user() which queries the DB.
     from cognee.modules.engine.operations.setup import setup

--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -1190,6 +1190,10 @@ async def _remember_inner(
     if remaining:
         raise TypeError(f"Unexpected keyword arguments: {', '.join(remaining)}")
 
+    # Cap on concurrently processed data items for both the add and cognify
+    # phases; without this the callees' own (lower) defaults would apply.
+    shared_kwargs.setdefault("data_per_batch", 2000)
+
     # Ensure database is initialized (same as add() does internally).
     # Must run before get_default_user() which queries the DB.
     from cognee.modules.engine.operations.setup import setup

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field, WithJsonSchema
 from cognee.memory import QAEntry, TraceEntry, FeedbackEntry, SkillRunEntry
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
-from cognee.tasks.ingestion.data_item import DataItem
+from cognee.tasks.ingestion.data_item import pair_labels_with_data
 from cognee.shared.utils import send_telemetry
 from cognee.shared.logging_utils import get_logger
 from cognee.shared.usage_logger import log_usage
@@ -296,30 +296,25 @@ def get_remember_router() -> APIRouter:
                 detail="Either datasetId or datasetName must be provided.",
             )
 
-        # Swagger UI submits untouched array entries as "" — normalize to None.
-        labels = [(entry or None) for entry in (label or [])]
-
         # Labels live on the Data records that normal add+cognify ingestion
         # creates. The session-cache, skills, and archive paths never create
         # those records, so a label there would be silently dropped — reject it
-        # instead.
-        if any(labels):
-            if session_id or content_type:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        "label is only supported for normal ingestion — "
-                        "remove session_id and content_type to use it."
-                    ),
-                )
-            if len(labels) != len(data or []):
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        f"Provide one label per uploaded file: got {len(labels)} labels "
-                        f"for {len(data or [])} files."
-                    ),
-                )
+        # instead. Untouched Swagger array entries arrive as "" and don't count.
+        if any(label or []) and (session_id or content_type):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "label is only supported for normal ingestion — "
+                    "remove session_id and content_type to use it."
+                ),
+            )
+
+        # Labels ride on DataItems, which ingestion unwraps to store each
+        # label on its file's Data record.
+        try:
+            data = pair_labels_with_data(data, label)
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
 
         if content_type == "cogx-archive":
             if not data:
@@ -392,11 +387,6 @@ def get_remember_router() -> APIRouter:
                         "ontology_resolver": RDFLibOntologyResolver(ontology_file=ontology_streams)
                     }
                 }
-
-            # Labels ride on DataItems, which ingestion unwraps to store each
-            # label on its file's Data record.
-            if any(labels):
-                data = [DataItem(data=item, label=lab) for item, lab in zip(data, labels)]
 
             result = await cognee_remember(
                 data,

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -122,14 +122,14 @@ def get_remember_router() -> APIRouter:
             default=None,
             examples=[""],
             description=(
-                'JSON array of per-file labels, e.g. ["finance", "people", ""]. Paired '
-                "positionally: the Nth label applies to the Nth uploaded file, so provide "
-                "one entry per file (an empty entry skips that file). Sent as a single "
-                "JSON string because multipart clients — Swagger UI included — cannot "
-                "reliably repeat array form fields. Stored on each file's data record "
-                "during ingestion. Only supported for normal ingestion — rejected when "
-                "combined with session_id or content_type, whose storage paths carry no "
-                "data records."
+                'Per-file labels, e.g. ["finance", "people", ""] — the Nth label applies '
+                "to the Nth uploaded file, one entry per file, an empty entry skips that "
+                'file. The comma-separated form "finance,people," is accepted '
+                "equivalently (it is what Swagger UI sends when you type a JSON array "
+                "here), so labels cannot contain commas unless the client sends real "
+                "JSON. Stored on each file's data record and returned when listing "
+                "dataset data. Only supported for normal ingestion — rejected when combined "
+                "with session_id or content_type."
             ),
         ),
         external_metadata: Optional[str] = Form(

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field, WithJsonSchema
 from cognee.memory import QAEntry, TraceEntry, FeedbackEntry, SkillRunEntry
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
-from cognee.tasks.ingestion.data_item import pair_labels_with_data
+from cognee.tasks.ingestion.data_item import pair_labels_with_data, parse_labels
 from cognee.shared.utils import send_telemetry
 from cognee.shared.logging_utils import get_logger
 from cognee.shared.usage_logger import log_usage
@@ -114,15 +114,18 @@ def get_remember_router() -> APIRouter:
     @log_usage(function_name="POST /v1/remember", log_type="api_endpoint")
     async def remember(
         data: List[UploadFile] = File(default=None),
-        label: Optional[List[EmptyExampleStr]] = Form(
+        labels: Optional[str] = Form(
             default=None,
-            examples=[[]],
+            examples=[""],
             description=(
-                "Per-file labels, paired positionally: the Nth label applies to the Nth "
-                "uploaded file, so provide one entry per file (leave an entry empty to "
-                "skip labeling that file). Stored on each file's data record during "
-                "ingestion. Only supported for normal ingestion — rejected when combined "
-                "with session_id or content_type, whose storage paths carry no data records."
+                'JSON array of per-file labels, e.g. ["finance", "people", ""]. Paired '
+                "positionally: the Nth label applies to the Nth uploaded file, so provide "
+                "one entry per file (an empty entry skips that file). Sent as a single "
+                "JSON string because multipart clients — Swagger UI included — cannot "
+                "reliably repeat array form fields. Stored on each file's data record "
+                "during ingestion. Only supported for normal ingestion — rejected when "
+                "combined with session_id or content_type, whose storage paths carry no "
+                "data records."
             ),
         ),
         datasetName: Optional[str] = Form(
@@ -253,10 +256,10 @@ def get_remember_router() -> APIRouter:
 
         ## Request Parameters
         - **data** (List[UploadFile]): Files to upload and process.
-        - **label** (Optional[List[str]]): Per-file labels, paired positionally with the
-          uploaded files (one entry per file; an empty entry skips that file). Stored on
-          each file's data record. Normal ingestion only — rejected with session_id or
-          content_type.
+        - **labels** (Optional[str]): JSON array of per-file labels, e.g.
+          ["finance", "people", ""], paired positionally with the uploaded files (one
+          entry per file; an empty entry skips that file). Stored on each file's data
+          record. Normal ingestion only — rejected with session_id or content_type.
         - **datasetName** (Optional[str]): Name of the target dataset.
         - **datasetId** (Optional[UUID]): UUID of an existing dataset.
         - **session_id** (Optional[str]): Session to attribute this memory to. When set,
@@ -296,15 +299,18 @@ def get_remember_router() -> APIRouter:
                 detail="Either datasetId or datasetName must be provided.",
             )
 
+        # Invalid JSON raises InvalidLabelsError (400) via the global handler.
+        parsed_labels = parse_labels(labels)
+
         # Labels live on the Data records that normal add+cognify ingestion
         # creates. The session-cache, skills, and archive paths never create
         # those records, so a label there would be silently dropped — reject it
-        # instead. Untouched Swagger array entries arrive as "" and don't count.
-        if any(label or []) and (session_id or content_type):
+        # instead.
+        if any(parsed_labels or []) and (session_id or content_type):
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    "label is only supported for normal ingestion — "
+                    "labels is only supported for normal ingestion — "
                     "remove session_id and content_type to use it."
                 ),
             )
@@ -312,7 +318,7 @@ def get_remember_router() -> APIRouter:
         # Labels ride on DataItems, which ingestion unwraps to store each
         # label on its file's Data record. A count mismatch raises
         # LabelCountMismatchError (400), returned by the global handler.
-        data = pair_labels_with_data(data, label)
+        data = pair_labels_with_data(data, parsed_labels)
 
         if content_type == "cogx-archive":
             if not data:

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -310,11 +310,9 @@ def get_remember_router() -> APIRouter:
             )
 
         # Labels ride on DataItems, which ingestion unwraps to store each
-        # label on its file's Data record.
-        try:
-            data = pair_labels_with_data(data, label)
-        except ValueError as error:
-            raise HTTPException(status_code=400, detail=str(error))
+        # label on its file's Data record. A count mismatch raises
+        # LabelCountMismatchError (400), returned by the global handler.
+        data = pair_labels_with_data(data, label)
 
         if content_type == "cogx-archive":
             if not data:

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -11,7 +11,11 @@ from pydantic import BaseModel, Field, WithJsonSchema
 from cognee.memory import QAEntry, TraceEntry, FeedbackEntry, SkillRunEntry
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
-from cognee.tasks.ingestion.data_item import pair_labels_with_data, parse_labels
+from cognee.tasks.ingestion.data_item import (
+    pair_labels_with_data,
+    parse_external_metadata,
+    parse_labels,
+)
 from cognee.shared.utils import send_telemetry
 from cognee.shared.logging_utils import get_logger
 from cognee.shared.usage_logger import log_usage
@@ -126,6 +130,19 @@ def get_remember_router() -> APIRouter:
                 "during ingestion. Only supported for normal ingestion — rejected when "
                 "combined with session_id or content_type, whose storage paths carry no "
                 "data records."
+            ),
+        ),
+        external_metadata: Optional[str] = Form(
+            default=None,
+            examples=[""],
+            description=(
+                "JSON array of per-file metadata objects, e.g. "
+                '[{"source": "crm", "ticket": 42}, null]. Paired positionally like labels: '
+                "the Nth entry applies to the Nth uploaded file (null or {} skips that "
+                "file), and one entry per file is required when any is given. Merged into "
+                "the file's stored external_metadata (your keys win over loader-derived "
+                "ones; 'node_set' is reserved). Only supported for normal ingestion — "
+                "rejected when combined with session_id or content_type."
             ),
         ),
         datasetName: Optional[str] = Form(
@@ -260,6 +277,11 @@ def get_remember_router() -> APIRouter:
           ["finance", "people", ""], paired positionally with the uploaded files (one
           entry per file; an empty entry skips that file). Stored on each file's data
           record. Normal ingestion only — rejected with session_id or content_type.
+        - **external_metadata** (Optional[str]): JSON array of per-file metadata objects,
+          e.g. [{"source": "crm"}, null], paired positionally with the uploaded files
+          (one entry per file; null or {} skips that file). Merged into each file's
+          stored external_metadata. Normal ingestion only — rejected with session_id
+          or content_type.
         - **datasetName** (Optional[str]): Name of the target dataset.
         - **datasetId** (Optional[UUID]): UUID of an existing dataset.
         - **session_id** (Optional[str]): Session to attribute this memory to. When set,
@@ -299,26 +321,29 @@ def get_remember_router() -> APIRouter:
                 detail="Either datasetId or datasetName must be provided.",
             )
 
-        # Invalid JSON raises InvalidLabelsError (400) via the global handler.
+        # Invalid JSON raises a CogneeApiError (400) via the global handler.
         parsed_labels = parse_labels(labels)
+        parsed_metadata = parse_external_metadata(external_metadata)
 
-        # Labels live on the Data records that normal add+cognify ingestion
-        # creates. The session-cache, skills, and archive paths never create
-        # those records, so a label there would be silently dropped — reject it
+        # Labels and metadata live on the Data records that normal add+cognify
+        # ingestion creates. The session-cache, skills, and archive paths never
+        # create those records, so they would be silently dropped — reject
         # instead.
-        if any(parsed_labels or []) and (session_id or content_type):
+        if (any(parsed_labels or []) or any(entry for entry in (parsed_metadata or []))) and (
+            session_id or content_type
+        ):
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    "labels is only supported for normal ingestion — "
-                    "remove session_id and content_type to use it."
+                    "labels and external_metadata are only supported for normal ingestion — "
+                    "remove session_id and content_type to use them."
                 ),
             )
 
-        # Labels ride on DataItems, which ingestion unwraps to store each
-        # label on its file's Data record. A count mismatch raises
-        # LabelCountMismatchError (400), returned by the global handler.
-        data = pair_labels_with_data(data, parsed_labels)
+        # Labels and metadata ride on DataItems, which ingestion unwraps to
+        # store them on each file's Data record. A count mismatch raises a
+        # CogneeApiError (400), returned by the global handler.
+        data = pair_labels_with_data(data, parsed_labels, parsed_metadata)
 
         if content_type == "cogx-archive":
             if not data:

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -145,14 +145,15 @@ def get_remember_router() -> APIRouter:
                 "to skip tagging."
             ),
         ),
-        label: Optional[str] = Form(
+        label: Optional[List[EmptyExampleStr]] = Form(
             default=None,
-            examples=[""],
+            examples=[[]],
             description=(
-                "Label to attach to every uploaded file in this request, stored on each "
-                "file's data record during ingestion. Only supported for normal ingestion "
-                "— rejected when combined with session_id or content_type, whose storage "
-                "paths carry no data records. Leave empty for no label."
+                "Per-file labels, paired positionally: the Nth label applies to the Nth "
+                "uploaded file, so provide one entry per file (leave an entry empty to "
+                "skip labeling that file). Stored on each file's data record during "
+                "ingestion. Only supported for normal ingestion — rejected when combined "
+                "with session_id or content_type, whose storage paths carry no data records."
             ),
         ),
         run_in_background: Optional[bool] = Form(
@@ -259,8 +260,10 @@ def get_remember_router() -> APIRouter:
           background; the session is tracked in the sessions dashboard. When omitted,
           data is ingested directly via add + cognify.
         - **node_set** (Optional[List[str]]): Node identifiers for graph organisation.
-        - **label** (Optional[str]): Label attached to every uploaded file, stored on each
-          file's data record. Normal ingestion only — rejected with session_id or content_type.
+        - **label** (Optional[List[str]]): Per-file labels, paired positionally with the
+          uploaded files (one entry per file; an empty entry skips that file). Stored on
+          each file's data record. Normal ingestion only — rejected with session_id or
+          content_type.
         - **run_in_background** (Optional[bool]): Run the cognify step asynchronously (default: False).
         - **custom_prompt** (Optional[str]): Custom prompt for entity extraction.
         - **chunk_size** (Optional[int]): Maximum tokens per chunk (default: 4096).
@@ -293,18 +296,30 @@ def get_remember_router() -> APIRouter:
                 detail="Either datasetId or datasetName must be provided.",
             )
 
-        # A label lives on the Data records that normal add+cognify ingestion
+        # Swagger UI submits untouched array entries as "" — normalize to None.
+        labels = [(entry or None) for entry in (label or [])]
+
+        # Labels live on the Data records that normal add+cognify ingestion
         # creates. The session-cache, skills, and archive paths never create
         # those records, so a label there would be silently dropped — reject it
         # instead.
-        if label and (session_id or content_type):
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "label is only supported for normal ingestion — "
-                    "remove session_id and content_type to use it."
-                ),
-            )
+        if any(labels):
+            if session_id or content_type:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "label is only supported for normal ingestion — "
+                        "remove session_id and content_type to use it."
+                    ),
+                )
+            if len(labels) != len(data or []):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Provide one label per uploaded file: got {len(labels)} labels "
+                        f"for {len(data or [])} files."
+                    ),
+                )
 
         if content_type == "cogx-archive":
             if not data:
@@ -378,10 +393,10 @@ def get_remember_router() -> APIRouter:
                     }
                 }
 
-            # A label wraps each upload in a DataItem, which ingestion unwraps
-            # to store the label on the file's Data record.
-            if label and data:
-                data = [DataItem(data=item, label=label) for item in data]
+            # Labels ride on DataItems, which ingestion unwraps to store each
+            # label on its file's Data record.
+            if any(labels):
+                data = [DataItem(data=item, label=lab) for item, lab in zip(data, labels)]
 
             result = await cognee_remember(
                 data,

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -114,6 +114,17 @@ def get_remember_router() -> APIRouter:
     @log_usage(function_name="POST /v1/remember", log_type="api_endpoint")
     async def remember(
         data: List[UploadFile] = File(default=None),
+        label: Optional[List[EmptyExampleStr]] = Form(
+            default=None,
+            examples=[[]],
+            description=(
+                "Per-file labels, paired positionally: the Nth label applies to the Nth "
+                "uploaded file, so provide one entry per file (leave an entry empty to "
+                "skip labeling that file). Stored on each file's data record during "
+                "ingestion. Only supported for normal ingestion — rejected when combined "
+                "with session_id or content_type, whose storage paths carry no data records."
+            ),
+        ),
         datasetName: Optional[str] = Form(
             default=None,
             examples=["default_dataset"],
@@ -143,17 +154,6 @@ def get_remember_router() -> APIRouter:
                 "groups). Extracted graph nodes are linked to these sets, and recall/search "
                 "can later be restricted to them via their node_name parameter. Leave empty "
                 "to skip tagging."
-            ),
-        ),
-        label: Optional[List[EmptyExampleStr]] = Form(
-            default=None,
-            examples=[[]],
-            description=(
-                "Per-file labels, paired positionally: the Nth label applies to the Nth "
-                "uploaded file, so provide one entry per file (leave an entry empty to "
-                "skip labeling that file). Stored on each file's data record during "
-                "ingestion. Only supported for normal ingestion — rejected when combined "
-                "with session_id or content_type, whose storage paths carry no data records."
             ),
         ),
         run_in_background: Optional[bool] = Form(
@@ -253,6 +253,10 @@ def get_remember_router() -> APIRouter:
 
         ## Request Parameters
         - **data** (List[UploadFile]): Files to upload and process.
+        - **label** (Optional[List[str]]): Per-file labels, paired positionally with the
+          uploaded files (one entry per file; an empty entry skips that file). Stored on
+          each file's data record. Normal ingestion only — rejected with session_id or
+          content_type.
         - **datasetName** (Optional[str]): Name of the target dataset.
         - **datasetId** (Optional[UUID]): UUID of an existing dataset.
         - **session_id** (Optional[str]): Session to attribute this memory to. When set,
@@ -260,10 +264,6 @@ def get_remember_router() -> APIRouter:
           background; the session is tracked in the sessions dashboard. When omitted,
           data is ingested directly via add + cognify.
         - **node_set** (Optional[List[str]]): Node identifiers for graph organisation.
-        - **label** (Optional[List[str]]): Per-file labels, paired positionally with the
-          uploaded files (one entry per file; an empty entry skips that file). Stored on
-          each file's data record. Normal ingestion only — rejected with session_id or
-          content_type.
         - **run_in_background** (Optional[bool]): Run the cognify step asynchronously (default: False).
         - **custom_prompt** (Optional[str]): Custom prompt for entity extraction.
         - **chunk_size** (Optional[int]): Maximum tokens per chunk (default: 4096).

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, WithJsonSchema
 from cognee.memory import QAEntry, TraceEntry, FeedbackEntry, SkillRunEntry
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
+from cognee.tasks.ingestion.data_item import DataItem
 from cognee.shared.utils import send_telemetry
 from cognee.shared.logging_utils import get_logger
 from cognee.shared.usage_logger import log_usage
@@ -144,6 +145,16 @@ def get_remember_router() -> APIRouter:
                 "to skip tagging."
             ),
         ),
+        label: Optional[str] = Form(
+            default=None,
+            examples=[""],
+            description=(
+                "Label to attach to every uploaded file in this request, stored on each "
+                "file's data record during ingestion. Only supported for normal ingestion "
+                "— rejected when combined with session_id or content_type, whose storage "
+                "paths carry no data records. Leave empty for no label."
+            ),
+        ),
         run_in_background: Optional[bool] = Form(
             default=False,
             description=(
@@ -248,6 +259,8 @@ def get_remember_router() -> APIRouter:
           background; the session is tracked in the sessions dashboard. When omitted,
           data is ingested directly via add + cognify.
         - **node_set** (Optional[List[str]]): Node identifiers for graph organisation.
+        - **label** (Optional[str]): Label attached to every uploaded file, stored on each
+          file's data record. Normal ingestion only — rejected with session_id or content_type.
         - **run_in_background** (Optional[bool]): Run the cognify step asynchronously (default: False).
         - **custom_prompt** (Optional[str]): Custom prompt for entity extraction.
         - **chunk_size** (Optional[int]): Maximum tokens per chunk (default: 4096).
@@ -278,6 +291,19 @@ def get_remember_router() -> APIRouter:
             raise HTTPException(
                 status_code=400,
                 detail="Either datasetId or datasetName must be provided.",
+            )
+
+        # A label lives on the Data records that normal add+cognify ingestion
+        # creates. The session-cache, skills, and archive paths never create
+        # those records, so a label there would be silently dropped — reject it
+        # instead.
+        if label and (session_id or content_type):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "label is only supported for normal ingestion — "
+                    "remove session_id and content_type to use it."
+                ),
             )
 
         if content_type == "cogx-archive":
@@ -351,6 +377,11 @@ def get_remember_router() -> APIRouter:
                         "ontology_resolver": RDFLibOntologyResolver(ontology_file=ontology_streams)
                     }
                 }
+
+            # A label wraps each upload in a DataItem, which ingestion unwraps
+            # to store the label on the file's Data record.
+            if label and data:
+                data = [DataItem(data=item, label=label) for item in data]
 
             result = await cognee_remember(
                 data,

--- a/cognee/tasks/ingestion/data_item.py
+++ b/cognee/tasks/ingestion/data_item.py
@@ -20,32 +20,32 @@ class DataItem:
 
 
 def parse_labels(labels: Optional[str]) -> Optional[List[Optional[str]]]:
-    """Parse the ``labels`` form field: a JSON array of per-file label strings.
+    """Parse the ``labels`` form field into per-file label entries.
 
-    The wire format is a single JSON-encoded string because multipart clients
-    cannot reliably repeat array form fields — Swagger UI serializes repeated
-    entries into one comma-joined part (swagger-api/swagger-ui#10221), which
-    silently corrupts per-file pairing. A single string part survives every
-    client verbatim.
+    The canonical format is a JSON array of strings ('["finance", "people", ""]'),
+    sent as one part because multipart clients cannot reliably repeat array
+    form fields (swagger-api/swagger-ui#10221). The comma-separated form
+    ("finance,people,") is accepted equivalently because Swagger UI rewrites a
+    typed JSON array of strings into exactly that before sending. Any value
+    that does not parse as a JSON array is read as comma-separated, so a label
+    cannot contain a comma unless the client sends real JSON.
 
-    Returns None when the field is absent or blank. Entries may be strings or
-    null; anything else is rejected.
+    Returns None when the field is absent or blank.
 
     Raises:
-        InvalidLabelsError: If the value is not valid JSON or not an array of
-            strings/nulls.
+        InvalidLabelsError: If a JSON array contains non-string entries.
     """
     if labels is None or not labels.strip():
         return None
     try:
         parsed = json.loads(labels)
-    except json.JSONDecodeError as error:
-        raise InvalidLabelsError(f"labels is not valid JSON: {error}")
-    if not isinstance(parsed, list) or not all(
-        entry is None or isinstance(entry, str) for entry in parsed
-    ):
-        raise InvalidLabelsError()
-    return parsed
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, list):
+        if not all(entry is None or isinstance(entry, str) for entry in parsed):
+            raise InvalidLabelsError()
+        return parsed
+    return [segment.strip() for segment in labels.split(",")]
 
 
 def parse_external_metadata(

--- a/cognee/tasks/ingestion/data_item.py
+++ b/cognee/tasks/ingestion/data_item.py
@@ -1,8 +1,9 @@
+import json
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 from uuid import UUID
 
-from cognee.tasks.ingestion.exceptions import LabelCountMismatchError
+from cognee.tasks.ingestion.exceptions import InvalidLabelsError, LabelCountMismatchError
 
 
 @dataclass
@@ -11,6 +12,35 @@ class DataItem:
     label: Optional[str] = None
     external_metadata: Optional[dict] = field(default=None)
     data_id: Optional[UUID] = None
+
+
+def parse_labels(labels: Optional[str]) -> Optional[List[Optional[str]]]:
+    """Parse the ``labels`` form field: a JSON array of per-file label strings.
+
+    The wire format is a single JSON-encoded string because multipart clients
+    cannot reliably repeat array form fields — Swagger UI serializes repeated
+    entries into one comma-joined part (swagger-api/swagger-ui#10221), which
+    silently corrupts per-file pairing. A single string part survives every
+    client verbatim.
+
+    Returns None when the field is absent or blank. Entries may be strings or
+    null; anything else is rejected.
+
+    Raises:
+        InvalidLabelsError: If the value is not valid JSON or not an array of
+            strings/nulls.
+    """
+    if labels is None or not labels.strip():
+        return None
+    try:
+        parsed = json.loads(labels)
+    except json.JSONDecodeError as error:
+        raise InvalidLabelsError(f"labels is not valid JSON: {error}")
+    if not isinstance(parsed, list) or not all(
+        entry is None or isinstance(entry, str) for entry in parsed
+    ):
+        raise InvalidLabelsError()
+    return parsed
 
 
 def pair_labels_with_data(

--- a/cognee/tasks/ingestion/data_item.py
+++ b/cognee/tasks/ingestion/data_item.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, List, Optional
 from uuid import UUID
 
 
@@ -9,3 +9,27 @@ class DataItem:
     label: Optional[str] = None
     external_metadata: Optional[dict] = field(default=None)
     data_id: Optional[UUID] = None
+
+
+def pair_labels_with_data(
+    data: Optional[list], labels: Optional[List[Optional[str]]]
+) -> Optional[list]:
+    """Pair per-item labels with data items, wrapping each in a DataItem.
+
+    Labels pair positionally: the Nth label applies to the Nth data item, and
+    an empty entry (``""`` or ``None``) leaves that item unlabeled. With no
+    non-empty label the data is returned unchanged; otherwise the label count
+    must match the item count — a partial list is ambiguous.
+
+    Raises:
+        ValueError: If any label is provided and the counts differ.
+    """
+    normalized = [(entry or None) for entry in (labels or [])]
+    if not any(normalized):
+        return data
+    if len(normalized) != len(data or []):
+        raise ValueError(
+            f"Provide one label per uploaded file: got {len(normalized)} labels "
+            f"for {len(data or [])} files."
+        )
+    return [DataItem(data=item, label=label) for item, label in zip(data, normalized)]

--- a/cognee/tasks/ingestion/data_item.py
+++ b/cognee/tasks/ingestion/data_item.py
@@ -3,7 +3,12 @@ from dataclasses import dataclass, field
 from typing import Any, List, Optional
 from uuid import UUID
 
-from cognee.tasks.ingestion.exceptions import InvalidLabelsError, LabelCountMismatchError
+from cognee.tasks.ingestion.exceptions import (
+    ExternalMetadataCountMismatchError,
+    InvalidExternalMetadataError,
+    InvalidLabelsError,
+    LabelCountMismatchError,
+)
 
 
 @dataclass
@@ -43,25 +48,85 @@ def parse_labels(labels: Optional[str]) -> Optional[List[Optional[str]]]:
     return parsed
 
 
-def pair_labels_with_data(
-    data: Optional[list], labels: Optional[List[Optional[str]]]
-) -> Optional[list]:
-    """Pair per-item labels with data items, wrapping each in a DataItem.
+def parse_external_metadata(
+    external_metadata: Optional[str],
+) -> Optional[List[Optional[dict]]]:
+    """Parse the ``external_metadata`` form field: a JSON array of objects.
 
-    Labels pair positionally: the Nth label applies to the Nth data item, and
-    an empty entry (``""`` or ``None``) leaves that item unlabeled. With no
-    non-empty label the data is returned unchanged; otherwise the label count
-    must match the item count — a partial list is ambiguous.
+    Same wire convention as ``labels``: one JSON-encoded string, paired
+    positionally with the uploaded files, ``null`` (or ``{}``) to skip a file.
+    ``node_set`` is rejected as a key because ingestion writes the request's
+    node_set into the stored dict after merging, which would silently
+    overwrite it — pass the node_set parameter instead.
+
+    Returns None when the field is absent or blank.
+
+    Raises:
+        InvalidExternalMetadataError: If the value is not valid JSON, not an
+            array of objects/nulls, or an entry contains the ``node_set`` key.
+    """
+    if external_metadata is None or not external_metadata.strip():
+        return None
+    try:
+        parsed = json.loads(external_metadata)
+    except json.JSONDecodeError as error:
+        raise InvalidExternalMetadataError(f"external_metadata is not valid JSON: {error}")
+    if not isinstance(parsed, list) or not all(
+        entry is None or isinstance(entry, dict) for entry in parsed
+    ):
+        raise InvalidExternalMetadataError()
+    for entry in parsed:
+        if entry and "node_set" in entry:
+            raise InvalidExternalMetadataError(
+                "external_metadata entries cannot contain the reserved key 'node_set' — "
+                "use the node_set parameter instead."
+            )
+    return parsed
+
+
+def pair_labels_with_data(
+    data: Optional[list],
+    labels: Optional[List[Optional[str]]],
+    external_metadata: Optional[List[Optional[dict]]] = None,
+) -> Optional[list]:
+    """Pair per-item labels and external metadata with data items as DataItems.
+
+    Both attribute lists pair positionally: the Nth entry applies to the Nth
+    data item. An empty label (``""``/``None``) or empty metadata entry
+    (``{}``/``None``) leaves that item's attribute unset, and either list may
+    be omitted entirely. With no non-empty entry in either list the data is
+    returned unchanged; otherwise each provided list's length must match the
+    item count — a partial list is ambiguous.
 
     Raises:
         LabelCountMismatchError: If any label is provided and the counts differ.
+        ExternalMetadataCountMismatchError: If any metadata entry is provided
+            and the counts differ.
     """
-    normalized = [(entry or None) for entry in (labels or [])]
-    if not any(normalized):
+    normalized_labels = [(entry or None) for entry in (labels or [])]
+    normalized_metadata = [(entry or None) for entry in (external_metadata or [])]
+    has_labels = any(normalized_labels)
+    has_metadata = any(normalized_metadata)
+    if not has_labels and not has_metadata:
         return data
-    if len(normalized) != len(data or []):
+
+    item_count = len(data or [])
+    if has_labels and len(normalized_labels) != item_count:
         raise LabelCountMismatchError(
-            f"Provide one label per uploaded file: got {len(normalized)} labels "
-            f"for {len(data or [])} files."
+            f"Provide one label per uploaded file: got {len(normalized_labels)} labels "
+            f"for {item_count} files."
         )
-    return [DataItem(data=item, label=label) for item, label in zip(data, normalized)]
+    if has_metadata and len(normalized_metadata) != item_count:
+        raise ExternalMetadataCountMismatchError(
+            f"Provide one external_metadata entry per uploaded file: got "
+            f"{len(normalized_metadata)} entries for {item_count} files."
+        )
+
+    if not has_labels:
+        normalized_labels = [None] * item_count
+    if not has_metadata:
+        normalized_metadata = [None] * item_count
+    return [
+        DataItem(data=item, label=label, external_metadata=metadata)
+        for item, label, metadata in zip(data, normalized_labels, normalized_metadata)
+    ]

--- a/cognee/tasks/ingestion/data_item.py
+++ b/cognee/tasks/ingestion/data_item.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from typing import Any, List, Optional
 from uuid import UUID
 
+from cognee.tasks.ingestion.exceptions import LabelCountMismatchError
+
 
 @dataclass
 class DataItem:
@@ -22,13 +24,13 @@ def pair_labels_with_data(
     must match the item count — a partial list is ambiguous.
 
     Raises:
-        ValueError: If any label is provided and the counts differ.
+        LabelCountMismatchError: If any label is provided and the counts differ.
     """
     normalized = [(entry or None) for entry in (labels or [])]
     if not any(normalized):
         return data
     if len(normalized) != len(data or []):
-        raise ValueError(
+        raise LabelCountMismatchError(
             f"Provide one label per uploaded file: got {len(normalized)} labels "
             f"for {len(data or [])} files."
         )

--- a/cognee/tasks/ingestion/exceptions/__init__.py
+++ b/cognee/tasks/ingestion/exceptions/__init__.py
@@ -5,4 +5,4 @@ This module defines a set of exceptions for handling various application errors,
 such as System, Validation, Configuration or TransientErrors
 """
 
-from .exceptions import S3FileSystemNotFoundError, LabelCountMismatchError
+from .exceptions import S3FileSystemNotFoundError, LabelCountMismatchError, InvalidLabelsError

--- a/cognee/tasks/ingestion/exceptions/__init__.py
+++ b/cognee/tasks/ingestion/exceptions/__init__.py
@@ -5,4 +5,4 @@ This module defines a set of exceptions for handling various application errors,
 such as System, Validation, Configuration or TransientErrors
 """
 
-from .exceptions import S3FileSystemNotFoundError
+from .exceptions import S3FileSystemNotFoundError, LabelCountMismatchError

--- a/cognee/tasks/ingestion/exceptions/__init__.py
+++ b/cognee/tasks/ingestion/exceptions/__init__.py
@@ -5,4 +5,10 @@ This module defines a set of exceptions for handling various application errors,
 such as System, Validation, Configuration or TransientErrors
 """
 
-from .exceptions import S3FileSystemNotFoundError, LabelCountMismatchError, InvalidLabelsError
+from .exceptions import (
+    S3FileSystemNotFoundError,
+    LabelCountMismatchError,
+    InvalidLabelsError,
+    InvalidExternalMetadataError,
+    ExternalMetadataCountMismatchError,
+)

--- a/cognee/tasks/ingestion/exceptions/exceptions.py
+++ b/cognee/tasks/ingestion/exceptions/exceptions.py
@@ -40,3 +40,13 @@ class DLTIngestionError(CogneeSystemError):
         status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR,
     ):
         super().__init__(message, name, status_code)
+
+
+class LabelCountMismatchError(CogneeValidationError):
+    def __init__(
+        self,
+        message: str = "Label count does not match data item count.",
+        name: str = "LabelCountMismatchError",
+        status_code: int = status.HTTP_400_BAD_REQUEST,
+    ):
+        super().__init__(message, name, status_code)

--- a/cognee/tasks/ingestion/exceptions/exceptions.py
+++ b/cognee/tasks/ingestion/exceptions/exceptions.py
@@ -60,3 +60,25 @@ class InvalidLabelsError(CogneeValidationError):
         status_code: int = status.HTTP_400_BAD_REQUEST,
     ):
         super().__init__(message, name, status_code)
+
+
+class InvalidExternalMetadataError(CogneeValidationError):
+    def __init__(
+        self,
+        message: str = (
+            'external_metadata must be a JSON array of objects, e.g. [{"source": "crm"}, null].'
+        ),
+        name: str = "InvalidExternalMetadataError",
+        status_code: int = status.HTTP_400_BAD_REQUEST,
+    ):
+        super().__init__(message, name, status_code)
+
+
+class ExternalMetadataCountMismatchError(CogneeValidationError):
+    def __init__(
+        self,
+        message: str = "external_metadata count does not match data item count.",
+        name: str = "ExternalMetadataCountMismatchError",
+        status_code: int = status.HTTP_400_BAD_REQUEST,
+    ):
+        super().__init__(message, name, status_code)

--- a/cognee/tasks/ingestion/exceptions/exceptions.py
+++ b/cognee/tasks/ingestion/exceptions/exceptions.py
@@ -50,3 +50,13 @@ class LabelCountMismatchError(CogneeValidationError):
         status_code: int = status.HTTP_400_BAD_REQUEST,
     ):
         super().__init__(message, name, status_code)
+
+
+class InvalidLabelsError(CogneeValidationError):
+    def __init__(
+        self,
+        message: str = 'labels must be a JSON array of strings, e.g. ["finance", ""].',
+        name: str = "InvalidLabelsError",
+        status_code: int = status.HTTP_400_BAD_REQUEST,
+    ):
+        super().__init__(message, name, status_code)

--- a/cognee/tasks/ingestion/ingest_data.py
+++ b/cognee/tasks/ingestion/ingest_data.py
@@ -188,7 +188,10 @@ async def ingest_data(
                 data_point.external_metadata = ext_metadata
                 data_point.node_set = json.dumps(node_set) if node_set else None
                 data_point.tenant_id = user.tenant_id if user.tenant_id else None
-                data_point.label = current_label
+                # Absent means "leave unchanged": a re-ingest without a label
+                # (current_label None) must not clear a previously stored one.
+                if current_label is not None:
+                    data_point.label = current_label
 
                 if content_changed:
                     data_point.pipeline_status = {}

--- a/cognee/tests/unit/api/v1/test_add_remember_label.py
+++ b/cognee/tests/unit/api/v1/test_add_remember_label.py
@@ -1,11 +1,13 @@
-"""The add and remember endpoints accept a `label` form field for uploads.
+"""The add and remember endpoints accept per-file `label` form entries.
 
-A provided label wraps each upload in a DataItem before it reaches the
-add/remember pipeline; ingestion unwraps the DataItem and stores the label
-on the item's Data record. Without a label the uploads pass through
-unchanged. On remember, a label is rejected when combined with session_id
-or content_type — those storage paths never create Data records, so the
-label would be silently dropped.
+Labels pair positionally with the uploaded files: the Nth label applies to
+the Nth file, and an empty entry skips that file. When any label is given,
+each upload is wrapped in a DataItem before it reaches the add/remember
+pipeline; ingestion unwraps the DataItem and stores the label on the file's
+Data record. Without labels the uploads pass through unchanged. A label
+count that doesn't match the file count is rejected, as is a label combined
+with session_id or content_type on remember — those storage paths never
+create Data records, so the label would be silently dropped.
 """
 
 import importlib
@@ -60,32 +62,48 @@ UPLOADS = [
 ]
 
 
-def test_add_with_label_wraps_uploads_in_data_items(client):
+def test_add_pairs_each_label_with_its_upload(client):
     with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
         mock_add.return_value = pipeline_run_completed()
 
         response = client.post(
             "/api/v1/add",
             files=UPLOADS,
-            data={"datasetName": "test_dataset", "label": "quarterly-report"},
+            data={"datasetName": "test_dataset", "label": ["finance", "engineering"]},
         )
 
         assert response.status_code == 200
         sent = mock_add.call_args.args[0]
         assert [type(item) for item in sent] == [DataItem, DataItem]
-        assert [item.label for item in sent] == ["quarterly-report", "quarterly-report"]
+        assert [item.label for item in sent] == ["finance", "engineering"]
         assert [item.data.filename for item in sent] == ["first.txt", "second.txt"]
 
 
-def test_add_without_label_passes_uploads_through(client):
+def test_add_empty_label_entry_skips_that_file(client):
     with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
         mock_add.return_value = pipeline_run_completed()
 
         response = client.post(
             "/api/v1/add",
-            files=UPLOADS[:1],
-            # Swagger UI submits untouched optional fields as "".
-            data={"datasetName": "test_dataset", "label": ""},
+            files=UPLOADS,
+            data={"datasetName": "test_dataset", "label": ["finance", ""]},
+        )
+
+        assert response.status_code == 200
+        sent = mock_add.call_args.args[0]
+        assert [item.label for item in sent] == ["finance", None]
+        assert [item.data.filename for item in sent] == ["first.txt", "second.txt"]
+
+
+def test_add_without_labels_passes_uploads_through(client):
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        mock_add.return_value = pipeline_run_completed()
+
+        response = client.post(
+            "/api/v1/add",
+            files=UPLOADS,
+            # Swagger UI submits untouched array entries as "".
+            data={"datasetName": "test_dataset", "label": ["", ""]},
         )
 
         assert response.status_code == 200
@@ -94,7 +112,20 @@ def test_add_without_label_passes_uploads_through(client):
         assert sent[0].filename == "first.txt"
 
 
-def test_remember_with_label_wraps_uploads_in_data_items(client):
+def test_add_rejects_label_count_mismatch(client):
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        response = client.post(
+            "/api/v1/add",
+            files=UPLOADS,
+            data={"datasetName": "test_dataset", "label": ["finance"]},
+        )
+
+        assert response.status_code == 400
+        assert "one label per uploaded file" in response.json()["error"]
+        mock_add.assert_not_awaited()
+
+
+def test_remember_pairs_each_label_with_its_upload(client):
     with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
         mock_remember.return_value = SimpleNamespace(
             status="completed", to_dict=lambda: {"status": "completed"}
@@ -103,17 +134,17 @@ def test_remember_with_label_wraps_uploads_in_data_items(client):
         response = client.post(
             "/api/v1/remember",
             files=UPLOADS,
-            data={"datasetName": "test_dataset", "label": "quarterly-report"},
+            data={"datasetName": "test_dataset", "label": ["finance", "engineering"]},
         )
 
         assert response.status_code == 200
         sent = mock_remember.call_args.args[0]
         assert [type(item) for item in sent] == [DataItem, DataItem]
-        assert [item.label for item in sent] == ["quarterly-report", "quarterly-report"]
+        assert [item.label for item in sent] == ["finance", "engineering"]
         assert [item.data.filename for item in sent] == ["first.txt", "second.txt"]
 
 
-def test_remember_without_label_passes_uploads_through(client):
+def test_remember_without_labels_passes_uploads_through(client):
     with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
         mock_remember.return_value = SimpleNamespace(
             status="completed", to_dict=lambda: {"status": "completed"}
@@ -122,12 +153,25 @@ def test_remember_without_label_passes_uploads_through(client):
         response = client.post(
             "/api/v1/remember",
             files=UPLOADS[:1],
-            data={"datasetName": "test_dataset", "label": ""},
+            data={"datasetName": "test_dataset", "label": [""]},
         )
 
         assert response.status_code == 200
         sent = mock_remember.call_args.args[0]
         assert not any(isinstance(item, DataItem) for item in sent)
+
+
+def test_remember_rejects_label_count_mismatch(client):
+    with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
+        response = client.post(
+            "/api/v1/remember",
+            files=UPLOADS,
+            data={"datasetName": "test_dataset", "label": ["finance"]},
+        )
+
+        assert response.status_code == 400
+        assert "one label per uploaded file" in response.json()["detail"]
+        mock_remember.assert_not_awaited()
 
 
 @pytest.mark.parametrize(
@@ -140,7 +184,7 @@ def test_remember_rejects_label_outside_normal_ingestion(client, extra_form):
         response = client.post(
             "/api/v1/remember",
             files=UPLOADS[:1],
-            data={"datasetName": "test_dataset", "label": "quarterly-report", **extra_form},
+            data={"datasetName": "test_dataset", "label": ["finance"], **extra_form},
         )
 
         assert response.status_code == 400

--- a/cognee/tests/unit/api/v1/test_add_remember_label.py
+++ b/cognee/tests/unit/api/v1/test_add_remember_label.py
@@ -1,0 +1,148 @@
+"""The add and remember endpoints accept a `label` form field for uploads.
+
+A provided label wraps each upload in a DataItem before it reaches the
+add/remember pipeline; ingestion unwraps the DataItem and stores the label
+on the item's Data record. Without a label the uploads pass through
+unchanged. On remember, a label is rejected when combined with session_id
+or content_type — those storage paths never create Data records, so the
+label would be silently dropped.
+"""
+
+import importlib
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cognee.api.client import app
+from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunCompleted
+from cognee.modules.users.methods import get_authenticated_user
+from cognee.tasks.ingestion.data_item import DataItem
+
+add_pkg = importlib.import_module("cognee.api.v1.add")
+remember_pkg = importlib.import_module("cognee.api.v1.remember")
+
+
+@pytest.fixture(scope="session")
+def test_client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def client(test_client):
+    async def override_get_authenticated_user():
+        return SimpleNamespace(
+            id=str(uuid.uuid4()),
+            email="test@example.com",
+            is_active=True,
+            tenant_id=str(uuid.uuid4()),
+        )
+
+    app.dependency_overrides[get_authenticated_user] = override_get_authenticated_user
+    yield test_client
+    app.dependency_overrides.pop(get_authenticated_user, None)
+
+
+def pipeline_run_completed():
+    return PipelineRunCompleted(
+        pipeline_run_id=uuid.uuid4(),
+        dataset_id=uuid.uuid4(),
+        dataset_name="test_dataset",
+    )
+
+
+UPLOADS = [
+    ("data", ("first.txt", b"first file", "text/plain")),
+    ("data", ("second.txt", b"second file", "text/plain")),
+]
+
+
+def test_add_with_label_wraps_uploads_in_data_items(client):
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        mock_add.return_value = pipeline_run_completed()
+
+        response = client.post(
+            "/api/v1/add",
+            files=UPLOADS,
+            data={"datasetName": "test_dataset", "label": "quarterly-report"},
+        )
+
+        assert response.status_code == 200
+        sent = mock_add.call_args.args[0]
+        assert [type(item) for item in sent] == [DataItem, DataItem]
+        assert [item.label for item in sent] == ["quarterly-report", "quarterly-report"]
+        assert [item.data.filename for item in sent] == ["first.txt", "second.txt"]
+
+
+def test_add_without_label_passes_uploads_through(client):
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        mock_add.return_value = pipeline_run_completed()
+
+        response = client.post(
+            "/api/v1/add",
+            files=UPLOADS[:1],
+            # Swagger UI submits untouched optional fields as "".
+            data={"datasetName": "test_dataset", "label": ""},
+        )
+
+        assert response.status_code == 200
+        sent = mock_add.call_args.args[0]
+        assert not any(isinstance(item, DataItem) for item in sent)
+        assert sent[0].filename == "first.txt"
+
+
+def test_remember_with_label_wraps_uploads_in_data_items(client):
+    with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
+        mock_remember.return_value = SimpleNamespace(
+            status="completed", to_dict=lambda: {"status": "completed"}
+        )
+
+        response = client.post(
+            "/api/v1/remember",
+            files=UPLOADS,
+            data={"datasetName": "test_dataset", "label": "quarterly-report"},
+        )
+
+        assert response.status_code == 200
+        sent = mock_remember.call_args.args[0]
+        assert [type(item) for item in sent] == [DataItem, DataItem]
+        assert [item.label for item in sent] == ["quarterly-report", "quarterly-report"]
+        assert [item.data.filename for item in sent] == ["first.txt", "second.txt"]
+
+
+def test_remember_without_label_passes_uploads_through(client):
+    with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
+        mock_remember.return_value = SimpleNamespace(
+            status="completed", to_dict=lambda: {"status": "completed"}
+        )
+
+        response = client.post(
+            "/api/v1/remember",
+            files=UPLOADS[:1],
+            data={"datasetName": "test_dataset", "label": ""},
+        )
+
+        assert response.status_code == 200
+        sent = mock_remember.call_args.args[0]
+        assert not any(isinstance(item, DataItem) for item in sent)
+
+
+@pytest.mark.parametrize(
+    "extra_form",
+    [{"session_id": "claude-code-1718000000"}, {"content_type": "skills"}],
+    ids=["session_id", "content_type"],
+)
+def test_remember_rejects_label_outside_normal_ingestion(client, extra_form):
+    with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
+        response = client.post(
+            "/api/v1/remember",
+            files=UPLOADS[:1],
+            data={"datasetName": "test_dataset", "label": "quarterly-report", **extra_form},
+        )
+
+        assert response.status_code == 400
+        assert "label is only supported for normal ingestion" in response.json()["detail"]
+        mock_remember.assert_not_awaited()

--- a/cognee/tests/unit/api/v1/test_add_remember_label.py
+++ b/cognee/tests/unit/api/v1/test_add_remember_label.py
@@ -1,15 +1,16 @@
-"""The add and remember endpoints accept a `labels` form field for uploads.
+"""The add and remember endpoints accept `labels` and `external_metadata` form fields.
 
-The field is a single JSON-encoded array (e.g. '["finance", "people", ""]')
-because multipart clients — Swagger UI included — cannot reliably repeat
-array form fields (swagger-api/swagger-ui#10221 serializes repeated entries
-into one comma-joined part). Labels pair positionally: the Nth label applies
-to the Nth file, and an empty entry skips that file. When any label is given,
-each upload is wrapped in a DataItem before it reaches the add/remember
-pipeline; ingestion unwraps the DataItem and stores the label on the file's
-Data record. Without labels the uploads pass through unchanged. Malformed
-JSON, a label count that doesn't match the file count, and labels combined
-with session_id or content_type on remember are all rejected with 400.
+Each field is a single JSON-encoded array (e.g. '["finance", ""]' or
+'[{"source": "crm"}, null]') because multipart clients — Swagger UI included —
+cannot reliably repeat array form fields (swagger-api/swagger-ui#10221
+serializes repeated entries into one comma-joined part). Entries pair
+positionally: the Nth entry applies to the Nth file, and an empty entry
+("" / null / {}) skips that file. When any entry is given, each upload is
+wrapped in a DataItem before it reaches the add/remember pipeline; ingestion
+unwraps the DataItem and stores the attributes on the file's Data record.
+Without either field the uploads pass through unchanged. Malformed JSON, a
+count that doesn't match the file count, and either field combined with
+session_id or content_type on remember are all rejected with 400.
 """
 
 import importlib
@@ -231,18 +232,129 @@ def test_remember_rejects_label_count_mismatch(client, files, labels):
 
 
 @pytest.mark.parametrize(
+    "attribute_form",
+    [{"labels": '["finance"]'}, {"external_metadata": '[{"source": "crm"}]'}],
+    ids=["labels", "external_metadata"],
+)
+@pytest.mark.parametrize(
     "extra_form",
     [{"session_id": "claude-code-1718000000"}, {"content_type": "skills"}],
     ids=["session_id", "content_type"],
 )
-def test_remember_rejects_labels_outside_normal_ingestion(client, extra_form):
+def test_remember_rejects_attributes_outside_normal_ingestion(client, extra_form, attribute_form):
     with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
         response = client.post(
             "/api/v1/remember",
             files=UPLOADS[:1],
-            data={"datasetName": "test_dataset", "labels": '["finance"]', **extra_form},
+            data={"datasetName": "test_dataset", **attribute_form, **extra_form},
         )
 
         assert response.status_code == 400
-        assert "labels is only supported for normal ingestion" in response.json()["detail"]
+        assert "only supported for normal ingestion" in response.json()["detail"]
         mock_remember.assert_not_awaited()
+
+
+def test_add_pairs_each_metadata_entry_with_its_upload(client):
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        mock_add.return_value = pipeline_run_completed()
+
+        response = client.post(
+            "/api/v1/add",
+            files=UPLOADS,
+            data={
+                "datasetName": "test_dataset",
+                "external_metadata": '[{"source": "crm", "ticket": 42}, null]',
+            },
+        )
+
+        assert response.status_code == 200
+        sent = mock_add.call_args.args[0]
+        assert [type(item) for item in sent] == [DataItem, DataItem]
+        assert [item.external_metadata for item in sent] == [
+            {"source": "crm", "ticket": 42},
+            None,
+        ]
+        assert [item.label for item in sent] == [None, None]
+        assert [item.data.filename for item in sent] == ["first.txt", "second.txt"]
+
+
+def test_add_pairs_labels_and_metadata_together(client):
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        mock_add.return_value = pipeline_run_completed()
+
+        response = client.post(
+            "/api/v1/add",
+            files=UPLOADS,
+            data={
+                "datasetName": "test_dataset",
+                "labels": '["finance", ""]',
+                "external_metadata": '[{}, {"source": "wiki"}]',
+            },
+        )
+
+        assert response.status_code == 200
+        sent = mock_add.call_args.args[0]
+        assert [item.label for item in sent] == ["finance", None]
+        assert [item.external_metadata for item in sent] == [None, {"source": "wiki"}]
+
+
+@pytest.mark.parametrize(
+    "files,external_metadata",
+    [
+        (UPLOADS, '[{"source": "crm"}]'),
+        (UPLOADS, '[{"a": 1}, {"b": 2}, {"c": 3}]'),
+        (None, '[{"source": "crm"}]'),
+    ],
+    ids=["fewer_entries", "more_entries", "entries_without_files"],
+)
+def test_add_rejects_metadata_count_mismatch(client, files, external_metadata):
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        response = client.post(
+            "/api/v1/add",
+            files=files,
+            data={"datasetName": "test_dataset", "external_metadata": external_metadata},
+        )
+
+        assert response.status_code == 400
+        assert "one external_metadata entry per uploaded file" in response.json()["detail"]
+        mock_add.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "external_metadata,expected",
+    [
+        ("source=crm", "not valid JSON"),
+        ('{"source": "crm"}', "JSON array of objects"),
+        ('["crm"]', "JSON array of objects"),
+        ('[{"node_set": ["x"]}]', "reserved key 'node_set'"),
+    ],
+    ids=["bare_string", "object_not_array", "non_object_entries", "reserved_node_set"],
+)
+def test_add_rejects_malformed_metadata(client, external_metadata, expected):
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        response = client.post(
+            "/api/v1/add",
+            files=UPLOADS[:1],
+            data={"datasetName": "test_dataset", "external_metadata": external_metadata},
+        )
+
+        assert response.status_code == 400
+        assert expected in response.json()["detail"]
+        mock_add.assert_not_awaited()
+
+
+def test_remember_pairs_metadata_with_its_upload(client):
+    with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
+        mock_remember.return_value = SimpleNamespace(
+            status="completed", to_dict=lambda: {"status": "completed"}
+        )
+
+        response = client.post(
+            "/api/v1/remember",
+            files=UPLOADS[:1],
+            data={"datasetName": "test_dataset", "external_metadata": '[{"source": "crm"}]'},
+        )
+
+        assert response.status_code == 200
+        sent = mock_remember.call_args.args[0]
+        assert [item.external_metadata for item in sent] == [{"source": "crm"}]

--- a/cognee/tests/unit/api/v1/test_add_remember_label.py
+++ b/cognee/tests/unit/api/v1/test_add_remember_label.py
@@ -1,13 +1,15 @@
-"""The add and remember endpoints accept per-file `label` form entries.
+"""The add and remember endpoints accept a `labels` form field for uploads.
 
-Labels pair positionally with the uploaded files: the Nth label applies to
-the Nth file, and an empty entry skips that file. When any label is given,
+The field is a single JSON-encoded array (e.g. '["finance", "people", ""]')
+because multipart clients — Swagger UI included — cannot reliably repeat
+array form fields (swagger-api/swagger-ui#10221 serializes repeated entries
+into one comma-joined part). Labels pair positionally: the Nth label applies
+to the Nth file, and an empty entry skips that file. When any label is given,
 each upload is wrapped in a DataItem before it reaches the add/remember
 pipeline; ingestion unwraps the DataItem and stores the label on the file's
-Data record. Without labels the uploads pass through unchanged. A label
-count that doesn't match the file count is rejected, as is a label combined
-with session_id or content_type on remember — those storage paths never
-create Data records, so the label would be silently dropped.
+Data record. Without labels the uploads pass through unchanged. Malformed
+JSON, a label count that doesn't match the file count, and labels combined
+with session_id or content_type on remember are all rejected with 400.
 """
 
 import importlib
@@ -69,7 +71,7 @@ def test_add_pairs_each_label_with_its_upload(client):
         response = client.post(
             "/api/v1/add",
             files=UPLOADS,
-            data={"datasetName": "test_dataset", "label": ["finance", "engineering"]},
+            data={"datasetName": "test_dataset", "labels": '["finance", "engineering"]'},
         )
 
         assert response.status_code == 200
@@ -86,7 +88,7 @@ def test_add_empty_label_entry_skips_that_file(client):
         response = client.post(
             "/api/v1/add",
             files=UPLOADS,
-            data={"datasetName": "test_dataset", "label": ["finance", ""]},
+            data={"datasetName": "test_dataset", "labels": '["finance", ""]'},
         )
 
         assert response.status_code == 200
@@ -96,20 +98,20 @@ def test_add_empty_label_entry_skips_that_file(client):
 
 
 @pytest.mark.parametrize(
-    "label_form",
-    # Swagger UI submits untouched array entries as ""; plain clients omit
-    # the field entirely. Both must behave as "no labels".
-    [{"label": ["", ""]}, {}],
-    ids=["empty_entries", "field_omitted"],
+    "labels_form",
+    # Swagger UI submits an untouched field as ""; plain clients omit it; an
+    # all-empty array carries no label. All must behave as "no labels".
+    [{"labels": ""}, {}, {"labels": '["", ""]'}],
+    ids=["field_blank", "field_omitted", "empty_entries"],
 )
-def test_add_without_labels_passes_uploads_through(client, label_form):
+def test_add_without_labels_passes_uploads_through(client, labels_form):
     with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
         mock_add.return_value = pipeline_run_completed()
 
         response = client.post(
             "/api/v1/add",
             files=UPLOADS,
-            data={"datasetName": "test_dataset", **label_form},
+            data={"datasetName": "test_dataset", **labels_form},
         )
 
         assert response.status_code == 200
@@ -121,12 +123,12 @@ def test_add_without_labels_passes_uploads_through(client, label_form):
 @pytest.mark.parametrize(
     "files,labels",
     [
-        (UPLOADS, ["finance"]),
-        (UPLOADS, ["a", "b", "c"]),
+        (UPLOADS, '["finance"]'),
+        (UPLOADS, '["a", "b", "c"]'),
         # An empty entry still counts toward the pairing — it means "no label
         # for that file", not "one fewer label".
-        (UPLOADS, ["finance", "people", ""]),
-        (None, ["orphan"]),
+        (UPLOADS, '["finance", "people", ""]'),
+        (None, '["orphan"]'),
     ],
     ids=["fewer_labels", "more_labels", "more_labels_with_empty", "labels_without_files"],
 )
@@ -135,11 +137,33 @@ def test_add_rejects_label_count_mismatch(client, files, labels):
         response = client.post(
             "/api/v1/add",
             files=files,
-            data={"datasetName": "test_dataset", "label": labels},
+            data={"datasetName": "test_dataset", "labels": labels},
         )
 
         assert response.status_code == 400
         assert "one label per uploaded file" in response.json()["detail"]
+        mock_add.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "labels,expected",
+    [
+        ("finance", "not valid JSON"),
+        ('"finance"', "JSON array of strings"),
+        ("[1, 2]", "JSON array of strings"),
+    ],
+    ids=["bare_string", "json_string_not_array", "non_string_entries"],
+)
+def test_add_rejects_malformed_labels(client, labels, expected):
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        response = client.post(
+            "/api/v1/add",
+            files=UPLOADS,
+            data={"datasetName": "test_dataset", "labels": labels},
+        )
+
+        assert response.status_code == 400
+        assert expected in response.json()["detail"]
         mock_add.assert_not_awaited()
 
 
@@ -152,7 +176,7 @@ def test_remember_pairs_each_label_with_its_upload(client):
         response = client.post(
             "/api/v1/remember",
             files=UPLOADS,
-            data={"datasetName": "test_dataset", "label": ["finance", "engineering"]},
+            data={"datasetName": "test_dataset", "labels": '["finance", "engineering"]'},
         )
 
         assert response.status_code == 200
@@ -163,11 +187,11 @@ def test_remember_pairs_each_label_with_its_upload(client):
 
 
 @pytest.mark.parametrize(
-    "label_form",
-    [{"label": [""]}, {}],
-    ids=["empty_entries", "field_omitted"],
+    "labels_form",
+    [{"labels": ""}, {}],
+    ids=["field_blank", "field_omitted"],
 )
-def test_remember_without_labels_passes_uploads_through(client, label_form):
+def test_remember_without_labels_passes_uploads_through(client, labels_form):
     with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
         mock_remember.return_value = SimpleNamespace(
             status="completed", to_dict=lambda: {"status": "completed"}
@@ -176,7 +200,7 @@ def test_remember_without_labels_passes_uploads_through(client, label_form):
         response = client.post(
             "/api/v1/remember",
             files=UPLOADS[:1],
-            data={"datasetName": "test_dataset", **label_form},
+            data={"datasetName": "test_dataset", **labels_form},
         )
 
         assert response.status_code == 200
@@ -187,9 +211,9 @@ def test_remember_without_labels_passes_uploads_through(client, label_form):
 @pytest.mark.parametrize(
     "files,labels",
     [
-        (UPLOADS, ["finance"]),
-        (UPLOADS, ["a", "b", "c"]),
-        (None, ["orphan"]),
+        (UPLOADS, '["finance"]'),
+        (UPLOADS, '["a", "b", "c"]'),
+        (None, '["orphan"]'),
     ],
     ids=["fewer_labels", "more_labels", "labels_without_files"],
 )
@@ -198,7 +222,7 @@ def test_remember_rejects_label_count_mismatch(client, files, labels):
         response = client.post(
             "/api/v1/remember",
             files=files,
-            data={"datasetName": "test_dataset", "label": labels},
+            data={"datasetName": "test_dataset", "labels": labels},
         )
 
         assert response.status_code == 400
@@ -211,14 +235,14 @@ def test_remember_rejects_label_count_mismatch(client, files, labels):
     [{"session_id": "claude-code-1718000000"}, {"content_type": "skills"}],
     ids=["session_id", "content_type"],
 )
-def test_remember_rejects_label_outside_normal_ingestion(client, extra_form):
+def test_remember_rejects_labels_outside_normal_ingestion(client, extra_form):
     with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
         response = client.post(
             "/api/v1/remember",
             files=UPLOADS[:1],
-            data={"datasetName": "test_dataset", "label": ["finance"], **extra_form},
+            data={"datasetName": "test_dataset", "labels": '["finance"]', **extra_form},
         )
 
         assert response.status_code == 400
-        assert "label is only supported for normal ingestion" in response.json()["detail"]
+        assert "labels is only supported for normal ingestion" in response.json()["detail"]
         mock_remember.assert_not_awaited()

--- a/cognee/tests/unit/api/v1/test_add_remember_label.py
+++ b/cognee/tests/unit/api/v1/test_add_remember_label.py
@@ -1,9 +1,11 @@
 """The add and remember endpoints accept `labels` and `external_metadata` form fields.
 
-Each field is a single JSON-encoded array (e.g. '["finance", ""]' or
-'[{"source": "crm"}, null]') because multipart clients — Swagger UI included —
-cannot reliably repeat array form fields (swagger-api/swagger-ui#10221
-serializes repeated entries into one comma-joined part). Entries pair
+Each field is a single part because multipart clients — Swagger UI included —
+cannot reliably repeat array form fields (swagger-api/swagger-ui#10221).
+`labels` accepts a JSON array ('["finance", ""]') or the comma-separated form
+("finance,") that Swagger UI produces when a JSON array of strings is typed
+into the field; `external_metadata` is a JSON array of objects
+('[{"source": "crm"}, null]'), which Swagger transmits intact. Entries pair
 positionally: the Nth entry applies to the Nth file, and an empty entry
 ("" / null / {}) skips that file. When any entry is given, each upload is
 wrapped in a DataItem before it reaches the add/remember pipeline; ingestion
@@ -146,26 +148,43 @@ def test_add_rejects_label_count_mismatch(client, files, labels):
         mock_add.assert_not_awaited()
 
 
+def test_add_rejects_json_labels_with_non_string_entries(client):
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        response = client.post(
+            "/api/v1/add",
+            files=UPLOADS,
+            data={"datasetName": "test_dataset", "labels": "[1, 2]"},
+        )
+
+        assert response.status_code == 400
+        assert "JSON array of strings" in response.json()["detail"]
+        mock_add.assert_not_awaited()
+
+
 @pytest.mark.parametrize(
     "labels,expected",
     [
-        ("finance", "not valid JSON"),
-        ('"finance"', "JSON array of strings"),
-        ("[1, 2]", "JSON array of strings"),
+        # Swagger UI rewrites a typed JSON array of strings into exactly this
+        # comma-joined form (captured from swagger-ui 5) — it must keep working.
+        ("finance,engineering", ["finance", "engineering"]),
+        ("finance,", ["finance", None]),
+        ("finance, engineering", ["finance", "engineering"]),
     ],
-    ids=["bare_string", "json_string_not_array", "non_string_entries"],
+    ids=["swagger_csv", "swagger_csv_trailing_empty", "csv_with_spaces"],
 )
-def test_add_rejects_malformed_labels(client, labels, expected):
+def test_add_accepts_comma_separated_labels(client, labels, expected):
     with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        mock_add.return_value = pipeline_run_completed()
+
         response = client.post(
             "/api/v1/add",
             files=UPLOADS,
             data={"datasetName": "test_dataset", "labels": labels},
         )
 
-        assert response.status_code == 400
-        assert expected in response.json()["detail"]
-        mock_add.assert_not_awaited()
+        assert response.status_code == 200
+        sent = mock_add.call_args.args[0]
+        assert [item.label for item in sent] == expected
 
 
 def test_remember_pairs_each_label_with_its_upload(client):

--- a/cognee/tests/unit/api/v1/test_add_remember_label.py
+++ b/cognee/tests/unit/api/v1/test_add_remember_label.py
@@ -139,7 +139,7 @@ def test_add_rejects_label_count_mismatch(client, files, labels):
         )
 
         assert response.status_code == 400
-        assert "one label per uploaded file" in response.json()["error"]
+        assert "one label per uploaded file" in response.json()["detail"]
         mock_add.assert_not_awaited()
 
 

--- a/cognee/tests/unit/api/v1/test_add_remember_label.py
+++ b/cognee/tests/unit/api/v1/test_add_remember_label.py
@@ -118,12 +118,24 @@ def test_add_without_labels_passes_uploads_through(client, label_form):
         assert sent[0].filename == "first.txt"
 
 
-def test_add_rejects_label_count_mismatch(client):
+@pytest.mark.parametrize(
+    "files,labels",
+    [
+        (UPLOADS, ["finance"]),
+        (UPLOADS, ["a", "b", "c"]),
+        # An empty entry still counts toward the pairing — it means "no label
+        # for that file", not "one fewer label".
+        (UPLOADS, ["finance", "people", ""]),
+        (None, ["orphan"]),
+    ],
+    ids=["fewer_labels", "more_labels", "more_labels_with_empty", "labels_without_files"],
+)
+def test_add_rejects_label_count_mismatch(client, files, labels):
     with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
         response = client.post(
             "/api/v1/add",
-            files=UPLOADS,
-            data={"datasetName": "test_dataset", "label": ["finance"]},
+            files=files,
+            data={"datasetName": "test_dataset", "label": labels},
         )
 
         assert response.status_code == 400
@@ -172,12 +184,21 @@ def test_remember_without_labels_passes_uploads_through(client, label_form):
         assert not any(isinstance(item, DataItem) for item in sent)
 
 
-def test_remember_rejects_label_count_mismatch(client):
+@pytest.mark.parametrize(
+    "files,labels",
+    [
+        (UPLOADS, ["finance"]),
+        (UPLOADS, ["a", "b", "c"]),
+        (None, ["orphan"]),
+    ],
+    ids=["fewer_labels", "more_labels", "labels_without_files"],
+)
+def test_remember_rejects_label_count_mismatch(client, files, labels):
     with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
         response = client.post(
             "/api/v1/remember",
-            files=UPLOADS,
-            data={"datasetName": "test_dataset", "label": ["finance"]},
+            files=files,
+            data={"datasetName": "test_dataset", "label": labels},
         )
 
         assert response.status_code == 400

--- a/cognee/tests/unit/api/v1/test_add_remember_label.py
+++ b/cognee/tests/unit/api/v1/test_add_remember_label.py
@@ -95,15 +95,21 @@ def test_add_empty_label_entry_skips_that_file(client):
         assert [item.data.filename for item in sent] == ["first.txt", "second.txt"]
 
 
-def test_add_without_labels_passes_uploads_through(client):
+@pytest.mark.parametrize(
+    "label_form",
+    # Swagger UI submits untouched array entries as ""; plain clients omit
+    # the field entirely. Both must behave as "no labels".
+    [{"label": ["", ""]}, {}],
+    ids=["empty_entries", "field_omitted"],
+)
+def test_add_without_labels_passes_uploads_through(client, label_form):
     with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
         mock_add.return_value = pipeline_run_completed()
 
         response = client.post(
             "/api/v1/add",
             files=UPLOADS,
-            # Swagger UI submits untouched array entries as "".
-            data={"datasetName": "test_dataset", "label": ["", ""]},
+            data={"datasetName": "test_dataset", **label_form},
         )
 
         assert response.status_code == 200
@@ -144,7 +150,12 @@ def test_remember_pairs_each_label_with_its_upload(client):
         assert [item.data.filename for item in sent] == ["first.txt", "second.txt"]
 
 
-def test_remember_without_labels_passes_uploads_through(client):
+@pytest.mark.parametrize(
+    "label_form",
+    [{"label": [""]}, {}],
+    ids=["empty_entries", "field_omitted"],
+)
+def test_remember_without_labels_passes_uploads_through(client, label_form):
     with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
         mock_remember.return_value = SimpleNamespace(
             status="completed", to_dict=lambda: {"status": "completed"}
@@ -153,7 +164,7 @@ def test_remember_without_labels_passes_uploads_through(client):
         response = client.post(
             "/api/v1/remember",
             files=UPLOADS[:1],
-            data={"datasetName": "test_dataset", "label": [""]},
+            data={"datasetName": "test_dataset", **label_form},
         )
 
         assert response.status_code == 200

--- a/cognee/tests/unit/tasks/ingestion/test_ingest_data_update_branch.py
+++ b/cognee/tests/unit/tasks/ingestion/test_ingest_data_update_branch.py
@@ -29,3 +29,42 @@ def test_ingest_data_update_branch_assigns_data_size():
 
     assert "data_size" in assigned_attrs
     assert "file_size" not in assigned_attrs
+
+
+def test_ingest_data_update_branch_preserves_label_when_absent():
+    """A re-ingest without a label must not clear a stored one: every
+    `data_point.label = ...` in the update branch has to sit under a
+    `current_label is not None` guard, so absent means "leave unchanged".
+    """
+    source_path = Path(__file__).parents[4] / "tasks" / "ingestion" / "ingest_data.py"
+    tree = ast.parse(source_path.read_text())
+
+    def label_assigns(node):
+        return [
+            sub
+            for sub in ast.walk(node)
+            if isinstance(sub, ast.Assign)
+            and isinstance(sub.targets[0], ast.Attribute)
+            and sub.targets[0].attr == "label"
+            and isinstance(sub.targets[0].value, ast.Name)
+            and sub.targets[0].value.id == "data_point"
+        ]
+
+    guarded = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.If)
+            and isinstance(node.test, ast.Compare)
+            and isinstance(node.test.left, ast.Name)
+            and node.test.left.id == "current_label"
+            and isinstance(node.test.ops[0], ast.IsNot)
+        ):
+            guarded.update(id(assign) for assign in label_assigns(node))
+
+    all_assigns = label_assigns(tree)
+    assert all_assigns, "expected a data_point.label assignment in the update branch"
+    unguarded = [assign for assign in all_assigns if id(assign) not in guarded]
+    assert not unguarded, (
+        f"{len(unguarded)} unguarded data_point.label assignment(s): a re-ingest "
+        "without a label would clear the stored label"
+    )


### PR DESCRIPTION
# Description

## Per-file labels and external metadata on the add and remember endpoints

`DataItem.label` / `DataItem.external_metadata` were reachable only from the SDK — HTTP clients had no way to attach either to an upload. Both endpoints now accept two optional form fields, each **one multipart part** paired positionally with the uploaded files (the Nth entry applies to the Nth file):

```bash
curl -X POST /api/v1/add \
  -F "data=@report.md" -F "data=@notes.md" \
  -F "datasetName=my_ds" \
  -F 'labels=["finance", ""]' \
  -F 'external_metadata=[{"source": "crm", "ticket": 4444}, null]'
```

- **`labels`** — a JSON array of strings; an empty entry leaves that file unlabeled. The comma-separated form `finance,` is accepted equivalently, because Swagger UI JSON-parses whatever is typed into the field and rewrites an array of strings into exactly that comma-joined scalar before sending (verified by capturing its requests with headless chromium; see swagger-ui#10221 for the underlying array-field behavior). Consequence: a label can contain a comma only via a client that sends real JSON.
- **`external_metadata`** — a JSON array of objects, `null`/`{}` to skip a file. Swagger transmits object arrays intact, so this field is strict JSON. Entries merge over loader-derived metadata (user keys win); the reserved `node_set` key is rejected explicitly since ingestion would silently overwrite it.

Why one JSON part instead of a repeated form field: Swagger UI serializes repeated multipart array fields into a single comma-joined part, which silently corrupts per-file pairing — the single-part format survives every client verbatim.

The endpoints wrap each upload in a `DataItem` (shared `pair_labels_with_data` + `parse_labels`/`parse_external_metadata` in `cognee/tasks/ingestion/data_item.py`); ingestion already unwraps DataItems, so the pipeline is untouched. Without either field, uploads pass through unchanged.

Fail-fast guards (all `CogneeValidationError` subclasses, returned as 400 by the global handler):

- entry count ≠ file count → `LabelCountMismatchError` / `ExternalMetadataCountMismatchError` (a partial list is ambiguous)
- malformed `external_metadata` / non-string JSON label entries → `InvalidExternalMetadataError` / `InvalidLabelsError`
- on `/v1/remember`, either field combined with `session_id` or `content_type` → 400 (those storage paths never create `Data` records, so the values would be silently dropped)

## Label preservation on re-ingest

The ingestion update branch (already-known content, e.g. the same file added to a second dataset) assigned `data_point.label` unconditionally, so any re-ingest without a label cleared a previously stored one. Absent now means "leave unchanged"; a provided label still replaces. Guarded by an AST regression test in `test_ingest_data_update_branch.py` (verified to fail on the unguarded code).

## Read-back

`GET /v1/datasets/{id}/data` now returns `label` and `externalMetadata` (`DataDTO`) — previously the values were persisted but unreadable over HTTP.

## data_per_batch default 20 → 2000

Raises the default cap on concurrently processed data items for `add()` and `cognify()` (SDK signatures and the cognify endpoint payload). `remember()` inherits it for both of its phases.

# Testing

- `cognee/tests/unit/api/v1/test_add_remember_label.py` (33 tests): pairing for both fields, empty-entry skips, passthrough (field omitted / blank / all-empty), count mismatches in both directions, malformed metadata shapes, the reserved `node_set` key, the remember 400 guards, and the exact comma-joined strings Swagger produces (captured from swagger-ui 5) pinned as cases.
- Headless-browser E2E through **authorized Swagger UI itself** (playwright): filling the try-it-out form exactly as a user does → 200, and the data listing returns the right label/metadata per file, including the two-file case with an empty second entry.
- Live curl E2E (`ENABLE_BACKEND_ACCESS_CONTROL=true`): per-file pairing, skips, all mismatch shapes, malformed input, and label preservation across unlabeled cross-dataset re-ingest (previously cleared, now kept; a provided label still replaces).

# Type of Change

- [x] New feature (non-breaking change which adds functionality)
