### PR TITLE
feat(dlt): Move CSV ingestion into the loader engine

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -286,11 +286,14 @@ jobs:
           uses: ./.github/actions/cognee_setup
           with:
             python-version: '3.11.x'
-            extra-dependencies: "aws"
+            extra-dependencies: "aws dlt"
 
         - name: Run S3 Bucket Test
           env:
             ENV: 'dev'
+            # dlt's telemetry thread is non-daemon and can hang interpreter
+            # exit on CI runners; the S3 test ingests through dlt now.
+            RUNTIME__DLTHUB_TELEMETRY: "false"
             LLM_MODEL: ${{ secrets.LLM_MODEL }}
             LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
             LLM_API_KEY: ${{ secrets.LLM_API_KEY }}

--- a/cognee/infrastructure/loaders/LoaderEngine.py
+++ b/cognee/infrastructure/loaders/LoaderEngine.py
@@ -5,7 +5,7 @@ import filetype
 from cognee.infrastructure.files.utils.guess_file_type import guess_file_type
 from cognee.shared.logging_utils import get_logger
 
-from .LoaderInterface import LoaderInterface
+from .LoaderInterface import LoaderInterface, LoaderResult
 
 logger = get_logger(__name__)
 
@@ -132,7 +132,7 @@ class LoaderEngine:
         file_path: str,
         preferred_loaders: dict[str, dict[str, Any]] | None = None,
         **kwargs: Any,
-    ) -> str:
+    ) -> "str | LoaderResult":
         """
         Load file using appropriate loader.
 

--- a/cognee/infrastructure/loaders/LoaderEngine.py
+++ b/cognee/infrastructure/loaders/LoaderEngine.py
@@ -35,6 +35,11 @@ class LoaderEngine:
             "image_loader",
             "audio_loader",
             "video_loader",
+            # dlt before csv on purpose: with the dlt extra installed, CSVs
+            # take the structured DLT route; csv_loader's text flattening is
+            # the fallback (no dlt) or an explicit per-call choice via
+            # preferred_loaders={"csv_loader": {}}.
+            "dlt_csv_loader",
             "csv_loader",
             "unstructured_loader",
             "advanced_pdf_loader",

--- a/cognee/infrastructure/loaders/LoaderInterface.py
+++ b/cognee/infrastructure/loaders/LoaderInterface.py
@@ -1,5 +1,23 @@
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar
+from dataclasses import dataclass
+from typing import Any, ClassVar, Optional
+from uuid import UUID
+
+
+@dataclass
+class LoaderResult:
+    """Rich loader output for loaders that own more than text extraction.
+
+    ``load()`` normally returns the stored derived-text path as a plain str.
+    A loader that also owns the record's identity and routing (dlt: the
+    manifest's stable data_id and the ``system_metadata`` route stamp) returns
+    this instead; ``ingest_data`` pins the record to ``data_id`` and stamps
+    ``system_metadata`` exactly as it does for pinned ``DataItem``s.
+    """
+
+    file_path: str
+    data_id: Optional[UUID] = None
+    system_metadata: Optional[dict] = None
 
 
 class LoaderInterface(ABC):

--- a/cognee/infrastructure/loaders/LoaderInterface.py
+++ b/cognee/infrastructure/loaders/LoaderInterface.py
@@ -68,7 +68,7 @@ class LoaderInterface(ABC):
         pass
 
     @abstractmethod
-    async def load(self, file_path: str, **kwargs: Any) -> str:
+    async def load(self, file_path: str, **kwargs: Any) -> "str | LoaderResult":
         """
         Load and process the file, returning standardized result.
 
@@ -76,6 +76,10 @@ class LoaderInterface(ABC):
             file_path: Path to the file to be processed
             file_stream: If file stream is provided it will be used to process file instead
             **kwargs: Additional loader-specific configuration
+
+        Returns:
+            The stored derived-text path, or a ``LoaderResult`` for loaders
+            that also own the record's identity and route stamp (dlt).
 
         Raises:
             Exception: If file cannot be processed

--- a/cognee/infrastructure/loaders/core/image_loader.py
+++ b/cognee/infrastructure/loaders/core/image_loader.py
@@ -254,7 +254,7 @@ class ImageLoader(LoaderInterface):
 
         try:
             with Image.open(file_path) as img:
-                exif_data = img._getexif()
+                exif_data = img._getexif()  # ty:ignore[unresolved-attribute]
         except Exception:
             return None
 
