### PR TITLE
fix: Remove flaky ontology assert in e2e test

### DIFF
--- a/cognee/tests/test_cognee_server_start.py
+++ b/cognee/tests/test_cognee_server_start.py
@@ -179,15 +179,6 @@ class TestCogneeServerStart(unittest.TestCase):
         )
         self.assertEqual(graph_response.status_code, 200)
 
-        graph_data = graph_response.json()
-        ontology_nodes = [
-            node for node in graph_data.get("nodes") if node.get("properties").get("ontology_valid")
-        ]
-
-        self.assertGreater(
-            len(ontology_nodes), 0, "No ontology nodes found - ontology was not integrated"
-        )
-
         # Search request
         url = "http://127.0.0.1:8000/api/v1/search"
 


### PR DESCRIPTION
## Description

The "Server Start Test" e2e job fails intermittently (e.g. [this run](https://github.com/topoteretes/cognee/actions/runs/31633676961/job/94238597291)) on:

```
AssertionError: 0 not greater than 0 : No ontology nodes found - ontology was not integrated
```

**Why it's flaky:** the assertion sits downstream of two chained nondeterministic LLM calls. The test cognifies `test_data/example.png` (the programmers/light-bulb joke) and asserts at least one node ends up with `ontology_valid=True`. That only happens when:

1. **image transcription** happens to focus on the joke's content rather than visual features (in the failing run it extracted `white background`, `sans-serif`, `left-aligned`, `top-left area`, …), and
2. **entity extraction** happens to split out `programmers` / `light bulb` / `hardware problem` as separate entities instead of keeping the whole joke as one entity (the failing run tried to ontology-match the literal full-joke string).

Ontology matching then uses fuzzy matching with a 0.8 cutoff (`cognee/modules/ontology/matching_strategies.py`), so none of those outputs ever match the tiny 8-class/3-individual test ontology — zero nodes get flagged and the assert fails. Whether the run goes green is pure LLM sampling luck.

**Change:** remove the ontology-match assertion and the dead `graph_data`/`ontology_nodes` code that only fed it. The test still validates the full server flow: health/root endpoints, auth, add, ontology upload (`200`), cognify, the dataset graph endpoint (`200`), and search.

A deterministic replacement (e.g. a text fixture whose extracted entities reliably hit the ontology, or asserting on graph construction rather than fuzzy ontology hits) can follow separately.