### PR TITLE
fix(search): Missing collection is empty results, not NoDataError

### DIFF
--- a/cognee/modules/retrieval/chunks_retriever.py
+++ b/cognee/modules/retrieval/chunks_retriever.py
@@ -2,7 +2,6 @@ from typing import Any, Optional, List, Union
 from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.modules.retrieval.base_retriever import BaseRetriever
-from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.infrastructure.databases.vector.exceptions.exceptions import CollectionNotFoundError
 
 logger = get_logger("ChunksRetriever")
@@ -97,7 +96,7 @@ class ChunksRetriever(BaseRetriever):
         """
         Retrieves document chunks context based on the query.
         Searches for document chunks relevant to the specified query using a vector engine.
-        Raises a NoDataError if no data is found in the system.
+        A missing chunk collection yields an empty result list.
         Parameters:
         -----------
             - query (str): The query string to search for relevant document chunks.
@@ -125,6 +124,10 @@ class ChunksRetriever(BaseRetriever):
 
             return found_chunks
 
-        except CollectionNotFoundError as error:
-            logger.error("DocumentChunk_text collection not found in vector database")
-            raise NoDataError("No data found in the system, please add data first.") from error
+        except CollectionNotFoundError:
+            # A dataset without this collection is a legitimate state (e.g. it
+            # holds only non-document data or was never cognified) — it
+            # contributes zero results. Raising here poisons multi-dataset
+            # searches: one such dataset would abort the whole merged query.
+            logger.info("DocumentChunk_text collection not found; returning no chunks")
+            return []

--- a/cognee/modules/retrieval/completion_retriever.py
+++ b/cognee/modules/retrieval/completion_retriever.py
@@ -6,7 +6,6 @@ from cognee.modules.retrieval.utils.completion import generate_completion
 from cognee.infrastructure.session.get_session_manager import get_session_manager
 from cognee.modules.retrieval.base_retriever import BaseRetriever
 from cognee.modules.retrieval.utils.used_graph_elements import extract_from_scored_results
-from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
 from cognee.context_global_variables import session_user
 from cognee.infrastructure.databases.cache.config import CacheConfig
@@ -57,9 +56,12 @@ class CompletionRetriever(BaseRetriever):
             )
 
             return found_chunks
-        except CollectionNotFoundError as error:
-            logger.error("DocumentChunk_text collection not found")
-            raise NoDataError("No data found in the system, please add data first.") from error
+        except CollectionNotFoundError:
+            # A dataset without document chunks is a legitimate state — it
+            # contributes zero results instead of aborting a multi-dataset
+            # search; the completion then answers over an empty context.
+            logger.info("DocumentChunk_text collection not found; returning no chunks")
+            return []
 
     def _extract_context_object_ids(self, retrieved_objects: Any) -> Optional[Dict[str, List[str]]]:
         """Extract node_ids from ScoredResult-like list for session QA."""
@@ -72,7 +74,7 @@ class CompletionRetriever(BaseRetriever):
         Retrieves relevant document chunks as context.
 
         Fetches document chunks based on a query from a vector engine and combines their text.
-        Returns empty string if no chunks are found. Raises NoDataError if the collection is not
+        Returns empty string if no chunks are found or the collection is not
         found.
 
         Parameters:

--- a/cognee/modules/retrieval/hybrid/chunks.py
+++ b/cognee/modules/retrieval/hybrid/chunks.py
@@ -49,7 +49,6 @@ async def retrieve_hybrid_chunks(
             candidate_limit,
             node_name,
             node_name_filter_operator,
-            required=True,
             query_vector=query_vector,
         ),
         search_collection(
@@ -148,7 +147,6 @@ async def search_collection(
     node_name: Optional[list[str]],
     node_name_filter_operator: str,
     *,
-    required: bool = False,
     apply_node_filter: bool = True,
     query_vector: Optional[list[float]] = None,
 ) -> list[Any]:
@@ -167,10 +165,9 @@ async def search_collection(
             node_name=search_node_name,
             node_name_filter_operator=search_operator,
         )
-    except CollectionNotFoundError as error:
-        if required:
-            logger.error("%s collection not found", collection_name)
-            raise NoDataError("No data found in the system, please add data first.") from error
+    except CollectionNotFoundError:
+        # A dataset without this collection is a legitimate state; the
+        # channel contributes nothing instead of aborting the whole search.
         logger.debug("%s collection not found; using empty channel", collection_name)
         return []
 

--- a/cognee/modules/retrieval/lexical_retriever.py
+++ b/cognee/modules/retrieval/lexical_retriever.py
@@ -81,10 +81,10 @@ class LexicalRetriever(BaseRetriever):
                     except Exception as e:
                         logger.error("Tokenizer failed for chunk %s: %s", chunk_id, str(e))
 
-            if chunk_count == 0:
-                logger.error("Initialization completed but no valid chunks were loaded.")
-                raise NoDataError("No valid chunks loaded during initialization.")
-
+            # A dataset without DocumentChunk nodes is a legitimate state
+            # (e.g. a route that stores rows instead of chunks, or data that
+            # was added but never cognified) — searches over an empty corpus
+            # return zero results instead of aborting a multi-dataset search.
             self._initialized = True
             logger.info("Initialized with %d document chunks", len(self.chunks))
 

--- a/cognee/modules/retrieval/summaries_retriever.py
+++ b/cognee/modules/retrieval/summaries_retriever.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, List, Union
 from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.modules.retrieval.base_retriever import BaseRetriever
-from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.infrastructure.databases.vector.exceptions.exceptions import CollectionNotFoundError
 
 logger = get_logger("SummariesRetriever")
@@ -31,8 +30,7 @@ class SummariesRetriever(BaseRetriever):
         """
         Retrieves text summary objects based on the query.
 
