### PR TITLE
refactor(dlt): Make column-value length cap opt-in

### DIFF
--- a/cognee/tasks/ingestion/config.py
+++ b/cognee/tasks/ingestion/config.py
@@ -20,12 +20,20 @@ class IngestionConfig(BaseSettings):
     # Env: DLT_COLUMN_VALUE_COLUMNS as JSON, or add(..., column_value_columns=...).
     dlt_column_value_columns: dict[str, list[str]] = {}
 
+    # Length bound on cell values selected for ColumnValue nodes; 0 (default)
+    # means unlimited — every selected value becomes a node regardless of
+    # length. Set a positive value (env: DLT_MAX_COLUMN_VALUE_LENGTH) to skip
+    # long free-text cells, which make poor shared categorical nodes and cost
+    # one embedding per unique value.
+    dlt_max_column_value_length: int = 0
+
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
     def to_dict(self) -> dict:
         return {
             "dlt_max_rows_per_table": self.dlt_max_rows_per_table,
             "dlt_column_value_columns": self.dlt_column_value_columns,
+            "dlt_max_column_value_length": self.dlt_max_column_value_length,
         }
 
 

--- a/cognee/tasks/ingestion/resolve_dlt_sources.py
+++ b/cognee/tasks/ingestion/resolve_dlt_sources.py
@@ -41,7 +41,6 @@ logger = get_logger("resolve_dlt_sources")
 
 # Cells longer than this never become ColumnValue nodes — long values are
 # free text, not categorical data, and would produce useless one-off nodes.
-MAX_COLUMN_VALUE_LENGTH = 256
 
 
 async def resolve_dlt_sources(
@@ -507,7 +506,9 @@ def _selected_column_values(dlt_row: DltRowData, selection: Optional[dict]) -> d
 
     ``selection`` maps table name to a column list; "*" is a wildcard for
     either side. Primary-key and foreign-key columns are excluded (they are
-    row identity and edges already), as are null, empty, and overlong values.
+    row identity and edges already), as are null and empty values. A positive
+    ``dlt_max_column_value_length`` (default 0 = unlimited) additionally
+    skips values longer than the bound.
     """
     if not selection:
         return {}
@@ -515,6 +516,7 @@ def _selected_column_values(dlt_row: DltRowData, selection: Optional[dict]) -> d
     if not columns:
         return {}
     take_all = "*" in columns
+    max_value_length = get_ingestion_config().dlt_max_column_value_length
 
     fk_columns = {fk.get("column", "") for fk in dlt_row.foreign_keys}
     picked = {}
@@ -526,7 +528,9 @@ def _selected_column_values(dlt_row: DltRowData, selection: Optional[dict]) -> d
         if value is None:
             continue
         text = str(value).strip()
-        if not text or len(text) > MAX_COLUMN_VALUE_LENGTH:
+        if not text:
+            continue
+        if max_value_length and len(text) > max_value_length:
             continue
         picked[column] = text
     return picked

--- a/cognee/tests/unit/tasks/ingestion/test_dlt_column_values.py
+++ b/cognee/tests/unit/tasks/ingestion/test_dlt_column_values.py
@@ -17,10 +17,7 @@ import cognee.tasks.ingestion.dlt_schema_graph as schema_graph_module
 from cognee.modules.engine.models import ColumnValue
 from cognee.tasks.ingestion.dlt_row_data import DltRowData
 from cognee.tasks.ingestion.dlt_schema_graph import emit_dlt_schema_graph
-from cognee.tasks.ingestion.resolve_dlt_sources import (
-    MAX_COLUMN_VALUE_LENGTH,
-    _selected_column_values,
-)
+from cognee.tasks.ingestion.resolve_dlt_sources import _selected_column_values
 
 graph_engine_module = importlib.import_module(
     "cognee.infrastructure.databases.graph.get_graph_engine"
@@ -81,16 +78,29 @@ class TestSelectedColumnValues:
         row = _row(row_data=self.ROW_DATA, foreign_keys=self.FOREIGN_KEYS)
         assert _selected_column_values(row, {"orders": ["id", "customer_id"]}) == {}
 
-    def test_null_empty_and_overlong_values_skipped(self):
+    def test_null_and_empty_values_skipped_long_values_kept(self):
+        """No length bound by default: a selected value of any length becomes
+        a node — only null/empty cells are skipped."""
+        long_value = "x" * 10_000
         row = _row(
             row_data={
                 "id": 1,
                 "status": None,
                 "note": "  ",
-                "blob": "x" * (MAX_COLUMN_VALUE_LENGTH + 1),
+                "blob": long_value,
                 "country": "RS",
             }
         )
+        assert _selected_column_values(row, {"orders": ["*"]}) == {
+            "blob": long_value,
+            "country": "RS",
+        }
+
+    def test_opt_in_length_bound_skips_long_values(self, monkeypatch):
+        from cognee.tasks.ingestion.config import get_ingestion_config
+
+        monkeypatch.setattr(get_ingestion_config(), "dlt_max_column_value_length", 8)
+        row = _row(row_data={"id": 1, "blob": "x" * 9, "country": "RS"})
         assert _selected_column_values(row, {"orders": ["*"]}) == {"country": "RS"}
 
     def test_values_coerced_to_stripped_strings(self):


### PR DESCRIPTION
## What

`MAX_COLUMN_VALUE_LENGTH` was a hardcoded 256-character bound that **silently dropped** selected cell values from `ColumnValue` node emission. Nobody asked for that number, and silently skipping data the user explicitly selected (via `column_value_columns`) is the wrong default.

## Change

- The module constant is gone. The bound is now `dlt_max_column_value_length` in the ingestion config (env: `DLT_MAX_COLUMN_VALUE_LENGTH`), **default 0 = unlimited** — every selected value becomes a node regardless of length.
- Kept as an opt-in knob rather than deleted outright because it guards a real cost footgun: with wildcard selection (`{"*": ["*"]}`), long free-text cells become one embedded node per unique value. That protection is now chosen, never imposed — same shape as the existing `dlt_max_rows_per_table` (0 = unlimited).

## Tests

- `test_null_and_empty_values_skipped_long_values_kept` — pins the new default: a 10k-char selected value becomes a node.
- `test_opt_in_length_bound_skips_long_values` — pins the knob: with the config set, overlong values are skipped.
- Full ingestion unit batch green (66 passed).