### PR TITLE
[COG-6130] feat: add opt-in divisive (top-down) bucket-construction s…

### DIFF
--- a/cognee/memify_pipelines/global_context_index.py
+++ b/cognee/memify_pipelines/global_context_index.py
@@ -8,6 +8,7 @@ from cognee.tasks.memify.global_context_index import (
     extract_global_context_index_input,
     update_global_context_index,
 )
+from cognee.tasks.memify.global_context_index.build import BuildStrategyName
 from cognee.tasks.memify.global_context_index.bucketing_strategy import BucketingStrategyName
 from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
@@ -17,6 +18,7 @@ def get_global_context_index_memify_tasks(
     placement_distance_threshold: float = 0.5,
     rebuild: bool = False,
     bucketing_strategy: BucketingStrategyName = "vector",
+    build_strategy: BuildStrategyName = "seed_and_absorb",
     min_overlap: float = 0.05,
 ):
     """
@@ -27,7 +29,8 @@ def get_global_context_index_memify_tasks(
     ``bucketing_strategy="graph"`` is experimental, uses ``min_overlap`` for
     level-0 graph placement, and falls back to vector bucketing for levels
     above 0. Switching between vector-built and graph-built indexes requires
-    ``rebuild=True``.
+    ``rebuild=True``. ``build_strategy="divisive"`` only affects a dataset's
+    very first build (see COG-6130); it has no effect on later updates.
     """
     return (
         [Task(extract_global_context_index_input)],
@@ -38,6 +41,7 @@ def get_global_context_index_memify_tasks(
                 max_bucket_size=max_bucket_size,
                 placement_distance_threshold=placement_distance_threshold,
                 bucketing_strategy=bucketing_strategy,
+                build_strategy=build_strategy,
                 min_overlap=min_overlap,
             )
         ],