-        On encountering a missing collection, raises NoDataError with a message to add data
-        first.
+        A missing summary collection yields an empty result list.
 
         Parameters:
         -----------
@@ -58,16 +56,19 @@ class SummariesRetriever(BaseRetriever):
             logger.info(f"Found {len(summaries_results)} summaries from vector search")
 
             return summaries_results
-        except CollectionNotFoundError as error:
-            logger.error("TextSummary_text collection not found in vector database")
-            raise NoDataError("No data found in the system, please add data first.") from error
+        except CollectionNotFoundError:
+            # A dataset without summaries is a legitimate state (e.g. its
+            # pipeline route skips summarization) — it contributes zero
+            # results instead of aborting a multi-dataset search.
+            logger.info("TextSummary_text collection not found; returning no summaries")
+            return []
 
     async def get_context_from_objects(self, query: str, retrieved_objects: Any) -> str:
         """
         Retrieves relevant summaries as context.
 
         Fetches text summaries based on a query from a vector engine and combines their text.
-        Returns empty string if no summaries are found. Raises NoDataError if the collection is not
+        Returns empty string if no summaries are found or the collection is not
         found.
 
         Parameters:

--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from operator import itemgetter
 from cognee.base_config import get_base_config
 from cognee.infrastructure.databases.unified import get_unified_engine
+from cognee.infrastructure.databases.vector.exceptions.exceptions import CollectionNotFoundError
 from cognee.infrastructure.llm.prompts import render_prompt
 from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
@@ -153,9 +154,16 @@ class TemporalRetriever(GraphCompletionRetriever):
         vector_engine = unified.vector
         query_vector = (await vector_engine.embedding_engine.embed_text([query]))[0]
 
-        vector_search_results = await vector_engine.search(
-            collection_name="Event_name", query_vector=query_vector, limit=self.top_k
-        )
+        try:
+            vector_search_results = await vector_engine.search(
+                collection_name="Event_name", query_vector=query_vector, limit=self.top_k
+            )
+        except CollectionNotFoundError:
+            # A dataset without temporal events is a legitimate state — it
+            # contributes zero results; get_context_from_objects then falls
+            # back to the triplet path instead of aborting the search.
+            logger.info("Event_name collection not found; returning no vector results")
+            vector_search_results = []
 
         return {"relevant_events": relevant_events, "vector_search_results": vector_search_results}
 

--- a/cognee/modules/retrieval/triplet_retriever.py
+++ b/cognee/modules/retrieval/triplet_retriever.py
@@ -51,8 +51,8 @@ class TripletRetriever(BaseRetriever):
         Retrieves relevant triplets.
 
         Fetches triplets based on a query from a vector engine.
-        Returns empty list if no triplets are found. Raises NoDataError if the collection is not
-        found.
+        Returns empty list if no triplets are found. Raises NoDataError with setup
+        guidance when triplet embeddings were never created.
 
         Parameters:
         -----------
@@ -86,9 +86,13 @@ class TripletRetriever(BaseRetriever):
                 return []
 
             return found_triplets
-        except CollectionNotFoundError as error:
-            logger.error("Triplet_text collection not found")
-            raise NoDataError("No data found in the system, please add data first.") from error
+        except CollectionNotFoundError:
+            # Race window only: the has_collection guard above already raised
+            # the actionable "run create_triplet_embeddings" error when the
+            # collection never existed. A vanish between guard and search
+            # contributes zero results rather than a misleading error.
+            logger.info("Triplet_text collection not found; returning no triplets")
+            return []
 
     def _extract_context_object_ids(self, retrieved_objects: Any) -> Optional[Dict[str, List[str]]]:
         """Triplets are non-elementary graph objects; do not report IDs for session QA - object ids cannot be resolved"""

--- a/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
+++ b/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
@@ -10,7 +10,6 @@ from cognee.tasks.storage import add_data_points
 from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.chunking.models import DocumentChunk
 from cognee.modules.data.processing.document_types import TextDocument
-from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.modules.retrieval.completion_retriever import CompletionRetriever
 from cognee.infrastructure.engine import DataPoint
 from cognee.modules.data.processing.document_types import Document
@@ -316,12 +315,12 @@ async def test_rag_completion_context_top_k_limits_results(
 
 @pytest.mark.asyncio
 async def test_get_rag_completion_context_on_empty_graph(setup_test_environment_empty):
-    """Integration test: verify CompletionRetriever handles empty graph correctly."""
+    """Integration test: an absent chunk collection yields zero results
+    (a legitimate dataset state), not an aborted search."""
     retriever = CompletionRetriever()
     query = "Christina Mayer"
 
-    with pytest.raises(NoDataError):
-        await retriever.get_retrieved_objects(query)
+    assert await retriever.get_retrieved_objects(query) == []
 
     vector_engine = await get_vector_engine_async()
     await vector_engine.create_collection(

--- a/cognee/tests/integration/retrieval/test_search_missing_collection_tolerance.py
+++ b/cognee/tests/integration/retrieval/test_search_missing_collection_tolerance.py
@@ -112,6 +112,11 @@ async def test_cross_dataset_search_survives_missing_collections(mixed_datasets)
     rag_results = await cognee.search(query_type=SearchType.RAG_COMPLETION, query_text="Zorblatt")
     assert rag_results, "RAG completion must survive the bare dataset"
 
+    lexical_results = await cognee.search(
+        query_type=SearchType.CHUNKS_LEXICAL, query_text="Zorblatt"
+    )
+    assert lexical_results, "lexical chunk search must survive the bare dataset"
+
 
 @pytest.mark.asyncio
 async def test_search_on_collectionless_dataset_returns_empty(mixed_datasets):
@@ -122,3 +127,8 @@ async def test_search_on_collectionless_dataset_returns_empty(mixed_datasets):
     )
     # The per-dataset envelope survives; its search_result is simply empty.
     assert all(entry["search_result"] == [] for entry in results), results
+
+    lexical = await cognee.search(
+        query_type=SearchType.CHUNKS_LEXICAL, query_text="anything", datasets=[BARE_DATASET]
+    )
+    assert all(entry["search_result"] == [] for entry in lexical), lexical

--- a/cognee/tests/integration/retrieval/test_search_missing_collection_tolerance.py
+++ b/cognee/tests/integration/retrieval/test_search_missing_collection_tolerance.py
@@ -1,0 +1,124 @@
+"""Multi-dataset search must survive datasets that lack a collection.
+
+A dataset can be legitimately cognified (or simply added-but-not-cognified)
+without carrying every standard vector collection — e.g. a pipeline route
+that skips summarization never creates TextSummary_text. With per-dataset
+databases (access control on, the default), CHUNKS/SUMMARIES/RAG searches
+iterate every readable dataset; a missing collection used to raise
+NoDataError ("No data found in the system") and abort the WHOLE merged
+search, hiding the results of every healthy dataset. Caught live by the
+backwards-compatibility CI when a DLT dataset broke the lorem searches.
+
+Offline: LLM and embeddings are mocked.
+"""
+
+import pathlib
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+
+import cognee
+from cognee.api.v1.search import SearchType
+from cognee.context_global_variables import graph_db_config, vector_db_config
+from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine import (
+    LiteLLMEmbeddingEngine,
+)
+from cognee.infrastructure.llm.LLMGateway import LLMGateway
+from cognee.modules.engine.operations.setup import setup as engine_setup
+
+DOCS_DATASET = "docs_ds"
+BARE_DATASET = "bare_ds"
+DOC_TEXT = "Zorblatt Industries manufactures underwater bicycles in Reykjavik."
+
+
+async def _mock_embed_text(self, texts):
+    return [[float(len(t) % 7) / 10.0 + 0.1] * self.dimensions for t in texts]
+
+
+async def _mock_llm(text_input, system_prompt, response_model, **kwargs):
+    from cognee.shared.data_models import Edge, KnowledgeGraph, Node, SummarizedContent
+
+    if isinstance(response_model, type) and issubclass(response_model, KnowledgeGraph):
+        return KnowledgeGraph(
+            nodes=[Node(id="zorblatt", name="Zorblatt", type="Company", description="mfg")],
+            edges=[
+                Edge(source_node_id="zorblatt", target_node_id="zorblatt", relationship_name="is")
+            ],
+        )
+    if isinstance(response_model, type) and issubclass(response_model, SummarizedContent):
+        return SummarizedContent(summary="Underwater bicycle maker.", description="")
+    if response_model is str:
+        return "mock answer"
+    return response_model()
+
+
+@pytest_asyncio.fixture
+async def mixed_datasets(tmp_path, monkeypatch):
+    pytest.importorskip("ladybug")
+
+    monkeypatch.setenv("COGNEE_SKIP_CONNECTION_TEST", "true")
+    root = pathlib.Path(tmp_path)
+
+    from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+    from cognee.infrastructure.databases.vector.create_vector_engine import _create_vector_engine
+
+    _create_graph_engine.cache_clear()
+    _create_vector_engine.cache_clear()
+    create_relational_engine.cache_clear()
+    graph_db_config.set(None)
+    vector_db_config.set(None)
+
+    cognee.config.set_relational_db_config({"db_provider": "sqlite"})
+    cognee.config.system_root_directory(str(root / "system"))
+    cognee.config.data_root_directory(str(root / "data"))
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    await engine_setup()
+
+    with (
+        patch.object(LiteLLMEmbeddingEngine, "embed_text", new=_mock_embed_text),
+        patch.object(LLMGateway, "acreate_structured_output", new=_mock_llm),
+    ):
+        # A healthy dataset with every standard collection...
+        await cognee.add(DOC_TEXT, dataset_name=DOCS_DATASET)
+        await cognee.cognify(datasets=[DOCS_DATASET])
+        # ...and a dataset that was added but never cognified: its vector
+        # database exists with NO collections at all.
+        await cognee.add("bare dataset content, never cognified", dataset_name=BARE_DATASET)
+        yield
+
+    try:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_cross_dataset_search_survives_missing_collections(mixed_datasets):
+    """Searches spanning both datasets return the healthy dataset's results."""
+    chunk_results = await cognee.search(query_type=SearchType.CHUNKS, query_text="Zorblatt")
+    assert chunk_results, "healthy dataset's chunks must survive the bare dataset"
+    assert "Zorblatt" in str(chunk_results)
+
+    summary_results = await cognee.search(query_type=SearchType.SUMMARIES, query_text="Zorblatt")
+    assert summary_results, "healthy dataset's summaries must survive the bare dataset"
+
+    rag_results = await cognee.search(query_type=SearchType.RAG_COMPLETION, query_text="Zorblatt")
+    assert rag_results, "RAG completion must survive the bare dataset"
+
+
+@pytest.mark.asyncio
+async def test_search_on_collectionless_dataset_returns_empty(mixed_datasets):
+    """A search scoped to ONLY the bare dataset yields empty results — not
+    the misleading "No data found in the system" error."""
+    results = await cognee.search(
+        query_type=SearchType.CHUNKS, query_text="anything", datasets=[BARE_DATASET]
+    )
+    # The per-dataset envelope survives; its search_result is simply empty.
+    assert all(entry["search_result"] == [] for entry in results), results

