### PR TITLE
feat(search): Expose session_id on recall/search history (SDK-407)

### DIFF
--- a/cognee/alembic/versions/a7c3e9f1b5d8_add_session_id_to_queries_and_results.py
+++ b/cognee/alembic/versions/a7c3e9f1b5d8_add_session_id_to_queries_and_results.py
@@ -1,0 +1,67 @@
+"""add_session_id_to_queries_and_results
+
+Revision ID: a7c3e9f1b5d8
+Revises: e5a7b9c1d3f4
+Create Date: 2026-08-12 00:00:00.000000
+
+Adds the caller-supplied session id a search/recall was made under, so recall
+history can be filtered per agent — the session id prefix names the tool that
+asked ("claude_..." from the Claude Code plugin, "codex_..." from Codex).
+Nullable and forward-looking: rows written before this migration keep NULL, and
+so do callers that send no session id at all.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a7c3e9f1b5d8"
+down_revision: Union[str, None] = "e5a7b9c1d3f4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLES = ("queries", "results")
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    existing_tables = set(insp.get_table_names())
+
+    for table in _TABLES:
+        if table not in existing_tables:
+            continue
+
+        columns = {col["name"] for col in insp.get_columns(table)}
+        if "session_id" not in columns:
+            op.add_column(table, sa.Column("session_id", sa.String(), nullable=True))
+
+        index_name = f"ix_{table}_session_id"
+        indexes = {idx["name"] for idx in insp.get_indexes(table)}
+        if index_name not in indexes:
+            op.create_index(index_name, table, ["session_id"])
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    existing_tables = set(insp.get_table_names())
+
+    for table in _TABLES:
+        if table not in existing_tables:
+            continue
+
+        index_name = f"ix_{table}_session_id"
+        indexes = {idx["name"] for idx in insp.get_indexes(table)}
+        if index_name in indexes:
+            op.drop_index(index_name, table_name=table)
+
+        columns = {col["name"] for col in insp.get_columns(table)}
+        if "session_id" in columns:
+            op.drop_column(table, "session_id")

--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -656,7 +656,9 @@ async def recall(
             # because it calls authorized_search() directly and skips the
             # logging that search() wraps around it. Agents recall through this
             # endpoint, so their questions were absent from history entirely.
-            await log_search_history(query_text, local_query_type.value, user.id, graph_results)
+            await log_search_history(
+                query_text, local_query_type.value, user.id, graph_results, session_id
+            )
 
             tagged = []
             for r in graph_results:

--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -147,7 +147,7 @@ async def search(
     # actually searched — dataset_ids=None means "every dataset the user can
     # read". Only the completion text is stored, never the raw result_objects,
     # which run 50-100 KB each and would grow the DB without bound.
-    await log_search_history(query_text, query_type.value, user.id, search_results)
+    await log_search_history(query_text, query_type.value, user.id, search_results, session_id)
 
     return _backwards_compatible_search_results(search_results, verbose)
 

--- a/cognee/modules/search/models/Query.py
+++ b/cognee/modules/search/models/Query.py
@@ -19,6 +19,12 @@ class Query(Base):
     # attribute the query to, so they stay NULL.
     dataset_id = Column(UUID, index=True, nullable=True)
 
+    # Caller-supplied session id (e.g. "claude_ab12cd34" from the Claude Code
+    # plugin, "codex_..." from Codex). It names the tool that asked, which is
+    # what recall history needs to report coverage per agent. NULL for callers
+    # that send none — raw API traffic — and for rows written before this.
+    session_id = Column(String, index=True, nullable=True)
+
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
     )

--- a/cognee/modules/search/models/Result.py
+++ b/cognee/modules/search/models/Result.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from uuid import uuid4
-from sqlalchemy import Column, DateTime, Text, UUID
+from sqlalchemy import Column, DateTime, String, Text, UUID
 from cognee.infrastructure.databases.relational import Base
 
 
@@ -16,6 +16,10 @@ class Result(Base):
     # Mirrors ``Query.dataset_id`` for the query this result answers, so
     # history can be filtered by dataset without joining back to queries.
     dataset_id = Column(UUID, index=True, nullable=True)
+
+    # Mirrors ``Query.session_id`` for the query this result answers, so
+    # history can be filtered by session without joining back to queries.
+    session_id = Column(String, index=True, nullable=True)
 
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True

--- a/cognee/modules/search/operations/get_history.py
+++ b/cognee/modules/search/operations/get_history.py
@@ -20,6 +20,7 @@ async def get_history(user_id: UUID, limit: int = 10) -> list[dict[str, Any]]:
         Query.created_at,
         literal("user").label("user"),
         Query.dataset_id,
+        Query.session_id,
     ).filter(Query.user_id == user_id)
 
     results_query = select(
@@ -28,6 +29,7 @@ async def get_history(user_id: UUID, limit: int = 10) -> list[dict[str, Any]]:
         Result.created_at,
         literal("system").label("user"),
         Result.dataset_id,
+        Result.session_id,
     ).filter(Result.user_id == user_id)
 
     history_query = queries_query.union(results_query).order_by("created_at")

--- a/cognee/modules/search/operations/log_query.py
+++ b/cognee/modules/search/operations/log_query.py
@@ -12,12 +12,14 @@ async def log_query(
     query_type: str,
     user_id: UUID,
     dataset_id: Optional[UUID] = None,
+    session_id: Optional[str] = None,
 ) -> Query:
     query = Query(
         text=query_text,
         query_type=query_type,
         user_id=user_id,
         dataset_id=dataset_id,
+        session_id=session_id,
     )
 
     if not _LOG_ENABLED:

--- a/cognee/modules/search/operations/log_result.py
+++ b/cognee/modules/search/operations/log_result.py
@@ -12,6 +12,7 @@ async def log_result(
     result: str,
     user_id: UUID,
     dataset_id: Optional[UUID] = None,
+    session_id: Optional[str] = None,
 ):
     if not _LOG_ENABLED:
         return
@@ -25,6 +26,7 @@ async def log_result(
                 query_id=query_id,
                 user_id=user_id,
                 dataset_id=dataset_id,
+                session_id=session_id,
             )
         )
 

--- a/cognee/modules/search/operations/log_search_history.py
+++ b/cognee/modules/search/operations/log_search_history.py
@@ -19,6 +19,7 @@ async def log_search_history(
     query_type: str,
     user_id: UUID,
     search_results: List[Any],
+    session_id: Optional[str] = None,
 ) -> None:
     """Record a searched question and its answers, one row per dataset.
 
