### PR TITLE
fix(engine): guard falsy metadata in get_embeddable_property_names

### DIFF
--- a/cognee/infrastructure/engine/models/DataPoint.py
+++ b/cognee/infrastructure/engine/models/DataPoint.py
@@ -285,7 +285,14 @@ class DataPoint(BaseModel):
             A list of property names corresponding to the index fields, or an empty list if none
             exist.
         """
-        return data_point.metadata["index_fields"] or []
+        # Match the sibling accessors (get_embeddable_data / _properties) and the
+        # index_data_points guard, which all treat falsy metadata as "nothing to
+        # index". Without this, a node whose metadata is None or {} raises
+        # TypeError / KeyError here (e.g. via upsert_nodes) where those paths
+        # return an empty result.
+        if not data_point.metadata:
+            return []
+        return data_point.metadata.get("index_fields") or []
 
     def update_version(self) -> None:
         """

--- a/cognee/tests/unit/infrastructure/engine/test_embeddable_accessors.py
+++ b/cognee/tests/unit/infrastructure/engine/test_embeddable_accessors.py
@@ -1,0 +1,36 @@
+"""``get_embeddable_property_names`` must tolerate falsy metadata.
+
+``get_embeddable_data`` and ``get_embeddable_properties`` both guard
+``if data_point.metadata`` and return an empty result when metadata is None or
+``{}`` — and the ``index_data_points`` task skips such nodes with the same
+``not data_point.metadata`` check. ``get_embeddable_property_names`` was the odd
+one out: it indexed ``metadata["index_fields"]`` directly and raised
+TypeError / KeyError on falsy metadata (reached e.g. from ``upsert_nodes``).
+"""
+
+import pytest
+
+from cognee.infrastructure.engine.models.DataPoint import DataPoint
+
+
+class Thing(DataPoint):
+    name: str
+    metadata: dict = {"index_fields": ["name"]}
+
+
+def test_returns_index_fields_when_present():
+    thing = Thing(name="x")
+    assert DataPoint.get_embeddable_property_names(thing) == ["name"]
+
+
+@pytest.mark.parametrize("bad_metadata", [None, {}])
+def test_falsy_metadata_returns_empty_like_siblings(bad_metadata):
+    thing = Thing(name="x")
+    # Assignment is not validated on DataPoint, and the rest of the codebase
+    # explicitly guards for this falsy state.
+    thing.metadata = bad_metadata
+
+    assert DataPoint.get_embeddable_property_names(thing) == []
+    # Parity with the sibling accessors on the same object.
+    assert DataPoint.get_embeddable_properties(thing) == []
+    assert DataPoint.get_embeddable_data(thing) is None


### PR DESCRIPTION
## Problem

`DataPoint` has three sibling accessors for embeddable fields. Two of them guard falsy metadata; the third does not:

```python
# get_embeddable_data / get_embeddable_properties
if data_point.metadata and len(data_point.metadata["index_fields"]) > 0: ...

# get_embeddable_property_names
return data_point.metadata["index_fields"] or []   # <- no guard
```

When `data_point.metadata` is `None` or `{}`, `get_embeddable_property_names` raises `TypeError` (`'NoneType' object is not subscriptable`) or `KeyError: 'index_fields'`, while the two siblings return `None` / `[]`. The `index_data_points` task guards the same state (`if not hasattr(...) or not data_point.metadata: continue`), so falsy metadata is an expected state throughout the codebase — this accessor is the odd one out.

`DataPoint` does not set `validate_assignment`, so `node.metadata` can become falsy after construction, and `get_embeddable_property_names` is called per node on the write path (`cognee/modules/graph/methods/upsert_nodes.py` → `indexed_fields`), where the crash would abort the whole upsert.

### Reproduction

```python
class Thing(DataPoint):
    name: str
    metadata: dict = {"index_fields": ["name"]}

t = Thing(name="x"); t.metadata = None
DataPoint.get_embeddable_data(t)            # None
DataPoint.get_embeddable_properties(t)      # []
DataPoint.get_embeddable_property_names(t)  # before: TypeError   after: []
```

## Fix

Guard falsy metadata and read `index_fields` with `.get()`, returning `[]` — matching the sibling accessors and the `index_data_points` guard.

## Tests

Adds `cognee/tests/unit/infrastructure/engine/test_embeddable_accessors.py`: `index_fields` are returned when present, and `metadata` of `None` / `{}` yields `[]` with parity asserted against both sibling accessors on the same object.

```
pytest cognee/tests/unit/infrastructure/engine/ -q   # passes
pre-commit run --files <changed files>               # passes
```