--- a/cognee/tests/unit/modules/retrieval/chunks_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/chunks_retriever_test.py
@@ -55,8 +55,9 @@ async def test_get_context_success(mock_vector_engine):
 
 
 @pytest.mark.asyncio
-async def test_get_context_collection_not_found_error(mock_vector_engine):
-    """Test that CollectionNotFoundError is converted to NoDataError."""
+async def test_get_context_collection_not_found_returns_empty(mock_vector_engine):
+    """A missing collection is a legitimate dataset state: the retriever
+    contributes zero results instead of aborting a multi-dataset search."""
     mock_vector_engine.search.side_effect = CollectionNotFoundError("Collection not found")
 
     retriever = ChunksRetriever()
@@ -65,8 +66,7 @@ async def test_get_context_collection_not_found_error(mock_vector_engine):
         "cognee.modules.retrieval.chunks_retriever.get_unified_engine",
         return_value=_make_unified_mock(mock_vector_engine),
     ):
-        with pytest.raises(NoDataError, match="No data found"):
-            await retriever.get_retrieved_objects("test query")
+        assert await retriever.get_retrieved_objects("test query") == []
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/retrieval/hybrid_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/hybrid_retriever_test.py
@@ -145,7 +145,9 @@ async def test_query_batch_is_rejected_before_work_starts():
 
 
 @pytest.mark.asyncio
