### PR TITLE
fix(web_scraper): drop the stale BeautifulSoupCrawler export

### DIFF
--- a/cognee/tasks/web_scraper/__init__.py
+++ b/cognee/tasks/web_scraper/__init__.py
@@ -26,7 +26,6 @@ def __getattr__(name):
 
 
 __all__ = [
-    "BeautifulSoupCrawler",
     "fetch_page_content",
     "cron_web_scraper_task",
     "web_scraper_task",

--- a/cognee/tasks/web_scraper/default_url_crawler.py
+++ b/cognee/tasks/web_scraper/default_url_crawler.py
@@ -56,7 +56,7 @@ class DefaultUrlCrawler:
         headers: Optional[Dict[str, str]] = None,
         robots_cache_ttl: float = 3600.0,
     ):
-        """Initialize the BeautifulSoupCrawler.
+        """Initialize the DefaultUrlCrawler.
 
         Args:
             concurrency: Number of concurrent requests allowed.

--- a/cognee/tests/unit/tasks/web_scraper/test_public_exports.py
+++ b/cognee/tests/unit/tasks/web_scraper/test_public_exports.py
@@ -1,0 +1,14 @@
+"""Unit tests for the public exports of the web scraper package."""
+
+import pytest
+
+from cognee.tasks import web_scraper
+
+
+@pytest.mark.parametrize("name", web_scraper.__all__)
+def test_public_export_is_resolvable(name):
+    """Every name in ``__all__`` must resolve, so ``from ... import *`` cannot raise."""
+    try:
+        getattr(web_scraper, name)
+    except ImportError:
+        pytest.skip(f"{name} requires an optional dependency that is not installed")


### PR DESCRIPTION
### The bug

`cognee/tasks/web_scraper/__init__.py` exports a name that no longer exists:

```python
__all__ = [
    "BeautifulSoupCrawler",   # <- nothing in the package defines this
    "fetch_page_content",
    "cron_web_scraper_task",
    "web_scraper_task",
    "DefaultUrlCrawler",
]
```

`BeautifulSoupCrawler` appears nowhere in the tree except as a leftover string
in this list and in a stale docstring. The crawler it named is now
`DefaultUrlCrawler` (exported two lines below), and the similarly-named
`BeautifulSoupLoader` is an unrelated loader under
`cognee/infrastructure/loaders/external/beautiful_soup_loader.py`.

Normally a dead `__all__` entry is inert until someone runs `import *`. Here it
is worse than that, because the module also defines `__getattr__` for the lazy
`*_web_scraper_task` names — so the star import routes the missing name through
`__getattr__`, which raises:

```
AttributeError: module 'cognee.tasks.web_scraper' has no attribute 'BeautifulSoupCrawler'
```

`from cognee.tasks.web_scraper import *` therefore fails outright, and
`BeautifulSoupCrawler` is also absent from `dir()` and from anything that reads
`__all__` (documentation tooling, re-export checks).

### Verification

Run against the module file exactly as it is on `dev`, with the sibling modules
stubbed so the optional `apscheduler` path behaves as it does in a plain unit
environment:

| | `from ... import *` | new test |
|---|---|---|
| before | `AttributeError: ... has no attribute 'BeautifulSoupCrawler'` | 1 failed, 2 passed, 2 skipped |
| after | ok — exports `DefaultUrlCrawler`, `cron_web_scraper_task`, `fetch_page_content`, `web_scraper_task` | 2 passed, 2 skipped |

The two skips are `cron_web_scraper_task` / `web_scraper_task`, whose lazy
import needs `apscheduler` (not a declared dependency); the test skips on
`ImportError` so it checks resolvability without pulling in an optional package.

### The change

- drop the dead `"BeautifulSoupCrawler"` entry from `__all__`;
- fix the `DefaultUrlCrawler.__init__` docstring, which still opened with
  *"Initialize the BeautifulSoupCrawler."* — same rename residue;
- add `cognee/tests/unit/tasks/web_scraper/test_public_exports.py`, which
  asserts every name in `__all__` resolves, so a future rename cannot leave the
  list stale again.

No behavior change for any name that exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
