### PR TITLE
fix: Anchor background remember tasks against GC

### DIFF
--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -40,6 +40,14 @@ from cognee.modules.observability import (
 
 logger = get_logger("remember")
 
+# Strong refs for fire-and-forget background remember tasks. The event loop only
+# keeps a weak reference to a task, and the API router drops the RememberResult
+# (the sole other holder of the task) after serializing it — without anchoring
+# here the gc can collect an in-flight task before it completes, silently
+# aborting the background add+cognify run or session bridge (#4312). Tasks
+# remove themselves on done.
+_BACKGROUND_REMEMBER_TASKS: set[asyncio.Task] = set()
+
 
 class RememberKwargs(TypedDict, total=False):
     """Power-user overrides for remember(). Most users never need these."""
@@ -1237,6 +1245,8 @@ async def _remember_inner(
                     logger.warning("remember: session improve failed (non-fatal): %s", exc)
 
             result._task = asyncio.create_task(_session_improve())
+            _BACKGROUND_REMEMBER_TASKS.add(result._task)
+            result._task.add_done_callback(_BACKGROUND_REMEMBER_TASKS.discard)
 
         return result
 
@@ -1295,6 +1305,8 @@ async def _remember_inner(
                 logger.exception("Background remember failed")
 
         result._task = asyncio.create_task(_remember_background())
+        _BACKGROUND_REMEMBER_TASKS.add(result._task)
+        result._task.add_done_callback(_BACKGROUND_REMEMBER_TASKS.discard)
         return result
 
     # Blocking mode

--- a/cognee/api/v1/validate/validate.py
+++ b/cognee/api/v1/validate/validate.py
@@ -223,9 +223,7 @@ async def validate(
     if dataset_names:
         authorized = await get_authorized_existing_datasets(dataset_names, "read", user)
         if len(authorized) != len(dataset_names):
-            raise DatasetNotFoundError(
-                message="Dataset not found or not readable."
-            )
+            raise DatasetNotFoundError(message="Dataset not found or not readable.")
         resolved_dataset = authorized[0]
 
     async with set_database_global_context_variables(

--- a/cognee/tests/unit/api/v1/remember/test_remember_background_task_anchoring.py
+++ b/cognee/tests/unit/api/v1/remember/test_remember_background_task_anchoring.py
@@ -1,0 +1,112 @@
+"""Guards the strong-reference anchor for background remember tasks (#4312).
+
+``remember`` launches its background work (permanent add+cognify run, or the
+session→graph bridge) with ``asyncio.create_task`` and keeps the task only on
+``RememberResult._task``. The API router serializes the result and drops it,
+and the event loop keeps only a *weak* reference to a task — so unless the
+task is anchored elsewhere it can be garbage-collected mid-flight, silently
+aborting the run while the HTTP call already returned success. The fix
+anchors it in the module-level ``_BACKGROUND_REMEMBER_TASKS`` set and
+discards it on completion (same pattern as #3251).
+"""
+
+import asyncio
+import gc
+import importlib
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+remember_module = importlib.import_module("cognee.api.v1.remember.remember")
+
+
+@pytest.fixture(autouse=True)
+def _no_db_setup(monkeypatch):
+    """remember() initializes the database before doing anything else."""
+
+    async def _noop_setup():
+        return None
+
+    monkeypatch.setattr("cognee.modules.engine.operations.setup.setup", _noop_setup)
+
+
+@pytest.mark.asyncio
+async def test_background_remember_task_is_anchored_until_done(monkeypatch):
+    release = asyncio.Event()
+
+    async def fake_add(*args, **kwargs):
+        return None
+
+    async def fake_cognify(*args, **kwargs):
+        await release.wait()
+        return {}
+
+    monkeypatch.setattr("cognee.api.v1.add.add", fake_add)
+    monkeypatch.setattr("cognee.api.v1.cognify.cognify", fake_cognify)
+
+    result = await remember_module.remember(
+        "note",
+        dataset_id=uuid4(),
+        run_in_background=True,
+        self_improvement=False,
+        user=SimpleNamespace(id=uuid4()),
+    )
+
+    assert result.status == "running"
+    task = result._task
+    assert task in remember_module._BACKGROUND_REMEMBER_TASKS
+
+    # The router drops the RememberResult after serializing it; the anchor must
+    # keep the task alive through a garbage-collection pass.
+    del result
+    gc.collect()
+    await asyncio.sleep(0)
+    assert not task.done()
+    assert task in remember_module._BACKGROUND_REMEMBER_TASKS
+
+    # Let the task finish; the done-callback must remove it from the anchor set.
+    release.set()
+    await task
+    await asyncio.sleep(0)
+    assert task not in remember_module._BACKGROUND_REMEMBER_TASKS
+
+
+@pytest.mark.asyncio
+async def test_session_bridge_task_is_anchored_until_done(monkeypatch):
+    release = asyncio.Event()
+
+    async def fake_add_to_session(session_id, data, user):
+        return None
+
+    async def fake_improve(*args, **kwargs):
+        await release.wait()
+
+    # The improve package re-exports the improve() function, shadowing the
+    # submodule — patch the package attribute directly.
+    improve_pkg = importlib.import_module("cognee.api.v1.improve")
+    monkeypatch.setattr(remember_module, "_add_to_session", fake_add_to_session)
+    monkeypatch.setattr(improve_pkg, "improve", fake_improve)
+
+    result = await remember_module.remember(
+        "note",
+        dataset_id=uuid4(),
+        session_id="session-4312",
+        self_improvement=True,
+        user=SimpleNamespace(id=uuid4()),
+    )
+
+    assert result.status == "session_stored"
+    task = result._task
+    assert task in remember_module._BACKGROUND_REMEMBER_TASKS
+
+    del result
+    gc.collect()
+    await asyncio.sleep(0)
+    assert not task.done()
+    assert task in remember_module._BACKGROUND_REMEMBER_TASKS
+
+    release.set()
+    await task
+    await asyncio.sleep(0)
+    assert task not in remember_module._BACKGROUND_REMEMBER_TASKS


### PR DESCRIPTION
## Description

Fixes the background-task lifetime gap in `remember()` diagnosed by @JiataiWang in #4312.

**The bug:** both background remember paths — the permanent `add()`+`cognify()` run (`remember.py`, `run_in_background=True`) and the session→graph bridge (`self_improvement` with a `session_id`) — used bare `asyncio.create_task(...)` and kept the task only on `RememberResult._task`. The HTTP router returns `jsonable_encoder(result.to_dict())` and drops the `RememberResult`, leaving the pending task with no application-level strong reference (the event loop keeps only a weak one; the remaining task↔closure↔result references form a closed cycle). Python's cycle collector can then destroy the task mid-flight: the API call already returned success, the add+cognify silently never completes, and the knowledge graph stays empty — exactly the "background returns successfully, graph never appears" failure mode reported in #4312.

I reproduced the destruction in a minimal script mirroring this reference shape: after `gc.collect()` the task weakref dies and asyncio emits `Task was destroyed but it is pending!`.

**The fix:** anchor both tasks in a module-level `_BACKGROUND_REMEMBER_TASKS` set with `add_done_callback(discard)` — the exact pattern #3251 (`0b126732d`) established for background sync and pipeline tasks (`_BACKGROUND_SYNC_TASKS`, `_BACKGROUND_PIPELINE_TASKS`), also used for telemetry tasks in `cognee/shared/utils.py`.

## Tests

`cognee/tests/unit/api/v1/remember/test_remember_background_task_anchoring.py`, mirroring the #3251 anchoring tests: for each path, asserts the task is in the anchor set while running, survives a `gc.collect()` after the result object is dropped, and is discarded from the set on completion. Both pass; the surrounding remember test files produce byte-identical results to clean dev (the pre-existing failures there are local-Postgres environment issues).

Closes #4312 (the task-lifetime part; the multipart-contract docs ask in that issue is separate).