-async def test_missing_document_chunk_collection_raises_no_data_error():
+async def test_missing_document_chunk_collection_is_empty_channel():
+    """A dataset without document chunks must not abort hybrid search — the
+    vector-chunk channel contributes nothing and the fusion continues."""
     vector = MagicMock()
     vector.search = _vector_search(missing_collections={"DocumentChunk_text"})
     graph = MagicMock()
@@ -157,8 +159,9 @@ async def test_missing_document_chunk_collection_raises_no_data_error():
         new_callable=AsyncMock,
         return_value=_unified(vector=vector, graph=graph),
     ):
-        with pytest.raises(NoDataError, match="No data found"):
-            await retriever.get_retrieved_objects(query="q")
+        retrieved = await retriever.get_retrieved_objects(query="q")
+
+    assert retrieved["chunks"] == []
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/retrieval/rag_completion_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/rag_completion_retriever_test.py
@@ -45,8 +45,9 @@ async def test_get_context_success(mock_vector_engine):
 
 
 @pytest.mark.asyncio
-async def test_get_context_collection_not_found_error(mock_vector_engine):
-    """Test that CollectionNotFoundError is converted to NoDataError."""
+async def test_get_context_collection_not_found_returns_empty(mock_vector_engine):
+    """A missing chunk collection contributes zero results; the completion
+    then answers over an empty context instead of aborting the search."""
     mock_vector_engine.search.side_effect = CollectionNotFoundError("Collection not found")
 
     retriever = CompletionRetriever()