@@ -348,7 +348,7 @@ def _dhash(image, hash_size: int = 8) -> str:
     """
     from PIL import Image  # ty: ignore[unresolved-import]
 
-    image = image.convert("L").resize((hash_size + 1, hash_size), Image.LANCZOS)
+    image = image.convert("L").resize((hash_size + 1, hash_size), Image.LANCZOS)  # ty:ignore[unresolved-attribute]
     pixels = list(image.getdata())
     # pixels now has (hash_size+1) * hash_size entries, row-major
     bits: list[str] = []

--- a/cognee/infrastructure/loaders/external/__init__.py
+++ b/cognee/infrastructure/loaders/external/__init__.py
@@ -41,3 +41,10 @@ try:
     __all__.append("DoclingLoader")
 except ImportError:
     pass
+
+try:
+    from .dlt_csv_loader import DltCsvLoader
+
+    __all__.append("DltCsvLoader")
+except ImportError:
+    pass

--- a/cognee/infrastructure/loaders/external/dlt_csv_loader.py
+++ b/cognee/infrastructure/loaders/external/dlt_csv_loader.py
@@ -1,0 +1,112 @@
+"""CSV ingestion through the DLT pipeline, packaged as a loader.
+
+Registered above the plain ``csv_loader`` in the engine's priority order, so
+when the ``dlt`` extra is installed every CSV takes the structured route:
+staging ingestion via dlt, one manifest per file with a stable data_id, and
+the no-LLM DLT cognify route (one DltRow node per row). Without the extra
+this module fails to import, the loader is never registered, and CSVs fall
+back to ``csv_loader``'s text flattening.
+
+The loader returns a ``LoaderResult`` instead of a plain path: the manifest
+text is the derived file, and the result carries the manifest's stable
+``data_id`` plus the ``system_metadata`` route stamp that cognify's per-item
+routing keys on. Per-call dlt options (``primary_key``, ``write_disposition``,
+``max_rows_per_table``, ``column_value_columns``) ride the standard
+``preferred_loaders`` config channel:
+``preferred_loaders={"dlt_csv_loader": {"primary_key": "id"}}``.
+"""
+
+import hashlib
+from typing import Any, Optional
+
+import dlt  # noqa: F401 — hard gate: without the extra this loader must not register
+
+from cognee.infrastructure.files.storage import get_file_storage, get_storage_config
+from cognee.infrastructure.files.utils.get_data_file_path import get_data_file_path
+from cognee.infrastructure.loaders.LoaderInterface import LoaderInterface, LoaderResult
+from cognee.modules.ingestion.exceptions import IngestionError
+
+
+class DltCsvLoader(LoaderInterface):
+    """Structured CSV loader: dlt staging ingestion + manifest emission."""
+
+    loader_name = "dlt_csv_loader"
+
+    @property
+    def supported_extensions(self) -> list[str]:
+        return ["csv"]
+
+    @property
+    def supported_mime_types(self) -> list[str]:
+        return ["text/csv"]
+
+    def can_handle(self, extension: str, mime_type: str) -> bool:
+        return extension in self.supported_extensions and mime_type in self.supported_mime_types
+
+    async def load(
+        self,
+        file_path: str,
+        dataset_name: Optional[str] = None,
+        dataset_id: Optional[Any] = None,
+        user: Optional[Any] = None,
+        original_file_name: Optional[str] = None,
+        primary_key: Optional[str] = None,
+        write_disposition: str = "replace",
+        max_rows_per_table: Optional[int] = None,
+        column_value_columns: Optional[dict] = None,
+        **kwargs: Any,
+    ) -> LoaderResult:
+        # Task-layer imports are lazy: the loaders package must not depend on
+        # cognee.tasks at import time (loaders are infrastructure).
+        from cognee.tasks.ingestion.create_dlt_source import (
+            create_dlt_source_from_csv,
+            csv_source_name,
+        )
+        from cognee.tasks.ingestion.ingest_dlt_source import ingest_dlt_source
+        from cognee.tasks.ingestion.resolve_dlt_sources import _build_source_manifest_item
+
+        if dataset_name is None or user is None:
+            raise IngestionError(
+                message="dlt_csv_loader runs only inside ingestion: dataset_name and "
+                "user must be provided by the ingest pipeline."
+            )
+
+        # The bytes may be a localized copy (s3 temp download, stored upload)
+        # whose basename is meaningless — the manifest identity derives from
+        # the ORIGINAL file name so it stays stable across runs.
+        source_name = csv_source_name(original_file_name or file_path)
+        local_path = get_data_file_path(file_path)
+
+        resource = create_dlt_source_from_csv(local_path, source_name=source_name)
+        rows = await ingest_dlt_source(
+            resource,
+            dataset_name,
+            primary_key=primary_key,
+            write_disposition=write_disposition,
+            max_rows_per_table=max_rows_per_table,
+        )
+
+        manifest_item = await _build_source_manifest_item(
+            rows,
+            source_name,
+            dataset_name,
+            user,
+            column_value_columns=column_value_columns,
+        )
+        if manifest_item is None:
+            raise IngestionError(
+                message=f"CSV source '{source_name}' produced no rows — nothing to ingest."
+            )
+
+        manifest_text = manifest_item.data
+        storage_file_name = (
+            "dlt_manifest_" + hashlib.md5(manifest_text.encode()).hexdigest() + ".txt"
+        )
+        storage = get_file_storage(get_storage_config()["data_root_directory"])
+        stored_path = await storage.store(storage_file_name, manifest_text)
+
+        return LoaderResult(
+            file_path=stored_path,
+            data_id=manifest_item.data_id,
+            system_metadata=manifest_item.system_metadata,
+        )

--- a/cognee/infrastructure/loaders/external/dlt_csv_loader.py
+++ b/cognee/infrastructure/loaders/external/dlt_csv_loader.py
@@ -19,7 +19,7 @@ routing keys on. Per-call dlt options (``primary_key``, ``write_disposition``,
 import hashlib
 from typing import Any, Optional
 
-import dlt  # noqa: F401 — hard gate: without the extra this loader must not register
+import dlt  # noqa: F401  # ty:ignore[unresolved-import] — hard gate: without the extra this loader must not register
 
 from cognee.infrastructure.files.storage import get_file_storage, get_storage_config
 from cognee.infrastructure.files.utils.get_data_file_path import get_data_file_path

--- a/cognee/infrastructure/loaders/supported_loaders.py
+++ b/cognee/infrastructure/loaders/supported_loaders.py
@@ -46,3 +46,13 @@ try:
     supported_loaders[DoclingLoader.loader_name] = DoclingLoader
 except ImportError:
     pass
+
+# Structured CSV ingestion through dlt; registered above csv_loader in the
+# engine's priority order, so with the dlt extra installed CSVs take the
+# DLT manifest route instead of text flattening.
+try:
+    from cognee.infrastructure.loaders.external import DltCsvLoader
+
+    supported_loaders[DltCsvLoader.loader_name] = DltCsvLoader
+except ImportError:
+    pass

--- a/cognee/modules/ingestion/classify.py
+++ b/cognee/modules/ingestion/classify.py
@@ -1,5 +1,5 @@
 from os import path
-from io import BufferedReader
+from io import BufferedReader, BytesIO
 from typing import Union, BinaryIO
 from tempfile import SpooledTemporaryFile
 
@@ -13,12 +13,18 @@ def classify(
     if isinstance(data, str):
         return TextData(data)
 
-    if isinstance(data, BufferedReader) or isinstance(data, SpooledTemporaryFile):
+    if isinstance(data, (BufferedReader, SpooledTemporaryFile, BytesIO)):
+        # In-memory uploads (BytesIO) carry no .name — the caller-supplied
+        # filename is the only identity there, so its absence is an error,
+        # never a made-up name.
+        source_name = filename if filename else getattr(data, "name", None)
+        if source_name is None:
+            raise IngestionError(message="Binary stream has no name: pass filename= to classify().")
         # Normalize both POSIX ("/") and Windows ("\") separators before taking the
         # basename. On Windows, data.name is a backslash path (e.g. C:\dir\file.pdf),
         # so splitting on "/" alone would keep the whole path as the file's name.
-        derived_name = str(data.name).replace("\\", "/").split("/")[-1]
-        return BinaryData(data, filename if filename else derived_name)
+        derived_name = str(source_name).replace("\\", "/").split("/")[-1]
+        return BinaryData(data, derived_name)
 
     try:
         from s3fs import S3File

--- a/cognee/modules/pipelines/operations/run_tasks_data_item.py
+++ b/cognee/modules/pipelines/operations/run_tasks_data_item.py
@@ -90,14 +90,7 @@ async def run_tasks_data_item_incremental(
             await session.execute(select(Data).filter(Data.id == data_id))
         ).scalar_one_or_none()
         if data_point:
-            # A stable-id DataItem carries its own content hash; when it
-            # differs from the stored one the content changed under the same
-            # identity, so the completed-skip must NOT fire — ingest_data then
-            # updates the row and clears pipeline_status for reprocessing.
-            content_changed_under_stable_id = getattr(
-                data_item, "content_hash", None
-            ) is not None and str(data_item.content_hash) != str(data_point.content_hash)
-            if not content_changed_under_stable_id and (
+            if (
                 data_point.pipeline_status.get(pipeline_name, {}).get(str(dataset.id))
                 == DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED
             ):

--- a/cognee/tasks/ingestion/create_dlt_source.py
+++ b/cognee/tasks/ingestion/create_dlt_source.py
@@ -76,8 +76,14 @@ def create_dlt_source_from_connection_string(
     return source
 
 
-def create_dlt_source_from_csv(csv_path: str):
-    """Auto-generate a dlt resource from a CSV file path."""
+def create_dlt_source_from_csv(csv_path: str, source_name: Optional[str] = None):
+    """Auto-generate a dlt resource from a CSV file path.
+
+    ``source_name`` overrides the filename-derived resource name — callers
+    reading from a localized copy (temp download, stored upload) pass the
+    name derived from the ORIGINAL file so the manifest identity is stable
+    across runs regardless of where the bytes were staged.
+    """
     from dlt.sources.filesystem import filesystem, read_csv
 
     parent_dir = os.path.dirname(os.path.abspath(csv_path))
@@ -93,7 +99,7 @@ def create_dlt_source_from_csv(csv_path: str):
     # A piped read_csv resource is otherwise always named "_read_csv", and the
     # manifest identity is seeded from (dataset, source name) — every CSV in a
     # dataset would collapse into one identity. Name per file instead.
-    return source.with_name(csv_source_name(filename))
+    return source.with_name(source_name or csv_source_name(filename))
 
 
 def _parse_sql_query(query: str) -> tuple:

--- a/cognee/tasks/ingestion/data_item.py
+++ b/cognee/tasks/ingestion/data_item.py
@@ -20,18 +20,6 @@ class DataItem:
     # Data.system_metadata — never merged with user external_metadata.
     system_metadata: Optional[dict] = field(default=None)
     data_id: Optional[UUID] = None
-    # Optional pre-computed content hash. When set together with an explicit
-    # data_id, the add pipeline's incremental skip compares it against the
-    # stored Data.content_hash and reprocesses on mismatch — this is how a
-    # stable-id item signals "same identity, new content". Sole remaining
-    # client: resolver-built DLT manifests for dlt resource / connection-string
-    # sources (a re-synced source keeps its manifest id, so without this the
-    # completed-skip would silently drop the change). CSVs do NOT use it —
-    # they enter as raw files whose own content hash changes naturally, and
-    # the dlt_csv_loader pins identity later, inside the pipeline. Must use
-    # the same formula as ingestion's content hashing (plain md5 over the
-    # stored bytes) or changed content goes undetected.
-    content_hash: Optional[str] = None
 
 
 def parse_labels(labels: Optional[str]) -> Optional[List[Optional[str]]]:

--- a/cognee/tasks/ingestion/data_item.py
+++ b/cognee/tasks/ingestion/data_item.py
@@ -23,9 +23,14 @@ class DataItem:
     # Optional pre-computed content hash. When set together with an explicit
     # data_id, the add pipeline's incremental skip compares it against the
     # stored Data.content_hash and reprocesses on mismatch — this is how a
-    # stable-id item (e.g. a DLT source manifest) signals "same identity, new
-    # content". Must use the same formula as ingestion's content hashing
-    # (plain md5 over the stored bytes) or changed content goes undetected.
+    # stable-id item signals "same identity, new content". Sole remaining
+    # client: resolver-built DLT manifests for dlt resource / connection-string
+    # sources (a re-synced source keeps its manifest id, so without this the
+    # completed-skip would silently drop the change). CSVs do NOT use it —
+    # they enter as raw files whose own content hash changes naturally, and
+    # the dlt_csv_loader pins identity later, inside the pipeline. Must use
+    # the same formula as ingestion's content hashing (plain md5 over the
+    # stored bytes) or changed content goes undetected.
     content_hash: Optional[str] = None
 
 

--- a/cognee/tasks/ingestion/data_item_to_text_file.py
+++ b/cognee/tasks/ingestion/data_item_to_text_file.py
@@ -36,7 +36,14 @@ async def pull_from_s3(file_path, destination_file) -> None:
 async def data_item_to_text_file(
     data_item_path: str,
     preferred_loaders: dict[str, dict[str, Any]] = None,
+    **loader_kwargs: Any,
 ) -> Tuple[str, LoaderInterface]:
+    """Run the loader engine on a data item's file.
+
+    ``loader_kwargs`` (ingestion context: dataset_name, dataset_id, user,
+    original_file_name) is forwarded to the selected loader's ``load()``;
+    loaders that don't need it ignore it via ``**kwargs``.
+    """
     if isinstance(data_item_path, str):
         parsed_url = urlparse(data_item_path)
 
@@ -59,9 +66,9 @@ async def data_item_to_text_file(
                 temp_file.flush()  # Data needs to be saved to local storage
                 temp_file.close()  # release the handle so the loader can reopen by name
                 loader = get_loader_engine()
-                return await loader.load_file(temp_file.name, preferred_loaders), loader.get_loader(
-                    temp_file.name, preferred_loaders
-                )
+                return await loader.load_file(
+                    temp_file.name, preferred_loaders, **loader_kwargs
+                ), loader.get_loader(temp_file.name, preferred_loaders)
             finally:
                 temp_file.close()  # idempotent; covers the early-exception path
                 try:
@@ -73,9 +80,9 @@ async def data_item_to_text_file(
         elif parsed_url.scheme == "file":
             if settings.accept_local_file_path:
                 loader = get_loader_engine()
-                return await loader.load_file(data_item_path, preferred_loaders), loader.get_loader(
-                    data_item_path, preferred_loaders
-                )
+                return await loader.load_file(
+                    data_item_path, preferred_loaders, **loader_kwargs
+                ), loader.get_loader(data_item_path, preferred_loaders)
             else:
                 raise IngestionError(message="Local files are not accepted.")
 
@@ -86,9 +93,9 @@ async def data_item_to_text_file(
             # Handle both Unix absolute paths (/path) and Windows absolute paths (C:\path)
             if settings.accept_local_file_path:
                 loader = get_loader_engine()
-                return await loader.load_file(data_item_path, preferred_loaders), loader.get_loader(
-                    data_item_path, preferred_loaders
-                )
+                return await loader.load_file(
+                    data_item_path, preferred_loaders, **loader_kwargs
+                ), loader.get_loader(data_item_path, preferred_loaders)
             else:
                 raise IngestionError(message="Local files are not accepted.")
     # data is not a supported type

--- a/cognee/tasks/ingestion/ingest_data.py
+++ b/cognee/tasks/ingestion/ingest_data.py
@@ -1,5 +1,6 @@
 import json
 import inspect
+import os
 from uuid import UUID, uuid4
 from typing import Union, BinaryIO, Any, List, Optional
 
@@ -14,6 +15,7 @@ from cognee.modules.users.methods import get_default_user
 from cognee.modules.users.permissions.methods import get_specific_user_permission_datasets
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
 from cognee.infrastructure.files.utils.get_data_file_path import get_data_file_path
+from cognee.infrastructure.loaders.LoaderInterface import LoaderResult
 from cognee.modules.data.methods import (
     get_authorized_existing_datasets,
     resolve_data_id,
@@ -151,10 +153,19 @@ async def ingest_data(
             original_file_path = cached.get("original_file_path")
             actual_file_path = cached.get("actual_file_path")
 
-            # Store all input data as text files in Cognee data storage
+            # Store all input data as text files in Cognee data storage.
+            # Ingestion context rides to the loader: loaders that own routing
+            # (dlt) need the dataset/user to build their staging artifacts.
             cognee_storage_file_path, loader_engine = await data_item_to_text_file(
                 actual_file_path,
                 preferred_loaders,
+                dataset_name=dataset.name,
+                dataset_id=dataset.id,
+                user=user,
+                # actual_file_path is the decoded form (file:// URIs carry
+                # percent-encoding, e.g. spaces as %20) — names derived from
+                # it match the user's real filename.
+                original_file_name=os.path.basename(actual_file_path),
             )
 
             if loader_engine is None:
@@ -162,6 +173,24 @@ async def ingest_data(
 
             # Use data_id computed in pre-loop
             data_id = cached.get("data_id")
+
+            # A loader may return a LoaderResult instead of a plain path: it
+            # then owns the record's identity and route stamp (dlt: the
+            # manifest's stable data_id + the system_metadata routing stamp).
+            # The pinned id replaces the pre-loop mint, and existence is
+            # re-resolved for it so re-adds hit the update branch.
+            if isinstance(cognee_storage_file_path, LoaderResult):
+                loader_result = cognee_storage_file_path
+                cognee_storage_file_path = loader_result.file_path
+                if loader_result.system_metadata is not None and item_system_metadata is None:
+                    item_system_metadata = loader_result.system_metadata
+                if loader_result.data_id is not None:
+                    data_id = loader_result.data_id
+                    if str(data_id) not in existing_data_map:
+                        async with db_engine.get_async_session() as session:
+                            pinned_row = await session.get(Data, data_id)
+                            if pinned_row is not None:
+                                existing_data_map[str(pinned_row.id)] = pinned_row
 
             # Find metadata from original file
             # Standard flow: extract metadata from both original and stored files

--- a/cognee/tasks/ingestion/ingest_dlt_source.py
+++ b/cognee/tasks/ingestion/ingest_dlt_source.py
@@ -28,6 +28,10 @@ except ImportError:
 
 logger = get_logger("ingest_dlt_source")
 
+# Serializes dlt staging runs: one shared pipeline name means one shared dlt
+# working directory, which concurrent runs corrupt (see the lock's use below).
+_staging_lock = asyncio.Lock()
+
 # Strict identifier pattern — only allow alphanumerics, underscores, dots, and hyphens
 _SAFE_IDENT_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
 
@@ -88,13 +92,6 @@ async def ingest_dlt_source(
             "Only 'sqlite' and 'postgres' are supported."
         )
 
-    # Execute dlt pipeline with error handling
-    pipeline = dlt.pipeline(
-        pipeline_name="ingest_dlt_source",
-        destination=destination,
-        dataset_name=dataset_name,
-    )
-
     # Build run kwargs based on disposition
     run_kwargs = {
         "write_disposition": write_disposition,
@@ -105,14 +102,25 @@ async def ingest_dlt_source(
     if write_disposition == "merge" and primary_key:
         run_kwargs["primary_key"] = primary_key
 
-    try:
-        # dlt's pipeline.run() is synchronous and potentially long-running;
-        # run it in a thread to avoid blocking the async event loop.
-        load_info = await asyncio.to_thread(pipeline.run, dlt_source, **run_kwargs)
-    except Exception as e:
-        raise DLTIngestionError(
-            message=f"DLT pipeline execution failed for dataset '{original_dataset_name}': {e}"
-        ) from e
+    # Every staging run shares one dlt pipeline name, and dlt's working
+    # directory for a pipeline is NOT safe for concurrent runs: normalize's
+    # package cleanup deletes folders under the other run's feet. The add
+    # pipeline processes items concurrently (two CSVs in one add() reach the
+    # dlt_csv_loader in parallel), so staging must serialize here.
+    async with _staging_lock:
+        pipeline = dlt.pipeline(
+            pipeline_name="ingest_dlt_source",
+            destination=destination,
+            dataset_name=dataset_name,
+        )
+        try:
+            # dlt's pipeline.run() is synchronous and potentially long-running;
+            # run it in a thread to avoid blocking the async event loop.
+            load_info = await asyncio.to_thread(pipeline.run, dlt_source, **run_kwargs)
+        except Exception as e:
+            raise DLTIngestionError(
+                message=f"DLT pipeline execution failed for dataset '{original_dataset_name}': {e}"
+            ) from e
 
     # Scope the read-back to the tables this source actually loaded. The
     # staging DB is shared per dataset, so it can still hold tables from other

--- a/cognee/tasks/ingestion/resolve_dlt_sources.py
+++ b/cognee/tasks/ingestion/resolve_dlt_sources.py
@@ -9,7 +9,6 @@ into the document path — each row becomes a text document that flows through
 normal cognify — by declaring a document-source tag (see
 dlt_utils.document_source_tag)."""
 
