### PR TITLE
feat: Add audit-grade provenance ledger (COG-6172)

### DIFF
--- a/cognee/alembic/env.py
+++ b/cognee/alembic/env.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 from cognee.infrastructure.databases.relational import get_relational_engine, Base
 import cognee.modules.session_lifecycle.models  # noqa: F401
 import cognee.modules.migrations.models  # noqa: F401
+import cognee.modules.provenance.models  # noqa: F401
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/cognee/alembic/versions/b8c1d3e5f7a9_add_provenance_entries_table.py
+++ b/cognee/alembic/versions/b8c1d3e5f7a9_add_provenance_entries_table.py
@@ -1,0 +1,110 @@
+"""Add provenance_entries table
+
+Revision ID: b8c1d3e5f7a9
+Revises: f2b4c6d8e0a1
+Create Date: 2026-08-14 00:00:00.000000
+
+Append-only, tamper-evident audit ledger for the opt-in provenance-tracking
+cognify task (env PROVENANCE_TRACKING, default off). One relational table;
+joins to graph provenance via source_ref_key. See cognee/modules/provenance/.
+
+Note: the design doc named this revision a1b2c3d4e5f6, but that id was already
+taken by add_label_column_to_data, so a fresh id is used.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b8c1d3e5f7a9"
+down_revision: Union[str, None] = "f2b4c6d8e0a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # The table may already exist: Base.metadata.create_all() on the startup
+    # path creates it once cognee.modules.provenance.models has been imported.
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    if "provenance_entries" in inspector.get_table_names():
+        return
+
+    op.create_table(
+        "provenance_entries",
+        # identity / PROV-O core
+        sa.Column("entity_id", sa.String(length=1024), primary_key=True),
+        sa.Column("entity_type", sa.String(length=64), nullable=False),
+        sa.Column("activity_id", sa.String(length=256), nullable=False),
+        sa.Column("agent_id", sa.String(length=256), nullable=False),
+        sa.Column("agent_type", sa.String(length=32), nullable=False),
+        sa.Column("is_automated", sa.Boolean(), nullable=False),
+        sa.Column("role", sa.String(length=128), nullable=True),
+        # audit-grade source
+        sa.Column("source_document", sa.Text(), nullable=False),
+        sa.Column("source_location", sa.Text(), nullable=True),
+        sa.Column("source_quote", sa.Text(), nullable=True),
+        sa.Column("source_ref_key", sa.String(length=256), nullable=True),
+        # temporal (ISO-8601 strings — hashed material must be dialect-stable)
+        sa.Column("timestamp", sa.String(length=64), nullable=False),
+        sa.Column("first_seen", sa.String(length=64), nullable=True),
+        sa.Column("last_updated", sa.String(length=64), nullable=True),
+        sa.Column("activity_started_at_time", sa.String(length=64), nullable=True),
+        sa.Column("activity_ended_at_time", sa.String(length=64), nullable=True),
+        sa.Column("valid_from", sa.String(length=64), nullable=True),
+        sa.Column("valid_until", sa.String(length=64), nullable=True),
+        # quality / hash chain
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("credibility", sa.Float(), nullable=True),
+        sa.Column("checksum", sa.String(length=64), nullable=True),
+        sa.Column("sequence_id", sa.Integer(), nullable=True),
+        sa.Column("previous_checksum", sa.String(length=64), nullable=True),
+        # lineage
+        sa.Column("parent_entity_id", sa.String(length=1024), nullable=True),
+        sa.Column("used_entities", sa.JSON(), nullable=False),
+        sa.Column("previous_version_id", sa.String(length=1024), nullable=True),
+        sa.Column("derived_from_id", sa.String(length=1024), nullable=True),
+        # governance
+        sa.Column("acted_on_behalf_of", sa.String(length=256), nullable=True),
+        sa.Column("informed_by_activities", sa.JSON(), nullable=False),
+        sa.Column("revision_type", sa.String(length=64), nullable=True),
+        sa.Column("supersedes", sa.String(length=1024), nullable=True),
+        sa.Column("bundle_id", sa.String(length=256), nullable=True),
+        # invalidation tombstone
+        sa.Column("invalidated", sa.Boolean(), nullable=False),
+        sa.Column("invalidated_at_time", sa.String(length=64), nullable=True),
+        sa.Column("invalidated_by", sa.String(length=256), nullable=True),
+        sa.Column("invalidation_reason", sa.Text(), nullable=True),
+        # chunk extras + free-form
+        sa.Column("start_index", sa.Integer(), nullable=True),
+        sa.Column("end_index", sa.Integer(), nullable=True),
+        sa.Column("metadata", sa.JSON(), nullable=False),
+        sa.Column("version", sa.String(length=16), nullable=False),
+    )
+
+    op.create_index("idx_provenance_entity_type", "provenance_entries", ["entity_type"])
+    op.create_index("idx_provenance_parent", "provenance_entries", ["parent_entity_id"])
+    op.create_index("idx_provenance_prev_version", "provenance_entries", ["previous_version_id"])
+    op.create_index("idx_provenance_derived_from", "provenance_entries", ["derived_from_id"])
+    op.create_index("idx_provenance_bundle", "provenance_entries", ["bundle_id"])
+    op.create_index("idx_provenance_source_ref_key", "provenance_entries", ["source_ref_key"])
+    op.create_index("idx_provenance_invalidated", "provenance_entries", ["invalidated"])
+    # THE chain guard: two writers cannot both claim the same slot.
+    op.create_index(
+        "ux_provenance_sequence_id",
+        "provenance_entries",
+        ["sequence_id"],
+        unique=True,
+        postgresql_where=sa.text("sequence_id IS NOT NULL"),
+        sqlite_where=sa.text("sequence_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    if "provenance_entries" in inspector.get_table_names():
+        op.drop_table("provenance_entries")

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -26,6 +26,7 @@ from cognee.tasks.documents import (
 )
 from cognee.tasks.graph.extract_graph_and_summarize import extract_graph_and_summarize
 from cognee.tasks.graph import detect_contradictions
+from cognee.tasks.provenance import record_provenance
 from cognee.tasks.graph.resolve_temporal_contradictions import resolve_temporal_contradictions
 from cognee.tasks.storage import add_data_points
 from cognee.modules.pipelines.layers.pipeline_execution_mode import get_pipeline_executor
@@ -356,6 +357,7 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
     cognify_config = get_cognify_config()
     embed_triplets = cognify_config.triplet_embedding
     check_contradictions = cognify_config.contradiction_detection
+    track_provenance = cognify_config.provenance_tracking
 
     if chunks_per_batch is None:
         chunks_per_batch = (
@@ -386,6 +388,16 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
             add_data_points,
             embed_triplets=embed_triplets,
             task_config={"batch_size": chunks_per_batch},
+        ),
+        # COGNIFY (opt-in): append an audit-grade provenance ledger entry for every
+        # document/chunk/entity/relationship this ingestion produced. Runs right
+        # after add_data_points (node ids persisted and stable) and before the
+        # contradiction spread so the ledger never depends on contradiction edges.
+        # Default OFF.
+        *(
+            [Task(record_provenance, task_config={"batch_size": chunks_per_batch})]
+            if track_provenance
+            else []
         ),
         # COGNIFY (opt-in): flag facts in this ingestion that contradict facts
         # already in the graph. Runs last so both new and existing facts are

--- a/cognee/modules/cognify/config.py
+++ b/cognee/modules/cognify/config.py
@@ -15,6 +15,9 @@ class CognifyConfig(BaseSettings):
     contradiction_detection: bool = False
     contradiction_confidence_threshold: float = 0.5
     contradiction_max_facts: int = 500
+    # Opt-in audit-grade provenance ledger (env: PROVENANCE_TRACKING). Default
+    # OFF so the standard cognify pipeline is unchanged.
+    provenance_tracking: bool = False
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
     def to_dict(self) -> dict:
@@ -26,6 +29,7 @@ class CognifyConfig(BaseSettings):
             "contradiction_detection": self.contradiction_detection,
             "contradiction_confidence_threshold": self.contradiction_confidence_threshold,
             "contradiction_max_facts": self.contradiction_max_facts,
+            "provenance_tracking": self.provenance_tracking,
         }
 
 

--- a/cognee/modules/provenance/__init__.py
+++ b/cognee/modules/provenance/__init__.py
@@ -1,0 +1,25 @@
+"""Audit-grade provenance ledger (append-only, tamper-evident).
+
+This module is the fourth — and only audit-grade — provenance system in cognee.
+It is deliberately distinct from the other three:
+
+- ``cognee/infrastructure/databases/provenance/`` — graph source-refs used for
+  delete/rollback ownership (``source_ref:v1:{dataset_id}:{data_id}`` keys).
+- ``source_*`` DataPoint stamping — write-time attribution on graph nodes.
+- the memory-provenance projection — actor-centric views over session memory.
+
+None of those is an append-only, hash-chained audit ledger with tombstones,
+versioning, and W3C PROV-O agents/activities. This module adds exactly that:
+one relational table (``provenance_entries``) plus an async manager, and it
+JOINS to the graph source-ref system by storing the existing source-ref key on
+every ledger entry (``source_ref_key``) instead of inventing a new identifier.
+
+It never touches graph marking, never overwrites ``source_*`` fields, and is
+written by a passive, opt-in cognify task (``PROVENANCE_TRACKING``, default
+off) that can never break ingestion.
+"""
+
+from .manager import ProvenanceBatch, ProvenanceManager, get_provenance_manager
+from .models import ProvenanceEntry
+
+__all__ = ["ProvenanceBatch", "ProvenanceManager", "get_provenance_manager", "ProvenanceEntry"]

--- a/cognee/modules/provenance/integrity.py
+++ b/cognee/modules/provenance/integrity.py
@@ -1,0 +1,125 @@
+"""Integrity primitives for the provenance ledger (pure, sync).
+
+Checksum canonicalization is a deliberate break from semantica's byte format,
+which had two defects: no-separator concatenation (field-boundary ambiguity)
+and ``None`` hashing differently on the object vs dict path. Cognee ships no
+semantica databases to migrate, so both are fixed here:
+
+- every field value is canonicalized as compact, sorted-key JSON (so raw
+  separator bytes inside a value, ``None`` vs ``""``, and list element
+  boundaries are all unambiguous), and
+- the JSON parts are joined with the ``\\x1f`` unit separator (JSON strings
+  escape control characters, so the separator can never appear inside a part).
+
+``_HASHED_FIELDS`` covers EVERY column of the ledger row except ``checksum``
+itself (the hash output) and the raw ``entity_id``. Order is a frozen
+contract — changing it (or the canonicalization rules) invalidates every
+stored checksum.
+
+The raw ``entity_id`` is not hashed directly because the manager's versioning
+archives a prior value by relabeling it to a new entity_id
+(``"X" -> "X:v:{last_updated}[:{n}]"``); hashing the raw id would change the
+archived copy's checksum and falsely break any later entry whose
+``previous_checksum`` had already chained from the pre-relabel value. Instead
+the CANONICAL entity id is hashed: the archive suffix — recognizable because
+it embeds the row's own ``last_updated`` — is stripped first, so a relabel is
+checksum-stable while swapping the entity_ids of two rows (reattributing an
+audit trail) still breaks verification.
+"""
+
+import hashlib
+import json
+from typing import Any, Optional
+
+# Order is the contract. Every ProvenanceEntry field except ``checksum`` (the
+# hash output) and ``entity_id`` (hashed in canonical form, see module docstring).
+_HASHED_FIELDS = (
+    "entity_type",
+    "activity_id",
+    "agent_id",
+    "agent_type",
+    "is_automated",
+    "role",
+    "source_document",
+    "source_location",
+    "source_quote",
+    "source_ref_key",
+    "timestamp",
+    "first_seen",
+    "last_updated",
+    "activity_started_at_time",
+    "activity_ended_at_time",
+    "valid_from",
+    "valid_until",
+    "confidence",
+    "credibility",
+    "sequence_id",
+    "previous_checksum",
+    "parent_entity_id",
+    "used_entities",
+    "previous_version_id",
+    "derived_from_id",
+    "acted_on_behalf_of",
+    "informed_by_activities",
+    "revision_type",
+    "supersedes",
+    "bundle_id",
+    "invalidated",
+    "invalidated_at_time",
+    "invalidated_by",
+    "invalidation_reason",
+    "start_index",
+    "end_index",
+    "metadata",
+    "version",
+)
+_SEP = "\x1f"  # unit separator: unambiguous field boundaries
+
+
+def canonical_entity_id(entry: Any) -> str:
+    """The entity id with any archive-relabel suffix stripped.
+
+    Archive ids are ``"{original}:v:{last_updated}"`` (plus ``":{n}"`` on
+    collision) where ``last_updated`` is the archived row's OWN last_updated —
+    so the suffix is recognizable from the entry itself and stripping it is
+    deterministic. Live entries pass through unchanged.
+    """
+    entity_id = getattr(entry, "entity_id", None) or ""
+    last_updated = getattr(entry, "last_updated", None)
+    if last_updated:
+        marker = f":v:{last_updated}"
+        index = entity_id.rfind(marker)
+        if index != -1:
+            tail = entity_id[index + len(marker) :]
+            if not tail or (tail.startswith(":") and tail[1:].isdigit()):
+                return entity_id[:index]
+    return entity_id
+
+
+def _canonical_part(value: Any) -> str:
+    """Compact, sorted-key JSON: unambiguous for None/str/bool/num/list/dict."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def compute_checksum(entry: Any) -> str:
+    """Compute the SHA-256 checksum over the entry's hashed fields.
+
+    Accepts any object exposing the ``_HASHED_FIELDS`` attributes (the Pydantic
+    ``ProvenanceEntry`` in practice).
+    """
+    parts = [_canonical_part(canonical_entity_id(entry))]
+    for name in _HASHED_FIELDS:
+        parts.append(_canonical_part(getattr(entry, name, None)))
+    return hashlib.sha256(_SEP.join(parts).encode("utf-8")).hexdigest()
+
+
+def verify_checksum(entry: Any, expected: Optional[str] = None) -> bool:
+    """Recompute the entry's checksum and compare it to the stored/expected one.
+
+    Returns False when no checksum is present to compare against.
+    """
+    if expected is None:
+        expected = getattr(entry, "checksum", None)
+    if expected is None:
+        return False
+    return compute_checksum(entry) == expected

