### PR TITLE
fix(graph): use uppercase TIMESTAMP() in ladybug adapter

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -985,11 +985,11 @@ class LadybugAdapter(GraphDBInterface):
                 relationship_name: $relationship_name
             }]->(to)
             ON CREATE SET
-                r.created_at = timestamp($created_at),
-                r.updated_at = timestamp($updated_at),
+                r.created_at = TIMESTAMP($created_at),
+                r.updated_at = TIMESTAMP($updated_at),
                 r.properties = $properties
             ON MATCH SET
-                r.updated_at = timestamp($updated_at),
+                r.updated_at = TIMESTAMP($updated_at),
                 r.properties = $properties
         """
         params = {
@@ -1070,7 +1070,7 @@ class LadybugAdapter(GraphDBInterface):
 
             # Add timestamp fields
             fields.extend(
-                ["created_at: timestamp($created_at)", "updated_at: timestamp($updated_at)"]
+                ["created_at: TIMESTAMP($created_at)", "updated_at: TIMESTAMP($updated_at)"]
             )
             params.update({"created_at": now, "updated_at": now})
 
@@ -1151,13 +1151,13 @@ class LadybugAdapter(GraphDBInterface):
                     n.name = node.name,
                     n.type = node.type,
                     n.properties = node.properties,
-                    n.created_at = timestamp(node.created_at),
-                    n.updated_at = timestamp(node.updated_at)
+                    n.created_at = TIMESTAMP(node.created_at),
+                    n.updated_at = TIMESTAMP(node.updated_at)
                 ON MATCH SET
                     n.name = node.name,
                     n.type = node.type,
                     n.properties = node.properties,
-                    n.updated_at = timestamp(node.updated_at)
+                    n.updated_at = TIMESTAMP(node.updated_at)
                 """
                 query_params = {"nodes": node_params}
                 if source_ref_key is not None:
@@ -1921,11 +1921,11 @@ class LadybugAdapter(GraphDBInterface):
                 relationship_name: edge.relationship_name
             }]->(to)
             ON CREATE SET
-                r.created_at = timestamp(edge.created_at),
-                r.updated_at = timestamp(edge.updated_at),
+                r.created_at = TIMESTAMP(edge.created_at),
+                r.updated_at = TIMESTAMP(edge.updated_at),
                 r.properties = edge.properties
             ON MATCH SET
-                r.updated_at = timestamp(edge.updated_at),
+                r.updated_at = TIMESTAMP(edge.updated_at),
                 r.properties = edge.properties
             """
             query_params = {"edges": edge_params}
@@ -2182,7 +2182,7 @@ class LadybugAdapter(GraphDBInterface):
         MATCH (n:Node)
         WHERE n.id = item.node_id
         SET n.properties = item.properties,
-            n.updated_at = timestamp($updated_at)
+            n.updated_at = TIMESTAMP($updated_at)
         RETURN n.id AS node_id
         """
         result = await self.query(query, {"items": updates, "updated_at": now})
@@ -2224,7 +2224,7 @@ class LadybugAdapter(GraphDBInterface):
         MATCH (n:Node)
         WHERE n.id = item.node_id
         SET n.properties = item.properties,
-            n.updated_at = timestamp($updated_at)
+            n.updated_at = TIMESTAMP($updated_at)
         RETURN n.id AS node_id
         """
         result = await self.query(query, {"items": updates, "updated_at": now})
@@ -2275,7 +2275,7 @@ class LadybugAdapter(GraphDBInterface):
           AND to.id = item.to_id
           AND r.relationship_name = item.relationship_name
         SET r.properties = item.properties,
-            r.updated_at = timestamp($updated_at)
+            r.updated_at = TIMESTAMP($updated_at)
         RETURN item.edge_object_id AS edge_object_id
         """
         result = await self.query(query, {"items": edge_updates, "updated_at": now})


### PR DESCRIPTION
## Summary

Fixes #4474.

The Ladybug adapter emits lowercase `timestamp(...)` casts that ladybug (Kuzu) 0.17.1 does not register as a function, causing `Catalog exception: function TiMESTAMP does not exist.` on batch writes (nodes and edges). This breaks `remember`/`cognify` with the default graph store.

Updates all 13 call sites in `cognee/infrastructure/databases/graph/ladybug/adapter.py` to `TIMESTAMP(...)`.

## Testing

Verified locally against ladybug 0.17.1:

- `RETURN TIMESTAMP('2026-01-01T00:00:00')` works; lowercase fails with the catalog error.
- Full `remember` → `recall` round trip through cognee-mcp succeeds (nodes and edges written with `created_at`/`updated_at`).