@@ -55,8 +56,7 @@ async def test_get_context_collection_not_found_error(mock_vector_engine):
         "cognee.modules.retrieval.completion_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
-        with pytest.raises(NoDataError, match="No data found"):
-            await retriever.get_retrieved_objects("test query")
+        assert await retriever.get_retrieved_objects("test query") == []
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/retrieval/summaries_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/summaries_retriever_test.py
@@ -52,8 +52,9 @@ async def test_get_context_success(mock_vector_engine):
 
 
 @pytest.mark.asyncio
-async def test_get_context_collection_not_found_error(mock_vector_engine):
-    """Test that CollectionNotFoundError is converted to NoDataError."""
+async def test_get_context_collection_not_found_returns_empty(mock_vector_engine):
+    """A dataset without summaries is a legitimate state (e.g. its pipeline
+    route skips summarization): zero results, not an aborted search."""
     mock_vector_engine.search.side_effect = CollectionNotFoundError("Collection not found")
 
     retriever = SummariesRetriever()
@@ -62,8 +63,7 @@ async def test_get_context_collection_not_found_error(mock_vector_engine):
         "cognee.modules.retrieval.summaries_retriever.get_unified_engine",
         return_value=_make_unified_mock(mock_vector_engine),
     ):
-        with pytest.raises(NoDataError, match="No data found"):
-            await retriever.get_retrieved_objects("test query")
+        assert await retriever.get_retrieved_objects("test query") == []
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
@@ -742,3 +742,36 @@ async def test_extract_time_from_query_with_none_values():
 
     assert time_from is None
     assert time_to is None