-import hashlib
 import json
 import os
 import shutil
@@ -374,13 +373,12 @@ async def _build_source_manifest_item(
     # The data_id is STABLE — seeded from (dataset, source name) with no
     # content hash — so a changed source updates its Data row in place instead
     # of orphaning it (which left the source absent from the graph between add
-    # and cognify). Change detection travels separately: DataItem.content_hash
-    # pierces the add pipeline's incremental skip when it differs from the
-    # stored Data.content_hash, and the DLT cognify route purges the source's
-    # stale derived artifacts before re-emitting. Renaming a source (or
-    # dataset) changes this identity and is remove + add — a one-time full
-    # rebuild, by design.
-    manifest_hash = hashlib.md5(manifest_text.encode()).hexdigest()
+    # and cognify). add() is idempotent: a re-add of the same source — changed
+    # or not — keeps the completed record as-is. Updating an existing source
+    # is update()'s job (explicit UUID), or an explicit re-ingest via
+    # add(..., incremental_loading=False, data_cache=False). Renaming a source (or dataset)
+    # changes this identity and is remove + add — a one-time full rebuild,
+    # by design.
     data_id = await get_unique_data_id(f"dlt_source:{dataset_name}:{source_name}", user)
 
     return DataItem(
@@ -394,7 +392,6 @@ async def _build_source_manifest_item(
             "row_count": len(manifest_rows),
         },
         data_id=data_id,
-        content_hash=manifest_hash,
     )
 
 

--- a/cognee/tasks/ingestion/resolve_dlt_sources.py
+++ b/cognee/tasks/ingestion/resolve_dlt_sources.py
@@ -27,9 +27,7 @@ from .create_dlt_source import (
     is_connection_string,
     is_csv_path,
     is_csv_upload,
-    csv_source_name,
     create_dlt_source_from_connection_string,
-    create_dlt_source_from_csv,
 )
 from .config import get_ingestion_config
 from .data_item import DataItem
@@ -86,13 +84,11 @@ async def resolve_dlt_sources(
     # Normalise to list for uniform processing
     data_list = data if isinstance(data, list) else [data]
 
-    # --- Auto-detect structured data (CSV paths / connection strings) ------
-    # Per item, so a mixed add like [csv_path, note_path] routes the CSV to
-    # the DLT manifest path instead of silently LLM-processing it as text.
-    # CSVs can arrive as local paths, file:// / s3:// locations, or file-like
-    # uploads; remote and streamed bytes are spooled into a temp directory so
-    # dlt's filesystem source can read them, deleted once ingestion is done.
-    data_list, spool_dir = await _normalize_structured_inputs(data_list, query)
+    # --- Auto-detect structured data (connection strings) ------------------
+    # CSVs are NOT handled here anymore: they route through the loader engine
+    # (dlt_csv_loader, registered above csv_loader) inside the ingest
+    # pipeline, which owns localization (s3/file://) and manifest emission.
+    data_list = _normalize_structured_inputs(data_list, query)
 
     dlt_items = []
     non_dlt_items = []
@@ -122,65 +118,59 @@ async def resolve_dlt_sources(
     # back (max_rows_per_table=0) so orphan cleanup can forget rows that dropped
     # out of the current corpus. write_disposition/primary_key default to
     # "replace"/"id" (see the kwargs resolution above).
-    try:
-        document_data_items: list[DataItem] = []
-        document_fresh_ids: Set[UUID] = set()
-        document_source_tags: set[str] = set()
-        for dlt_item in document_items:
-            source_tag = document_source_tag(dlt_item)
-            document_source_tags.add(source_tag)
-            rows = await ingest_dlt_source(
-                dlt_item,
-                dataset_name,
-                primary_key=primary_key or "id",
-                write_disposition=write_disposition,
-                max_rows_per_table=0,
-            )
-            # Dataset-scoped ids with the pre-scoping adoption probe: rows are
-            # dataset-scoped with id as primary key, so a dataset-free
-            # derivation would pin the same id when one source loads into two
-            # datasets — a hard collision on the foreign-pin guard.
-            row_ids = await _stable_row_ids(rows, user, dataset_id)
-            for row, data_id in zip(rows, row_ids):
-                document_fresh_ids.add(data_id)
-                document_data_items.append(_build_document_data_item(row, data_id, source_tag))
+    document_data_items: list[DataItem] = []
+    document_fresh_ids: Set[UUID] = set()
+    document_source_tags: set[str] = set()
+    for dlt_item in document_items:
+        source_tag = document_source_tag(dlt_item)
+        document_source_tags.add(source_tag)
+        rows = await ingest_dlt_source(
+            dlt_item,
+            dataset_name,
+            primary_key=primary_key or "id",
+            write_disposition=write_disposition,
+            max_rows_per_table=0,
+        )
+        # Dataset-scoped ids with the pre-scoping adoption probe: rows are
+        # dataset-scoped with id as primary key, so a dataset-free
+        # derivation would pin the same id when one source loads into two
+        # datasets — a hard collision on the foreign-pin guard.
+        row_ids = await _stable_row_ids(rows, user, dataset_id)
+        for row, data_id in zip(rows, row_ids):
+            document_fresh_ids.add(data_id)
+            document_data_items.append(_build_document_data_item(row, data_id, source_tag))
 
-        # --- Relational sources: one manifest DataItem per source -----------
-        expanded_items: list[DataItem] = []
-        manifest_data_ids: Set[UUID] = set()
-        for dlt_item in relational_items:
-            rows = await ingest_dlt_source(
-                dlt_item,
-                dataset_name,
-                primary_key=primary_key,
-                write_disposition=write_disposition,
-                max_rows_per_table=max_rows_per_table,
-            )
-            source_name = getattr(dlt_item, "name", None) or dataset_name
-            item = await _build_source_manifest_item(
-                rows,
-                source_name,
-                dataset_name,
-                user,
-                column_value_columns=column_value_columns,
-            )
-            if item is not None:
-                if item.data_id in manifest_data_ids:
-                    # Stable ids are seeded from (dataset, source name): two
-                    # resources sharing a name would silently overwrite each
-                    # other's manifest. Fail loudly instead of last-write-wins.
-                    raise ValueError(
-                        f"Two DLT sources in one add() resolve to the same identity "
-                        f"(dataset {dataset_name!r}, source {source_name!r}). "
-                        "Give each source a unique name."
-                    )
-                expanded_items.append(item)
-                manifest_data_ids.add(item.data_id)
-    finally:
-        # Spooled CSV copies are only needed while dlt reads them (the ingest
-        # calls above); drop them even when ingestion fails.
-        if spool_dir is not None:
-            shutil.rmtree(spool_dir, ignore_errors=True)
+    # --- Relational sources: one manifest DataItem per source -----------
+    expanded_items: list[DataItem] = []
+    manifest_data_ids: Set[UUID] = set()
+    for dlt_item in relational_items:
+        rows = await ingest_dlt_source(
+            dlt_item,
+            dataset_name,
+            primary_key=primary_key,
+            write_disposition=write_disposition,
+            max_rows_per_table=max_rows_per_table,
+        )
+        source_name = getattr(dlt_item, "name", None) or dataset_name
+        item = await _build_source_manifest_item(
+            rows,
+            source_name,
+            dataset_name,
+            user,
+            column_value_columns=column_value_columns,
+        )
+        if item is not None:
+            if item.data_id in manifest_data_ids:
+                # Stable ids are seeded from (dataset, source name): two
+                # resources sharing a name would silently overwrite each
+                # other's manifest. Fail loudly instead of last-write-wins.
+                raise ValueError(
+                    f"Two DLT sources in one add() resolve to the same identity "
+                    f"(dataset {dataset_name!r}, source {source_name!r}). "
+                    "Give each source a unique name."
+                )
+            expanded_items.append(item)
+            manifest_data_ids.add(item.data_id)
 
     # Manifest source names, collected before document items join the list.
     ingested_source_names = {item.system_metadata["source_name"] for item in expanded_items}
@@ -236,84 +226,21 @@ async def resolve_dlt_sources(
     return result, orphan_cleanup
 
 
-async def _normalize_structured_inputs(data_list: list, query: Optional[str]) -> tuple:
+def _normalize_structured_inputs(data_list: list, query: Optional[str]) -> list:
     """Wrap auto-detected structured inputs in dlt sources.
 
-    CSV inputs (local path strings, file:// / s3:// locations, and file-like
-    uploads) become dlt filesystem resources; connection strings become dlt
-    sql_database sources; everything else passes through unchanged. Returns
-    ``(normalized_list, spool_dir)`` where ``spool_dir`` (or None) is a temp
-    directory holding local copies of remote/streamed CSVs — the caller must
-    delete it once dlt has read the files.
+    Connection strings become dlt sql_database sources; everything else
+    passes through unchanged. CSV inputs are deliberately NOT handled here —
+    the loader engine's dlt_csv_loader owns them inside the ingest pipeline
+    (with localization of s3:// and file:// locations built in).
     """
-    spool_dir: Optional[str] = None
     normalized = []
-    try:
-        for item in data_list:
-            if isinstance(item, str) and is_connection_string(item):
-                normalized.append(create_dlt_source_from_connection_string(item, query=query))
-            elif (isinstance(item, str) and is_csv_path(item)) or is_csv_upload(item):
-                local_path, spool_dir = await _as_local_csv_path(item, spool_dir)
-                normalized.append(create_dlt_source_from_csv(local_path))
-            else:
-                normalized.append(item)
-    except Exception:
-        if spool_dir is not None:
-            shutil.rmtree(spool_dir, ignore_errors=True)
-        raise
-    return normalized, spool_dir
-
-
-async def _as_local_csv_path(item, spool_dir: Optional[str]) -> tuple:
-    """Return a local path dlt's filesystem source can read for one CSV input.
-
-    Plain local path strings pass through untouched; file:// URIs are
-    unwrapped. s3:// paths and file-like uploads are spooled into a shared
-    temp directory (created on first use and returned for caller cleanup).
-    Spooled files are stored as ``{csv_source_name}.csv`` so the on-disk name,
-    dlt's file glob, and the manifest identity all agree.
-    """
-    if isinstance(item, str):
-        parsed = urlparse(item)
-        if parsed.scheme == "file":
-            return url2pathname(parsed.path), spool_dir
-        if parsed.scheme != "s3":
-            return item, spool_dir
-
-    filename = (
-        item
-        if isinstance(item, str)
-        else getattr(item, "filename", None) or getattr(item, "name", "")
-    )
-    if spool_dir is None:
-        spool_dir = tempfile.mkdtemp(prefix="cognee_dlt_csv_")
-    target = os.path.join(spool_dir, f"{csv_source_name(filename)}.csv")
-    if os.path.exists(target):
-        # Manifest identity is seeded from the source name, so two inputs
-        # landing on one spooled file would also collide there — fail loudly
-        # before the first one's bytes get overwritten.
-        raise ValueError(
-            f"Two CSV inputs in one add() resolve to the same source name "
-            f"{csv_source_name(filename)!r}. Give the files distinct names."
-        )
-
-    if isinstance(item, str):
-        # s3:// path — read through cognee's storage layer (configured
-        # credentials) instead of teaching dlt a second credential path.
-        from cognee.infrastructure.files.utils.open_data_file import open_data_file
-
-        async with open_data_file(item, mode="rb") as remote_file:
-            with open(target, "wb") as local_file:
-                shutil.copyfileobj(remote_file, local_file)
-    else:
-        stream = getattr(item, "file", None) or item
-        try:
-            stream.seek(0)
-        except (AttributeError, OSError, ValueError):
-            pass
-        with open(target, "wb") as local_file:
-            shutil.copyfileobj(stream, local_file)
-    return target, spool_dir
+    for item in data_list:
+        if isinstance(item, str) and is_connection_string(item):
+            normalized.append(create_dlt_source_from_connection_string(item, query=query))
+        else:
+            normalized.append(item)
+    return normalized
 
 
 def _log_structured_inputs_without_dlt(data_list: list) -> None:

--- a/cognee/tasks/ingestion/utils.py
+++ b/cognee/tasks/ingestion/utils.py
@@ -39,15 +39,13 @@ async def _read_stream_bytes(stream: Any) -> bytes:
 async def materialize_stream_for_background(data_item: Any, index: int = 0) -> Any:
     if isinstance(data_item, DataItem):
         # Copy EVERY DataItem field: dropping one here silently breaks the
-        # background path only (system_metadata carries the DLT routing stamp,
-        # content_hash pierces the incremental skip on changed stable-id items).
+        # background path only (system_metadata carries the DLT routing stamp).
         return DataItem(
             data=await materialize_stream_for_background(data_item.data, index=index),
             label=data_item.label,
             external_metadata=data_item.external_metadata,
             system_metadata=data_item.system_metadata,
             data_id=data_item.data_id,
-            content_hash=data_item.content_hash,
         )
 
     if isinstance(data_item, list):

--- a/cognee/tests/integration/tasks/test_dlt_csv_loader_route.py
+++ b/cognee/tests/integration/tasks/test_dlt_csv_loader_route.py
@@ -123,3 +123,39 @@ async def test_csv_takes_dlt_route_through_loader(clean_env):
 
     assert census.get("DltRow") == 3, f"expected 3 DltRow nodes, census: {census}"
     assert census.get("SchemaTable") == 1, f"schema node missing: {census}"
+
+
+@pytest.mark.asyncio
+async def test_two_csvs_in_one_add_stage_concurrently(clean_env, tmp_path):
+    """Two CSVs in one add() reach the dlt_csv_loader in parallel (the add
+    pipeline runs items concurrently). Staging serializes on the shared dlt
+    working directory — regression guard: dlt's normalize cleanup used to
+    race the sibling run's package folders and crash ingestion."""
+    first_csv = clean_env
+    second = pathlib.Path(tmp_path) / "sensors.csv"
+    second.write_text("id,kind,unit\n1,thermometer,C\n2,hygrometer,%\n3,anemometer,m/s\n")
+
+    await cognee.add([first_csv, str(second)], dataset_name="csv_pair_ds")
+
+    user = await get_default_user()
+    dataset = (
+        await get_authorized_existing_datasets(
+            user=user, permission_type="read", datasets=["csv_pair_ds"]
+        )
+    )[0]
+    manifests = [r for r in await get_dataset_data(dataset.id) if is_dlt_source_manifest(r)]
+    assert len(manifests) == 2, f"both CSVs must become manifests, got {len(manifests)}"
+    assert {m.system_metadata.get("source_name") for m in manifests} == {"instruments", "sensors"}
+    assert all(m.loader_engine == "dlt_csv_loader" for m in manifests)
+
+    await cognee.cognify(datasets=["csv_pair_ds"])
+
+    from cognee.infrastructure.databases.graph import get_graph_engine
+
+    graph = await get_graph_engine()
+    nodes, _ = await graph.get_graph_data()
+    census: dict = {}
+    for _, props in nodes:
+        census[props.get("type", "?")] = census.get(props.get("type", "?"), 0) + 1
+    assert census.get("DltRow") == 6, f"3 rows per CSV expected, census: {census}"
+    assert census.get("SchemaTable") == 2, f"one schema table per CSV, census: {census}"

--- a/cognee/tests/integration/tasks/test_dlt_csv_loader_route.py
+++ b/cognee/tests/integration/tasks/test_dlt_csv_loader_route.py
@@ -1,0 +1,125 @@
+"""A CSV through plain add()/cognify() must take the DLT route via the loader engine.
+
+CSV handling moved out of resolve_dlt_sources into the loader system:
+``dlt_csv_loader`` (registered above the text-flattening ``csv_loader``) runs
+staging ingestion inside the ingest pipeline and returns the manifest as a
+``LoaderResult`` carrying the stable ``data_id`` and the ``system_metadata``
+route stamp. This drives the whole path end to end, hermetically: local CSV,
+mocked embeddings (the DLT route makes no LLM calls).
+"""
+
+import json
+import pathlib
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+
+import cognee
+from cognee.context_global_variables import graph_db_config, vector_db_config
+from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine import (
+    LiteLLMEmbeddingEngine,
+)
+from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.modules.data.methods.get_dataset_data import get_dataset_data
+from cognee.modules.engine.operations.setup import setup as engine_setup
+from cognee.modules.users.methods import get_default_user
+from cognee.tasks.ingestion.dlt_utils import is_dlt_source_manifest
+
+DATASET = "csv_loader_ds"
+CSV_CONTENT = "id,name,section\n1,anemometer,weather\n2,barometer,weather\n3,seismograph,geology\n"
+
+
+async def _mock_embed_text(self, texts):
+    return [[float(len(t) % 7) / 10.0 + 0.1] * self.dimensions for t in texts]
+
+
+@pytest_asyncio.fixture
+async def clean_env(tmp_path, monkeypatch):
+    pytest.importorskip("dlt")
+    pytest.importorskip("ladybug")
+
+    monkeypatch.setenv("COGNEE_SKIP_CONNECTION_TEST", "true")
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+    root = pathlib.Path(tmp_path)
+    monkeypatch.setenv("DLT_DATA_DIR", str(root / "dlt"))
+
+    from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+    from cognee.infrastructure.databases.vector.create_vector_engine import _create_vector_engine
+
+    _create_graph_engine.cache_clear()
+    _create_vector_engine.cache_clear()
+    create_relational_engine.cache_clear()
+    graph_db_config.set(None)
+    vector_db_config.set(None)
+
+    cognee.config.set_relational_db_config({"db_provider": "sqlite"})
+    cognee.config.system_root_directory(str(root / "system"))
+    cognee.config.data_root_directory(str(root / "data"))
+    cognee.config.set_vector_db_url(str(root / "system" / "databases" / "cognee.lancedb"))
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    await engine_setup()
+
+    csv_file = root / "instruments.csv"
+    csv_file.write_text(CSV_CONTENT)
+
+    with patch.object(LiteLLMEmbeddingEngine, "embed_text", new=_mock_embed_text):
+        yield str(csv_file)
+
+    try:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_csv_takes_dlt_route_through_loader(clean_env):
+    csv_path = clean_env
+
+    await cognee.add([csv_path], dataset_name=DATASET)
+
+    user = await get_default_user()
+    dataset = (
+        await get_authorized_existing_datasets(
+            user=user, permission_type="read", datasets=[DATASET]
+        )
+    )[0]
+    records = await get_dataset_data(dataset.id)
+    manifests = [record for record in records if is_dlt_source_manifest(record)]
+    assert len(manifests) == 1, f"CSV must become one manifest record, got {len(manifests)}"
+    manifest = manifests[0]
+    assert manifest.system_metadata.get("row_count") == 3
+    assert manifest.loader_engine == "dlt_csv_loader"
+
+    # raw_data_location holds the manifest text the DLT cognify route reads.
+    from cognee.infrastructure.files.utils.open_data_file import open_data_file
+
+    async with open_data_file(manifest.raw_data_location) as manifest_file:
+        manifest_body = json.loads(manifest_file.read())
+    assert len(manifest_body["rows"]) == 3
+
+    # Re-adding the identical CSV must not mint a second record.
+    await cognee.add([csv_path], dataset_name=DATASET)
+    records_after = await get_dataset_data(dataset.id)
+    manifests_after = [r for r in records_after if is_dlt_source_manifest(r)]
+    assert len(manifests_after) == 1
+    assert manifests_after[0].id == manifest.id
+
+    await cognee.cognify(datasets=[DATASET])
+
+    from cognee.infrastructure.databases.graph import get_graph_engine
+
+    graph = await get_graph_engine()
+    nodes, _ = await graph.get_graph_data()
+    census: dict = {}
+    for _, props in nodes:
+        census[props.get("type", "?")] = census.get(props.get("type", "?"), 0) + 1
+
+    assert census.get("DltRow") == 3, f"expected 3 DltRow nodes, census: {census}"
+    assert census.get("SchemaTable") == 1, f"schema node missing: {census}"

--- a/cognee/tests/integration/tasks/test_dlt_orphan_graph_vector_purge.py
+++ b/cognee/tests/integration/tasks/test_dlt_orphan_graph_vector_purge.py
@@ -1,12 +1,14 @@
 """A row hard-deleted upstream must vanish from ALL per-dataset stores
 (relational, graph, vector) after a re-sync, under multi-user access control.
 
-Mechanism, under stable manifest identity: the re-sync updates the SAME
-manifest Data record in place (DataItem.content_hash pierces the add
-pipeline's completed-skip), and the deleted row's derived artifacts are
-purged by ``purge_stale_dlt_source_artifacts`` at the head of the DLT route
-during re-cognify — inside the run's per-dataset DB context, so the purge
-hits the per-dataset graph + vector stores, not the default engines.
+Mechanism, under stable manifest identity: an explicit re-ingest
+(add(..., incremental_loading=False, data_cache=False) — plain add() is
+idempotent and skips completed items; update() is the UUID-based
+alternative) updates the SAME manifest Data record in place, and the
+deleted row's derived artifacts are purged by
+``purge_stale_dlt_source_artifacts`` at the head of the DLT route during
+re-cognify — inside the run's per-dataset DB context, so the purge hits
+the per-dataset graph + vector stores, not the default engines.
 (Historically this scenario went through ``_delete_dlt_orphans`` at add
 time: a changed source produced a NEW content-addressed id and orphaned the
 old manifest. Stable ids removed that churn; ``_delete_dlt_orphans`` now
@@ -215,13 +217,17 @@ async def test_deleted_row_purged_from_per_dataset_stores_on_resync(clean_env):
         nodes_before, vec_before = await _store_counts(dataset)
         assert nodes_before > 0 and vec_before == 2  # graph populated, 2 chunks
 
-        # Delete 'b' upstream and re-sync through the real add pipeline. The
-        # manifest keeps its STABLE Data id: the re-sync updates the record in
-        # place (content hash changed -> the completed-skip is pierced and
-        # pipeline_status cleared), so nothing is orphaned and the source is
+        # Delete 'b' upstream and re-sync via an EXPLICIT re-ingest (plain
+        # add() is idempotent — completed items keep the fast skip). The
+        # manifest keeps its STABLE Data id: the record updates in place and
+        # pipeline_status clears, so nothing is orphaned and the source is
         # never absent from the relational store.
         await cognee.add(
-            _dlt_source([{"id": "b", "_deleted": True}]), dataset_name=DATASET, **kwargs
+            _dlt_source([{"id": "b", "_deleted": True}]),
+            dataset_name=DATASET,
+            incremental_loading=False,
+            data_cache=False,
+            **kwargs,
         )
         # Re-cognify: purge_stale_dlt_source_artifacts drops the source's
         # previous graph/vector artifacts (including row 'b') inside the

--- a/cognee/tests/integration/tasks/test_dlt_stable_id_reprocess.py
+++ b/cognee/tests/integration/tasks/test_dlt_stable_id_reprocess.py
@@ -138,24 +138,39 @@ async def test_changed_row_reprocesses_without_vanishing(clean_env):
     texts = await _row_texts()
     assert "pending" in texts
 
-    # Re-sync with one changed row. The Data row must survive in place:
-    # same id, new hash, never absent.
+    # Re-sync with one changed row through plain add(): add() is IDEMPOTENT.
+    # The completed record keeps the fast skip — same id, same stored hash,
+    # graph untouched. Updating an existing source is update()'s job
+    # (explicit UUID) or an explicit re-ingest (below).
+    changed_rows = [
+        {"id": "1", "status": "active"},
+        {"id": "2", "status": "shipped"},
+    ]
+    await cognee.add(_dlt_source(changed_rows), dataset_name=DATASET, **kwargs)
+    _, records = await _manifest_record(user)
+    assert len(records) == 1, "manifest must never be absent after a re-add"
+    assert records[0].id == manifest_id, "stable identity: same Data id across re-adds"
+    assert str(records[0].content_hash) == str(first_hash), (
+        "plain re-add must not mutate the completed record"
+    )
+    texts = await _row_texts()
+    assert "pending" in texts, "plain re-add must leave the graph untouched"
+
+    # Explicit re-ingest: the completed-skip runs whenever data_cache OR
+    # incremental_loading is on, so bypassing it takes both flags off; the
+    # record then updates in place and re-cognify purges + re-emits.
     await cognee.add(
-        _dlt_source(
-            [
-                {"id": "1", "status": "active"},
-                {"id": "2", "status": "shipped"},
-            ]
-        ),
+        _dlt_source(changed_rows),
         dataset_name=DATASET,
+        incremental_loading=False,
+        data_cache=False,
         **kwargs,
     )
     _, records = await _manifest_record(user)
-    assert len(records) == 1, "manifest must never be absent after a changed re-add"
-    assert records[0].id == manifest_id, "stable identity: same Data id across the change"
-    assert str(records[0].content_hash) != str(first_hash), "content hash tracked the change"
+    assert len(records) == 1
+    assert records[0].id == manifest_id, "stable identity survives the explicit re-ingest"
+    assert str(records[0].content_hash) != str(first_hash), "record tracked the change"
 
-    # Re-cognify: purge + re-emit. New value searchable, old value gone.
     await cognee.cognify(datasets=[DATASET])
     texts = await _row_texts()
     assert "shipped" in texts, "updated row value must be in the graph"

--- a/cognee/tests/test_s3.py
+++ b/cognee/tests/test_s3.py
@@ -73,6 +73,80 @@ async def main():
         f"Expected at least one 'contains' edge, but found {edge_type_counts.get('contains', 0)}"
     )
 
+    await dlt_csv_from_s3()
+
+
+DLT_CSV_BUCKET = "github-runner-cognee-tests"
+DLT_CSV_DATASET = "s3_csv_dlt_ds"
+DLT_CSV_ROWS = "id,name,section\n1,anemometer,weather\n2,barometer,weather\n3,seismograph,geology\n"
+
+
+async def dlt_csv_from_s3():
+    """A bare s3://...csv path through plain add()/cognify() must take the
+    DLT route via the loader engine: data_item_to_text_file localizes the
+    object through cognee's storage layer (S3Config credentials), the
+    dlt_csv_loader stages it, and one manifest record with a DltRow per line
+    lands in the graph.
+
+    The CSV is self-provisioned into a run-scoped key (the bucket is shared
+    across CI runs) and removed afterwards. Requires the dlt extra (the job
+    installs it) and the job's AWS credentials — the same ones the S3 file
+    storage tests write with.
+    """
+    import uuid
+
+    import dlt  # noqa: F401 — hard requirement; the CI job installs the extra
+    import s3fs
+
+    from cognee.context_global_variables import set_database_global_context_variables
+    from cognee.modules.data.methods import get_authorized_existing_datasets
+    from cognee.modules.data.methods.get_dataset_data import get_dataset_data
+    from cognee.modules.users.methods import get_default_user
+    from cognee.tasks.ingestion.dlt_utils import is_dlt_source_manifest
+
+    fs = s3fs.S3FileSystem()
+    key = f"{DLT_CSV_BUCKET}/dlt_csv_ingestion/{uuid.uuid4().hex}/instruments.csv"
+    with fs.open(key, "w") as remote_file:
+        remote_file.write(DLT_CSV_ROWS)
+
+    try:
+        s3_csv_url = f"s3://{key}"
+        logging.info("Adding CSV from %s through the DLT loader path", s3_csv_url)
+        await cognee.add([s3_csv_url], dataset_name=DLT_CSV_DATASET)
+        await cognee.cognify(datasets=[DLT_CSV_DATASET])
+    finally:
+        fs.rm(key)
+
+    user = await get_default_user()
+    dataset = (
+        await get_authorized_existing_datasets(
+            user=user, permission_type="read", datasets=[DLT_CSV_DATASET]
+        )
+    )[0]
+
+    manifests = [
+        record for record in await get_dataset_data(dataset.id) if is_dlt_source_manifest(record)
+    ]
+    assert len(manifests) == 1, f"Expected 1 DLT manifest for the S3 CSV, found {len(manifests)}"
+    assert manifests[0].system_metadata.get("row_count") == 3, (
+        f"Expected row_count 3, got {manifests[0].system_metadata.get('row_count')}"
+    )
+    assert manifests[0].loader_engine == "dlt_csv_loader", (
+        f"Expected the dlt_csv_loader to own the record, got {manifests[0].loader_engine!r}"
+    )
+
+    async with set_database_global_context_variables(dataset.id, dataset.owner_id):
+        graph_engine = await get_graph_engine()
+        nodes, _ = await graph_engine.get_graph_data()
+    csv_census = Counter(props.get("type") for _, props in nodes)
+    assert csv_census.get("DltRow", 0) == 3, (
+        f"Expected 3 DltRow nodes from the S3 CSV, found {csv_census.get('DltRow', 0)}"
+    )
+    assert csv_census.get("SchemaTable", 0) == 1, (
+        f"Expected 1 SchemaTable node, found {csv_census.get('SchemaTable', 0)}"
+    )
+    logging.info("S3 CSV DLT ingestion verified: %s", dict(csv_census))
+
 
 if __name__ == "__main__":
     import asyncio

--- a/cognee/tests/unit/tasks/ingestion/test_dlt_csv_inputs.py
+++ b/cognee/tests/unit/tasks/ingestion/test_dlt_csv_inputs.py
@@ -1,174 +1,134 @@
-"""CSV inputs to the DLT auto-detection: paths, uploads, and s3 locations.
+"""CSV ingestion routes through the loader engine's dlt_csv_loader.
 
-resolve_dlt_sources auto-routes CSVs to the DLT manifest path. Three input
-shapes must all land there with a filename-derived source name (the manifest
-identity is seeded from it):
-
-1. local path strings (and file:// URIs) — read in place, nothing spooled
-2. file-like uploads (API UploadFile / SDK binary handles) — spooled to a
-   temp dir dlt's filesystem source can read
-3. s3:// paths — downloaded through cognee's storage layer, then spooled
-
-Naming per file (instead of dlt's fixed "_read_csv" pipe name) is what keeps
-two CSVs in one dataset from collapsing into a single manifest identity.
+With the dlt extra installed, the engine's priority order puts
+``dlt_csv_loader`` above the plain ``csv_loader``, so every CSV takes the
+structured DLT route: staging ingestion, one manifest per file with a stable
+``data_id``, and the ``system_metadata`` route stamp — returned to
+``ingest_data`` as a ``LoaderResult``. The text-flattening ``csv_loader``
+remains reachable as an explicit per-call choice via ``preferred_loaders``,
+and is the automatic fallback when dlt is not installed (this loader never
+registers then).
 """
 
-import io
-import logging
-import os
-from contextlib import asynccontextmanager
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 
-# The unit CI matrices install the base extras only — dlt is optional there,
-# and the resolve_dlt_sources import chain below pulls dlt at module level.
+# The unit CI matrices install the base extras only — without dlt the loader
+# under test is deliberately not registered.
 pytest.importorskip("dlt")
 
-import cognee.infrastructure.files.utils.open_data_file as open_data_file_module
-from cognee.tasks.ingestion.create_dlt_source import (
-    create_dlt_source_from_csv,
-    csv_source_name,
-    is_csv_upload,
-)
-from cognee.tasks.ingestion.resolve_dlt_sources import (
-    _log_structured_inputs_without_dlt,
-    _normalize_structured_inputs,
-)
+import importlib  # noqa: E402
+
+# The ingestion package re-exports these names, shadowing the submodules on
+# plain ``import a.b.c as m`` — import_module returns the real modules.
+ingest_dlt_source_module = importlib.import_module("cognee.tasks.ingestion.ingest_dlt_source")
+resolve_module = importlib.import_module("cognee.tasks.ingestion.resolve_dlt_sources")
+from cognee.infrastructure.loaders.create_loader_engine import create_loader_engine  # noqa: E402
+from cognee.infrastructure.loaders.external.dlt_csv_loader import DltCsvLoader  # noqa: E402
+from cognee.infrastructure.loaders.LoaderInterface import LoaderResult  # noqa: E402
+from cognee.modules.ingestion.exceptions import IngestionError  # noqa: E402
+from cognee.tasks.ingestion.data_item import DataItem  # noqa: E402
 
 CSV_BYTES = b"id,name\n1,Ada\n2,Alan\n"
 
 
-def _upload(filename="people.csv", content=CSV_BYTES):
-    """Duck-typed API upload: .file + .filename, like starlette's UploadFile."""
-    return SimpleNamespace(file=io.BytesIO(content), filename=filename)
-
-
-def _csv_file(tmp_path, name="people.csv", content=CSV_BYTES):
-    path = tmp_path / name
-    path.write_bytes(content)
+@pytest.fixture
+def csv_file(tmp_path):
+    path = tmp_path / "people.csv"
+    path.write_bytes(CSV_BYTES)
     return str(path)
 
 
-class TestCsvSourceName:
-    def test_stem_is_sanitized_and_lowercased(self):
-        assert csv_source_name("My Data-2024.csv") == "my_data_2024"
+class TestDispatch:
+    def test_dlt_loader_wins_csv_dispatch(self, csv_file):
+        engine = create_loader_engine()
+        loader = engine.get_loader(csv_file, None)
+        assert loader is not None
+        assert loader.loader_name == "dlt_csv_loader"
 
-    def test_path_is_reduced_to_basename(self):
-        assert csv_source_name("/some/dir/people.csv") == "people"
-
-    def test_unusable_stem_falls_back(self):
-        assert csv_source_name("---.csv") == "csv_source"
-
-
-class TestIsCsvUpload:
-    def test_api_upload_shape(self):
-        assert is_csv_upload(_upload())
-
-    def test_binary_handle_shape(self, tmp_path):
-        with open(_csv_file(tmp_path), "rb") as handle:
-            assert is_csv_upload(handle)
-
-    def test_strings_are_not_uploads(self):
-        assert not is_csv_upload("people.csv")
-
-    def test_non_csv_filename_rejected(self):
-        assert not is_csv_upload(SimpleNamespace(file=io.BytesIO(), filename="notes.txt"))
-
-    def test_filename_less_object_rejected(self):
-        assert not is_csv_upload(io.BytesIO(CSV_BYTES))
+    def test_preferred_loader_forces_plain_csv(self, csv_file):
+        engine = create_loader_engine()
+        loader = engine.get_loader(csv_file, {"csv_loader": {}})
+        assert loader is not None
+        assert loader.loader_name == "csv_loader"
 
 
-class TestCreateDltSourceFromCsv:
-    def test_resource_named_after_file(self, tmp_path):
-        source = create_dlt_source_from_csv(_csv_file(tmp_path, "Employee Roster.csv"))
-        assert source.name == "employee_roster"
+class TestLoad:
+    @pytest.mark.asyncio
+    async def test_load_returns_manifest_loader_result(self, csv_file, tmp_path, monkeypatch):
+        """load() must run staging ingestion + manifest build and hand back
+        the manifest's stable id and route stamp as a LoaderResult."""
+        manifest_id = uuid4()
+        stamp = {"source": "dlt_source", "source_name": "people", "row_count": 2}
+        manifest_item = DataItem(data='{"rows": []}', data_id=manifest_id, system_metadata=stamp)
 
+        captured = {}
 
-@pytest.mark.asyncio
-class TestNormalizeStructuredInputs:
-    async def test_local_path_passes_through_without_spooling(self, tmp_path):
-        items, spool_dir = await _normalize_structured_inputs([_csv_file(tmp_path)], None)
-        assert spool_dir is None
-        assert items[0].name == "people"
+        def fake_create(path, source_name=None):
+            captured["source_name"] = source_name
+            captured["path"] = path
+            return SimpleNamespace(name=source_name)
 
-    async def test_file_uri_is_unwrapped(self, tmp_path):
-        items, spool_dir = await _normalize_structured_inputs(
-            [f"file://{_csv_file(tmp_path)}"], None
+        import cognee.tasks.ingestion.create_dlt_source as create_module
+        import cognee.infrastructure.loaders.external.dlt_csv_loader as loader_module
+
+        monkeypatch.setattr(create_module, "create_dlt_source_from_csv", fake_create)
+        monkeypatch.setattr(
+            ingest_dlt_source_module, "ingest_dlt_source", AsyncMock(return_value=["row"])
         )
-        assert spool_dir is None
-        assert items[0].name == "people"
-
-    async def test_upload_is_spooled_and_named_after_filename(self, tmp_path):
-        items, spool_dir = await _normalize_structured_inputs(
-            [_upload("Employee Roster.csv")], None
+        monkeypatch.setattr(
+            resolve_module, "_build_source_manifest_item", AsyncMock(return_value=manifest_item)
         )
-        try:
-            assert spool_dir is not None
-            assert items[0].name == "employee_roster"
-            spooled = os.path.join(spool_dir, "employee_roster.csv")
-            with open(spooled, "rb") as spooled_file:
-                assert spooled_file.read() == CSV_BYTES
-        finally:
-            if spool_dir:
-                import shutil
 
-                shutil.rmtree(spool_dir, ignore_errors=True)
+        stored = {}
 
-    async def test_non_structured_items_pass_through(self):
-        items, spool_dir = await _normalize_structured_inputs(["a plain note"], None)
-        assert spool_dir is None
-        assert items == ["a plain note"]
+        def fake_get_file_storage(root):
+            async def store(name, content):
+                stored["name"] = name
+                stored["content"] = content
+                return str(tmp_path / name)
 
-    async def test_same_name_uploads_fail_loudly(self):
-        with pytest.raises(ValueError, match="same source name"):
-            await _normalize_structured_inputs([_upload("dup.csv"), _upload("dup.csv")], None)
+            return SimpleNamespace(store=store)
 
-    async def test_s3_path_is_downloaded_via_storage_layer(self, monkeypatch):
-        opened = []
-
-        @asynccontextmanager
-        async def fake_open_data_file(file_path, mode="rb", **kwargs):
-            opened.append((file_path, mode))
-            yield io.BytesIO(CSV_BYTES)
-
-        monkeypatch.setattr(open_data_file_module, "open_data_file", fake_open_data_file)
-
-        items, spool_dir = await _normalize_structured_inputs(
-            ["s3://bucket/exports/orders.csv"], None
+        monkeypatch.setattr(loader_module, "get_file_storage", fake_get_file_storage)
+        monkeypatch.setattr(
+            loader_module,
+            "get_storage_config",
+            lambda: {"data_root_directory": str(tmp_path)},
         )
-        try:
-            assert opened == [("s3://bucket/exports/orders.csv", "rb")]
-            assert items[0].name == "orders"
-            spooled = os.path.join(spool_dir, "orders.csv")
-            with open(spooled, "rb") as spooled_file:
-                assert spooled_file.read() == CSV_BYTES
-        finally:
-            if spool_dir:
-                import shutil
 
-                shutil.rmtree(spool_dir, ignore_errors=True)
+        result = await DltCsvLoader().load(
+            csv_file,
+            dataset_name="ds",
+            user=SimpleNamespace(id=uuid4()),
+            original_file_name="Lab Machines.csv",
+        )
 
+        assert isinstance(result, LoaderResult)
+        assert result.data_id == manifest_id
+        assert result.system_metadata == stamp
+        assert stored["content"] == '{"rows": []}'
+        assert result.file_path.endswith(stored["name"])
+        # The manifest identity derives from the ORIGINAL file name, not the
+        # (possibly temp/stored) copy the loader actually read.
+        assert captured["source_name"] == "lab_machines"
+        assert captured["path"] == csv_file
 
-class TestDltMissingWarning:
-    def test_warns_for_structured_inputs(self, caplog):
-        with caplog.at_level(logging.WARNING):
-            _log_structured_inputs_without_dlt(
-                [
-                    "data/people.csv",
-                    _upload("roster.csv"),
-                    "postgresql://user:secret@host/db",
-                    "a plain note",
-                ]
-            )
-        assert "3 structured input(s)" in caplog.text
-        assert "people.csv" in caplog.text
-        assert "roster.csv" in caplog.text
-        # Connection strings can embed credentials — never logged verbatim.
-        assert "secret" not in caplog.text
-        assert "<connection string>" in caplog.text
+    @pytest.mark.asyncio
+    async def test_load_without_ingestion_context_fails_loudly(self, csv_file):
+        with pytest.raises(IngestionError):
+            await DltCsvLoader().load(csv_file)
 
-    def test_silent_when_nothing_structured(self, caplog):
-        with caplog.at_level(logging.WARNING):
-            _log_structured_inputs_without_dlt(["a plain note", 42])
-        assert caplog.text == ""
+    @pytest.mark.asyncio
+    async def test_empty_source_fails_loudly(self, csv_file, monkeypatch):
+        monkeypatch.setattr(
+            ingest_dlt_source_module, "ingest_dlt_source", AsyncMock(return_value=[])
+        )
+        monkeypatch.setattr(
+            resolve_module, "_build_source_manifest_item", AsyncMock(return_value=None)
+        )
+        with pytest.raises(IngestionError, match="no rows"):
+            await DltCsvLoader().load(csv_file, dataset_name="ds", user=SimpleNamespace(id=uuid4()))

--- a/cognee/tests/unit/tasks/ingestion/test_dlt_stable_manifest_id.py
+++ b/cognee/tests/unit/tasks/ingestion/test_dlt_stable_manifest_id.py
@@ -1,19 +1,17 @@
-"""Stable manifest identity: hash-based change detection and loud collisions.
+"""Stable manifest identity: idempotent re-adds and loud collisions.
 
 The manifest Data id is seeded from (dataset, source name) — no content hash —
-so a changed source updates in place instead of vanishing between add and
-cognify. Three invariants keep that safe:
+so re-adding a source resolves to the SAME record instead of orphaning it
+between add and cognify. Two invariants keep that safe:
 
-1. DataItem.content_hash uses the SAME formula as ingestion's stored
-   content_hash (plain md5 over the stored bytes). A mismatch would make every
-   re-add look changed and silently resurrect full churn.
-2. A differing hash pierces the add pipeline's completed-skip; an equal hash
-   keeps the fast skip.
-3. Two sources resolving to one identity in one add() fail loudly instead of
+1. add() is idempotent: a completed item keeps the fast skip on re-add,
+   changed content or not. Updating an existing source is update()'s job
+   (explicit UUID), or an explicit re-ingest via
+   add(..., incremental_loading=False, data_cache=False).
+2. Two sources resolving to one identity in one add() fail loudly instead of
    last-write-wins.
 """
 
-import hashlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -21,7 +19,6 @@ from uuid import uuid4
 import pytest
 
 import cognee.modules.pipelines.operations.run_tasks_data_item as item_module
-from cognee.infrastructure.files.utils.get_file_content_hash import get_file_content_hash
 from cognee.modules.pipelines.models.PipelineRunInfo import (
     PipelineRunAlreadyCompleted,
     PipelineRunCompleted,
@@ -29,27 +26,14 @@ from cognee.modules.pipelines.models.PipelineRunInfo import (
 from cognee.tasks.ingestion.data_item import DataItem
 
 
-@pytest.mark.asyncio
-async def test_manifest_hash_formula_matches_ingestion(tmp_path):
-    """md5(text) as computed by resolve_dlt_sources == ingestion's file hash."""
-    manifest_text = '{"rows":[{"node_id":"abc"}],"version":1}'
-    manifest_hash = hashlib.md5(manifest_text.encode()).hexdigest()
-
-    file_path = tmp_path / "manifest.json"
-    file_path.write_text(manifest_text)
-    stored_hash = await get_file_content_hash(str(file_path))
-
-    assert stored_hash == manifest_hash
-
-
-def _incremental_run(monkeypatch, stored_hash, item_hash, completed=True):
+def _incremental_run(monkeypatch, completed=True):
     """Drive run_tasks_data_item_incremental against a mocked Data row."""
     data_id = uuid4()
     dataset = SimpleNamespace(id=uuid4(), name="ds")
 
     data_point = SimpleNamespace(
         id=data_id,
-        content_hash=stored_hash,
+        content_hash="stored-hash",
         pipeline_status={
             "add_pipeline": {
                 str(dataset.id): item_module.DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED
@@ -78,7 +62,7 @@ def _incremental_run(monkeypatch, stored_hash, item_hash, completed=True):
 
     monkeypatch.setattr(item_module, "run_tasks_with_telemetry", _empty_pipeline)
 
-    data_item = DataItem(data="new text", data_id=data_id, content_hash=item_hash)
+    data_item = DataItem(data="new text", data_id=data_id)
 
     async def _collect():
         events = []
@@ -99,23 +83,26 @@ def _incremental_run(monkeypatch, stored_hash, item_hash, completed=True):
 
 
 @pytest.mark.asyncio
-async def test_changed_content_hash_pierces_the_completed_skip(monkeypatch):
-    collect = _incremental_run(monkeypatch, stored_hash="old-hash", item_hash="new-hash")
-    events = await collect()
-
-    run_infos = [e["run_info"] for e in events if isinstance(e, dict) and "run_info" in e]
-    assert not any(isinstance(info, PipelineRunAlreadyCompleted) for info in run_infos)
-    assert any(isinstance(info, PipelineRunCompleted) for info in run_infos)
-
-
-@pytest.mark.asyncio
-async def test_equal_content_hash_keeps_the_fast_skip(monkeypatch):
-    collect = _incremental_run(monkeypatch, stored_hash="same-hash", item_hash="same-hash")
+async def test_completed_stable_id_item_keeps_the_fast_skip(monkeypatch):
+    """add() is idempotent: a completed item is skipped on re-add, changed
+    content or not — update() (explicit UUID) or turning off both
+    data_cache and incremental_loading are the sanctioned refresh paths."""
+    collect = _incremental_run(monkeypatch, completed=True)
     events = await collect()
 
     run_infos = [e["run_info"] for e in events if isinstance(e, dict) and "run_info" in e]
     assert any(isinstance(info, PipelineRunAlreadyCompleted) for info in run_infos)
     assert not any(isinstance(info, PipelineRunCompleted) for info in run_infos)
+
+
+@pytest.mark.asyncio
+async def test_uncompleted_stable_id_item_processes(monkeypatch):
+    collect = _incremental_run(monkeypatch, completed=False)
+    events = await collect()
+
+    run_infos = [e["run_info"] for e in events if isinstance(e, dict) and "run_info" in e]
+    assert not any(isinstance(info, PipelineRunAlreadyCompleted) for info in run_infos)
+    assert any(isinstance(info, PipelineRunCompleted) for info in run_infos)
 
 
 @pytest.mark.asyncio
@@ -142,7 +129,6 @@ async def test_duplicate_source_identity_is_rejected_loudly():
         data="{}",
         system_metadata={"source": "dlt_source", "source_name": "orders"},
         data_id=shared_id,
-        content_hash="h",
     )
 
     with (

--- a/cognee/tests/unit/tasks/ingestion/test_dlt_stable_manifest_id.py
+++ b/cognee/tests/unit/tasks/ingestion/test_dlt_stable_manifest_id.py
@@ -160,11 +160,12 @@ async def test_duplicate_source_identity_is_rejected_loudly():
 
 
 @pytest.mark.asyncio
-async def test_csv_path_inside_a_list_is_auto_detected():
-    """A CSV path in a MIXED add must route to the DLT manifest path.
+async def test_csv_paths_pass_through_resolve_untouched():
+    """resolve no longer converts CSV paths into dlt sources.
 
-    Auto-detection used to fire only when add() received a bare string, so
-    [csv_path, note_path] silently LLM-processed the CSV as text.
+    CSVs are owned by the loader engine's dlt_csv_loader (registered above
+    csv_loader) inside the ingest pipeline; resolve must leave them exactly
+    as they arrived so they reach the loader dispatch.
     """
     pytest.importorskip("dlt")
     import sys
@@ -173,29 +174,10 @@ async def test_csv_path_inside_a_list_is_auto_detected():
 
     resolve_module = sys.modules["cognee.tasks.ingestion.resolve_dlt_sources"]
 
-    converted = []
+    data = ["/data/orders.csv", "just a plain note"]
+    result, cleanup = await resolve_module.resolve_dlt_sources(
+        data, "ds", user=SimpleNamespace(id=uuid4())
+    )
 
-    def _fake_csv_source(path):
-        import dlt
-
-        converted.append(path)
-
-        @dlt.resource(name="rows")
-        def rows():
-            yield {"id": 1}
-
-        return rows()
-
-    with (
-        patch.object(resolve_module, "create_dlt_source_from_csv", _fake_csv_source),
-        patch.object(resolve_module, "ingest_dlt_source", new=AsyncMock(return_value=[])),
-        patch.object(
-            resolve_module, "_build_source_manifest_item", new=AsyncMock(return_value=None)
-        ),
-    ):
-        result, _cleanup = await resolve_module.resolve_dlt_sources(
-            ["/data/orders.csv", "just a plain note"], "ds", user=SimpleNamespace(id=uuid4())
-        )
-
-    assert converted == ["/data/orders.csv"]
-    assert "just a plain note" in result  # non-CSV items pass through untouched
+    assert result == data
+    assert cleanup is None


### PR DESCRIPTION
## What

CSV ingestion moves out of `resolve_dlt_sources`' pre-pipeline special-casing and into the loader system, as designed with @Vasilije1990: a new **`dlt_csv_loader`** registers **above** the text-flattening `csv_loader` in the engine's priority order, so with the `dlt` extra installed every CSV — local path, `file://` / `s3://` location, or upload — takes the structured DLT route (staging ingestion, one manifest per file, no-LLM cognify) **inside the ingest pipeline**.

## How

- **`LoaderResult`** (new, in `LoaderInterface`): a loader that owns more than text extraction returns `{file_path, data_id, system_metadata}` instead of a plain path. `ingest_data` pins the record to the loader's `data_id` exactly like a pinned `DataItem` (re-resolving existence so re-adds hit the update branch) and stamps `system_metadata` for cognify's per-item routing. This fulfills the long-standing TODO ("allow getting of external metadata through ingestion loader").
- **Context threading**: `ingest_data` passes `dataset_name/dataset_id/user/original_file_name` through `data_item_to_text_file` → `load_file` → `loader.load(**kwargs)`; loaders that don't need it ignore it. The manifest identity derives from the **original** file name (decoded, not the temp/stored copy), so it is stable across runs and identical to the previous resolver-based identity.
- **Resolver slimmed**: the CSV/upload branches and the whole spool-dir lifecycle are deleted from `resolve_dlt_sources`; it keeps connection strings, dlt source objects, and the orphan sweep. S3/file localization now reuses the loader path's existing `pull_from_s3` machinery.
- **`classify()` accepts `BytesIO`**: in-memory uploads reach standard ingestion for the first time (previously intercepted by the resolver); classify knew only `BufferedReader`/`SpooledTemporaryFile`. Nameless streams fail loudly.
- **Explicit choice preserved**: `preferred_loaders={"csv_loader": {}}` forces the old text flattening per call; without the `dlt` extra the loader never registers and `csv_loader` wins automatically.

## Behavior notes

- Per-call dlt options ride the standard loader-config channel: `preferred_loaders={"dlt_csv_loader": {"primary_key": "id", "write_disposition": "merge"}}` (previously `add(**kwargs)`).
- Empty CSVs and missing ingestion context fail loudly instead of silently degrading.

## Tests

- `test_dlt_csv_inputs.py` (rewritten): dispatch priority, per-call override, `LoaderResult` contract, original-name identity, loud failures.
- `test_dlt_csv_loader_route.py` (new, hermetic): CSV through real `add()`/`cognify()` — one manifest (`loader_engine == "dlt_csv_loader"`, `row_count == 3`), idempotent re-add (same record id), census `DltRow: 3 / SchemaTable: 1`.
- `test_dlt_mixed_input_e2e.py`: **assertions unmodified, passes locally with real LLM** — CSV upload (space-in-filename) + text doc, mixed routing intact.
- Wide sweep green locally: 1,052 unit tests (ingestion, data, infrastructure), DLT integration trio, migrations.