@@ -34,8 +35,8 @@ async def log_search_history(
 
     for payload in payloads:
         dataset_id = getattr(payload, "dataset_id", None)
-        query = await log_query(query_text, query_type, user_id, dataset_id)
+        query = await log_query(query_text, query_type, user_id, dataset_id, session_id)
         # Every query keeps a result row even when the search produced no text
         # — CHUNKS and SUMMARIES return objects, not completions — so history
         # stays one result per query, as it was before this fanned out.
-        await log_result(query.id, _completion_of(payload) or "", user_id, dataset_id)
+        await log_result(query.id, _completion_of(payload) or "", user_id, dataset_id, session_id)

--- a/cognee/tests/unit/modules/search/test_search_history_session_id.py
+++ b/cognee/tests/unit/modules/search/test_search_history_session_id.py
@@ -1,0 +1,117 @@
+"""Round-trip coverage for ``session_id`` on recall/search history.
+
+Same shape as ``test_search_history_dataset_id``: exercise the real log -> read
+path against a temporary SQLite database. What matters beyond the round trip is
+that ``log_search_history`` carries the session id onto **every** row it writes,
+because a search that fans out over three datasets becomes three query rows and
+all three belong to the same session.
+"""
+
+import importlib
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from cognee.infrastructure.databases.relational import Base
+from cognee.infrastructure.databases.relational.create_relational_engine import (
+    create_relational_engine,
+)
+from cognee.modules.search.models.Query import Query
+from cognee.modules.search.models.Result import Result
+
+log_query_mod = importlib.import_module("cognee.modules.search.operations.log_query")
+log_result_mod = importlib.import_module("cognee.modules.search.operations.log_result")
+get_history_mod = importlib.import_module("cognee.modules.search.operations.get_history")
+log_history_mod = importlib.import_module("cognee.modules.search.operations.log_search_history")
+
+
+class _Payload:
+    """Minimal stand-in for a SearchResultPayload."""
+
+    def __init__(self, dataset_id):
+        self.dataset_id = dataset_id
+        self.completion = "an answer"
+
+
+@pytest_asyncio.fixture
+async def history_engine(tmp_path, monkeypatch):
+    """A SQLite engine holding only the two history tables."""
+    engine = create_relational_engine(
+        db_path=str(tmp_path),
+        db_name="history_session_test.db",
+        db_host="",
+        db_port="",
+        db_username="",
+        db_password="",
+        db_provider="sqlite",
+    )
+
+    async with engine.engine.begin() as connection:
+        await connection.run_sync(
+            Base.metadata.create_all, tables=[Query.__table__, Result.__table__]
+        )
+
+    for module in (log_query_mod, log_result_mod, get_history_mod):
+        monkeypatch.setattr(module, "get_relational_engine", lambda: engine)
+        # Logging is gated on an env var read at import time; pin it on so the
+        # test does not depend on the ambient environment.
+        if hasattr(module, "_LOG_ENABLED"):
+            monkeypatch.setattr(module, "_LOG_ENABLED", True)
+
+    yield engine
+
+    await engine.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_session_id_round_trips_through_history(history_engine):
+    user_id = uuid4()
+
+    query = await log_query_mod.log_query(
+        "who wrote it?", "GRAPH_COMPLETION", user_id, None, "claude_ab12cd34"
+    )
+    await log_result_mod.log_result(query.id, '["an answer"]', user_id, None, "claude_ab12cd34")
+
+    history = await get_history_mod.get_history(user_id, limit=0)
+
+    assert len(history) == 2
+    # Both the question and the answer carry the session attribution.
+    assert {row["user"] for row in history} == {"user", "system"}
+    assert all(row["session_id"] == "claude_ab12cd34" for row in history)
+
+
+@pytest.mark.asyncio
+async def test_caller_without_a_session_records_null(history_engine):
+    """Raw API traffic sends no session id; that is NULL, not an error."""
+    user_id = uuid4()
+
+    query = await log_query_mod.log_query("anything?", "GRAPH_COMPLETION", user_id)
+    await log_result_mod.log_result(query.id, "[]", user_id)
+
+    history = await get_history_mod.get_history(user_id, limit=0)
+
+    assert len(history) == 2
+    assert all(row["session_id"] is None for row in history)
+
+
+@pytest.mark.asyncio
+async def test_every_fanned_out_row_carries_the_session(history_engine):
+    """One search over three datasets is three rows, all in the same session."""
+    user_id = uuid4()
+    dataset_ids = [uuid4() for _ in range(3)]
+
+    await log_history_mod.log_search_history(
+        "what changed?",
+        "GRAPH_COMPLETION",
+        user_id,
+        [_Payload(dataset_id) for dataset_id in dataset_ids],
+        "codex_ef56ab78",
+    )
+
+    history = await get_history_mod.get_history(user_id, limit=0)
+
+    # Three queries plus their three results.
+    assert len(history) == 6
+    assert all(row["session_id"] == "codex_ef56ab78" for row in history)
+    assert {row["dataset_id"] for row in history} == set(dataset_ids)


### PR DESCRIPTION
## Description

Adds `session_id` to recall/search history — deliberately the same shape as #4426 (SDK-393), which added `dataset_id`.

History already records **who** asked (`Query.user_id`) and **which dataset** answered (`Query.dataset_id`), but not **what** asked. The session id is the only thing that names the tool: the Claude Code plugin mints `claude_<host-session-id>` and Codex mints `codex_<host-session-id>` (`_plugin_common.py::_generate_session_id` in cognee-integrations), and both already send it on recall (`_recall_http.py` sets `body["session_id"]`). So the attribution exists on the wire today and is simply discarded at log time.

`session_id` was already a parameter of `search()` and `recall()` and already in scope at both logging call sites — it just was never passed down to `log_query` / `log_result`, and there is no join back, since `session_records` is keyed `(session_id, user_id)` and a query row holds nothing pointing at a session. That makes this plumbing plus a column, with no derivation logic — the one part of #4426 that needed real thought (working out which dataset a fanned-out search resolved to) has no analogue here.

Ticket: SDK-407 — https://linear.app/cognee/issue/SDK-407/add-session-id-to-recallsearch-history

## What changed

24 lines of production code:

| File | Change |
|---|---|
| `models/Query.py`, `models/Result.py` | `session_id = Column(String, index=True, nullable=True)` |
| `operations/log_query.py`, `log_result.py` | one optional parameter, passed onto the row |
| `operations/log_search_history.py` | accept it, forward to both writers |
| `operations/get_history.py` | project it on both sides of the UNION |
| `methods/search.py`, `api/v1/recall/recall.py` | pass it at the two call sites |

Plus one alembic revision (`a7c3e9f1b5d8`, near-verbatim copy of `e5a7b9c1d3f4`) and one test file.

Nullable, indexed, forward-looking. Every new parameter is optional, so no existing caller changes.

## The one case worth reviewing

`log_search_history` writes **one row per dataset payload** (#4436), so a search fanning over three datasets becomes three query rows — all of which belong to the same session. If `session_id` were stamped only on the first, per-agent attribution would be silently wrong for every multi-dataset search. `test_every_fanned_out_row_carries_the_session` covers exactly that.

## Not in scope

- **No backfill.** Existing rows keep NULL, exactly as SDK-393 chose.
- **Getting session ids into the remaining integrations.** Claude Code, Codex and `web-widget` already send one. The other integrations weren't audited. Raw API callers correctly record NULL.

## Verification

- `57 passed` in `cognee/tests/unit/modules/search/`
- `pre-commit run --all-files` — all hooks pass
- Single alembic head (`a7c3e9f1b5d8`)
- Migration applied **and rolled back** against a temp SQLite DB stamped at `e5a7b9c1d3f4`: column and index appear on both `queries` and `results`, and both are gone after downgrade

## Merge order (@NMZivkovic worth a look)

This revises `e5a7b9c1d3f4` as `a7c3e9f1b5d8`. Branch `feat/recall-coverage` (#4443, SDK-406) also revises `e5a7b9c1d3f4`, as `c7e9a1b3d5f2`. Whichever merges second needs its `down_revision` rebased onto the other, and #4443 has a single-head assertion whose constant needs updating. This PR is the smaller one and unblocks the other, so merging it first is the cheaper order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