+
+
+@pytest.mark.asyncio
+async def test_missing_event_collection_is_empty_results(mock_graph_engine, mock_vector_engine):
+    """A dataset without temporal events (no Event_name collection) must not
+    abort the search: vector results are empty and context falls back to the
+    triplet path."""
+    from cognee.infrastructure.databases.vector.exceptions.exceptions import (
+        CollectionNotFoundError,
+    )
+
+    retriever = TemporalRetriever(top_k=5)
+
+    mock_graph_engine.collect_time_ids.return_value = ["e1"]
+    mock_graph_engine.collect_events.return_value = [
+        {"events": [{"id": "e1", "description": "Event 1"}]}
+    ]
+    mock_vector_engine.search.side_effect = CollectionNotFoundError("Event_name missing")
+
+    unified_mock = _make_unified_mock(mock_graph_engine, mock_vector_engine)
+
+    with (
+        patch.object(
+            retriever, "extract_time_from_query", return_value=("2024-01-01", "2024-12-31")
+        ),
+        patch(
+            "cognee.modules.retrieval.temporal_retriever.get_unified_engine",
+            return_value=unified_mock,
+        ),
+    ):
+        objects = await retriever.get_retrieved_objects("What happened in 2024?")
+
+    assert objects["vector_search_results"] == []

--- a/cognee/tests/unit/modules/retrieval/test_bm25_retriever.py
+++ b/cognee/tests/unit/modules/retrieval/test_bm25_retriever.py
@@ -119,3 +119,17 @@ async def test_no_match_query_returns_zero_scored_chunks():
     # LexicalRetriever still returns top_k payloads for a no-match query; all score 0.0.
     assert len(results) == 2
     assert all(score == 0.0 for _, score in results)
