### PR TITLE
fix: Allow ACL readers to download raw data

### DIFF
--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -696,25 +696,39 @@ def get_datasets_router() -> APIRouter:
             },
         )
 
-        from cognee.modules.data.methods import get_data
+        from cognee.modules.data.methods import get_dataset_data, resolve_data_id
 
         # Verify user has permission to read dataset
         dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
 
         if not dataset:
             return JSONResponse(
-                status_code=404, content={"detail": f"Dataset ({dataset_id}) not found."}
+                status_code=404, content={"message": f"Dataset ({dataset_id}) not found."}
             )
 
         # Dataset-scoped lookup: resolves the exact id or, for a row whose
         # identity forked in the dataset-scoping upgrade, its recorded
         # pre-fork legacy_id — every id ever issued keeps resolving.
-        data = await get_data(user.id, data_id, dataset[0].id)
+        resolved_id = await resolve_data_id(dataset[0].id, data_id)
 
-        if data is None:
+        if resolved_id is None:
             raise DataNotFoundError(
                 message=f"Data ({data_id}) not found in dataset ({dataset_id})."
             )
+
+        matching_data = [
+            data for data in await get_dataset_data(dataset[0].id) if data.id == resolved_id
+        ]
+
+        if len(matching_data) == 0:
+            raise DataNotFoundError(
+                message=f"Data ({data_id}) not found in dataset ({dataset_id})."
+            )
+
+        # Use the data object already verified to belong to the authorized dataset,
+        # rather than calling get_data() which checks owner_id and would reject
+        # ACL-granted readers who are not the data owner.
+        data = matching_data[0]
 
         raw_location = data.raw_data_location
         parsed_uri = urlparse(raw_location)

--- a/cognee/tests/unit/api/test_get_raw_data_endpoint.py
+++ b/cognee/tests/unit/api/test_get_raw_data_endpoint.py
@@ -67,19 +67,21 @@ def _patch_raw_download_dependencies(
 
     monkeypatch.setattr(
         data_methods_module,
-        "get_dataset_data",
-        AsyncMock(return_value=[SimpleNamespace(id=data_id)]),
+        "resolve_data_id",
+        AsyncMock(return_value=data_id),
     )
     monkeypatch.setattr(
         data_methods_module,
-        "get_data",
+        "get_dataset_data",
         AsyncMock(
-            return_value=SimpleNamespace(
-                id=data_id,
-                raw_data_location=raw_data_location,
-                name=name,
-                mime_type=mime_type,
-            )
+            return_value=[
+                SimpleNamespace(
+                    id=data_id,
+                    raw_data_location=raw_data_location,
+                    name=name,
+                    mime_type=mime_type,
+                )
+            ]
         ),
     )
 


### PR DESCRIPTION
## Description

CI mirror of contributor PR #4200 by @rkfshakti (`rkfshakti:fix/raw-data-acl-readers-4162`), pushed as an in-repo branch so the full CI suite (including secret-gated jobs) runs against it. Fixes #4162 (Linear: COG-5923).

From the original PR:

> When a user with a dataset-level **read** grant (via ACL) tries to download a raw data file, the `GET /api/v1/datasets/{dataset_id}/data/{data_id}/raw` endpoint calls `get_data(user.id, data_id)`, which checks `data.owner_id == user_id` and raises `UnauthorizedDataAccessError` (401) for non-owners.
>
> This breaks the ACL permission model: a user who can **list** the dataset's data cannot **download** the actual files.

## Rebase notes (differences from #4200)

The original branch predates #4435 (dataset-scoped Data rows), which rewrote this lookup to route through `resolve_data_id` for pre-fork `legacy_id` resolution — the owner-only gate in `get_data._check_owner` remains, so the bug still reproduces on `dev`. Resolving the cherry-pick conflict, the fix is ported onto that scheme using the same pattern as `datasets.delete_data`:

- `resolve_data_id(dataset.id, data_id)` keeps every id ever issued resolving (exact id, then `legacy_id`), scoped to the already-authorized dataset.
- The row is then taken from `get_dataset_data()` membership instead of the owner-gated `get_data()`, so ACL-granted readers can download.
- A follow-up commit adapts the unit-test mocks in `test_get_raw_data_endpoint.py` to the new lookup.

All credit to @rkfshakti — review and merge should happen on #4200; this PR exists to exercise CI.