### PR TITLE
fix(files): detect file extensions case-insensitively

### DIFF
--- a/cognee/infrastructure/files/utils/guess_file_type.py
+++ b/cognee/infrastructure/files/utils/guess_file_type.py
@@ -52,6 +52,14 @@ def guess_file_type(file: BinaryIO, name: str | None = None) -> filetype.Type:
     elif name is not None:
         ext = Path(name).suffix
 
+    # File extensions are case-insensitive: a file named "data.CSV" must be
+    # detected the same as "data.csv". Without this, uppercase extensions for
+    # types that have no magic number (csv/md/json/xml/yaml) fall through to
+    # filetype.guess, return None, and get mislabeled as text/plain — so e.g. a
+    # ".CSV" is classified as a plain TextDocument instead of a CsvDocument.
+    if ext is not None:
+        ext = ext.lower()
+
     if ext in [".txt", ".text"]:
         file_type = Type("text/plain", "txt")
         return file_type

--- a/cognee/tests/unit/infrastructure/files/utils/test_guess_file_type.py
+++ b/cognee/tests/unit/infrastructure/files/utils/test_guess_file_type.py
@@ -1,0 +1,43 @@
+"""``guess_file_type`` must detect extensions case-insensitively.
+
+Extensions are case-insensitive by convention, but the extension-based mapping
+only matched lowercase. For types with no magic-number signature
+(csv/md/json/xml/yaml), an uppercase extension fell through to
+``filetype.guess``, returned ``None``, and was mislabeled ``text/plain`` — so a
+``data.CSV`` was classified as a plain ``TextDocument`` instead of a
+``CsvDocument`` (the crash for these was fixed in #3662, but the wrong type
+survived). PDFs and other magic-number formats are unaffected either way.
+"""
+
+import io
+
+import pytest
+
+from cognee.infrastructure.files.utils.guess_file_type import guess_file_type
+
+# Content with no magic number, so detection depends on the extension.
+_CSV_BYTES = b"name,age\nJohn,30\nJane,25\n"
+
+
+@pytest.mark.parametrize(
+    "name, expected_mime, expected_ext",
+    [
+        ("data.csv", "text/csv", "csv"),
+        ("data.CSV", "text/csv", "csv"),
+        ("notes.md", "text/markdown", "md"),
+        ("notes.MD", "text/markdown", "md"),
+        ("conf.json", "application/json", "json"),
+        ("conf.JSON", "application/json", "json"),
+        ("doc.XML", "application/xml", "xml"),
+        ("conf.YAML", "application/yaml", "yaml"),
+    ],
+)
+def test_extension_detection_is_case_insensitive(name, expected_mime, expected_ext):
+    file_type = guess_file_type(io.BytesIO(_CSV_BYTES), name=name)
+    assert file_type.mime == expected_mime
+    assert file_type.extension == expected_ext
+
+
+def test_uppercase_txt_is_still_plain_text():
+    file_type = guess_file_type(io.BytesIO(b"just some text"), name="README.TXT")
+    assert file_type.mime == "text/plain"


### PR DESCRIPTION
## Problem

`guess_file_type` (`cognee/infrastructure/files/utils/guess_file_type.py`) maps extensions to types with **case-sensitive** comparisons:

```python
if ext in [".txt", ".text"]: ...
if ext in [".csv"]: ...
if ext in [".md", ".markdown"]: ...
if ext in [".json"]: ...
if ext in [".xml"]: ...
if ext in [".yaml", ".yml"]: ...
```

`Path("data.CSV").suffix` is `".CSV"`, which matches none of these. For the extension-only types (csv/md/json/xml/yaml — none have a magic-number signature), an uppercase extension falls through to `filetype.guess`, which returns `None`, and the file is labeled `text/plain`.

`get_file_metadata` stores that guessed extension/mime, and `classify_documents` then selects the document class from it — so an uppercase `data.CSV` becomes a plain `TextDocument` (and the text chunker) instead of a `CsvDocument`.

### Reproduction

```python
import io
from cognee.infrastructure.files.utils.guess_file_type import guess_file_type
t = guess_file_type(io.BytesIO(b"name,age\nJohn,30\n"), name="data.CSV")
print(t.mime, t.extension)   # before: text/plain txt   |  after: text/csv csv
```

#3662 fixed the `KeyError` crash these files used to cause and lowercased the extension in `classify_documents`, but by then the type had already been lost upstream here.

## Fix

Lowercase the extension before the lookup. Magic-number formats (PDF, images, video, ...) were already case-independent and are unaffected; uppercase `.TXT` still resolves to `text/plain` as before.

## Tests

Adds `cognee/tests/unit/infrastructure/files/utils/test_guess_file_type.py`: parametrized lower/upper cases for csv/md/json/xml/yaml assert the same mime + extension regardless of case, plus a check that `.TXT` stays `text/plain`.

```
pytest cognee/tests/unit/infrastructure/files/utils/ -q   # passes
pre-commit run --files <changed files>                    # passes
```

Related: #3657 / #3662 (which addressed the crash; this restores correct type detection for the uppercase case).