+
+
+@pytest.mark.asyncio
+async def test_empty_corpus_returns_no_results():
+    """A dataset with zero DocumentChunk nodes is a legitimate state (e.g. a
+    route that stores rows instead of chunks, or added-but-not-cognified
+    data): lexical search returns zero results instead of raising NoDataError
+    and aborting a multi-dataset search."""
+    retriever = BM25ChunksRetriever(top_k=3, with_scores=True)
+
+    with _patch_graph({}):
+        results = await retriever.get_retrieved_objects("anything")
+
+    assert results == []

--- a/cognee/tests/unit/modules/retrieval/triplet_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/triplet_retriever_test.py
@@ -79,8 +79,11 @@ async def test_get_context_empty_results(mock_vector_engine):
 
 
 @pytest.mark.asyncio
-async def test_get_objects_collection_not_found_error(mock_vector_engine):
-    """Test that CollectionNotFoundError is converted to NoDataError."""
+async def test_get_objects_collection_not_found_returns_empty(mock_vector_engine):
+    """The race window between the has_collection guard and the search
+    contributes zero results instead of a misleading error. (A collection
+    that never existed still raises the actionable memify guidance — see
+    test above.)"""
     mock_vector_engine.has_collection.side_effect = CollectionNotFoundError("Collection not found")
 
     retriever = TripletRetriever()
@@ -89,8 +92,7 @@ async def test_get_objects_collection_not_found_error(mock_vector_engine):
         "cognee.modules.retrieval.triplet_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
-        with pytest.raises(NoDataError, match="No data found"):
-            await retriever.get_retrieved_objects("test query")
+        assert await retriever.get_retrieved_objects("test query") == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

A dataset can be legitimately cognified **without** carrying every standard vector collection — a pipeline route that skips summarization never creates `TextSummary_text`, and an added-but-never-cognified dataset has no collections at all. With per-dataset databases (access control on, the default), `CHUNKS` / `SUMMARIES` / `RAG_COMPLETION` / hybrid searches iterate every readable dataset — and **one** such dataset raised `NoDataError` (*"No data found in the system, please add data first"*), aborting the entire merged search and hiding every healthy dataset's results behind a message that is simply false.

Caught live by the backwards-compatibility CI on the DLT branch: a DLT dataset (which legitimately has no summaries) broke the SUMMARIES smoke search over the document dataset sitting right next to it.

## The fix

The inference *"missing collection ⇒ empty system"* predates routes that skip pipeline stages; it no longer holds. Retrievers now treat a missing collection exactly like the graph-completion vector sweep already does (`node_edge_vector_search.py` catches per collection and continues): **that scope contributes zero results and the search goes on.**

- `chunks_retriever`, `summaries_retriever`, `completion_retriever` (RAG): `CollectionNotFoundError` → `[]`
- hybrid `search_collection`: the `required=True` escape hatch removed — a missing collection is always an empty channel
- `triplet_retriever`: **deliberately unchanged** where it matters — the `has_collection` guard still raises its actionable *"first use the create_triplet_embeddings memify pipeline"* guidance for the opt-in feature; only the race-window catch behind it returns empty now

Nothing in production catches `NoDataError` (verified — only tests), so no handler/API contract changes; empty-result semantics also match the documented permission-filtering behavior ("returns empty list rather than error").

## Testing

- **New integration test** pins the demonstrated scenario: one healthy cognified dataset + one collectionless dataset; `CHUNKS`/`SUMMARIES`/`RAG_COMPLETION` spanning both return the healthy dataset's results, and a search scoped to the bare dataset returns an empty `search_result` instead of erroring. Offline (LLM + embeddings mocked).
- Five existing unit tests flipped from asserting `NoDataError` to asserting empty results; the triplet guidance test unchanged.
- Full retrieval unit suite green (400 tests), flipped RAG integration test green.

## Note

No Linear key yet — happy to add `COG-xxx` to the title once a ticket exists (the `Require Linear issue` check will flag until then).