@@ -52,6 +56,7 @@ async def global_context_index_pipeline(
     placement_distance_threshold: float = 0.5,
     rebuild: bool = False,
     bucketing_strategy: BucketingStrategyName = "vector",
+    build_strategy: BuildStrategyName = "seed_and_absorb",
     min_overlap: float = 0.05,
 ):
     """
@@ -66,6 +71,7 @@ async def global_context_index_pipeline(
         placement_distance_threshold=placement_distance_threshold,
         rebuild=rebuild,
         bucketing_strategy=bucketing_strategy,
+        build_strategy=build_strategy,
         min_overlap=min_overlap,
     )
 

--- a/cognee/tasks/memify/global_context_index/bucketing/divisive/__init__.py
+++ b/cognee/tasks/memify/global_context_index/bucketing/divisive/__init__.py
@@ -1,0 +1,1 @@
+"""Divisive (top-down) bucket-construction helpers for the global context index."""

--- a/cognee/tasks/memify/global_context_index/bucketing/divisive/graph_distance.py
+++ b/cognee/tasks/memify/global_context_index/bucketing/divisive/graph_distance.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+from ..graph.scoring import entities_weight, weighted_jaccard
+
+
+def build_graph_pole_a_fn(
+    entities_by_summary_id: Mapping[str, set[str]],
+    idf_weights: Mapping[str, float],
+) -> Callable[[list[str]], str]:
+    """
+    Pole A: the item with the highest aggregate entity distinctiveness (same
+    signal ``_sort_entity_seeds`` uses in the bottom-up strategy). Ties break
+    on ascending id.
+    """
+
+    def pole_a_fn(ids: list[str]) -> str:
+        return sorted(
+            ids,
+            key=lambda item_id: (
+                -entities_weight(entities_by_summary_id.get(item_id, set()), idf_weights),
+                item_id,
+            ),
+        )[0]
+
+    return pole_a_fn
+
+
+def build_graph_similarity_fn(
+    entities_by_summary_id: Mapping[str, set[str]],
+    idf_weights: Mapping[str, float],
+) -> Callable[[str, str], float]:
+    """
+    Entity-overlap similarity between two items, reusing ``weighted_jaccard``
+    exactly as the bottom-up strategy does. Only valid at level 0, where each
+    item is a single TextSummary.
+    """
+
+    def similarity_fn(left_id: str, right_id: str) -> float:
+        left_entities = entities_by_summary_id.get(left_id, set())
+        right_entities = entities_by_summary_id.get(right_id, set())
+        return weighted_jaccard(left_entities, right_entities, idf_weights)
+
+    return similarity_fn
+
+
+def build_graph_group_similarity_fn(
+    entities_by_summary_id: Mapping[str, set[str]],
+    idf_weights: Mapping[str, float],
+) -> Callable[[str, list[str]], float]:
+    """
+    Resolves a tie between the two poles: similarity of an item to the union
+    of entities of a group's members, used only for items that scored
+    exactly equal against both poles (see ``split.py``'s ``_resolve_ties``).
+    """
+
+    def group_similarity_fn(item_id: str, group_ids: list[str]) -> float:
+        item_entities = entities_by_summary_id.get(item_id, set())
+        group_entities: set[str] = set()
+        for group_id in group_ids:
+            group_entities.update(entities_by_summary_id.get(group_id, set()))
+        return weighted_jaccard(item_entities, group_entities, idf_weights)
+
+    return group_similarity_fn

--- a/cognee/tasks/memify/global_context_index/bucketing/divisive/placement.py
+++ b/cognee/tasks/memify/global_context_index/bucketing/divisive/placement.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .graph_distance import (
+    build_graph_group_similarity_fn,
+    build_graph_pole_a_fn,
+    build_graph_similarity_fn,
+)
+from .split import divisive_split
+from .vector_distance import (
+    build_vector_group_similarity_fn,
+    build_vector_pole_a_fn,
+    build_vector_similarity_fn,
+    embed_items_for_divisive_split,
+)
+from ..common import create_bucket_node, mark_bucket_for_persistence, record_bucket_assignment
+from ..graph.placement import _partition_summaries
+from ...bucketing_strategy import BucketingStrategyName
+from ...models import BucketAssignment, SummaryNode
+
+
+async def build_divisive_buckets_for_level(
+    items: list[SummaryNode],
+    level: int,
+    dataset_id: str,
+    max_bucket_size: int,
+    bucketing_strategy: BucketingStrategyName,
+    vector_engine: Any,
+    entities_by_summary_id: Mapping[str, set[str]],
+    idf_weights: Mapping[str, float],
+) -> tuple[dict[str, SummaryNode], list[BucketAssignment]]:
+    """
+    Build one level of buckets top-down (divisive) for a dataset's very first,
+    complete build. Only called when there are no existing buckets at this
+    level (see build.py's ``is_first_build``/dispatch gating) -- incremental
+    updates always fall through to the existing bottom-up placement code,
+    which accepts these buckets unmodified because they have the same shape.
+
+    Uses the entity-overlap graph signal only at level 0 with
+    ``bucketing_strategy == "graph"``; every other case (level 0 with
+    ``"vector"``, or any level >= 1 regardless of ``bucketing_strategy``) uses
+    a vector-embedding signal instead.
+    """
+    if max_bucket_size < 1:
+        raise ValueError("max_bucket_size must be at least 1.")
+    if not items:
+        return {}, []
+
+    buckets_to_persist: dict[str, SummaryNode] = {}
+    assignments: list[BucketAssignment] = []
+
+    if level == 0 and bucketing_strategy == "graph":
+        entity_items, misc_items = _partition_summaries(items, entities_by_summary_id, idf_weights)
+        if entity_items:
+            pole_a_fn = build_graph_pole_a_fn(entities_by_summary_id, idf_weights)
+            similarity_fn = build_graph_similarity_fn(entities_by_summary_id, idf_weights)
+            group_similarity_fn = build_graph_group_similarity_fn(
+                entities_by_summary_id, idf_weights
+            )
+            item_id_groups = divisive_split(
+                [item.id for item in entity_items],
+                similarity_fn,
+                pole_a_fn,
+                max_bucket_size,
+                group_similarity_fn,
+            )
+            for child_ids in item_id_groups:
+                _add_bucket(
+                    child_ids,
+                    dataset_id,
+                    level,
+                    buckets_to_persist,
+                    assignments,
+                    graph_bucket_entity_ids=_union_entities(child_ids, entities_by_summary_id),
+                )
+
+        for chunk in _chunk_ids(sorted(item.id for item in misc_items), max_bucket_size):
+            _add_bucket(
+                chunk,
+                dataset_id,
+                level,
+                buckets_to_persist,
+                assignments,
+                graph_bucket_entity_ids=set(),
+            )
+
+        return buckets_to_persist, assignments
+
+    vectors_by_id = await embed_items_for_divisive_split(items, vector_engine)
+    pole_a_fn = build_vector_pole_a_fn(vectors_by_id)
+    similarity_fn = build_vector_similarity_fn(vectors_by_id)
+    group_similarity_fn = build_vector_group_similarity_fn(vectors_by_id)
+    item_id_groups = divisive_split(
+        [item.id for item in items], similarity_fn, pole_a_fn, max_bucket_size, group_similarity_fn
+    )
+    for child_ids in item_id_groups:
+        _add_bucket(child_ids, dataset_id, level, buckets_to_persist, assignments)
+
+    return buckets_to_persist, assignments
+
+
+def _add_bucket(
+    child_ids: list[str],
+    dataset_id: str,
+    level: int,
+    buckets_to_persist: dict[str, SummaryNode],
+    assignments: list[BucketAssignment],
+    graph_bucket_entity_ids: set[str] | None = None,
+) -> None:
+    bucket = create_bucket_node(
+        child_ids, dataset_id, level, graph_bucket_entity_ids=graph_bucket_entity_ids
+    )
+    mark_bucket_for_persistence(buckets_to_persist, bucket)
+    for child_id in child_ids:
+        record_bucket_assignment(assignments, child_id, bucket.id)
+
+
+def _union_entities(
+    child_ids: list[str],
+    entities_by_summary_id: Mapping[str, set[str]],
+) -> set[str]:
+    entity_ids: set[str] = set()
+    for child_id in child_ids:
+        entity_ids.update(entities_by_summary_id.get(child_id, set()))
+    return entity_ids
+
+
+def _chunk_ids(item_ids: list[str], chunk_size: int) -> list[list[str]]:
+    return [item_ids[index : index + chunk_size] for index in range(0, len(item_ids), chunk_size)]

--- a/cognee/tasks/memify/global_context_index/bucketing/divisive/split.py
+++ b/cognee/tasks/memify/global_context_index/bucketing/divisive/split.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+# Below this fraction of a group's size, a side is treated as "too imbalanced"
+# and the deterministic alphabetical fallback is used instead. Guards against
+# recursion depth degrading toward O(n) when a genuine pole-based split keeps
+# producing lopsided sides (e.g. many items tie against the same pole).
+MIN_SIDE_FRACTION = 0.1
+
+
+def divisive_split(
+    item_ids: Sequence[str],
+    similarity_fn: Callable[[str, str], float],
+    pole_a_fn: Callable[[list[str]], str],
+    max_bucket_size: int,
+    group_similarity_fn: Callable[[str, list[str]], float] | None = None,
+) -> list[list[str]]:
+    """
+    Recursively partition ``item_ids`` top-down: pick two "poles" (dissimilar
+    reference items), assign every other item to whichever pole it scores
+    strictly higher against, and recurse on each side until every group fits
+    ``max_bucket_size``.
+
+    ``similarity_fn``/``pole_a_fn`` are pluggable so the same algorithm serves
+    both the graph-based (entity) and vector-based (embedding cosine
+    similarity) flavors -- see ``graph_distance.py``/``vector_distance.py``.
+
+    Items that score exactly equal against both poles are held aside and
+    resolved against the two sides actually formed by the strict winners
+    (via ``group_similarity_fn``, e.g. distance from each side's centroid or
+    entity union), instead of defaulting to a fixed pole. If
+    ``group_similarity_fn`` is omitted, ties default to pole A's side.
+    """
+    if max_bucket_size < 1:
+        raise ValueError("max_bucket_size must be at least 1.")
+    if not item_ids:
+        return []
+
+    buckets: list[list[str]] = []
+    _split(
+        sorted(item_ids), similarity_fn, pole_a_fn, max_bucket_size, buckets, group_similarity_fn
+    )
+    return buckets
+
+
+def _split(
+    ids: list[str],
+    similarity_fn: Callable[[str, str], float],
+    pole_a_fn: Callable[[list[str]], str],
+    max_bucket_size: int,
+    buckets: list[list[str]],
+    group_similarity_fn: Callable[[str, list[str]], float] | None,
+) -> None:
+    if len(ids) <= max_bucket_size:
+        buckets.append(ids)
+        return
+
+    pole_a, pole_b = _choose_poles(ids, similarity_fn, pole_a_fn)
+
+    side_a: list[str] = []
+    side_b: list[str] = []
+    tied: list[str] = []
+    for item_id in ids:
+        score_a = similarity_fn(item_id, pole_a)
+        score_b = similarity_fn(item_id, pole_b)
+        if score_a > score_b:
+            side_a.append(item_id)
+        elif score_b > score_a:
+            side_b.append(item_id)
+        else:
+            tied.append(item_id)
+
+    _resolve_ties(tied, side_a, side_b, group_similarity_fn)
+
+    if _is_stalled_or_imbalanced(side_a, side_b, len(ids)):
+        midpoint = len(ids) // 2
+        side_a, side_b = ids[:midpoint], ids[midpoint:]
+
+    _split(side_a, similarity_fn, pole_a_fn, max_bucket_size, buckets, group_similarity_fn)
+    _split(side_b, similarity_fn, pole_a_fn, max_bucket_size, buckets, group_similarity_fn)
+
+
+def _resolve_ties(
+    tied: list[str],
+    side_a: list[str],
+    side_b: list[str],
+    group_similarity_fn: Callable[[str, list[str]], float] | None,
+) -> None:
+    if not tied:
+        return
+
+    if group_similarity_fn is None:
+        side_a.extend(tied)
+        return
+
+    # Score every tied item against a fixed snapshot of the strict winners --
+    # not the lists as they grow -- so resolving one tie never shifts the
+    # reference group used for the next one.
+    strict_side_a = list(side_a)
+    strict_side_b = list(side_b)
+
+    for item_id in tied:
+        group_score_a = (
+            group_similarity_fn(item_id, strict_side_a) if strict_side_a else float("-inf")
+        )
+        group_score_b = (
+            group_similarity_fn(item_id, strict_side_b) if strict_side_b else float("-inf")
+        )
+        (side_a if group_score_a >= group_score_b else side_b).append(item_id)
+
+
+def _choose_poles(
+    ids: list[str],
+    similarity_fn: Callable[[str, str], float],
+    pole_a_fn: Callable[[list[str]], str],
+) -> tuple[str, str]:
+    pole_a = pole_a_fn(ids)
+
+    best_pole_b: str | None = None
+    best_score = float("inf")
+    for candidate_id in ids:
+        if candidate_id == pole_a:
+            continue
+        score = similarity_fn(pole_a, candidate_id)
+        if score < best_score:
+            best_score = score
+            best_pole_b = candidate_id
+
+    return pole_a, best_pole_b
+
+
+def _is_stalled_or_imbalanced(side_a: list[str], side_b: list[str], group_size: int) -> bool:
+    if not side_a or not side_b:
+        return True
+
+    min_side_size = max(1, round(MIN_SIDE_FRACTION * group_size))
+    return min(len(side_a), len(side_b)) < min_side_size

--- a/cognee/tasks/memify/global_context_index/bucketing/divisive/vector_distance.py
+++ b/cognee/tasks/memify/global_context_index/bucketing/divisive/vector_distance.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any
+
+from ...models import SummaryNode
+
+
+def cosine_distance(left_vector: Iterable[float], right_vector: Iterable[float]) -> float:
+    left = list(left_vector)
+    right = list(right_vector)
+    dot_product = sum(left_dim * right_dim for left_dim, right_dim in zip(left, right))
+    left_norm = math.sqrt(sum(left_dim * left_dim for left_dim in left))
+    right_norm = math.sqrt(sum(right_dim * right_dim for right_dim in right))
+    if left_norm == 0 or right_norm == 0:
+        return 1.0
+    return 1.0 - dot_product / (left_norm * right_norm)
+
+
+async def embed_items_for_divisive_split(
+    items: list[SummaryNode],
+    vector_engine: Any,
+) -> dict[str, list[float]]:
+    """
+    Batch-embed every item's text once, so pole-selection/side-assignment can
+    compare arbitrary pairs. The existing "vector" strategy only does ANN
+    ``search()`` for top-K neighbors, which can't give a pairwise distance
+    between two arbitrary items -- this re-embeds directly via the embedding
+    engine instead.
+    """
+    if not items:
+        return {}
+
+    texts = [item.text for item in items]
+    vectors = await vector_engine.embedding_engine.embed_text(texts)
+    return {item.id: vector for item, vector in zip(items, vectors)}
+
+
+def build_vector_pole_a_fn(
+    vectors_by_id: Mapping[str, list[float]],
+) -> Callable[[list[str]], str]:
+    """
+    Pole A: the item farthest (by cosine distance) from the current
+    subgroup's centroid -- the vector-space analog of "most distinctive".
+    Ties break on ascending id.
+    """
+
+    def pole_a_fn(ids: list[str]) -> str:
+        dimensions = len(vectors_by_id[ids[0]])
+        centroid = [
+            sum(vectors_by_id[item_id][dimension] for item_id in ids) / len(ids)
+            for dimension in range(dimensions)
+        ]
+        return sorted(
+            ids,
+            key=lambda item_id: (-cosine_distance(vectors_by_id[item_id], centroid), item_id),
+        )[0]
+
+    return pole_a_fn
+
+
+def build_vector_similarity_fn(
+    vectors_by_id: Mapping[str, list[float]],
+) -> Callable[[str, str], float]:
+    def similarity_fn(left_id: str, right_id: str) -> float:
+        return 1.0 - cosine_distance(vectors_by_id[left_id], vectors_by_id[right_id])
+
+    return similarity_fn
+
+
+def build_vector_group_similarity_fn(
+    vectors_by_id: Mapping[str, list[float]],
+) -> Callable[[str, list[str]], float]:
+    """
+    Resolves a tie between the two poles: similarity of an item to a group's
+    centroid, used only for items that scored exactly equal against both
+    poles (see ``split.py``'s ``_resolve_ties``).
+    """
+
+    def group_similarity_fn(item_id: str, group_ids: list[str]) -> float:
+        dimensions = len(vectors_by_id[group_ids[0]])
+        centroid = [
+            sum(vectors_by_id[group_id][dimension] for group_id in group_ids) / len(group_ids)
+            for dimension in range(dimensions)
+        ]
+        return 1.0 - cosine_distance(vectors_by_id[item_id], centroid)
+
+    return group_similarity_fn

--- a/cognee/tasks/memify/global_context_index/build.py
+++ b/cognee/tasks/memify/global_context_index/build.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from cognee.modules.pipelines.models import PipelineContext
 from cognee.tasks.summarization.models import GlobalContextSummary
 
+from .bucketing.divisive.placement import build_divisive_buckets_for_level
 from .bucketing.graph.placement import (
     place_graph_summaries_incrementally,
     rebuild_graph_buckets_for_level,
@@ -21,6 +22,8 @@ from .summarize import (
     generate_bucket_summary_datapoints,
 )
 
+BuildStrategyName = Literal["seed_and_absorb", "divisive"]
+
 
 @dataclass(frozen=True)
 class BuildOptions:
@@ -32,6 +35,8 @@ class BuildOptions:
     min_overlap: float
     entities_by_summary_id: Mapping[str, set[str]]
     idf_weights: Mapping[str, float]
+    build_strategy: BuildStrategyName
+    is_first_build: bool
     ctx: PipelineContext | None
 
 
@@ -120,6 +125,38 @@ async def place_vector_items(
     )
 
 
+async def place_divisive_items(
+    all_items: list[SummaryNode],
+    level: int,
+    options: BuildOptions,
+) -> tuple[dict[str, SummaryNode], list[BucketAssignment]]:
+    return await build_divisive_buckets_for_level(
+        all_items,
+        level,
+        options.dataset_id,
+        options.max_bucket_size,
+        options.bucketing_strategy,
+        options.vector_engine,
+        options.entities_by_summary_id,
+        options.idf_weights,
+    )
+
+
+# Only the first, complete build of a dataset's index can use an alternative
+# build strategy (see ``is_first_build`` gating below); "seed_and_absorb" has
+# no entry because it means "no override -- fall through to the ordinary
+# bucketing_strategy dispatch".
+BUILD_STRATEGY_HANDLERS: dict[BuildStrategyName, Any] = {
+    "divisive": place_divisive_items,
+}
+
+# "graph" bucketing only ever applies at level 0; any level above it, or any
+# bucketing_strategy without an entry here, falls through to place_vector_items.
+BUCKETING_STRATEGY_LEVEL_ZERO_HANDLERS: dict[BucketingStrategyName, Any] = {
+    "graph": place_graph_items,
+}
+
+
 async def place_items_for_level(
     changed_items: list[SummaryNode],
     all_items: list[SummaryNode],
@@ -127,8 +164,15 @@ async def place_items_for_level(
     level: int,
     options: BuildOptions,
 ) -> tuple[dict[str, SummaryNode], list[BucketAssignment]]:
-    if options.bucketing_strategy == "graph" and level == 0:
-        return place_graph_items(changed_items, all_items, existing_buckets, level, options)
+    if options.is_first_build and not existing_buckets:
+        build_handler = BUILD_STRATEGY_HANDLERS.get(options.build_strategy)
+        if build_handler is not None:
+            return await build_handler(all_items, level, options)
+
+    if level == 0:
+        bucketing_handler = BUCKETING_STRATEGY_LEVEL_ZERO_HANDLERS.get(options.bucketing_strategy)
+        if bucketing_handler is not None:
+            return bucketing_handler(changed_items, all_items, existing_buckets, level, options)
 
     return await place_vector_items(changed_items, all_items, existing_buckets, level, options)
 
@@ -207,6 +251,7 @@ async def build_context_index(
     max_bucket_size: int,
     placement_distance_threshold: float,
     bucketing_strategy: BucketingStrategyName = "vector",
+    build_strategy: BuildStrategyName = "seed_and_absorb",
     min_overlap: float = 0.05,
     entities_by_summary_id: dict[str, set[str]] | None = None,
     idf_weights: dict[str, float] | None = None,
@@ -220,7 +265,14 @@ async def build_context_index(
     level does not exist yet. The loop stops once the topmost non-root level
     fits in the root's capacity. Root is regenerated when anything below
     changed or when no root exists yet.
+
+    ``build_strategy="divisive"`` only takes effect for a dataset's very
+    first, complete build (no existing root or buckets at all) -- it picks
+    poles top-down instead of seeding-and-absorbing bottom-up. It has no
+    effect once an index already exists; ordinary incremental placement is
+    used from then on regardless of how the index was originally built.
     """
+    is_first_build = existing_root is None and not any(buckets_by_level.values())
     options = BuildOptions(
         dataset_id=dataset_id,
         vector_engine=vector_engine,
@@ -230,6 +282,8 @@ async def build_context_index(
         min_overlap=min_overlap,
         entities_by_summary_id=entities_by_summary_id or {},
         idf_weights=idf_weights or {},
+        build_strategy=build_strategy,
+        is_first_build=is_first_build,
         ctx=ctx,
     )
 

--- a/cognee/tasks/memify/global_context_index/update.py
+++ b/cognee/tasks/memify/global_context_index/update.py
@@ -19,7 +19,7 @@ from .bucketing.graph.placement import (
     validate_graph_buckets_can_be_extended,
     validate_vector_buckets_can_be_extended,
 )
-from .build import build_context_index, group_buckets_by_level
+from .build import BuildStrategyName, build_context_index, group_buckets_by_level
 from .bucketing_strategy import BucketingStrategyName
 from .load import dataset_id_from_context, load_context_index_input_from_graph
 from .models import GlobalContextIndexUpdateData, SummaryNode
@@ -41,6 +41,7 @@ def validate_global_context_index_config(
     placement_distance_threshold: float,
     bucketing_strategy: BucketingStrategyName,
     min_overlap: float,
+    build_strategy: BuildStrategyName = "seed_and_absorb",
 ) -> None:
     if isinstance(max_bucket_size, bool) or not isinstance(max_bucket_size, int):
         raise ValueError("max_bucket_size must be an integer.")
@@ -56,6 +57,9 @@ def validate_global_context_index_config(
 
     if bucketing_strategy not in ("vector", "graph"):
         raise ValueError('bucketing_strategy must be "vector" or "graph".')
+
+    if build_strategy not in ("seed_and_absorb", "divisive"):
+        raise ValueError('build_strategy must be "seed_and_absorb" or "divisive".')
 
     if isinstance(min_overlap, bool) or not isinstance(min_overlap, Real):
         raise ValueError("min_overlap must be a finite number in [0.0, 1.0].")
@@ -235,6 +239,7 @@ async def build_and_persist_context_index(
     min_overlap: float,
     graph_bucketing_inputs: GraphBucketingInputs | None,
     ctx: PipelineContext | None,
+    build_strategy: BuildStrategyName = "seed_and_absorb",
 ) -> list[GlobalContextSummary]:
     entities_by_summary_id, idf_weights = unpack_graph_bucketing_inputs(graph_bucketing_inputs)
     context_datapoints, assignments = await build_context_index(
@@ -247,6 +252,7 @@ async def build_and_persist_context_index(
         max_bucket_size=max_bucket_size,
         placement_distance_threshold=placement_distance_threshold,
         bucketing_strategy=bucketing_strategy,
+        build_strategy=build_strategy,
         min_overlap=min_overlap,
         entities_by_summary_id=entities_by_summary_id,
         idf_weights=idf_weights,
@@ -264,6 +270,7 @@ async def update_global_context_index(
     max_bucket_size: int = 20,
     placement_distance_threshold: float = 0.5,
     bucketing_strategy: BucketingStrategyName = "vector",
+    build_strategy: BuildStrategyName = "seed_and_absorb",
     min_overlap: float = 0.05,
     ctx: PipelineContext | None = None,
 ) -> list[GlobalContextSummary]:
@@ -278,12 +285,22 @@ async def update_global_context_index(
     vector-built buckets cannot be extended by graph incremental mode, and
     existing graph-built buckets cannot be extended by vector incremental mode;
     use ``rebuild=True`` to switch strategies.
+
+    ``build_strategy="divisive"`` only takes effect when building a dataset's
+    index for the very first time (no existing buckets or root at all,
+    including right after ``rebuild=True`` wipes the index) -- it picks poles
+    top-down instead of seeding-and-absorbing bottom-up. If the dataset
+    already has an index, this parameter has no effect and ordinary
+    ``bucketing_strategy`` incremental placement is used (divisively-built
+    buckets are structurally identical to bottom-up ones, so this is always
+    safe, never inconsistent -- see COG-6130).
     """
     validate_global_context_index_config(
         max_bucket_size,
         placement_distance_threshold,
         bucketing_strategy,
         min_overlap,
+        build_strategy,
     )
     scope = await load_update_scope(data, bucketing_strategy, ctx)
     unified_engine, graph_bucketing_inputs = await prepare_existing_context_index(
@@ -318,4 +335,5 @@ async def update_global_context_index(
         min_overlap,
         graph_bucketing_inputs,
         ctx,
+        build_strategy,
     )

--- a/cognee/tests/unit/tasks/memify/test_global_context_index_divisive_bucketing.py
+++ b/cognee/tests/unit/tasks/memify/test_global_context_index_divisive_bucketing.py
@@ -1,0 +1,723 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cognee.tasks.memify.global_context_index.build as build_module
+import cognee.tasks.memify.global_context_index.update as update_module
+from cognee.tasks.memify.global_context_index.bucketing.divisive.graph_distance import (
+    build_graph_group_similarity_fn,
+    build_graph_pole_a_fn,
+    build_graph_similarity_fn,
+)
+from cognee.tasks.memify.global_context_index.bucketing.divisive.placement import (
+    build_divisive_buckets_for_level,
+)
+from cognee.tasks.memify.global_context_index.bucketing.divisive.split import divisive_split
+from cognee.tasks.memify.global_context_index.bucketing.divisive.vector_distance import (
+    build_vector_group_similarity_fn,
+    build_vector_pole_a_fn,
+    build_vector_similarity_fn,
+    cosine_distance,
+    embed_items_for_divisive_split,
+)
+from cognee.tasks.memify.global_context_index.bucketing.graph.placement import (
+    place_graph_summaries_incrementally,
+)
+from cognee.tasks.memify.global_context_index.bucketing.graph.scoring import weighted_jaccard
+from cognee.tasks.memify.global_context_index.bucketing.vector.placement import (
+    assign_items_to_buckets,
+)
+from cognee.tasks.memify.global_context_index.build import BuildOptions, place_items_for_level
+from cognee.tasks.memify.global_context_index.ids import create_bucket_id
+from cognee.tasks.memify.global_context_index.models import SummaryNode
+from cognee.tasks.memify.global_context_index.update import (
+    build_and_persist_context_index,
+    validate_global_context_index_config,
+)
+
+
+def _summary(summary_id: str, text: str | None = None) -> SummaryNode:
+    return SummaryNode(
+        id=summary_id, text=text if text is not None else f"{summary_id} text", type="TextSummary"
+    )
+
+
+def _bucket(bucket_id: str, child_ids: set[str], graph_bucket_entity_ids) -> SummaryNode:
+    return SummaryNode(
+        id=bucket_id,
+        text=f"{bucket_id} text",
+        type="GlobalContextSummary",
+        level=0,
+        child_ids=child_ids,
+        graph_bucket_entity_ids=graph_bucket_entity_ids,
+    )
+
+
+def _fake_vector_engine(vectors_by_text: dict[str, list[float]]):
+    async def embed_text(texts):
+        return [vectors_by_text[text] for text in texts]
+
+    return SimpleNamespace(embedding_engine=SimpleNamespace(embed_text=embed_text))
+
+
+def _make_similarity(pairs: dict[frozenset, float]):
+    def similarity_fn(left_id: str, right_id: str) -> float:
+        if left_id == right_id:
+            return 1.0
+        return pairs[frozenset({left_id, right_id})]
+
+    return similarity_fn
+
+
+# ---------------------------------------------------------------------------
+# split.py
+# ---------------------------------------------------------------------------
+
+
+def test_divisive_split_returns_single_leaf_when_group_fits_max_bucket_size():
+    buckets = divisive_split(
+        ["c", "a", "b"], lambda a, b: 0.0, lambda ids: ids[0], max_bucket_size=5
+    )
+
+    assert buckets == [["a", "b", "c"]]
+
+
+def test_divisive_split_recurses_until_every_leaf_fits_max_bucket_size():
+    groups = {"a1", "a2", "a3", "a4"}, {"b1", "b2", "b3", "b4"}
+    membership = {item_id: group_idx for group_idx, group in enumerate(groups) for item_id in group}
+
+    def similarity_fn(a, b):
+        return 1.0 if membership[a] == membership[b] else 0.0
+
+    def pole_a_fn(ids):
+        return sorted(ids)[0]
+
+    buckets = divisive_split(
+        ["a1", "a2", "a3", "a4", "b1", "b2", "b3", "b4"],
+        similarity_fn,
+        pole_a_fn,
+        max_bucket_size=2,
+    )
+
+    assert buckets == [["a1", "a2"], ["a3", "a4"], ["b1", "b2"], ["b3", "b4"]]
+
+
+def test_divisive_split_pole_b_tie_broken_by_ascending_id():
+    pairs = {
+        frozenset({"seed", "x1"}): 0.5,
+        frozenset({"seed", "x2"}): 0.5,
+        frozenset({"seed", "x3"}): 0.9,
+        frozenset({"x1", "x2"}): 0.5,
+        frozenset({"x1", "x3"}): 0.1,
+        frozenset({"x2", "x3"}): 0.1,
+    }
+    similarity_fn = _make_similarity(pairs)
+
+    buckets = divisive_split(
+        ["seed", "x1", "x2", "x3"], similarity_fn, lambda ids: "seed", max_bucket_size=3
+    )
+
+    # pole B is chosen as "x1" (first ascending-id item tied for lowest score
+    # against "seed"), not "x2" -- so "x1" ends up isolated, "x2" stays with seed.
+    # "x2" ties exactly against both poles and is resolved after the strict
+    # winners ("seed", "x3"), hence its position at the end of the list.
+    assert buckets == [["seed", "x3", "x2"], ["x1"]]
+
+
+def test_divisive_split_side_assignment_tie_goes_to_pole_a():
+    pairs = {
+        frozenset({"p", "q"}): 0.5,
+        frozenset({"p", "m"}): 0.3,
+        frozenset({"q", "m"}): 0.5,
+    }
+    similarity_fn = _make_similarity(pairs)
+
+    buckets = divisive_split(["p", "q", "m"], similarity_fn, lambda ids: "p", max_bucket_size=2)
+
+    # "q" ties exactly (0.5/0.5) between pole A ("p") and pole B ("m") -> stays with "p".
+    assert buckets == [["p", "q"], ["m"]]
+
+
+def test_divisive_split_anti_stall_guard_triggers_on_constructed_all_one_side_input():
+    buckets = divisive_split(
+        ["a", "b", "c", "d"], lambda a, b: 1.0, lambda ids: ids[0], max_bucket_size=2
+    )
+
+    # every item ties (constant similarity) -> side_b would be empty -> guard
+    # forces a deterministic alphabetical bisection instead.
+    assert buckets == [["a", "b"], ["c", "d"]]
+
+
+def test_divisive_split_anti_imbalance_guard_triggers_below_threshold_fraction():
+    ids = [f"x{i:02d}" for i in range(20)]
+
+    def similarity_fn(a, b):
+        if {a, b} == {"x00", "x01"}:
+            return 0.0
+        return 0.9
+
+    buckets = divisive_split(ids, similarity_fn, lambda group_ids: "x00", max_bucket_size=10)
+
+    # A natural pole-based split would put only "x01" on one side (1/20 = 5%,
+    # below the 10% imbalance threshold) -- the guard forces an even bisection.
+    assert buckets == [
+        [f"x{i:02d}" for i in range(10)],
+        [f"x{i:02d}" for i in range(10, 20)],
+    ]
+
+
+def test_divisive_split_is_deterministic_regardless_of_input_order():
+    groups = {"a1", "a2", "a3"}, {"b1", "b2", "b3"}
+    membership = {item_id: idx for idx, group in enumerate(groups) for item_id in group}
+
+    def similarity_fn(a, b):
+        return 1.0 if membership[a] == membership[b] else 0.0
+
+    def pole_a_fn(ids):
+        return sorted(ids)[0]
+
+    order_1 = ["a1", "b2", "a3", "b1", "a2", "b3"]
+    order_2 = ["b3", "a1", "b1", "a2", "b2", "a3"]
+
+    result_1 = divisive_split(order_1, similarity_fn, pole_a_fn, max_bucket_size=2)
+    result_2 = divisive_split(order_2, similarity_fn, pole_a_fn, max_bucket_size=2)
+
+    assert result_1 == result_2
+
+
+def test_divisive_split_raises_for_invalid_max_bucket_size():
+    with pytest.raises(ValueError, match="max_bucket_size"):
+        divisive_split(["a"], lambda a, b: 0.0, lambda ids: ids[0], max_bucket_size=0)
+
+
+def test_divisive_split_resolves_tie_via_group_similarity_when_provided():
+    pairs = {
+        frozenset({"A", "B"}): 0.9,
+        frozenset({"A", "C"}): 0.1,
+        frozenset({"A", "T"}): 0.5,
+        frozenset({"B", "C"}): 0.2,
+        frozenset({"B", "T"}): 0.1,
+        frozenset({"C", "T"}): 0.5,
+    }
+    similarity_fn = _make_similarity(pairs)
+
+    def group_similarity_fn(item_id, group_ids):
+        return sum(similarity_fn(item_id, group_id) for group_id in group_ids) / len(group_ids)
+
+    # pole A = "A" (forced), pole B = "C" (lowest score against "A"). "B" is a
+    # strict winner for side A (0.9 > 0.2). "T" ties exactly against both
+    # poles (0.5/0.5) -- resolved against the *formed* sides: average
+    # similarity to {"A", "B"} is 0.3, average similarity to {"C"} is 0.5, so
+    # "T" joins side B despite the tie against the raw poles.
+    buckets = divisive_split(
+        ["A", "B", "C", "T"],
+        similarity_fn,
+        lambda ids: "A",
+        max_bucket_size=2,
+        group_similarity_fn=group_similarity_fn,
+    )
+
+    assert buckets == [["A", "B"], ["C", "T"]]
+
+
+def test_divisive_split_group_similarity_ignored_without_group_similarity_fn():
+    pairs = {
+        frozenset({"A", "B"}): 0.9,
+        frozenset({"A", "C"}): 0.1,
+        frozenset({"A", "T"}): 0.5,
+        frozenset({"B", "C"}): 0.2,
+        frozenset({"C", "T"}): 0.5,
+    }
+    similarity_fn = _make_similarity(pairs)
+
+    buckets = divisive_split(
+        ["A", "B", "C", "T"], similarity_fn, lambda ids: "A", max_bucket_size=3
+    )
+
+    # Without a group_similarity_fn, the tied "T" defaults to pole A's side,
+    # exactly like the pre-existing tie-break rule.
+    assert buckets == [["A", "B", "T"], ["C"]]
+
+
+def test_divisive_split_group_similarity_all_tied_still_triggers_anti_stall_guard():
+    buckets = divisive_split(
+        ["a", "b", "c", "d"],
+        lambda a, b: 1.0,
+        lambda ids: ids[0],
+        max_bucket_size=2,
+        group_similarity_fn=lambda item_id, group_ids: 1.0,
+    )
+
+    # every item (including both poles) ties against everything -> both
+    # strict-winner sides are empty -> the -inf/-inf tie-break defaults to
+    # side A, which empties side B and triggers the same alphabetical
+    # fallback as the group_similarity_fn=None case.
+    assert buckets == [["a", "b"], ["c", "d"]]
+
+
+# ---------------------------------------------------------------------------
+# graph_distance.py
+# ---------------------------------------------------------------------------
+
+
+def test_build_graph_pole_a_fn_picks_highest_entities_weight_tie_broken_by_id():
+    entities_by_summary_id = {"s1": {"rare"}, "s2": {"common"}, "s3": {"rare"}}
+    idf_weights = {"rare": 2.0, "common": 0.5}
+
+    pole_a_fn = build_graph_pole_a_fn(entities_by_summary_id, idf_weights)
+
+    assert pole_a_fn(["s1", "s2", "s3"]) == "s1"
+
+
+def test_build_graph_similarity_fn_matches_weighted_jaccard():
+    entities_by_summary_id = {"s1": {"alice", "project-x"}, "s2": {"project-x", "bob"}}
+    idf_weights = {"alice": 2.0, "project-x": 1.0, "bob": 3.0}
+
+    similarity_fn = build_graph_similarity_fn(entities_by_summary_id, idf_weights)
+
+    expected = weighted_jaccard({"alice", "project-x"}, {"project-x", "bob"}, idf_weights)
+    assert similarity_fn("s1", "s2") == pytest.approx(expected)
+
+
+def test_build_graph_group_similarity_fn_matches_weighted_jaccard_against_entity_union():
+    entities_by_summary_id = {
+        "s1": {"alice"},
+        "s2": {"bob"},
+        "target": {"alice", "carol"},
+    }
+    idf_weights = {"alice": 1.0, "bob": 1.0, "carol": 1.0}
+
+    group_similarity_fn = build_graph_group_similarity_fn(entities_by_summary_id, idf_weights)
+
+    expected = weighted_jaccard({"alice", "carol"}, {"alice", "bob"}, idf_weights)
+    assert group_similarity_fn("target", ["s1", "s2"]) == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# vector_distance.py
+# ---------------------------------------------------------------------------
+
+
+def test_build_vector_pole_a_fn_picks_farthest_item_from_centroid_tie_broken_by_id():
+    vectors_by_id = {
+        "a": [1.0, 0.0],
+        "b": [-0.5, 0.8660254],
+        "c": [-0.5, -0.8660254],
+    }
+
+    pole_a_fn = build_vector_pole_a_fn(vectors_by_id)
+
+    # the three vectors are symmetric around the origin -> centroid is [0, 0]
+    # -> cosine_distance from a zero vector is 1.0 for all three (a genuine
+    # tie) -> smallest id wins, regardless of input order.
+    assert pole_a_fn(["c", "b", "a"]) == "a"
+
+
+def test_build_vector_similarity_fn_matches_one_minus_cosine_distance():
+    vectors_by_id = {"a": [1.0, 0.0], "b": [0.0, 1.0]}
+
+    similarity_fn = build_vector_similarity_fn(vectors_by_id)
+
+    expected = 1.0 - cosine_distance([1.0, 0.0], [0.0, 1.0])
+    assert similarity_fn("a", "b") == pytest.approx(expected)
+
+
+def test_build_vector_group_similarity_fn_matches_one_minus_cosine_distance_from_centroid():
+    vectors_by_id = {
+        "target": [1.0, 1.0],
+        "a": [1.0, 0.0],
+        "b": [0.0, 1.0],
+    }
+
+    group_similarity_fn = build_vector_group_similarity_fn(vectors_by_id)
+
+    centroid = [0.5, 0.5]
+    expected = 1.0 - cosine_distance([1.0, 1.0], centroid)
+    assert group_similarity_fn("target", ["a", "b"]) == pytest.approx(expected)
+
+
+@pytest.mark.asyncio
+async def test_embed_items_for_divisive_split_batches_embed_text_once():
+    items = [_summary("s1", text="alpha"), _summary("s2", text="beta")]
+    embed_text = AsyncMock(return_value=[[1.0, 0.0], [0.0, 1.0]])
+    vector_engine = SimpleNamespace(embedding_engine=SimpleNamespace(embed_text=embed_text))
+
+    vectors_by_id = await embed_items_for_divisive_split(items, vector_engine)
+
+    embed_text.assert_awaited_once_with(["alpha", "beta"])
+    assert vectors_by_id == {"s1": [1.0, 0.0], "s2": [0.0, 1.0]}
+
+
+# ---------------------------------------------------------------------------
+# placement.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_divisive_buckets_for_level_graph_signal_routes_misc_summaries_separately():
+    entity_items = [_summary(f"s{i}") for i in range(4)]
+    misc_items = [_summary(f"m{i}") for i in range(3)]
+    entities_by_summary_id = {
+        "s0": {"alice"},
+        "s1": {"alice"},
+        "s2": {"bob"},
+        "s3": {"bob"},
+        "m0": set(),
+        "m1": set(),
+        "m2": set(),
+    }
+    idf_weights = {"alice": 1.0, "bob": 1.0}
+
+    buckets, _ = await build_divisive_buckets_for_level(
+        entity_items + misc_items,
+        level=0,
+        dataset_id="dataset-1",
+        max_bucket_size=2,
+        bucketing_strategy="graph",
+        vector_engine=None,
+        entities_by_summary_id=entities_by_summary_id,
+        idf_weights=idf_weights,
+    )
+
+    child_sets = {frozenset(bucket.child_ids) for bucket in buckets.values()}
+    assert frozenset({"s0", "s1"}) in child_sets
+    assert frozenset({"s2", "s3"}) in child_sets
+    assert frozenset({"m0", "m1"}) in child_sets
+    assert frozenset({"m2"}) in child_sets
+
+    misc_buckets = [b for b in buckets.values() if b.child_ids & {"m0", "m1", "m2"}]
+    assert all(bucket.graph_bucket_entity_ids == set() for bucket in misc_buckets)
+
+
+@pytest.mark.asyncio
+async def test_build_divisive_buckets_for_level_respects_max_bucket_size_at_every_leaf():
+    items = [_summary(f"s{i}", text=f"s{i}") for i in range(9)]
+    vector_engine = _fake_vector_engine({f"s{i}": [float(i), 0.0] for i in range(9)})
+
+    buckets, _ = await build_divisive_buckets_for_level(
+        items,
+        level=0,
+        dataset_id="dataset-1",
+        max_bucket_size=3,
+        bucketing_strategy="vector",
+        vector_engine=vector_engine,
+        entities_by_summary_id={},
+        idf_weights={},
+    )
+
+    assert all(len(bucket.child_ids) <= 3 for bucket in buckets.values())
+    assert sum(len(bucket.child_ids) for bucket in buckets.values()) == 9
+
+
+@pytest.mark.asyncio
+async def test_build_divisive_buckets_for_level_graph_signal_sets_union_entity_ids():
+    items = [_summary("s1"), _summary("s2")]
+    entities_by_summary_id = {"s1": {"alice"}, "s2": {"alice", "bob"}}
+    idf_weights = {"alice": 1.0, "bob": 1.0}
+
+    buckets, _ = await build_divisive_buckets_for_level(
+        items,
+        level=0,
+        dataset_id="dataset-1",
+        max_bucket_size=5,
+        bucketing_strategy="graph",
+        vector_engine=None,
+        entities_by_summary_id=entities_by_summary_id,
+        idf_weights=idf_weights,
+    )
+
+    assert len(buckets) == 1
+    bucket = next(iter(buckets.values()))
+    assert bucket.graph_bucket_entity_ids == {"alice", "bob"}
+
+
+@pytest.mark.asyncio
+async def test_build_divisive_buckets_for_level_vector_signal_leaves_entity_ids_none():
+    items = [_summary("s1", text="s1"), _summary("s2", text="s2")]
+    vector_engine = _fake_vector_engine({"s1": [1.0, 0.0], "s2": [0.0, 1.0]})
+
+    buckets_vector, _ = await build_divisive_buckets_for_level(
+        items,
+        level=0,
+        dataset_id="dataset-1",
+        max_bucket_size=5,
+        bucketing_strategy="vector",
+        vector_engine=vector_engine,
+        entities_by_summary_id={},
+        idf_weights={},
+    )
+    assert all(bucket.graph_bucket_entity_ids is None for bucket in buckets_vector.values())
+
+    # level >= 1 always uses vector, even when bucketing_strategy="graph".
+    buckets_level1, _ = await build_divisive_buckets_for_level(
+        items,
+        level=1,
+        dataset_id="dataset-1",
+        max_bucket_size=5,
+        bucketing_strategy="graph",
+        vector_engine=vector_engine,
+        entities_by_summary_id={},
+        idf_weights={},
+    )
+    assert all(bucket.graph_bucket_entity_ids is None for bucket in buckets_level1.values())
+
+
+@pytest.mark.asyncio
+async def test_build_divisive_buckets_for_level_bucket_ids_are_deterministic():
+    items = [_summary("s1"), _summary("s2")]
+    entities_by_summary_id = {"s1": {"alice"}, "s2": {"alice"}}
+    idf_weights = {"alice": 1.0}
+
+    buckets, _ = await build_divisive_buckets_for_level(
+        items,
+        level=0,
+        dataset_id="dataset-1",
+        max_bucket_size=5,
+        bucketing_strategy="graph",
+        vector_engine=None,
+        entities_by_summary_id=entities_by_summary_id,
+        idf_weights=idf_weights,
+    )
+
+    bucket = next(iter(buckets.values()))
+    assert bucket.id == str(create_bucket_id("dataset-1", 0, ["s1", "s2"]))
+
+
+@pytest.mark.asyncio
+async def test_build_divisive_buckets_for_level_topic_separability_quality():
+    topics = {
+        "sports": {"soccer", "goal", "referee"},
+        "cooking": {"recipe", "oven", "spice"},
+    }
+    entities_by_summary_id: dict[str, set[str]] = {}
+    true_topic_by_item: dict[str, str] = {}
+    items = []
+    for topic, entities in topics.items():
+        for i in range(6):
+            item_id = f"{topic}_{i}"
+            items.append(_summary(item_id))
+            entities_by_summary_id[item_id] = set(entities)
+            true_topic_by_item[item_id] = topic
+    idf_weights = {entity: 1.0 for entities in topics.values() for entity in entities}
+
+    buckets, _ = await build_divisive_buckets_for_level(
+        items,
+        level=0,
+        dataset_id="dataset-1",
+        max_bucket_size=3,
+        bucketing_strategy="graph",
+        vector_engine=None,
+        entities_by_summary_id=entities_by_summary_id,
+        idf_weights=idf_weights,
+    )
+
+    for bucket in buckets.values():
+        topics_in_bucket = {true_topic_by_item[child_id] for child_id in bucket.child_ids}
+        assert len(topics_in_bucket) == 1
+
+
+@pytest.mark.asyncio
+async def test_build_divisive_buckets_for_level_does_not_mutate_input_summaries():
+    items = [_summary("s1"), _summary("s2")]
+    entities_by_summary_id = {"s1": {"alice"}, "s2": {"alice"}}
+    idf_weights = {"alice": 1.0}
+    original_ids = [item.id for item in items]
+    original_texts = [item.text for item in items]
+
+    await build_divisive_buckets_for_level(
+        items,
+        level=0,
+        dataset_id="dataset-1",
+        max_bucket_size=5,
+        bucketing_strategy="graph",
+        vector_engine=None,
+        entities_by_summary_id=entities_by_summary_id,
+        idf_weights=idf_weights,
+    )
+
+    assert [item.id for item in items] == original_ids
+    assert [item.text for item in items] == original_texts
+    assert all(item.global_context_bucket_id is None for item in items)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion: divisively-built buckets extend via the existing,
+# unmodified incremental placement code with zero id churn.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_divisively_built_graph_bucket_extends_via_place_graph_summaries_incrementally_with_zero_id_churn():
+    items = [_summary("s1"), _summary("s2")]
+    entities_by_summary_id = {"s1": {"alice"}, "s2": {"alice"}, "s3": {"alice"}}
+    idf_weights = {"alice": 1.0}
+
+    buckets, _ = await build_divisive_buckets_for_level(
+        items,
+        level=0,
+        dataset_id="dataset-1",
+        max_bucket_size=5,
+        bucketing_strategy="graph",
+        vector_engine=None,
+        entities_by_summary_id=entities_by_summary_id,
+        idf_weights=idf_weights,
+    )
+    existing_bucket = next(iter(buckets.values()))
+    original_bucket_id = existing_bucket.id
+
+    new_summary = _summary("s3")
+    place_graph_summaries_incrementally(
+        [new_summary],
+        [existing_bucket],
+        entities_by_summary_id,
+        idf_weights,
+        dataset_id="dataset-1",
+        level=0,
+        max_bucket_size=5,
+        min_overlap=0.05,
+    )
+
+    assert existing_bucket.id == original_bucket_id
+    assert existing_bucket.child_ids == {"s1", "s2", "s3"}
+
+
+@pytest.mark.asyncio
+async def test_divisively_built_vector_bucket_extends_via_assign_items_to_buckets_with_zero_id_churn():
+    items = [_summary("s1", text="s1"), _summary("s2", text="s2")]
+    build_vector_engine = _fake_vector_engine({"s1": [1.0, 0.0], "s2": [1.0, 0.0]})
+
+    buckets, _ = await build_divisive_buckets_for_level(
+        items,
+        level=0,
+        dataset_id="dataset-1",
+        max_bucket_size=5,
+        bucketing_strategy="vector",
+        vector_engine=build_vector_engine,
+        entities_by_summary_id={},
+        idf_weights={},
+    )
+    existing_bucket = next(iter(buckets.values()))
+    original_bucket_id = existing_bucket.id
+    assert existing_bucket.child_ids == {"s1", "s2"}
+
+    class _NearestResult:
+        def __init__(self, id_: str, score: float):
+            self.id = id_
+            self.score = score
+
+    search_results = [_NearestResult("s1", 0.1), _NearestResult("s2", 0.1)]
+    search_vector_engine = SimpleNamespace(search=AsyncMock(return_value=search_results))
+    new_summary = _summary("s3", text="s3")
+
+    await assign_items_to_buckets(
+        [new_summary],
+        [existing_bucket],
+        level=0,
+        dataset_id="dataset-1",
+        vector_engine=search_vector_engine,
+        source_collection="TextSummary_text",
+        max_bucket_size=5,
+        placement_distance_threshold=0.5,
+    )
+
+    assert existing_bucket.id == original_bucket_id
+    assert existing_bucket.child_ids == {"s1", "s2", "s3"}
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-level tests
+# ---------------------------------------------------------------------------
+
+
+def _build_options(**overrides) -> BuildOptions:
+    defaults = dict(
+        dataset_id="dataset-1",
+        vector_engine=None,
+        max_bucket_size=5,
+        placement_distance_threshold=0.5,
+        bucketing_strategy="vector",
+        min_overlap=0.05,
+        entities_by_summary_id={},
+        idf_weights={},
+        build_strategy="seed_and_absorb",
+        is_first_build=False,
+        ctx=None,
+    )
+    defaults.update(overrides)
+    return BuildOptions(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_place_items_for_level_dispatches_to_divisive_when_requested_and_no_existing_buckets(
+    monkeypatch,
+):
+    calls = []
+
+    async def fake_divisive(all_items, level, options):
+        calls.append("divisive")
+        return {}, []
+
+    monkeypatch.setitem(build_module.BUILD_STRATEGY_HANDLERS, "divisive", fake_divisive)
+
+    options = _build_options(build_strategy="divisive", is_first_build=True)
+    await place_items_for_level([], [], [], level=0, options=options)
+
+    assert calls == ["divisive"]
+
+
+@pytest.mark.asyncio
+async def test_place_items_for_level_ignores_divisive_when_existing_buckets_present(monkeypatch):
+    calls = []
+
+    async def fake_divisive(all_items, level, options):
+        calls.append("divisive")
+        return {}, []
+
+    def fake_graph_items(changed_items, all_items, existing_buckets, level, options):
+        calls.append("graph")
+        return {}, []
+
+    monkeypatch.setitem(build_module.BUILD_STRATEGY_HANDLERS, "divisive", fake_divisive)
+    monkeypatch.setitem(
+        build_module.BUCKETING_STRATEGY_LEVEL_ZERO_HANDLERS, "graph", fake_graph_items
+    )
+
+    options = _build_options(
+        bucketing_strategy="graph", build_strategy="divisive", is_first_build=True
+    )
+    existing_bucket = _bucket("bucket-1", {"s1"}, {"alice"})
+
+    await place_items_for_level([], [], [existing_bucket], level=0, options=options)
+
+    assert calls == ["graph"]
+
+
+def test_validate_global_context_index_config_rejects_invalid_build_strategy():
+    with pytest.raises(ValueError, match="build_strategy"):
+        validate_global_context_index_config(20, 0.5, "vector", 0.05, build_strategy="invalid")
+
+
+@pytest.mark.asyncio
+async def test_build_and_persist_context_index_threads_build_strategy(monkeypatch):
+    captured = {}
+
+    async def fake_build_context_index(**kwargs):
+        captured.update(kwargs)
+        return [], []
+
+    monkeypatch.setattr(update_module, "build_context_index", fake_build_context_index)
+    monkeypatch.setattr(update_module, "persist_context_index_edges", AsyncMock())
+
+    scope = SimpleNamespace(
+        text_summaries=[],
+        dataset_id="dataset-1",
+        context_input=SimpleNamespace(buckets=[], root=None),
+    )
+    unified_engine = SimpleNamespace(vector=SimpleNamespace())
+
+    await build_and_persist_context_index(
+        scope, [], unified_engine, 20, 0.5, "graph", 0.05, None, None, build_strategy="divisive"
+    )
+
+    assert captured["build_strategy"] == "divisive"


### PR DESCRIPTION
## Summary

Adds `build_strategy: Literal["seed_and_absorb", "divisive"] = "seed_and_absorb"` as a
new, opt-in parameter for the global context index build, alongside the existing
`bucketing_strategy` ("graph" / "vector"). Default behavior is unchanged.

- **`seed_and_absorb`** (existing, default): bottom-up, greedy seed-and-absorb.
- **`divisive`** (new): top-down. Picks two dissimilar "poles" per group, assigns every
  item to whichever pole it scores strictly higher against, and recurses until every
  group fits `max_bucket_size`. Items that score exactly equal against both poles are
  resolved against the two sides actually formed by the strict winners (centroid
  distance for the vector-flavored signal, entity-union overlap for the graph-flavored
  signal), instead of defaulting to a fixed pole.
- Includes a deterministic anti-stall/anti-imbalance guard: if a pole-based split would
  leave one side empty or severely lopsided (< 10% of the group), it falls back to a
  deterministic alphabetical bisection instead.
- `divisive` only applies to a dataset's very first, complete build (`is_first_build`
  and no existing buckets at that level). Any later incremental update always falls
  through to the existing, unmodified bottom-up placement code — divisively-built
  buckets are structurally identical to bottom-up ones, so this requires zero new
  incremental-update logic and produces zero bucket-id churn.

## Scope note

This branch is built directly on `dev`, independent of the (still unmerged) COG-6129
entity-type/relationship-pattern similarity work. The graph-flavored divisive distance
therefore uses plain entity overlap (`weighted_jaccard`) only — no type/pattern
weighting. If COG-6129 merges first, a follow-up can extend the graph-flavored signal
to reuse `combined_similarity` the same way the bottom-up strategy will.

## Test plan

- [x] New `test_global_context_index_divisive_bucketing.py` (31 tests): split algorithm
      (pole selection, tie-breaking, anti-stall/imbalance guard, determinism), both
      distance flavors, placement orchestration, dispatch-level wiring, and the
      zero-id-churn acceptance criteria for incremental extension.
- [x] Full regression sweep (`cognee/tests/unit/tasks/memify/` +
      `cognee/tests/unit/modules/graph/`): 246 passed, no existing test modified.
- [x] `ruff check` / `ruff format --check` clean.


## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