--- a/cognee/modules/provenance/manager.py
+++ b/cognee/modules/provenance/manager.py
@@ -1,0 +1,707 @@
+"""Async ProvenanceManager over the audit-grade provenance ledger.
+
+Port of semantica's ProvenanceManager onto cognee's shared relational DB
+(SQLite + Postgres) via the async repository in ``storage.py``. The manager is
+stateless (sessions per call), so acquisition is a trivial cached factory.
+
+Tracking methods (``track_entity`` / ``track_relationship`` / ``track_chunk``)
+log and return ``None`` on storage failure — provenance must never break the
+host operation. ``invalidate`` is the exception: it is a user-initiated audit
+action and raises on an untracked entity.
+
+Bulk writers should collect operations on ``manager.batch()`` and ``commit()``
+once: the whole batch becomes a single chained transaction (one lock
+acquisition, one COMMIT) instead of a round-trip per entry.
+
+Scoping: the ledger key is whatever ``entity_id`` the caller passes — the
+manager applies no user/dataset scoping of its own. Callers whose raw ids are
+globally deterministic (cognee entity ids are name-derived uuid5s) MUST
+namespace them per access-control scope, or different tenants' mentions of the
+same name would cross-contaminate one version chain. The cognify task
+(``cognee/tasks/provenance/record_provenance.py``) prefixes every id with the
+dataset id for exactly this reason; readers join with the same prefixed key.
+"""
+
+from functools import lru_cache
+from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cognee.shared.logging_utils import get_logger
+
+from . import storage
+from .integrity import compute_checksum, verify_checksum
+from .models import ProvenanceEntry
+from .models.ProvenanceEntry import utc_now_iso
+
+logger = get_logger("provenance_manager")
+
+
+class ProvenanceManager:
+    """Append-only, tamper-evident provenance ledger manager."""
+
+    # Typed kwargs accepted by track_entity/track_relationship (anything else
+    # is ignored with a debug log; free-form data belongs in ``metadata``).
+    _TRACK_ENTITY_KWARGS = frozenset(
+        {
+            "entity_type",
+            "activity_id",
+            "agent_id",
+            "agent_type",
+            "is_automated",
+            "role",
+            "source_location",
+            "source_quote",
+            "source_ref_key",
+            "confidence",
+            "credibility",
+            "parent_entity_id",
+            "used_entities",
+            "activity_started_at_time",
+            "activity_ended_at_time",
+            "acted_on_behalf_of",
+            "informed_by",
+            "valid_from",
+            "valid_until",
+            "revision_type",
+            "supersedes",
+            "bundle_id",
+        }
+    )
+
+    def _warn_unknown_kwargs(self, method: str, kwargs: Dict[str, Any]) -> None:
+        unknown = set(kwargs) - self._TRACK_ENTITY_KWARGS
+        if unknown:
+            logger.debug("%s ignoring unknown kwargs: %s", method, sorted(unknown))
+
+    @staticmethod
+    def _base_entry_fields(source: str, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Shared kwarg -> field resolution for the track_* methods."""
+        return {
+            "agent_id": kwargs.get("agent_id", "cognee"),
+            "agent_type": kwargs.get("agent_type", "software_agent"),
+            "is_automated": kwargs.get("is_automated", True),
+            "role": kwargs.get("role"),
+            "source_document": source,
+            "source_location": kwargs.get("source_location"),
+            "source_quote": kwargs.get("source_quote"),
+            "source_ref_key": kwargs.get("source_ref_key"),
+            "confidence": kwargs.get("confidence", 1.0),
+            "credibility": kwargs.get("credibility"),
+            "activity_started_at_time": kwargs.get("activity_started_at_time"),
+            "activity_ended_at_time": kwargs.get("activity_ended_at_time"),
+            "acted_on_behalf_of": kwargs.get("acted_on_behalf_of"),
+            "informed_by_activities": list(kwargs.get("informed_by") or []),
+            "valid_from": kwargs.get("valid_from"),
+            "valid_until": kwargs.get("valid_until"),
+            "revision_type": kwargs.get("revision_type"),
+            "supersedes": kwargs.get("supersedes"),
+            "bundle_id": kwargs.get("bundle_id"),
+        }
+
+    # === Tracking ===
+
+    @staticmethod
+    def _validate_id(value: Any, name: str) -> None:
+        if value is None:
+            raise ValueError(f"{name} cannot be None")
+        if not isinstance(value, str):
+            raise TypeError(f"{name} must be a string, got {type(value).__name__}")
+
+    def _entity_write(
+        self,
+        entity_id: str,
+        source: str,
+        metadata: Optional[Dict[str, Any]],
+        kwargs: Dict[str, Any],
+    ) -> Callable[[AsyncSession, int, Optional[str]], Awaitable[ProvenanceEntry]]:
+        """Build the chained write for one entity track (see ``track_entity``)."""
+
+        async def write(
+            session: AsyncSession, next_seq: int, prev_checksum: Optional[str]
+        ) -> ProvenanceEntry:
+            existing_row = await storage.retrieve_row(session, entity_id)
+
+            parent_id = kwargs.get("parent_entity_id")
+            if not parent_id and metadata and isinstance(metadata, Mapping):
+                derived_from = metadata.get("derived_from")
+                if derived_from and isinstance(derived_from, str):
+                    parent_id = derived_from
+            if not parent_id and source and isinstance(source, str):
+                if await storage.retrieve_row(session, source) is not None:
+                    parent_id = source
+            explicit_parent_supplied = parent_id is not None
+
+            now = utc_now_iso()
+            archived_history_id = None
+            old_snapshot = None
+            if existing_row is not None:
+                # Pure relabel: the archived copy keeps its checksum,
+                # sequence_id, and previous_checksum exactly as they were.
+                # compute_checksum() hashes the CANONICAL entity id (the
+                # archive suffix strips away) so the archived row still
+                # verifies; recomputing (or assigning a fresh sequence slot)
+                # would falsely break the chain.
+                old_snapshot = ProvenanceEntry.from_row(existing_row)
+                archived_history_id = await storage.find_free_archive_id(
+                    session, entity_id, existing_row.last_updated
+                )
+                if not explicit_parent_supplied:
+                    parent_id = archived_history_id
+                first_seen = existing_row.first_seen
+            else:
+                first_seen = now
+
+            entry = ProvenanceEntry(
+                entity_id=entity_id,
+                entity_type=kwargs.get("entity_type", "entity"),
+                activity_id=kwargs.get("activity_id", "entity_tracking"),
+                metadata=dict(metadata or {}),
+                timestamp=now,
+                first_seen=first_seen,
+                last_updated=now,
+                parent_entity_id=parent_id,
+                used_entities=list(kwargs.get("used_entities") or []),
+                previous_version_id=archived_history_id,
+                derived_from_id=parent_id if explicit_parent_supplied else None,
+                **self._base_entry_fields(source, kwargs),
+            )
+            if archived_history_id and explicit_parent_supplied:
+                entry.used_entities.append(archived_history_id)
+
+            entry.sequence_id = next_seq
+            entry.previous_checksum = prev_checksum
+            entry.checksum = compute_checksum(entry)
+
+            if existing_row is not None:
+                # Statement order matters: the unique sequence index is checked
+                # per statement. UPDATE the live row first (freeing its old
+                # slot), then INSERT the archive row carrying the old values.
+                entry.apply_to_row(existing_row)
+                await session.flush()
+                archive_entry = old_snapshot.model_copy(update={"entity_id": archived_history_id})
+                session.add(archive_entry.to_row())
+                await session.flush()
+            else:
+                session.add(entry.to_row())
+                await session.flush()
+            return entry
+
+        return write
+
+    async def track_entity(
+        self,
+        entity_id: str,
+        source: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> Optional[ProvenanceEntry]:
+        """Track an entity, auto-versioning (archive + relabel) on re-track.
+
+        Parent resolution precedence: ``kwargs["parent_entity_id"]`` >
+        ``metadata["derived_from"]`` > source-is-a-tracked-id heuristic.
+        ``derived_from_id`` is set only on an explicitly resolved parent, never
+        from the automatic archival link; when both an archive and an explicit
+        parent exist, the archive id is appended to ``used_entities``.
+        """
+        self._validate_id(entity_id, "entity_id")
+        self._warn_unknown_kwargs("track_entity", kwargs)
+        try:
+            return await storage.append_chained(
+                self._entity_write(entity_id, source, metadata, kwargs)
+            )
+        except (ValueError, TypeError):
+            raise
+        except Exception as error:
+            logger.error("Failed to track entity %r: %s", entity_id, error, exc_info=True)
+            return None
+
+    def _relationship_write(
+        self,
+        relationship_id: str,
+        source: str,
+        metadata: Optional[Dict[str, Any]],
+        kwargs: Dict[str, Any],
+    ) -> Callable[[AsyncSession, int, Optional[str]], Awaitable[ProvenanceEntry]]:
+        """Build the chained write for one relationship track (never versions)."""
+
+        async def write(
+            session: AsyncSession, next_seq: int, prev_checksum: Optional[str]
+        ) -> ProvenanceEntry:
+            existing_row = await storage.retrieve_row(session, relationship_id)
+            if existing_row is not None:
+                return ProvenanceEntry.from_row(existing_row)
+
+            now = utc_now_iso()
+            entry = ProvenanceEntry(
+                entity_id=relationship_id,
+                entity_type="relationship",
+                activity_id=kwargs.get("activity_id", "relationship_tracking"),
+                metadata=dict(metadata or {}),
+                timestamp=now,
+                first_seen=now,
+                last_updated=now,
+                used_entities=list(kwargs.get("used_entities") or []),
+                **self._base_entry_fields(source, kwargs),
+            )
+            entry.sequence_id = next_seq
+            entry.previous_checksum = prev_checksum
+            entry.checksum = compute_checksum(entry)
+            session.add(entry.to_row())
+            await session.flush()
+            return entry
+
+        return write
+
+    async def track_relationship(
+        self,
+        relationship_id: str,
+        source: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> Optional[ProvenanceEntry]:
+        """Track a relationship. Relationships never version.
+
+        Re-tracking an already-recorded relationship id is a no-op returning
+        the stored entry: relationship ids are deterministic content hashes
+        (``rel:{src}:{name}:{dst}``), and rewriting the row would either forge
+        a gap in the sequence chain or invalidate its checksum.
+        """
+        self._validate_id(relationship_id, "relationship_id")
+        self._warn_unknown_kwargs("track_relationship", kwargs)
+        try:
+            return await storage.append_chained(
+                self._relationship_write(relationship_id, source, metadata, kwargs)
+            )
+        except (ValueError, TypeError):
+            raise
+        except Exception as error:
+            logger.error(
+                "Failed to track relationship %r: %s", relationship_id, error, exc_info=True
+            )
+            return None
+
+    def _chunk_write(
+        self,
+        chunk_id: str,
+        source_document: str,
+        source_path: Optional[str],
+        start_index: int,
+        end_index: int,
+        parent_chunk_id: Optional[str],
+        metadata: Dict[str, Any],
+    ) -> Callable[[AsyncSession, int, Optional[str]], Awaitable[ProvenanceEntry]]:
+        """Build the chained write for one chunk track (see ``track_chunk``)."""
+        metadata = dict(metadata)
+        column_kwargs = {
+            key: metadata.pop(key) for key in list(metadata) if key in self._TRACK_ENTITY_KWARGS
+        }
+        column_kwargs.setdefault("source_location", source_path)
+
+        async def write(
+            session: AsyncSession, next_seq: int, prev_checksum: Optional[str]
+        ) -> ProvenanceEntry:
+            existing_row = await storage.retrieve_row(session, chunk_id)
+            if existing_row is not None:
+                return ProvenanceEntry.from_row(existing_row)
+
+            now = utc_now_iso()
+            entry = ProvenanceEntry(
+                entity_id=chunk_id,
+                entity_type="chunk",
+                activity_id=column_kwargs.get("activity_id", "chunking"),
+                metadata=dict(metadata),
+                timestamp=now,
+                first_seen=now,
+                last_updated=now,
+                start_index=start_index,
+                end_index=end_index,
+                parent_entity_id=parent_chunk_id,
+                derived_from_id=parent_chunk_id,
+                used_entities=list(column_kwargs.get("used_entities") or []),
+                **self._base_entry_fields(source_document, column_kwargs),
+            )
+            entry.sequence_id = next_seq
+            entry.previous_checksum = prev_checksum
+            entry.checksum = compute_checksum(entry)
+            session.add(entry.to_row())
+            await session.flush()
+            return entry
+
+        return write
+
+    async def track_chunk(
+        self,
+        chunk_id: str,
+        source_document: str,
+        source_path: Optional[str] = None,
+        start_index: int = 0,
+        end_index: int = 0,
+        parent_chunk_id: Optional[str] = None,
+        **metadata,
+    ) -> Optional[ProvenanceEntry]:
+        """Track a chunk. ``parent_chunk_id`` sets BOTH ``parent_entity_id`` and
+        ``derived_from_id`` — a split is a derivation, not a correction.
+
+        Column-backed keys in ``**metadata`` (agent/activity/bundle/source-ref
+        etc.) are lifted onto the entry; the remainder is free-form metadata.
+        Re-tracking an existing chunk id is a chain-preserving no-op.
+        """
+        self._validate_id(chunk_id, "chunk_id")
+        try:
+            return await storage.append_chained(
+                self._chunk_write(
+                    chunk_id,
+                    source_document,
+                    source_path,
+                    start_index,
+                    end_index,
+                    parent_chunk_id,
+                    metadata,
+                )
+            )
+        except (ValueError, TypeError):
+            raise
+        except Exception as error:
+            logger.error("Failed to track chunk %r: %s", chunk_id, error, exc_info=True)
+            return None
+
+    def batch(self) -> "ProvenanceBatch":
+        """Collector for many track_* operations committed as ONE chained
+        transaction — the write path bulk callers (the cognify task) must use."""
+        return ProvenanceBatch(self)
+
+    # === Invalidation (tombstone, not hard delete) ===
+
+    async def invalidate(
+        self,
+        entity_id: str,
+        agent_id: str,
+        reason: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> ProvenanceEntry:
+        """Mark a tracked entity invalidated (prov:Invalidation) — never delete.
+
+        Archives the pre-invalidation state under a versioned key (the same
+        pattern ``track_entity`` uses), then writes the tombstone as a fresh
+        chained append. Mutating the row's checksum in place would falsely
+        break any later entry already chained from the old value.
+
+        Raises ``ValueError`` if the entity was never tracked — this is a
+        user-initiated audit action, NOT gracefully degraded.
+        """
+
+        async def write(
+            session: AsyncSession, next_seq: int, prev_checksum: Optional[str]
+        ) -> ProvenanceEntry:
+            existing_row = await storage.retrieve_row(session, entity_id)
+            if existing_row is None:
+                raise ValueError(
+                    f"Cannot invalidate: no provenance entry found for entity_id={entity_id!r}"
+                )
+
+            old_snapshot = ProvenanceEntry.from_row(existing_row)
+            archived_history_id = await storage.find_free_archive_id(
+                session, entity_id, existing_row.last_updated
+            )
+
+            # The tombstone is a NEW ledger event: it gets its own recorded-at
+            # and last_updated (only first_seen carries over), so revision
+            # history dates the invalidation when it happened, not when the
+            # fact was first tracked.
+            now = utc_now_iso()
+            entry = old_snapshot.model_copy(deep=True)
+            entry.timestamp = now
+            entry.last_updated = now
+            entry.invalidated = True
+            entry.invalidated_at_time = now
+            entry.invalidated_by = agent_id
+            entry.invalidation_reason = reason
+            entry.previous_version_id = archived_history_id
+            if metadata:
+                entry.metadata = {**entry.metadata, **metadata}
+            entry.sequence_id = next_seq
+            entry.previous_checksum = prev_checksum
+            entry.checksum = compute_checksum(entry)
+
+            entry.apply_to_row(existing_row)
+            await session.flush()
+            archive_entry = old_snapshot.model_copy(update={"entity_id": archived_history_id})
+            session.add(archive_entry.to_row())
+            await session.flush()
+            return entry
+
+        return await storage.append_chained(write)
+
+    # === Queries ===
+
+    async def get_provenance(self, entity_id: str) -> Optional[Dict[str, Any]]:
+        entry = await storage.retrieve(entity_id)
+        return entry.to_dict() if entry else None
+
+    async def get_lineage(self, entity_id: str) -> Dict[str, Any]:
+        """Aggregate the full upstream lineage for an entity ({} if untracked).
+
+        Metadata is aggregated ancestors-first so the queried entity's own
+        keys win on conflict.
+        """
+        lineage_entries = await storage.trace_lineage(entity_id)
+        if not lineage_entries:
+            return {}
+
+        aggregated_metadata: Dict[str, Any] = {}
+        for entry in reversed(lineage_entries):
+            if isinstance(entry.metadata, dict):
+                aggregated_metadata.update(entry.metadata)
+
+        integrity_verified = all(verify_checksum(entry) for entry in lineage_entries)
+        chain_dicts = [entry.to_dict() for entry in lineage_entries]
+        return {
+            "entity_id": entity_id,
+            "lineage_chain": chain_dicts,
+            "entries": chain_dicts,
+            "source_documents": list(
+                {entry.source_document for entry in lineage_entries if entry.source_document}
+            ),
+            "first_seen": min(
+                (entry.first_seen for entry in lineage_entries if entry.first_seen),
+                default=None,
+            ),
+            "last_updated": max(
+                (entry.last_updated for entry in lineage_entries if entry.last_updated),
+                default=None,
+            ),
+            "entity_count": len(lineage_entries),
+            "metadata": aggregated_metadata,
+            "integrity_verified": integrity_verified,
+        }
+
+    async def trace_lineage(
+        self, entity_id: str, max_depth: Optional[int] = None
+    ) -> List[ProvenanceEntry]:
+        return await storage.trace_lineage(entity_id, max_depth=max_depth)
+
+    async def revision_history(self, entity_id: str) -> List[Dict[str, Any]]:
+        """Version history, oldest first, walking previous_version_id (cycle-guarded).
+
+        ``valid_from``/``valid_until`` use each entry's own explicit fields
+        when set; otherwise valid_from defaults to when the version was
+        recorded and valid_until to the next version's timestamp (None for the
+        current version). Empty list if entity_id was never tracked.
+        """
+        current = await storage.retrieve(entity_id)
+        if current is None:
+            return []
+
+        chain: List[ProvenanceEntry] = [current]
+        visited = {entity_id}
+        cursor = current
+        while cursor.previous_version_id:
+            prev_id = cursor.previous_version_id
+            if prev_id in visited:
+                break
+            prev_entry = await storage.retrieve(prev_id)
+            if prev_entry is None:
+                break
+            chain.append(prev_entry)
+            visited.add(prev_id)
+            cursor = prev_entry
+
+        chain.reverse()  # oldest first
+
+        history: List[Dict[str, Any]] = []
+        for index, entry in enumerate(chain):
+            default_valid_until = chain[index + 1].timestamp if index + 1 < len(chain) else None
+            version_dict: Dict[str, Any] = {
+                "version": index + 1,
+                "valid_from": entry.valid_from or entry.timestamp,
+                "valid_until": entry.valid_until or default_valid_until,
+                "recorded_at": entry.timestamp,
+                "author": entry.agent_id,
+            }
+            if entry.revision_type:
+                version_dict["revision_type"] = entry.revision_type
+            if entry.supersedes:
+                version_dict["supersedes"] = entry.supersedes
+            history.append(version_dict)
+        return history
+
+    # === Integrity ===
+
+    async def verify_chain(self) -> Dict[str, Any]:
+        """Verify per-row checksums and the sequence hash chain.
+
+        Expected state advances from each entry's OWN stored values, so a
+        single corrupted entry never cascades into spurious breaks for every
+        entry after it. Entries are STREAMED in sequence order (keyset
+        pagination) — the ledger is never materialized client-side.
+        """
+        broken_links: List[Dict[str, Any]] = []
+        total_entries = 0
+        expected_previous: Optional[str] = None
+        expected_sequence: Optional[int] = None
+        async for entry in storage.iter_chained():
+            total_entries += 1
+            if not verify_checksum(entry):
+                broken_links.append(
+                    {
+                        "entity_id": entry.entity_id,
+                        "sequence_id": entry.sequence_id,
+                        "reason": "checksum_mismatch",
+                    }
+                )
+            else:
+                sequence_gap = (
+                    expected_sequence is not None and entry.sequence_id != expected_sequence + 1
+                )
+                checksum_break = entry.previous_checksum != expected_previous
+                if sequence_gap or checksum_break:
+                    broken_links.append(
+                        {
+                            "entity_id": entry.entity_id,
+                            "sequence_id": entry.sequence_id,
+                            "reason": "chain_break",
+                            "expected_previous_checksum": expected_previous,
+                            "actual_previous_checksum": entry.previous_checksum,
+                            "expected_sequence_id": (
+                                expected_sequence + 1 if expected_sequence is not None else None
+                            ),
+                        }
+                    )
+
+            expected_previous = entry.checksum
+            expected_sequence = entry.sequence_id
+
+        return {
+            "valid": len(broken_links) == 0,
+            "total_entries": total_entries,
+            "broken_links": broken_links,
+        }
+
+    async def check(self, strict: bool = False) -> Dict[str, Any]:
+        """Referential-integrity check (dangling lineage links), not hashes.
+
+        Loads only the id columns for the reference sets, then STREAMS full
+        rows page by page — never a client-side full-table materialization.
+        """
+        all_ids = await storage.retrieve_all_ids()
+        all_activity_ids = await storage.retrieve_all_activity_ids()
+
+        missing_refs: List[str] = []
+        total_entries = 0
+        invalidated_count = 0
+        async for entry in storage.iter_all():
+            total_entries += 1
+            if entry.invalidated:
+                invalidated_count += 1
+            if entry.parent_entity_id and entry.parent_entity_id not in all_ids:
+                missing_refs.append(f"{entry.entity_id} -> {entry.parent_entity_id}")
+            for used_id in entry.used_entities:
+                if used_id not in all_ids:
+                    missing_refs.append(f"{entry.entity_id} -> {used_id}")
+            for ref_id in (entry.previous_version_id, entry.derived_from_id, entry.supersedes):
+                if ref_id and ref_id not in all_ids:
+                    missing_refs.append(f"{entry.entity_id} -> {ref_id}")
+            # informed_by_activities references activity ids, a distinct id space.
+            for activity_id in entry.informed_by_activities:
+                if activity_id not in all_activity_ids:
+                    missing_refs.append(f"{entry.entity_id} (activity) -> {activity_id}")
+
+        return {
+            "valid": len(missing_refs) == 0,
+            "total_entries": total_entries,
+            "missing_references": missing_refs,
+            "invalidated_count": invalidated_count,
+            "strict": strict,
+            "errors": len(missing_refs),
+        }
+
+    # === Utility ===
+
+    async def get_statistics(self) -> Dict[str, Any]:
+        """DB-side aggregates (counts, group-by, distinct) — no full-table load."""
+        return await storage.aggregate_statistics()
+
+    async def clear(self) -> int:
+        """Bulk ledger reset for dev/test teardown — use invalidate() for audits."""
+        return await storage.clear()
+
+
+class ProvenanceBatch:
+    """Collects track_* operations and commits them as ONE chained transaction.
+
+    ``track_*`` here only validates and queues (sync, cheap); ``commit()``
+    claims consecutive sequence slots for the whole batch under a single lock
+    acquisition and COMMIT via ``storage.append_chained_many``. Later
+    operations in a batch see earlier ones (same session), so
+    chunk-then-entity parent heuristics work unchanged.
+
+    Mirrors the manager's degradation contract: ``commit()`` logs and returns
+    ``None`` on storage failure — provenance never breaks the host operation.
+    """
+
+    def __init__(self, manager: ProvenanceManager):
+        self._manager = manager
+        self._write_fns: List[Callable] = []
+
+    def __len__(self) -> int:
+        return len(self._write_fns)
+
+    def track_entity(
+        self, entity_id: str, source: str, metadata: Optional[Dict[str, Any]] = None, **kwargs
+    ) -> None:
+        self._manager._validate_id(entity_id, "entity_id")
+        self._manager._warn_unknown_kwargs("track_entity", kwargs)
+        self._write_fns.append(self._manager._entity_write(entity_id, source, metadata, kwargs))
+
+    def track_relationship(
+        self, relationship_id: str, source: str, metadata: Optional[Dict[str, Any]] = None, **kwargs
+    ) -> None:
+        self._manager._validate_id(relationship_id, "relationship_id")
+        self._manager._warn_unknown_kwargs("track_relationship", kwargs)
+        self._write_fns.append(
+            self._manager._relationship_write(relationship_id, source, metadata, kwargs)
+        )
+
+    def track_chunk(
+        self,
+        chunk_id: str,
+        source_document: str,
+        source_path: Optional[str] = None,
+        start_index: int = 0,
+        end_index: int = 0,
+        parent_chunk_id: Optional[str] = None,
+        **metadata,
+    ) -> None:
+        self._manager._validate_id(chunk_id, "chunk_id")
+        self._write_fns.append(
+            self._manager._chunk_write(
+                chunk_id,
+                source_document,
+                source_path,
+                start_index,
+                end_index,
+                parent_chunk_id,
+                metadata,
+            )
+        )
+
+    async def commit(self) -> Optional[List[Optional[ProvenanceEntry]]]:
+        write_fns, self._write_fns = self._write_fns, []
+        if not write_fns:
+            return []
+        try:
+            return await storage.append_chained_many(write_fns)
+        except Exception as error:
+            logger.error(
+                "Failed to commit provenance batch of %d entries: %s",
+                len(write_fns),
+                error,
+                exc_info=True,
+            )
+            return None
+
+
+@lru_cache
+def get_provenance_manager() -> ProvenanceManager:
+    return ProvenanceManager()

--- a/cognee/modules/provenance/models/ProvenanceEntry.py
+++ b/cognee/modules/provenance/models/ProvenanceEntry.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .ProvenanceEntryRow import ProvenanceEntryRow
+
+
+def utc_now_iso() -> str:
+    """Timezone-aware ISO-8601 timestamp (fixes semantica's naive-utcnow quirk)."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+class ProvenanceEntry(BaseModel):
+    """W3C PROV-O flavored provenance entry (API/wire shape).
+
+    Field-for-field mirror of ``ProvenanceEntryRow``; the only mapping is the
+    free-form dict, named ``metadata`` here and ``entry_metadata`` on the row
+    (``metadata`` is reserved on SQLAlchemy Declarative models).
+
+    ``entity_type`` and ``agent_type`` stay plain ``str`` for semantica
+    compatibility (no enums in PR1).
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    # identity / PROV-O core
+    entity_id: str
+    entity_type: str = "entity"
+    activity_id: str = "entity_tracking"
+    agent_id: str = "cognee"
+    agent_type: str = "software_agent"
+    is_automated: bool = True
+    role: Optional[str] = None
+
+    # audit-grade source
+    source_document: str = ""
+    source_location: Optional[str] = None
+    source_quote: Optional[str] = None
+    source_ref_key: Optional[str] = None
+
+    # temporal
+    timestamp: str = Field(default_factory=utc_now_iso)
+    first_seen: Optional[str] = None
+    last_updated: Optional[str] = None
+    activity_started_at_time: Optional[str] = None
+    activity_ended_at_time: Optional[str] = None
+    valid_from: Optional[str] = None
+    valid_until: Optional[str] = None
+
+    # quality / hash chain
+    confidence: float = 1.0
+    credibility: Optional[float] = None
+    checksum: Optional[str] = None
+    sequence_id: Optional[int] = None
+    previous_checksum: Optional[str] = None
+
+    # lineage
+    parent_entity_id: Optional[str] = None
+    used_entities: List[str] = Field(default_factory=list)
+    previous_version_id: Optional[str] = None
+    derived_from_id: Optional[str] = None
+
+    # governance
+    acted_on_behalf_of: Optional[str] = None
+    informed_by_activities: List[str] = Field(default_factory=list)
+    revision_type: Optional[str] = None
+    supersedes: Optional[str] = None
+    bundle_id: Optional[str] = None
+
+    # invalidation tombstone
+    invalidated: bool = False
+    invalidated_at_time: Optional[str] = None
+    invalidated_by: Optional[str] = None
+    invalidation_reason: Optional[str] = None
+
+    # chunk extras + free-form
+    start_index: Optional[int] = None
+    end_index: Optional[int] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    version: str = "1.0"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self.model_dump()
+
+    def to_row(self) -> ProvenanceEntryRow:
+        """Build a new ORM row from this entry (metadata -> entry_metadata)."""
+        values = self.model_dump()
+        values["entry_metadata"] = values.pop("metadata")
+        return ProvenanceEntryRow(**values)
+
+    def apply_to_row(self, row: ProvenanceEntryRow) -> None:
+        """Copy every field onto an existing ORM row (in-place UPDATE)."""
+        values = self.model_dump()
+        values["entry_metadata"] = values.pop("metadata")
+        for name, value in values.items():
+            setattr(row, name, value)
+
+    @classmethod
+    def from_row(cls, row: ProvenanceEntryRow) -> "ProvenanceEntry":
+        column_names = [column.key for column in ProvenanceEntryRow.__mapper__.column_attrs]
+        values = {name: getattr(row, name) for name in column_names}
+        values["metadata"] = values.pop("entry_metadata") or {}
+        values["used_entities"] = list(values.get("used_entities") or [])
+        values["informed_by_activities"] = list(values.get("informed_by_activities") or [])
+        return cls(**values)

--- a/cognee/modules/provenance/models/ProvenanceEntryRow.py
+++ b/cognee/modules/provenance/models/ProvenanceEntryRow.py
@@ -1,0 +1,94 @@
+from sqlalchemy import JSON, Boolean, Float, Index, Integer, String, Text, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from cognee.infrastructure.databases.relational import Base
+
+
+class ProvenanceEntryRow(Base):
+    """One row of the append-only provenance ledger.
+
+    PK is a plain string, not a UUID column: cognee DataPoint ids are stored as
+    ``str(uuid)``, but archival relabels (``"{entity_id}:v:{last_updated}"``)
+    and relationship ids (``"rel:{src}:{name}:{dst}"``) are not UUIDs.
+
+    All temporal fields are ISO-8601 strings, not ``DateTime``: they participate
+    in the checksum, and dialect-dependent timestamp round-tripping (Postgres
+    microsecond/tz formatting) would silently change recomputed hashes.
+    """
+
+    __tablename__ = "provenance_entries"
+
+    # identity / PROV-O core
+    entity_id: Mapped[str] = mapped_column(String(1024), primary_key=True)
+    entity_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    activity_id: Mapped[str] = mapped_column(String(256), nullable=False)
+    agent_id: Mapped[str] = mapped_column(String(256), default="cognee")
+    agent_type: Mapped[str] = mapped_column(String(32), default="software_agent")
+    is_automated: Mapped[bool] = mapped_column(Boolean, default=True)
+    role: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+    # audit-grade source
+    source_document: Mapped[str] = mapped_column(Text, default="")
+    source_location: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_quote: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Join point to graph provenance ownership: source_ref:v1:{dataset_id}:{data_id}
+    source_ref_key: Mapped[str | None] = mapped_column(String(256), nullable=True)
+
+    # temporal (ISO-8601 strings — hashed material must be dialect-stable)
+    timestamp: Mapped[str] = mapped_column(String(64), nullable=False)
+    first_seen: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    last_updated: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    activity_started_at_time: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    activity_ended_at_time: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    valid_from: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    valid_until: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    # quality / hash chain
+    confidence: Mapped[float] = mapped_column(Float, default=1.0)
+    credibility: Mapped[float | None] = mapped_column(Float, nullable=True)
+    checksum: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    sequence_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    previous_checksum: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    # lineage
+    parent_entity_id: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    used_entities: Mapped[list] = mapped_column(JSON, default=list)
+    previous_version_id: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    derived_from_id: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+
+    # governance
+    acted_on_behalf_of: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    informed_by_activities: Mapped[list] = mapped_column(JSON, default=list)
+    revision_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    supersedes: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    bundle_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
+
+    # invalidation tombstone (never hard-delete)
+    invalidated: Mapped[bool] = mapped_column(Boolean, default=False)
+    invalidated_at_time: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    invalidated_by: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    invalidation_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # chunk extras + free-form ("metadata" is reserved on Declarative models)
+    start_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    end_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    entry_metadata: Mapped[dict] = mapped_column("metadata", JSON, default=dict)
+    version: Mapped[str] = mapped_column(String(16), default="1.0")
+
+    __table_args__ = (
+        Index("idx_provenance_entity_type", "entity_type"),
+        Index("idx_provenance_parent", "parent_entity_id"),
+        Index("idx_provenance_prev_version", "previous_version_id"),
+        Index("idx_provenance_derived_from", "derived_from_id"),
+        Index("idx_provenance_bundle", "bundle_id"),
+        Index("idx_provenance_source_ref_key", "source_ref_key"),
+        Index("idx_provenance_invalidated", "invalidated"),
+        # THE chain guard: two writers cannot both claim the same slot.
+        Index(
+            "ux_provenance_sequence_id",
+            "sequence_id",
+            unique=True,
+            postgresql_where=text("sequence_id IS NOT NULL"),
+            sqlite_where=text("sequence_id IS NOT NULL"),
+        ),
+    )

--- a/cognee/modules/provenance/models/__init__.py
+++ b/cognee/modules/provenance/models/__init__.py
@@ -1,0 +1,11 @@
+"""Provenance ledger models.
+
+Importing this package registers ``ProvenanceEntryRow`` on the shared
+``Base.metadata`` so both the startup ``create_all`` path and alembic's
+``env.py`` see the ``provenance_entries`` table.
+"""
+
+from .ProvenanceEntry import ProvenanceEntry
+from .ProvenanceEntryRow import ProvenanceEntryRow
+
+__all__ = ["ProvenanceEntry", "ProvenanceEntryRow"]

--- a/cognee/modules/provenance/storage.py
+++ b/cognee/modules/provenance/storage.py
@@ -1,0 +1,301 @@
+"""Async repository for the provenance ledger over the shared relational DB.
+
+Hash-chain appends must be race-free under async SQLAlchemy on SQLite AND
+Postgres, possibly multi-process. Three layers of defense:
+
+1. A process-local per-event-loop ``asyncio.Lock`` (cheap serialization of the
+   common case).
+2. A Postgres advisory transaction lock (cross-process serialization; a no-op
+   on SQLite, which is single-writer anyway).
+3. The partial unique index on ``sequence_id`` plus a bounded retry — the
+   correctness backstop: a lost race is an ``IntegrityError``, never a forked
+   chain.
+
+Unlike semantica, a failing ``get_chain_head`` is NOT swallowed (its silent
+"restart at sequence_id=1" failure mode is removed) — the manager's
+graceful-degradation catch lives one level up and writes nothing on failure.
+"""
+
+import asyncio
+from typing import AsyncIterator, Awaitable, Callable, Dict, List, Optional, Tuple
+from weakref import WeakKeyDictionary
+
+from sqlalchemy import delete, distinct, func, select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cognee.infrastructure.databases.relational import get_async_session
+
+from .models import ProvenanceEntry, ProvenanceEntryRow
+
+# Constant app-level advisory lock id for the provenance chain (Postgres only).
+_PG_ADVISORY_KEY = 0x_C09_EE01
+
+# asyncio.Lock binds to the event loop it is first awaited on, so a single
+# module-level lock breaks when several loops exist (each pytest-asyncio test
+# gets a fresh loop). Keep one lock per loop instead.
+_chain_locks: "WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]" = WeakKeyDictionary()
+
+
+def _get_chain_lock() -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    lock = _chain_locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _chain_locks[loop] = lock
+    return lock
+
+
+async def _acquire_chain_write_lock(session: AsyncSession) -> None:
+    if session.bind.dialect.name == "postgresql":
+        # Released automatically at COMMIT/ROLLBACK; serializes across processes.
+        await session.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": _PG_ADVISORY_KEY})
+
+
+async def get_chain_head(session: AsyncSession) -> Optional[Tuple[int, Optional[str]]]:
+    """Return (sequence_id, checksum) of the newest chained entry, or None if empty."""
+    row = (
+        await session.execute(
+            select(ProvenanceEntryRow.sequence_id, ProvenanceEntryRow.checksum)
+            .where(ProvenanceEntryRow.sequence_id.is_not(None))
+            .order_by(ProvenanceEntryRow.sequence_id.desc())
+            .limit(1)
+        )
+    ).first()
+    return (row[0], row[1]) if row else None
+
+
+_WriteFn = Callable[[AsyncSession, int, Optional[str]], Awaitable[Optional[ProvenanceEntry]]]
+
+
+async def append_chained_many(write_fns: List[_WriteFn]) -> List[Optional[ProvenanceEntry]]:
+    """Run many logical chained writes as ONE transaction claiming consecutive slots.
+
+    This is the batching seam: one lock acquisition, one head read, and one
+    COMMIT for the whole list — instead of a transaction per ledger entry —
+    so pipeline-scale writes (thousands of entries per cognify batch) do not
+    serialize a round-trip each behind the chain locks.
+
+    Each ``write_fn(session, next_seq, prev_checksum)`` performs ALL statements
+    for one logical track/invalidate call. A write_fn that claims its slot
+    returns an entry with ``sequence_id == next_seq``, advancing the head for
+    the next write_fn; a chain-preserving no-op (relationship/chunk re-track)
+    returns the stored entry and consumes nothing. A lost cross-process race on
+    the ``ux_provenance_sequence_id`` index rolls back the whole batch and
+    retries it with a fresh head; the chain can never fork.
+    """
+    if not write_fns:
+        return []
+    async with _get_chain_lock():
+        for attempt in range(5):
+            async with get_async_session() as session:
+                try:
+                    async with session.begin():
+                        await _acquire_chain_write_lock(session)
+                        head = await get_chain_head(session)
+                        next_seq = head[0] + 1 if head else 1
+                        prev_checksum = head[1] if head else None
+                        results: List[Optional[ProvenanceEntry]] = []
+                        for write_fn in write_fns:
+                            entry = await write_fn(session, next_seq, prev_checksum)
+                            if entry is not None and entry.sequence_id == next_seq:
+                                prev_checksum = entry.checksum
+                                next_seq += 1
+                            results.append(entry)
+                        return results
+                except IntegrityError:
+                    # Lost a cross-process race on ux_provenance_sequence_id.
+                    if attempt == 4:
+                        raise
+                    await asyncio.sleep(0.05 * (attempt + 1))
+
+
+async def append_chained(write_fn: _WriteFn) -> ProvenanceEntry:
+    """Run one logical chained write as a single transaction claiming one slot."""
+    return (await append_chained_many([write_fn]))[0]
+
+
+async def retrieve_row(session: AsyncSession, entity_id: str) -> Optional[ProvenanceEntryRow]:
+    return await session.get(ProvenanceEntryRow, entity_id)
+
+
+async def find_free_archive_id(session: AsyncSession, entity_id: str, last_updated) -> str:
+    """Free ``"{entity_id}:v:{last_updated}"`` key (``:1``, ``:2``… on collision)."""
+    base_id = f"{entity_id}:v:{last_updated}"
+    candidate = base_id
+    counter = 1
+    while await retrieve_row(session, candidate) is not None:
+        candidate = f"{base_id}:{counter}"
+        counter += 1
+    return candidate
+
+
+async def retrieve(entity_id: str) -> Optional[ProvenanceEntry]:
+    async with get_async_session() as session:
+        row = await retrieve_row(session, entity_id)
+        return ProvenanceEntry.from_row(row) if row else None
+
+
+async def retrieve_many(entity_ids: List[str]) -> List[Optional[ProvenanceEntry]]:
+    """Fetch several entries in one session, preserving input order (None gaps)."""
+    if not entity_ids:
+        return []
+    async with get_async_session() as session:
+        rows = (
+            await session.execute(
+                select(ProvenanceEntryRow).where(ProvenanceEntryRow.entity_id.in_(entity_ids))
+            )
+        ).scalars()
+        by_id = {row.entity_id: ProvenanceEntry.from_row(row) for row in rows}
+    return [by_id.get(entity_id) for entity_id in entity_ids]
+
+
+async def retrieve_all() -> List[ProvenanceEntry]:
+    """Materialize the whole ledger. Small ledgers / tests only — the audit
+    walks (``verify_chain``/``check``) use the paged iterators below."""
+    async with get_async_session() as session:
+        rows = (await session.execute(select(ProvenanceEntryRow))).scalars()
+        return [ProvenanceEntry.from_row(row) for row in rows]
+
+
+async def iter_chained(page_size: int = 1000) -> AsyncIterator[ProvenanceEntry]:
+    """Stream chained entries in ``sequence_id`` order, one page at a time.
+
+    Keyset pagination on the unique partial index — constant memory no matter
+    how large the append-only ledger has grown.
+    """
+    last_sequence_id: Optional[int] = None
+    async with get_async_session() as session:
+        while True:
+            statement = select(ProvenanceEntryRow).where(
+                ProvenanceEntryRow.sequence_id.is_not(None)
+            )
+            if last_sequence_id is not None:
+                statement = statement.where(ProvenanceEntryRow.sequence_id > last_sequence_id)
+            statement = statement.order_by(ProvenanceEntryRow.sequence_id.asc()).limit(page_size)
+            rows = (await session.execute(statement)).scalars().all()
+            if not rows:
+                return
+            for row in rows:
+                yield ProvenanceEntry.from_row(row)
+            last_sequence_id = rows[-1].sequence_id
+
+
+async def iter_all(page_size: int = 1000) -> AsyncIterator[ProvenanceEntry]:
+    """Stream every ledger entry (keyset pagination on the PK), constant memory."""
+    last_entity_id: Optional[str] = None
+    async with get_async_session() as session:
+        while True:
+            statement = select(ProvenanceEntryRow)
+            if last_entity_id is not None:
+                statement = statement.where(ProvenanceEntryRow.entity_id > last_entity_id)
+            statement = statement.order_by(ProvenanceEntryRow.entity_id.asc()).limit(page_size)
+            rows = (await session.execute(statement)).scalars().all()
+            if not rows:
+                return
+            for row in rows:
+                yield ProvenanceEntry.from_row(row)
+            last_entity_id = rows[-1].entity_id
+
+
+async def retrieve_all_ids() -> set:
+    """Every entity_id in the ledger (id column only — no row materialization)."""
+    async with get_async_session() as session:
+        result = await session.execute(select(ProvenanceEntryRow.entity_id))
+        return set(result.scalars())
+
+
+async def retrieve_all_activity_ids() -> set:
+    """Every distinct non-null activity_id in the ledger."""
+    async with get_async_session() as session:
+        result = await session.execute(
+            select(distinct(ProvenanceEntryRow.activity_id)).where(
+                ProvenanceEntryRow.activity_id.is_not(None)
+            )
+        )
+        return set(result.scalars())
+
+
+async def aggregate_statistics() -> Dict:
+    """DB-side ledger statistics — no client-side full-table load."""
+    async with get_async_session() as session:
+        total = (
+            await session.execute(select(func.count()).select_from(ProvenanceEntryRow))
+        ).scalar()
+        type_rows = await session.execute(
+            select(ProvenanceEntryRow.entity_type, func.count()).group_by(
+                ProvenanceEntryRow.entity_type
+            )
+        )
+        unique_sources = (
+            await session.execute(
+                select(func.count(distinct(ProvenanceEntryRow.source_document))).where(
+                    ProvenanceEntryRow.source_document.is_not(None),
+                    ProvenanceEntryRow.source_document != "",
+                )
+            )
+        ).scalar()
+        invalidated_count = (
+            await session.execute(
+                select(func.count()).where(ProvenanceEntryRow.invalidated.is_(True))
+            )
+        ).scalar()
+    return {
+        "total_entries": total or 0,
+        "entity_types": {entity_type: count for entity_type, count in type_rows},
+        "unique_sources": unique_sources or 0,
+        "invalidated_count": invalidated_count or 0,
+    }
+
+
+async def trace_lineage(entity_id: str, max_depth: Optional[int] = None) -> List[ProvenanceEntry]:
+    """Batched BFS over parent_entity_id + used_entities links, seed at depth 0.
+
+    One SELECT per level (``WHERE entity_id IN (frontier)``), output in BFS
+    order. Matching semantica's depth semantics: with ``max_depth`` set, only
+    nodes at depth < max_depth are visited.
+    """
+    lineage: List[ProvenanceEntry] = []
+    visited: set = set()
+    frontier: List[str] = [entity_id]
+    depth = 0
+
+    async with get_async_session() as session:
+        while frontier:
+            if max_depth is not None and depth >= max_depth:
+                break
+
+            rows = (
+                await session.execute(
+                    select(ProvenanceEntryRow).where(ProvenanceEntryRow.entity_id.in_(frontier))
+                )
+            ).scalars()
+            by_id = {row.entity_id: ProvenanceEntry.from_row(row) for row in rows}
+
+            next_frontier: List[str] = []
+            for current_id in frontier:
+                if current_id in visited:
+                    continue
+                visited.add(current_id)
+                entry = by_id.get(current_id)
+                if entry is None:
+                    continue
+                lineage.append(entry)
+                if entry.parent_entity_id and entry.parent_entity_id not in visited:
+                    next_frontier.append(entry.parent_entity_id)
+                for used_id in entry.used_entities:
+                    if used_id not in visited and used_id not in next_frontier:
+                        next_frontier.append(used_id)
+
+            frontier = next_frontier
+            depth += 1
+
+    return lineage
+
+
+async def clear() -> int:
+    """Delete every ledger row (dev/test teardown only). Returns rows removed."""
+    async with get_async_session() as session:
+        async with session.begin():
+            result = await session.execute(delete(ProvenanceEntryRow))
+            return result.rowcount or 0

--- a/cognee/tasks/provenance/__init__.py
+++ b/cognee/tasks/provenance/__init__.py
@@ -1,0 +1,3 @@
+from .record_provenance import record_provenance
+
+__all__ = ["record_provenance"]

--- a/cognee/tasks/provenance/record_provenance.py
+++ b/cognee/tasks/provenance/record_provenance.py
@@ -1,0 +1,275 @@
+"""Opt-in cognify task writing the audit-grade provenance ledger.
+
+Pipeline seam: spliced in by ``get_default_tasks`` right after
+``add_data_points`` (node ids are persisted and stable) and before the
+contradiction-detection spread, when the ``provenance_tracking`` CognifyConfig
+flag is on (env ``PROVENANCE_TRACKING``, default off).
+
+For every item this ingestion produced it appends document -> chunk -> entity
+-> relationship lineage entries to the relational ``provenance_entries``
+ledger, joined to graph provenance by the existing source-ref key. All entries
+for one task invocation are committed as ONE chained transaction
+(``manager.batch()``), matching the pipeline's batching convention.
+
+Tenant/dataset scoping: cognee entity ids are globally deterministic
+(name-derived uuid5s), and the ledger lives in the always-shared relational
+DB — so every ledger key is prefixed with the dataset id from ctx
+(``"{dataset_id}:{raw_id}"``). Without this, two tenants mentioning the same
+entity name would share (and cross-overwrite) one version chain. Readers must
+join with the same prefixed key; entries written without ctx stay unprefixed.
+
+Custom ``graph_model`` pipelines whose DataPoints lack the default
+made_from/is_part_of/contains shape are covered by a generic fallback that
+walks the model with ``get_graph_from_model`` (the same traversal
+``add_data_points`` uses) and records every node and edge.
+
+Hard constraints, mirroring ``detect_contradictions``: the task returns its
+input unchanged and swallows all of its own errors — provenance can never
+break ingestion. Missing ctx, missing dataset/data ids, or raw items with no
+document degrade to entries with ``source_ref_key=None``, never a raise.
+"""
+
+from typing import List, Optional
+
+from cognee.infrastructure.databases.provenance import data_item_id, make_source_ref_key
+from cognee.infrastructure.engine import DataPoint
+from cognee.modules.graph.utils.get_graph_from_model import get_graph_from_model
+from cognee.modules.pipelines.models.PipelineContext import PipelineContext
+from cognee.modules.pipelines.tasks.task import task_summary
+from cognee.modules.provenance import get_provenance_manager
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("record_provenance")
+
+
+def _agent_from_ctx(ctx: Optional[PipelineContext]) -> str:
+    """user.email > str(user.id) > "cognee" (mirrors source_user stamping rules)."""
+    user = getattr(ctx, "user", None)
+    if user is not None:
+        email = getattr(user, "email", None)
+        if email:
+            return str(email)
+        user_id = getattr(user, "id", None)
+        if user_id is not None:
+            return str(user_id)
+    return "cognee"
+
+
+def _source_ref_key_from_ctx(ctx: Optional[PipelineContext]) -> Optional[str]:
+    """Reuse the graph-provenance source-ref key; None when either id is missing."""
+    if ctx is None:
+        return None
+    dataset = getattr(ctx, "dataset", None)
+    dataset_id = getattr(dataset, "id", None) if dataset is not None else None
+    data_id = data_item_id(getattr(ctx, "data_item", None))
+    if dataset_id and data_id:
+        return make_source_ref_key(dataset_id, data_id)
+    return None
+
+
+def _scope_from_ctx(ctx: Optional[PipelineContext]) -> Optional[str]:
+    """Dataset id as the ledger namespace (per-tenant/dataset isolation)."""
+    dataset = getattr(ctx, "dataset", None) if ctx is not None else None
+    dataset_id = getattr(dataset, "id", None) if dataset is not None else None
+    return str(dataset_id) if dataset_id else None
+
+
+def _entity_type_name(entity) -> Optional[str]:
+    is_a = getattr(entity, "is_a", None)
+    name = getattr(is_a, "name", None) if is_a is not None else None
+    return name or type(entity).__name__
+
+
+def _relationship_name(edge, default: str) -> str:
+    return getattr(edge, "relationship_type", None) or default
+
+
+def _has_default_shape(item, chunk) -> bool:
+    """True when the item follows the default cognify schema walk."""
+    return (
+        getattr(item, "made_from", None) is not None
+        or getattr(chunk, "is_part_of", None) is not None
+        or getattr(chunk, "contains", None) is not None
+    )
+
+
+@task_summary("Recorded provenance for {n} item(s)")
+async def record_provenance(
+    data_points: List[DataPoint], ctx: Optional[PipelineContext] = None
+) -> List[DataPoint]:
+    """Append ledger entries for everything this ingestion produced.
+
+    Receives the batch ``add_data_points`` returns: ``TextSummary`` items
+    wrapping chunks via ``made_from``, ``DocumentChunk`` objects directly, or
+    custom-schema DataPoints (generic traversal). Returns the input unchanged
+    so it can be appended to any pipeline.
+    """
+    if not isinstance(data_points, list) or not data_points:
+        return data_points
+
+    try:
+        manager = get_provenance_manager()
+
+        run_id = str(ctx.pipeline_run_id) if ctx and ctx.pipeline_run_id else None
+        common = {
+            "activity_id": f"cognify:{run_id}" if run_id else "cognify",
+            "agent_id": _agent_from_ctx(ctx),
+            "bundle_id": run_id,
+            "source_ref_key": _source_ref_key_from_ctx(ctx),
+        }
+        scope = _scope_from_ctx(ctx)
+
+        def scoped(raw_id: str) -> str:
+            return f"{scope}:{raw_id}" if scope else raw_id
+
+        batch = manager.batch()
+
+        # Dedup state is per invocation, but the task runs once per chunk
+        # batch — for documents spanning batches the ledger itself is
+        # consulted: an entry already carrying THIS run's bundle_id was
+        # written by an earlier batch of the same ingestion, so re-tracking
+        # (which would forge a spurious version) is skipped.
+        tracked_documents = set()
+
+        async def should_track_document(ledger_id: str) -> bool:
+            if ledger_id in tracked_documents:
+                return False
+            tracked_documents.add(ledger_id)
+            if common["bundle_id"]:
+                existing = await manager.get_provenance(ledger_id)
+                if existing and existing.get("bundle_id") == common["bundle_id"]:
+                    return False
+            return True
+
+        # Shared traversal state for the generic (custom-schema) path.
+        generic_added_nodes: dict = {}
+        generic_added_edges: dict = {}
+        generic_visited: dict = {}
+
+        for item in data_points:
+            chunk = getattr(item, "made_from", None) or item
+
+            if not _has_default_shape(item, chunk) and isinstance(item, DataPoint):
+                # Custom graph_model schema: no made_from/is_part_of/contains.
+                # Walk the model generically so the audit still covers every
+                # node and edge this ingestion produced.
+                nodes, edges = await get_graph_from_model(
+                    item,
+                    added_nodes=generic_added_nodes,
+                    added_edges=generic_added_edges,
+                    visited_properties=generic_visited,
+                )
+                root_id = str(item.id)
+                for node in nodes:
+                    node_id = str(node.id)
+                    batch.track_entity(
+                        scoped(node_id),
+                        source="" if node_id == root_id else scoped(root_id),
+                        entity_type="entity",
+                        metadata={
+                            "name": getattr(node, "name", None),
+                            "type": getattr(node, "type", type(node).__name__),
+                        },
+                        **common,
+                    )
+                for edge_source_id, edge_target_id, relationship_name, _ in edges:
+                    source_id = scoped(str(edge_source_id))
+                    target_id = scoped(str(edge_target_id))
+                    batch.track_relationship(
+                        f"rel:{source_id}:{relationship_name}:{target_id}",
+                        source=scoped(root_id),
+                        used_entities=[source_id, target_id],
+                        metadata={"relationship_name": relationship_name},
+                        **common,
+                    )
+                continue
+
+            document = getattr(chunk, "is_part_of", None)
+
+            document_id = None
+            if document is not None and getattr(document, "id", None) is not None:
+                document_id = scoped(str(document.id))
+                if await should_track_document(document_id):
+                    batch.track_entity(
+                        document_id,
+                        source=getattr(document, "raw_data_location", None)
+                        or getattr(document, "name", None)
+                        or "",
+                        entity_type="document",
+                        **common,
+                    )
+
+            chunk_id = getattr(chunk, "id", None)
+            chunk_id = scoped(str(chunk_id)) if chunk_id is not None else None
+            if chunk_id is not None:
+                chunk_index = getattr(chunk, "chunk_index", 0) or 0
+                batch.track_chunk(
+                    chunk_id,
+                    source_document=(
+                        getattr(document, "raw_data_location", None) or "" if document else ""
+                    ),
+                    parent_chunk_id=document_id,
+                    start_index=chunk_index,
+                    end_index=chunk_index,
+                    chunk_size=getattr(chunk, "chunk_size", None),
+                    **common,
+                )
+
+            for entry in getattr(chunk, "contains", None) or []:
+                # ``contains`` entries are Entity/Event nodes or (Edge, node) tuples.
+                edge = entry[0] if isinstance(entry, tuple) else None
+                entity = entry[1] if isinstance(entry, tuple) else entry
+                entity_id = getattr(entity, "id", None)
+                if entity_id is None:
+                    continue
+                entity_id = scoped(str(entity_id))
+
+                # Re-mention across documents auto-versions: entity ids are
+                # name-derived uuid5s (deterministic within the dataset scope
+                # applied above), so the version chain is exactly the audit
+                # record of every mention within one dataset.
+                batch.track_entity(
+                    entity_id,
+                    source=chunk_id or "",
+                    entity_type="entity",
+                    metadata={
+                        "name": getattr(entity, "name", None),
+                        "type": _entity_type_name(entity),
+                    },
+                    **common,
+                )
+
+                relationship_pairs = []
+                if edge is not None and chunk_id is not None:
+                    relationship_pairs.append(
+                        (chunk_id, _relationship_name(edge, "contains"), entity_id)
+                    )
+                for relation in getattr(entity, "relations", None) or []:
+                    if not isinstance(relation, tuple) or len(relation) != 2:
+                        continue
+                    relation_edge, target = relation
+                    target_id = getattr(target, "id", None)
+                    if target_id is None:
+                        continue
+                    relationship_pairs.append(
+                        (
+                            entity_id,
+                            _relationship_name(relation_edge, "related_to"),
+                            scoped(str(target_id)),
+                        )
+                    )
+
+                for source_id, relationship_name, target_id in relationship_pairs:
+                    batch.track_relationship(
+                        f"rel:{source_id}:{relationship_name}:{target_id}",
+                        source=chunk_id or "",
+                        used_entities=[source_id, target_id],
+                        metadata={"relationship_name": relationship_name},
+                        **common,
+                    )
+
+        await batch.commit()
+    except Exception as error:
+        logger.warning("Provenance recording failed; ingestion unaffected: %s", error)
+
+    return data_points

--- a/cognee/tests/unit/modules/provenance/conftest.py
+++ b/cognee/tests/unit/modules/provenance/conftest.py
@@ -1,0 +1,57 @@
+"""Fixtures for the provenance-ledger unit tests.
+
+A private async SQLite database (one file per test, via ``tmp_path``) stands in
+for the shared relational DB: only the ``provenance_entries`` table is created,
+``cognee.modules.provenance.storage.get_async_session`` is patched to hand out
+sessions bound to it, and both cached factories are cleared so no state leaks
+between tests.
+"""
+
+from contextlib import asynccontextmanager
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from cognee.infrastructure.databases.relational import Base
+from cognee.modules.provenance import storage as provenance_storage
+from cognee.modules.provenance.manager import get_provenance_manager
+from cognee.modules.provenance.models import ProvenanceEntryRow
+
+
+@pytest_asyncio.fixture
+async def provenance_engine(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/provenance.db")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all, tables=[ProvenanceEntryRow.__table__])
+    yield engine
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def manager(provenance_engine, monkeypatch):
+    session_maker = async_sessionmaker(provenance_engine, expire_on_commit=False)
+
+    @asynccontextmanager
+    async def fake_get_async_session(auto_commit=False):
+        async with session_maker() as session:
+            yield session
+            if auto_commit:
+                await session.commit()
+
+    monkeypatch.setattr(provenance_storage, "get_async_session", fake_get_async_session)
+    get_provenance_manager.cache_clear()
+    yield get_provenance_manager()
+    get_provenance_manager.cache_clear()
+
+
+@pytest.fixture
+def tamper(provenance_engine):
+    """Run raw SQL against the ledger, bypassing the manager (tamper simulation)."""
+
+    async def _run(sql, params=None):
+        async with provenance_engine.begin() as connection:
+            await connection.execute(text(sql), params or {})
+
+    return _run

--- a/cognee/tests/unit/modules/provenance/test_integrity.py
+++ b/cognee/tests/unit/modules/provenance/test_integrity.py
@@ -1,0 +1,124 @@
+"""Checksum canonicalization and tamper detection (pure, no DB)."""
+
+import pytest
+
+from cognee.modules.provenance.integrity import (
+    _HASHED_FIELDS,
+    canonical_entity_id,
+    compute_checksum,
+    verify_checksum,
+)
+from cognee.modules.provenance.models import ProvenanceEntry
+
+_LAST_UPDATED = "2026-08-14T00:00:00+00:00"
+
+
+def _entry(**overrides) -> ProvenanceEntry:
+    values = {
+        "entity_id": "entity-1",
+        "entity_type": "entity",
+        "activity_id": "cognify:run-1",
+        "source_document": "/tmp/doc.txt",
+        "timestamp": "2026-08-14T00:00:00+00:00",
+        "last_updated": _LAST_UPDATED,
+        "used_entities": ["a", "b"],
+    }
+    values.update(overrides)
+    return ProvenanceEntry(**values)
+
+
+class TestCanonicalization:
+    def test_deterministic(self):
+        assert compute_checksum(_entry()) == compute_checksum(_entry())
+
+    def test_separator_prevents_field_bleed(self):
+        # Without a separator "ab"+"c" and "a"+"bc" would concatenate equal.
+        first = _entry(entity_type="ab", activity_id="c")
+        second = _entry(entity_type="a", activity_id="bc")
+        assert compute_checksum(first) != compute_checksum(second)
+
+    def test_separator_inside_a_value_cannot_bleed(self):
+        # JSON-encoding each part escapes \x1f, so content cannot move across
+        # a field boundary and hash the same.
+        first = _entry(invalidated_by="alice", invalidation_reason="reason")
+        second = _entry(invalidated_by="alice\x1freason", invalidation_reason="")
+        assert compute_checksum(first) != compute_checksum(second)
+
+    def test_list_element_boundaries_are_unambiguous(self):
+        assert compute_checksum(_entry(used_entities=["a,b"])) != compute_checksum(
+            _entry(used_entities=["a", "b"])
+        )
+
+    def test_none_and_empty_string_are_distinct(self):
+        # JSON canonicalization: null vs "" are different audit states.
+        assert compute_checksum(_entry(parent_entity_id=None)) != compute_checksum(
+            _entry(parent_entity_id="")
+        )
+
+    def test_entity_id_relabel_does_not_change_checksum(self):
+        # The archival-relabel invariant: the archive suffix (which embeds the
+        # row's own last_updated) canonicalizes away.
+        entry = _entry()
+        for suffix in ("", ":3"):
+            relabeled = entry.model_copy(
+                update={"entity_id": f"entity-1:v:{_LAST_UPDATED}{suffix}"}
+            )
+            assert canonical_entity_id(relabeled) == "entity-1"
+            assert compute_checksum(entry) == compute_checksum(relabeled)
+
+    def test_entity_id_swap_changes_checksum(self):
+        # Reattributing a row to another entity must break verification.
+        entry = _entry()
+        swapped = entry.model_copy(update={"entity_id": "entity-2"})
+        assert compute_checksum(entry) != compute_checksum(swapped)
+
+    def test_hashed_fields_cover_the_whole_entry(self):
+        # Every column except the hash output participates (entity_id joins in
+        # canonical form). A field added to the model must be added to the
+        # frozen contract deliberately.
+        expected = set(ProvenanceEntry.model_fields) - {"entity_id", "checksum"}
+        assert set(_HASHED_FIELDS) == expected
+
+
+_TAMPER_VALUES = {
+    "used_entities": ["a", "b", "tampered"],
+    "informed_by_activities": ["tampered"],
+    "invalidated": True,
+    "is_automated": False,
+    "confidence": 0.123,
+    "credibility": 0.5,
+    "sequence_id": 999,
+    "start_index": 41,
+    "end_index": 43,
+    "metadata": {"tampered": True},
+}
+
+
+class TestVerifyChecksum:
+    def test_verify_roundtrip(self):
+        entry = _entry()
+        entry.checksum = compute_checksum(entry)
+        assert verify_checksum(entry) is True
+
+    def test_missing_checksum_is_invalid(self):
+        assert verify_checksum(_entry()) is False
+
+    @pytest.mark.parametrize("field", _HASHED_FIELDS)
+    def test_editing_any_hashed_field_fails_verification(self, field):
+        entry = _entry(
+            parent_entity_id="p",
+            previous_version_id="v",
+            derived_from_id="d",
+            previous_checksum="prev",
+            sequence_id=7,
+            start_index=1,
+            end_index=2,
+            metadata={"kind": "test"},
+            invalidated_at_time="2026-08-14T00:00:01+00:00",
+            invalidated_by="auditor",
+            invalidation_reason="reason",
+        )
+        entry.checksum = compute_checksum(entry)
+        tampered = entry.model_copy(update={field: _TAMPER_VALUES.get(field, f"tampered-{field}")})
+        tampered.checksum = entry.checksum
+        assert verify_checksum(tampered) is False

--- a/cognee/tests/unit/modules/provenance/test_provenance_entry_model.py
+++ b/cognee/tests/unit/modules/provenance/test_provenance_entry_model.py
@@ -1,0 +1,94 @@
+"""Pydantic <-> ORM roundtrip and defaults for ProvenanceEntry."""
+
+from datetime import datetime
+
+from cognee.modules.provenance.models import ProvenanceEntry, ProvenanceEntryRow
+
+
+def _full_entry() -> ProvenanceEntry:
+    return ProvenanceEntry(
+        entity_id="entity-1",
+        entity_type="entity",
+        activity_id="cognify:run-1",
+        agent_id="user@example.com",
+        role="generator",
+        source_document="/tmp/doc.txt",
+        source_location="page 2",
+        source_quote="quoted text",
+        source_ref_key="source_ref:v1:ds:data",
+        first_seen="2026-08-14T00:00:00+00:00",
+        last_updated="2026-08-14T00:00:01+00:00",
+        confidence=0.9,
+        credibility=0.8,
+        checksum="ab" * 32,
+        sequence_id=7,
+        previous_checksum="cd" * 32,
+        parent_entity_id="parent-1",
+        used_entities=["parent-1", "other-1"],
+        previous_version_id="entity-1:v:x",
+        derived_from_id="parent-1",
+        acted_on_behalf_of="org-1",
+        informed_by_activities=["cognify:run-0"],
+        revision_type="correction",
+        supersedes="entity-0",
+        bundle_id="run-1",
+        invalidated=True,
+        invalidated_at_time="2026-08-14T00:00:02+00:00",
+        invalidated_by="auditor",
+        invalidation_reason="retracted",
+        start_index=3,
+        end_index=4,
+        metadata={"name": "Alice", "nested": {"k": [1, 2]}},
+    )
+
+
+class TestRoundtrip:
+    def test_row_roundtrip_preserves_every_field(self):
+        entry = _full_entry()
+        row = entry.to_row()
+        restored = ProvenanceEntry.from_row(row)
+        assert restored.model_dump() == entry.model_dump()
+
+    def test_metadata_maps_to_entry_metadata_column(self):
+        entry = _full_entry()
+        row = entry.to_row()
+        # Attribute is entry_metadata; the actual column name stays "metadata".
+        assert row.entry_metadata == entry.metadata
+        assert "metadata" in ProvenanceEntryRow.__table__.c
+        assert ProvenanceEntryRow.entry_metadata.expression.name == "metadata"
+
+    def test_json_list_and_dict_fields_survive(self):
+        entry = _full_entry()
+        restored = ProvenanceEntry.from_row(entry.to_row())
+        assert restored.used_entities == ["parent-1", "other-1"]
+        assert restored.informed_by_activities == ["cognify:run-0"]
+        assert restored.metadata["nested"] == {"k": [1, 2]}
+
+    def test_apply_to_row_overwrites_in_place(self):
+        row = _full_entry().to_row()
+        updated = _full_entry().model_copy(update={"agent_id": "other", "sequence_id": 9})
+        updated.apply_to_row(row)
+        assert row.agent_id == "other"
+        assert row.sequence_id == 9
+
+
+class TestDefaults:
+    def test_defaults(self):
+        entry = ProvenanceEntry(entity_id="x")
+        assert entry.entity_type == "entity"
+        assert entry.agent_id == "cognee"
+        assert entry.agent_type == "software_agent"
+        assert entry.is_automated is True
+        assert entry.confidence == 1.0
+        assert entry.used_entities == []
+        assert entry.informed_by_activities == []
+        assert entry.metadata == {}
+        assert entry.invalidated is False
+        assert entry.version == "1.0"
+        assert entry.sequence_id is None
+        assert entry.checksum is None
+
+    def test_default_timestamp_is_timezone_aware_iso(self):
+        entry = ProvenanceEntry(entity_id="x")
+        parsed = datetime.fromisoformat(entry.timestamp)
+        assert parsed.tzinfo is not None

--- a/cognee/tests/unit/modules/provenance/test_provenance_manager.py
+++ b/cognee/tests/unit/modules/provenance/test_provenance_manager.py
@@ -1,0 +1,319 @@
+"""ProvenanceManager behavior over an isolated async SQLite ledger."""
+
+import pytest
+
+from cognee.modules.provenance import storage
+from cognee.modules.provenance.integrity import compute_checksum
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _archive_entries(entity_id):
+    return [
+        entry
+        for entry in await storage.retrieve_all()
+        if entry.entity_id.startswith(f"{entity_id}:v:")
+    ]
+
+
+class TestTrackEntity:
+    async def test_create(self, manager):
+        entry = await manager.track_entity("e1", source="/tmp/doc.txt", metadata={"name": "A"})
+        assert entry is not None
+        assert entry.sequence_id == 1
+        assert entry.previous_checksum is None
+        assert entry.checksum == compute_checksum(entry)
+        assert entry.first_seen == entry.last_updated == entry.timestamp
+
+        stored = await manager.get_provenance("e1")
+        assert stored["source_document"] == "/tmp/doc.txt"
+        assert stored["metadata"] == {"name": "A"}
+
+    async def test_validation(self, manager):
+        with pytest.raises(ValueError):
+            await manager.track_entity(None, source="s")
+        with pytest.raises(TypeError):
+            await manager.track_entity(123, source="s")
+
+    async def test_retrack_archives_old_version(self, manager):
+        first = await manager.track_entity("e1", source="doc-a")
+        second = await manager.track_entity("e1", source="doc-b")
+
+        archives = await _archive_entries("e1")
+        assert len(archives) == 1
+        archive = archives[0]
+        # Pure relabel: the archive keeps the OLD checksum/sequence/prev link.
+        assert archive.checksum == first.checksum
+        assert archive.sequence_id == first.sequence_id
+        assert archive.previous_checksum == first.previous_checksum
+        # And, since entity_id is excluded from the hash, it still verifies.
+        assert compute_checksum(archive) == archive.checksum
+
+        assert second.previous_version_id == archive.entity_id
+        assert second.first_seen == first.first_seen
+        assert second.sequence_id == 2
+        assert second.previous_checksum == first.checksum
+        # No explicit parent: the archival link doubles as the parent, but is
+        # NOT a derivation.
+        assert second.parent_entity_id == archive.entity_id
+        assert second.derived_from_id is None
+
+    async def test_parent_precedence_kwarg_wins(self, manager):
+        await manager.track_entity("a", source="root")
+        await manager.track_entity("b", source="root")
+        entry = await manager.track_entity(
+            "c", source="b", metadata={"derived_from": "b"}, parent_entity_id="a"
+        )
+        assert entry.parent_entity_id == "a"
+        assert entry.derived_from_id == "a"
+
+    async def test_parent_precedence_metadata_derived_from(self, manager):
+        await manager.track_entity("a", source="root")
+        entry = await manager.track_entity("c", source="untracked", metadata={"derived_from": "a"})
+        assert entry.parent_entity_id == "a"
+        assert entry.derived_from_id == "a"
+
+    async def test_parent_precedence_source_heuristic(self, manager):
+        await manager.track_entity("a", source="root")
+        entry = await manager.track_entity("c", source="a")
+        assert entry.parent_entity_id == "a"
+        assert entry.derived_from_id == "a"
+
+    async def test_untracked_source_gives_no_parent(self, manager):
+        entry = await manager.track_entity("c", source="nowhere.txt")
+        assert entry.parent_entity_id is None
+        assert entry.derived_from_id is None
+
+    async def test_archive_plus_explicit_parent_lands_in_used_entities(self, manager):
+        await manager.track_entity("a", source="root")
+        await manager.track_entity("e1", source="doc-a")
+        entry = await manager.track_entity("e1", source="doc-b", parent_entity_id="a")
+        archives = await _archive_entries("e1")
+        assert entry.derived_from_id == "a"
+        assert entry.previous_version_id == archives[0].entity_id
+        assert archives[0].entity_id in entry.used_entities
+
+
+class TestTrackChunkAndRelationship:
+    async def test_track_chunk_sets_parent_and_derived_from(self, manager):
+        await manager.track_entity("doc", source="/tmp/doc.txt", entity_type="document")
+        entry = await manager.track_chunk(
+            "chunk-1",
+            source_document="/tmp/doc.txt",
+            parent_chunk_id="doc",
+            start_index=0,
+            end_index=0,
+            chunk_size=128,
+        )
+        assert entry.entity_type == "chunk"
+        assert entry.activity_id == "chunking"
+        assert entry.parent_entity_id == "doc"
+        assert entry.derived_from_id == "doc"
+        assert entry.metadata == {"chunk_size": 128}
+
+    async def test_relationship_never_versions(self, manager):
+        first = await manager.track_relationship("rel:a:knows:b", source="chunk-1")
+        again = await manager.track_relationship("rel:a:knows:b", source="chunk-2")
+
+        assert first.entity_type == "relationship"
+        assert first.activity_id == "relationship_tracking"
+        # Re-track is a chain-preserving no-op returning the stored entry.
+        assert again.checksum == first.checksum
+        assert again.sequence_id == first.sequence_id
+        assert again.previous_version_id is None
+        assert await _archive_entries("rel:a:knows:b") == []
+        assert (await manager.get_statistics())["entity_types"]["relationship"] == 1
+
+    async def test_relationship_records_used_entities(self, manager):
+        entry = await manager.track_relationship(
+            "rel:a:knows:b", source="chunk-1", used_entities=["a", "b"]
+        )
+        assert entry.used_entities == ["a", "b"]
+
+
+class TestInvalidate:
+    async def test_invalidate_tombstone(self, manager):
+        await manager.track_entity("e1", source="doc-a")
+        entry = await manager.invalidate("e1", agent_id="auditor", reason="retracted")
+
+        assert entry.invalidated is True
+        assert entry.invalidated_by == "auditor"
+        assert entry.invalidation_reason == "retracted"
+        assert entry.checksum == compute_checksum(entry)
+
+        stored = await manager.get_provenance("e1")
+        assert stored["invalidated"] is True
+
+        archives = await _archive_entries("e1")
+        assert len(archives) == 1
+        assert archives[0].invalidated is False
+        assert entry.previous_version_id == archives[0].entity_id
+
+        # The tombstone is dated when the invalidation happened, not when the
+        # fact was first tracked.
+        assert entry.timestamp == entry.last_updated == entry.invalidated_at_time
+        assert entry.timestamp >= archives[0].timestamp
+        assert entry.first_seen == archives[0].first_seen
+        history = await manager.revision_history("e1")
+        assert history[-1]["recorded_at"] == entry.timestamp
+        assert history[0]["valid_until"] == entry.timestamp
+
+        assert (await manager.verify_chain())["valid"] is True
+
+    async def test_invalidate_untracked_raises(self, manager):
+        with pytest.raises(ValueError):
+            await manager.invalidate("ghost", agent_id="auditor")
+
+
+class TestRevisionHistory:
+    async def test_order_and_synthesized_validity(self, manager):
+        await manager.track_entity("e1", source="v1")
+        await manager.track_entity("e1", source="v2")
+        await manager.track_entity("e1", source="v3")
+
+        history = await manager.revision_history("e1")
+        assert [item["version"] for item in history] == [1, 2, 3]
+        recorded = [item["recorded_at"] for item in history]
+        assert recorded == sorted(recorded)
+        # Every non-current version's window closes at the next version.
+        assert history[0]["valid_until"] == history[1]["recorded_at"]
+        assert history[1]["valid_until"] == history[2]["recorded_at"]
+        assert history[2]["valid_until"] is None
+
+    async def test_cycle_guard(self, manager, tamper):
+        await manager.track_entity("e1", source="v1")
+        await manager.track_entity("e1", source="v2")
+        archives = await _archive_entries("e1")
+        # Forge a cycle: archive points back at the live entry.
+        await tamper(
+            "UPDATE provenance_entries SET previous_version_id = 'e1' WHERE entity_id = :aid",
+            {"aid": archives[0].entity_id},
+        )
+        history = await manager.revision_history("e1")
+        assert len(history) == 2  # terminated, no infinite walk
+
+    async def test_untracked_is_empty(self, manager):
+        assert await manager.revision_history("ghost") == []
+
+
+class TestLineage:
+    async def test_get_lineage_aggregation(self, manager):
+        await manager.track_entity("doc", source="/tmp/doc.txt", metadata={"kind": "pdf"})
+        await manager.track_chunk("chunk-1", source_document="/tmp/doc.txt", parent_chunk_id="doc")
+        await manager.track_entity(
+            "ent-1", source="chunk-1", metadata={"kind": "entity", "name": "Alice"}
+        )
+
+        lineage = await manager.get_lineage("ent-1")
+        assert lineage["entity_id"] == "ent-1"
+        assert lineage["entity_count"] == 3
+        assert [item["entity_id"] for item in lineage["lineage_chain"]] == [
+            "ent-1",
+            "chunk-1",
+            "doc",
+        ]
+        assert set(lineage["source_documents"]) == {"chunk-1", "/tmp/doc.txt"}
+        # Ancestors first, queried entity wins on conflicting keys.
+        assert lineage["metadata"]["kind"] == "entity"
+        assert lineage["metadata"]["name"] == "Alice"
+        assert lineage["integrity_verified"] is True
+
+    async def test_get_lineage_untracked(self, manager):
+        assert await manager.get_lineage("ghost") == {}
+
+    async def test_integrity_flag_flips_on_tamper(self, manager, tamper):
+        await manager.track_entity("doc", source="/tmp/doc.txt")
+        await manager.track_chunk("chunk-1", source_document="/tmp/doc.txt", parent_chunk_id="doc")
+        await tamper("UPDATE provenance_entries SET agent_id = 'evil' WHERE entity_id = 'doc'")
+        lineage = await manager.get_lineage("chunk-1")
+        assert lineage["integrity_verified"] is False
+
+    async def test_trace_lineage_max_depth(self, manager):
+        await manager.track_entity("doc", source="/tmp/doc.txt")
+        await manager.track_chunk("chunk-1", source_document="/tmp/doc.txt", parent_chunk_id="doc")
+        await manager.track_entity("ent-1", source="chunk-1")
+        entries = await manager.trace_lineage("ent-1", max_depth=1)
+        assert [entry.entity_id for entry in entries] == ["ent-1"]
+
+
+class TestBatch:
+    async def test_batch_commits_one_chained_transaction(self, manager, monkeypatch):
+        calls = []
+        original = storage.append_chained_many
+
+        async def counting(write_fns):
+            calls.append(len(write_fns))
+            return await original(write_fns)
+
+        monkeypatch.setattr(storage, "append_chained_many", counting)
+
+        batch = manager.batch()
+        batch.track_entity("doc", source="/tmp/doc.txt", entity_type="document")
+        batch.track_chunk("chunk-1", source_document="/tmp/doc.txt", parent_chunk_id="doc")
+        batch.track_entity("ent-1", source="chunk-1")
+        batch.track_relationship(
+            "rel:chunk-1:contains:ent-1", source="chunk-1", used_entities=["chunk-1", "ent-1"]
+        )
+        results = await batch.commit()
+
+        assert calls == [4]  # one append_chained_many for the whole batch
+        assert [entry.sequence_id for entry in results] == [1, 2, 3, 4]
+        # Later operations see earlier ones inside the same transaction: the
+        # source-heuristic parent resolved against the just-written chunk.
+        assert results[2].parent_entity_id == "chunk-1"
+        assert (await manager.verify_chain())["valid"] is True
+        assert len(batch) == 0  # commit drains the batch
+
+    async def test_batch_noop_retrack_consumes_no_slot(self, manager):
+        await manager.track_relationship("rel:a:knows:b", source="chunk-1")
+        batch = manager.batch()
+        batch.track_relationship("rel:a:knows:b", source="chunk-2")
+        batch.track_entity("e1", source="doc")
+        results = await batch.commit()
+        assert results[0].sequence_id == 1  # the stored entry — no new slot
+        assert results[1].sequence_id == 2  # chain advanced only for the real write
+        assert (await manager.verify_chain())["valid"] is True
+
+    async def test_batch_validation_raises_at_add_time(self, manager):
+        batch = manager.batch()
+        with pytest.raises(ValueError):
+            batch.track_entity(None, source="doc")
+        with pytest.raises(TypeError):
+            batch.track_relationship(123, source="doc")
+
+    async def test_batch_commit_degrades_gracefully(self, manager, monkeypatch):
+        async def explode(write_fns):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(storage, "append_chained_many", explode)
+        batch = manager.batch()
+        batch.track_entity("e1", source="doc")
+        assert await batch.commit() is None
+
+
+class TestUtility:
+    async def test_check_reports_missing_references(self, manager):
+        await manager.track_entity("e1", source="root", parent_entity_id="ghost")
+        report = await manager.check()
+        assert report["valid"] is False
+        assert "e1 -> ghost" in report["missing_references"]
+
+    async def test_statistics_and_clear(self, manager):
+        await manager.track_entity("e1", source="doc-a")
+        await manager.track_relationship("rel:a:knows:b", source="chunk-1")
+        stats = await manager.get_statistics()
+        assert stats["total_entries"] == 2
+        assert stats["entity_types"] == {"entity": 1, "relationship": 1}
+        assert stats["unique_sources"] == 2
+
+        assert await manager.clear() == 2
+        assert (await manager.get_statistics())["total_entries"] == 0
+
+    async def test_tracking_degrades_gracefully_on_storage_failure(self, manager, monkeypatch):
+        async def explode(*args, **kwargs):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(storage, "append_chained", explode)
+        assert await manager.track_entity("e1", source="doc") is None
+        assert await manager.track_relationship("rel:a:b:c", source="doc") is None
+        assert await manager.track_chunk("chunk-1", source_document="doc") is None

--- a/cognee/tests/unit/modules/provenance/test_record_provenance_task.py
+++ b/cognee/tests/unit/modules/provenance/test_record_provenance_task.py
@@ -1,0 +1,295 @@
+"""record_provenance task: ledger writes, degradation, and pipeline wiring."""
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from cognee.api.v1.cognify.cognify import get_default_tasks
+from cognee.infrastructure.databases.provenance import make_source_ref_key
+from cognee.infrastructure.engine import DataPoint
+from cognee.modules.cognify.config import CognifyConfig, get_cognify_config
+from cognee.modules.pipelines.models.PipelineContext import PipelineContext
+from cognee.modules.provenance import storage
+from cognee.tasks.provenance import record_provenance
+
+# Grab the actual module object for patching (the package __init__ re-exports
+# the record_provenance FUNCTION, shadowing the submodule for dotted patching).
+record_provenance_module = sys.modules["cognee.tasks.provenance.record_provenance"]
+cognify_module = sys.modules["cognee.api.v1.cognify.cognify"]
+
+
+class FakeEdge:
+    def __init__(self, relationship_type):
+        self.relationship_type = relationship_type
+
+
+class FakeEntity:
+    def __init__(self, name, entity_type_name=None, relations=None):
+        self.id = uuid4()
+        self.name = name
+        self.is_a = SimpleNamespace(name=entity_type_name) if entity_type_name else None
+        self.relations = relations or []
+
+
+class FakeDocument:
+    def __init__(self):
+        self.id = uuid4()
+        self.name = "doc.txt"
+        self.raw_data_location = "/tmp/doc.txt"
+
+
+class FakeChunk:
+    def __init__(self, document, contains):
+        self.id = uuid4()
+        self.is_part_of = document
+        self.contains = contains
+        self.chunk_index = 3
+        self.chunk_size = 42
+
+
+class FakeSummary:
+    def __init__(self, chunk):
+        self.id = uuid4()
+        self.made_from = chunk
+
+
+def _pipeline_data():
+    document = FakeDocument()
+    target = FakeEntity("Acme", "Organization")
+    entity = FakeEntity("Alice", "Person", relations=[(FakeEdge("works_at"), target)])
+    chunk = FakeChunk(document, contains=[entity, (FakeEdge("mentions"), target)])
+    return document, chunk, entity, target, [FakeSummary(chunk)]
+
+
+def _ctx(dataset_id=None, pipeline_run_id=None):
+    return PipelineContext(
+        user=SimpleNamespace(email="user@example.com", id=uuid4()),
+        data_item=SimpleNamespace(id=uuid4()),
+        dataset=SimpleNamespace(id=dataset_id or uuid4()),
+        pipeline_run_id=pipeline_run_id or uuid4(),
+    )
+
+
+class TestRecordProvenanceTask:
+    @pytest.mark.asyncio
+    async def test_writes_all_four_entry_types(self, manager):
+        document, chunk, entity, target, data_points = _pipeline_data()
+        ctx = _ctx()
+        scope = str(ctx.dataset.id)
+
+        result = await record_provenance(data_points, ctx=ctx)
+        assert result is data_points
+
+        entries = {entry.entity_id: entry for entry in await storage.retrieve_all()}
+        run_id = str(ctx.pipeline_run_id)
+        expected_ref = make_source_ref_key(ctx.dataset.id, ctx.data_item.id)
+
+        # Every ledger key is namespaced by the dataset id (tenant isolation
+        # over globally deterministic uuid5 entity ids).
+        doc_entry = entries[f"{scope}:{document.id}"]
+        assert doc_entry.entity_type == "document"
+        assert doc_entry.source_document == "/tmp/doc.txt"
+        assert doc_entry.parent_entity_id is None
+
+        chunk_entry = entries[f"{scope}:{chunk.id}"]
+        assert chunk_entry.entity_type == "chunk"
+        assert chunk_entry.parent_entity_id == f"{scope}:{document.id}"
+        assert chunk_entry.derived_from_id == f"{scope}:{document.id}"
+        assert chunk_entry.start_index == chunk_entry.end_index == 3
+        assert chunk_entry.metadata == {"chunk_size": 42}
+
+        entity_entry = entries[f"{scope}:{entity.id}"]
+        assert entity_entry.entity_type == "entity"
+        assert entity_entry.metadata == {"name": "Alice", "type": "Person"}
+        # Source-heuristic parent: the chunk is already tracked.
+        assert entity_entry.parent_entity_id == f"{scope}:{chunk.id}"
+
+        mention_rel = entries[f"rel:{scope}:{chunk.id}:mentions:{scope}:{target.id}"]
+        works_rel = entries[f"rel:{scope}:{entity.id}:works_at:{scope}:{target.id}"]
+        assert mention_rel.entity_type == works_rel.entity_type == "relationship"
+        assert works_rel.used_entities == [f"{scope}:{entity.id}", f"{scope}:{target.id}"]
+        assert works_rel.metadata == {"relationship_name": "works_at"}
+
+        for entry in entries.values():
+            assert entry.bundle_id == run_id
+            assert entry.activity_id == f"cognify:{run_id}"
+            assert entry.agent_id == "user@example.com"
+            assert entry.source_ref_key == expected_ref
+
+        stats = await manager.get_statistics()
+        assert stats["entity_types"] == {
+            "document": 1,
+            "chunk": 1,
+            "entity": 2,
+            "relationship": 2,
+        }
+        assert (await manager.verify_chain())["valid"] is True
+        assert (await manager.check())["valid"] is True
+
+    @pytest.mark.asyncio
+    async def test_single_chained_transaction_per_invocation(self, manager, monkeypatch):
+        calls = []
+        original = storage.append_chained_many
+
+        async def counting(write_fns):
+            calls.append(len(write_fns))
+            return await original(write_fns)
+
+        monkeypatch.setattr(storage, "append_chained_many", counting)
+        _, _, _, _, data_points = _pipeline_data()
+        await record_provenance(data_points, ctx=_ctx())
+        # One batched append for the whole invocation, never one per entry.
+        assert calls == [6]
+
+    @pytest.mark.asyncio
+    async def test_no_ctx_degrades_to_entries_without_source_ref(self, manager):
+        _, chunk, _, _, data_points = _pipeline_data()
+        result = await record_provenance(data_points, ctx=None)
+        assert result is data_points
+
+        entries = await storage.retrieve_all()
+        assert entries, "entries must still be written without ctx"
+        for entry in entries:
+            assert entry.source_ref_key is None
+            assert entry.bundle_id is None
+            assert entry.activity_id == "cognify"
+            assert entry.agent_id == "cognee"
+
+    @pytest.mark.asyncio
+    async def test_document_not_reversioned_across_batches_of_same_run(self, manager):
+        # The task runs once per chunk batch; a document spanning batches must
+        # be tracked once per run, not once per batch.
+        document = FakeDocument()
+        ctx = _ctx()
+        scope = str(ctx.dataset.id)
+        first_batch = [FakeSummary(FakeChunk(document, contains=[]))]
+        second_batch = [FakeSummary(FakeChunk(document, contains=[]))]
+
+        await record_provenance(first_batch, ctx=ctx)
+        await record_provenance(second_batch, ctx=ctx)
+
+        entries = await storage.retrieve_all()
+        doc_key = f"{scope}:{document.id}"
+        archives = [entry for entry in entries if entry.entity_id.startswith(f"{doc_key}:v:")]
+        assert archives == []  # no forged version history
+        history = await manager.revision_history(doc_key)
+        assert len(history) == 1
+
+        # A NEW run of the same dataset re-tracks (and versions) the document.
+        await record_provenance(
+            [FakeSummary(FakeChunk(document, contains=[]))],
+            ctx=_ctx(dataset_id=ctx.dataset.id),
+        )
+        assert len(await manager.revision_history(doc_key)) == 2
+
+    @pytest.mark.asyncio
+    async def test_dataset_scoping_isolates_tenants(self, manager):
+        # Same (deterministic) entity ids ingested under two datasets must not
+        # share a version chain.
+        document, chunk, entity, _, _ = _pipeline_data()
+        data_points_a = [FakeSummary(chunk)]
+        ctx_a, ctx_b = _ctx(), _ctx()
+
+        await record_provenance(data_points_a, ctx=ctx_a)
+        await record_provenance(data_points_a, ctx=ctx_b)
+
+        key_a = f"{ctx_a.dataset.id}:{entity.id}"
+        key_b = f"{ctx_b.dataset.id}:{entity.id}"
+        entry_a = await manager.get_provenance(key_a)
+        entry_b = await manager.get_provenance(key_b)
+        assert entry_a is not None and entry_b is not None
+        assert entry_a["source_ref_key"] != entry_b["source_ref_key"]
+        # No cross-tenant archiving happened.
+        assert entry_a["previous_version_id"] is None
+        assert entry_b["previous_version_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_custom_datapoint_schema_uses_generic_traversal(self, manager):
+        # Custom graph_model DataPoints (no made_from/is_part_of/contains) must
+        # still land entity + relationship rows, via get_graph_from_model.
+        class CustomLeaf(DataPoint):
+            name: str
+
+        class CustomRoot(DataPoint):
+            name: str
+            points_to: CustomLeaf
+
+        leaf = CustomLeaf(name="leaf")
+        root = CustomRoot(name="root", points_to=leaf)
+
+        await record_provenance([root], ctx=None)
+
+        entries = {entry.entity_id: entry for entry in await storage.retrieve_all()}
+        assert str(root.id) in entries
+        assert str(leaf.id) in entries
+        relationships = [entry for entry in entries.values() if entry.entity_type == "relationship"]
+        assert len(relationships) == 1
+        assert relationships[0].used_entities == [str(root.id), str(leaf.id)]
+        assert (await manager.verify_chain())["valid"] is True
+
+    @pytest.mark.asyncio
+    async def test_raw_item_without_document_still_tracked(self, manager):
+        raw_item = SimpleNamespace(id=uuid4())  # no made_from, no is_part_of
+        result = await record_provenance([raw_item], ctx=None)
+        assert result == [raw_item]
+        entries = await storage.retrieve_all()
+        assert [entry.entity_id for entry in entries] == [str(raw_item.id)]
+        assert entries[0].parent_entity_id is None
+
+    @pytest.mark.asyncio
+    async def test_manager_failure_never_raises(self, monkeypatch):
+        def explode():
+            raise RuntimeError("ledger down")
+
+        monkeypatch.setattr(record_provenance_module, "get_provenance_manager", explode)
+        _, _, _, _, data_points = _pipeline_data()
+        result = await record_provenance(data_points, ctx=_ctx())
+        assert result is data_points
+
+    @pytest.mark.asyncio
+    async def test_empty_input_is_a_noop(self):
+        assert await record_provenance([]) == []
+
+
+async def _task_names(provenance_flag, contradiction_flag=False):
+    config = CognifyConfig(
+        provenance_tracking=provenance_flag,
+        contradiction_detection=contradiction_flag,
+    )
+    with patch.object(cognify_module, "get_cognify_config", return_value=config):
+        tasks = await get_default_tasks(
+            # Non-None config skips the ontology-env branch; explicit chunk_size
+            # keeps get_max_chunk_tokens() from being called.
+            config={"ontology_config": {"ontology_resolver": None}},
+            chunk_size=1024,
+        )
+    return [task.executable.__name__ for task in tasks]
+
+
+class TestPipelineWiring:
+    def test_flag_defaults_off_and_lands_in_to_dict(self):
+        with patch.dict(os.environ, {}, clear=True):
+            config = CognifyConfig()
+            assert config.provenance_tracking is False
+            assert config.to_dict()["provenance_tracking"] is False
+
+    def test_env_var_enables_flag(self):
+        with patch.dict(os.environ, {"PROVENANCE_TRACKING": "true"}):
+            get_cognify_config.cache_clear()
+            assert get_cognify_config().provenance_tracking is True
+        get_cognify_config.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_flag_off_pipeline_unchanged(self):
+        names = await _task_names(provenance_flag=False)
+        assert "record_provenance" not in names
+
+    @pytest.mark.asyncio
+    async def test_flag_on_splices_after_add_data_points_before_contradictions(self):
+        names = await _task_names(provenance_flag=True, contradiction_flag=True)
+        assert names.index("record_provenance") == names.index("add_data_points") + 1
+        assert names.index("record_provenance") < names.index("detect_contradictions")

--- a/cognee/tests/unit/modules/provenance/test_verify_chain.py
+++ b/cognee/tests/unit/modules/provenance/test_verify_chain.py
@@ -1,0 +1,70 @@
+"""Hash-chain verification: tamper detection, deletion detection, concurrency."""
+
+import asyncio
+
+import pytest
+
+from cognee.modules.provenance import storage
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed(manager, count=5):
+    for index in range(1, count + 1):
+        await manager.track_entity(f"e{index}", source=f"doc-{index}")
+
+
+class TestVerifyChain:
+    async def test_clean_chain_is_valid(self, manager):
+        await _seed(manager, 3)
+        await manager.track_entity("e1", source="doc-1b")  # re-track: archive + relabel
+        await manager.track_chunk("chunk-1", source_document="doc-1")
+        await manager.track_relationship("rel:e1:knows:e2", source="chunk-1")
+        await manager.invalidate("e2", agent_id="auditor", reason="retracted")
+
+        report = await manager.verify_chain()
+        assert report["valid"] is True
+        assert report["broken_links"] == []
+
+    async def test_in_place_edit_is_checksum_mismatch(self, manager, tamper):
+        await _seed(manager, 3)
+        await tamper("UPDATE provenance_entries SET agent_id = 'evil' WHERE entity_id = 'e2'")
+
+        report = await manager.verify_chain()
+        assert report["valid"] is False
+        assert len(report["broken_links"]) == 1
+        assert report["broken_links"][0] == {
+            "entity_id": "e2",
+            "sequence_id": 2,
+            "reason": "checksum_mismatch",
+        }
+
+    async def test_deleting_a_middle_row_is_a_chain_break(self, manager, tamper):
+        await _seed(manager, 5)
+        await tamper("DELETE FROM provenance_entries WHERE sequence_id = 2")
+
+        report = await manager.verify_chain()
+        assert report["valid"] is False
+        # Exactly the successor of the deleted row is flagged — no cascade.
+        assert len(report["broken_links"]) == 1
+        broken = report["broken_links"][0]
+        assert broken["reason"] == "chain_break"
+        assert broken["sequence_id"] == 3
+        assert broken["expected_sequence_id"] == 2
+        assert broken["actual_previous_checksum"] != broken["expected_previous_checksum"]
+
+    async def test_streaming_pagination_matches_full_scan(self, manager):
+        await _seed(manager, 5)
+        streamed = [entry async for entry in storage.iter_chained(page_size=2)]
+        assert [entry.sequence_id for entry in streamed] == [1, 2, 3, 4, 5]
+        everything = [entry async for entry in storage.iter_all(page_size=2)]
+        assert len(everything) == 5
+
+    async def test_concurrent_appends_never_fork_the_chain(self, manager):
+        await asyncio.gather(
+            *(manager.track_entity(f"e{index}", source=f"doc-{index}") for index in range(20))
+        )
+
+        entries = await storage.retrieve_all()
+        assert {entry.sequence_id for entry in entries} == set(range(1, 21))
+        assert (await manager.verify_chain())["valid"] is True


### PR DESCRIPTION
## Description

Ports the provenance feature from [semantica](https://github.com/semantica-agi/semantica) (MIT) into cognee as an **append-only, tamper-evident audit ledger** — the one provenance capability cognee's existing subsystems (graph source-refs for delete/rollback, `source_*` DataPoint stamping, the memory-provenance projection) don't cover. High-stakes domains (finance, healthcare, legal, pharma) need to prove where every fact came from, when it changed, who retracted it, and that the record itself was never altered.

Linear: COG-6172

### What's included

- **`cognee/modules/provenance/`** — async `ProvenanceManager` (`track_entity` with auto-versioning, `track_chunk`, `track_relationship`, `get_lineage`/`trace_lineage`, `revision_history`, `invalidate` tombstones, `verify_chain`, `check`, `get_statistics`), W3C PROV-O field set (agents, activities, bitemporal validity, derivation-vs-versioning split).
- **Hash-chain integrity** — every entry carries a SHA-256 checksum over all fields (canonical JSON, so separator/list-boundary games can't produce collisions) plus a link to the previous entry's checksum via a partial-unique `sequence_id`; `verify_chain()` detects row deletion, reordering, and single-field edits. Verification streams via keyset pagination; statistics are DB-side aggregates.
- **Storage** — one `provenance_entries` table on the shared relational DB (SQLite + Postgres), created via `Base.metadata` and an idempotent Alembic migration (`b8c1d3e5f7a9`); both paths verified to produce identical schemas. Appends are batched (`append_chained_many`): one transaction per pipeline task invocation instead of one per entry.
- **Tenant isolation** — ledger keys are dataset-prefixed, so identical deterministic entity ids in different datasets never share a version chain.
- **Opt-in cognify hook** — `cognee/tasks/provenance/record_provenance.py`, gated by `PROVENANCE_TRACKING` (default **false**), attaches after `add_data_points` the same way contradiction detection does and swallows its own errors, so it can never break ingestion. Records document → chunk → entity → relationship lineage; custom `graph_model` schemas are covered via the same `get_graph_from_model` traversal `add_data_points` uses. Entries join to existing graph provenance through the `source_ref:v1:{dataset_id}:{data_id}` key instead of a new id space.

### Deliberately deferred (later PRs)

Bridge axioms / translation chains, PROV-O RDF export, per-module `*WithProvenance` wrappers, explorer/visualization UI, graph-side invalidation propagation.

## Test plan

- 99 new unit tests in `cognee/tests/unit/modules/provenance/` — schema roundtrip, full-field hash coverage (guard test asserts the hashed set equals all model fields minus `checksum`), tamper/deletion/entity-id-swap detection, 20-way concurrent-append chain integrity, batching slot semantics, invalidation dating, cross-batch document dedup, tenant scoping, custom-schema traversal, streaming verification.
- Regression: `cognee/tests/unit/modules/cognify` (63) plus existing provenance-projection suites all pass — 162 total locally.
- Migration `upgrade()`/`downgrade()` executed against scratch SQLite; nullability diff vs the ORM model is empty.
- `pre-commit run` (ruff check + format) clean.

With `PROVENANCE_TRACKING` unset, the cognify task list is unchanged and no ledger writes occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)