### PR TITLE
fix: Plumb LLM_TEMPERATURE into calls, add LLM_SEED (COG-6174)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -537,7 +537,11 @@ WEB_SCRAPER_MAX_DELAY=10.0
 ################################################################################
 
 # -- LLM tuning ---------------------------------------------------------------
+# Sampling temperature, sent with every LLM call when set. Leave unset to use
+# the provider's default — note gpt-5 models reject any value other than 1.
 #LLM_TEMPERATURE=0.0
+# Sampling seed for reproducible outputs, sent when set (provider support varies).
+#LLM_SEED=42
 #LLM_STREAMING=false
 # Optional fallback model used when the primary completion fails.
 #FALLBACK_MODEL=""

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -109,6 +109,7 @@ class LLMConfig(BaseSettings):
     llm_query_api_version: str | None = None
 
     llm_temperature: float = 0.0
+    llm_seed: int | None = None
     llm_streaming: bool = False
     llm_max_completion_tokens: int = 16384
 
@@ -198,6 +199,29 @@ class LLMConfig(BaseSettings):
                 from cognee.infrastructure.llm.exceptions import ProviderNotDeducibleError
 
                 raise ProviderNotDeducibleError(model)
+
+        return self
+
+    @model_validator(mode="after")
+    def fold_sampling_params_into_llm_args(self) -> "LLMConfig":
+        """
+        Fold ``llm_temperature`` / ``llm_seed`` into ``llm_args``, the dict every
+        adapter merges into each completion call — without this fold the two
+        fields are read by nothing and never reach the provider.
+
+        ``llm_temperature`` is folded only when set explicitly (env var or
+        kwarg): the default model family (gpt-5) rejects any temperature other
+        than the provider default, so an unset field must not silently send
+        ``0.0``. Keys given directly in ``LLM_ARGS`` win over the dedicated
+        fields.
+        """
+        folded: dict[str, Any] = {}
+        if "llm_temperature" in self.model_fields_set:
+            folded["temperature"] = self.llm_temperature
+        if self.llm_seed is not None:
+            folded["seed"] = self.llm_seed
+        if folded:
+            self.llm_args = {**folded, **(self.llm_args or {})}
 
         return self
 
@@ -324,6 +348,7 @@ class LLMConfig(BaseSettings):
             "api_key": self.llm_api_key,
             "api_version": self.llm_api_version,
             "temperature": self.llm_temperature,
+            "seed": self.llm_seed,
             "streaming": self.llm_streaming,
             "max_completion_tokens": self.llm_max_completion_tokens,
             "transcription_model": self.transcription_model,

--- a/cognee/tests/unit/infrastructure/llm/test_llm_config.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_config.py
@@ -201,6 +201,60 @@ def test_instructor_mode_table_and_adapter_wiring():
     assert OpenAIAdapter.default_instructor_mode == get_instructor_mode("openai")
 
 
+def _clear_sampling_env(monkeypatch):
+    for var in ("LLM_TEMPERATURE", "LLM_SEED", "LLM_ARGS", "LLM_PROVIDER", "LLM_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_unset_temperature_is_not_folded_into_llm_args(monkeypatch):
+    """
+    An unset llm_temperature must not be sent to the provider: the default
+    model family (gpt-5) rejects any temperature other than its own default.
+    """
+    _clear_sampling_env(monkeypatch)
+
+    config = LLMConfig(_env_file=None)
+    assert config.llm_args is None
+
+
+def test_explicit_temperature_kwarg_folds_into_llm_args(monkeypatch):
+    _clear_sampling_env(monkeypatch)
+
+    config = LLMConfig(llm_temperature=0.0, _env_file=None)
+    assert config.llm_args == {"temperature": 0.0}
+
+
+def test_env_temperature_folds_into_llm_args(monkeypatch):
+    """
+    LLM_TEMPERATURE set via env reaches llm_args (env-set fields land in
+    model_fields_set). This is the fix for the field being dead config: it was
+    documented as the determinism knob but never plumbed to any adapter.
+    """
+    _clear_sampling_env(monkeypatch)
+    monkeypatch.setenv("LLM_TEMPERATURE", "0.0")
+
+    config = LLMConfig(_env_file=None)
+    assert config.llm_args == {"temperature": 0.0}
+
+
+def test_llm_args_temperature_wins_over_dedicated_field(monkeypatch):
+    _clear_sampling_env(monkeypatch)
+
+    config = LLMConfig(
+        llm_temperature=0.0,
+        llm_args={"temperature": 0.7, "max_tokens": 1024},
+        _env_file=None,
+    )
+    assert config.llm_args == {"temperature": 0.7, "max_tokens": 1024}
+
+
+def test_seed_folds_into_llm_args_and_preserves_existing_keys(monkeypatch):
+    _clear_sampling_env(monkeypatch)
+
+    config = LLMConfig(llm_seed=42, llm_args={"max_tokens": 1024}, _env_file=None)
+    assert config.llm_args == {"seed": 42, "max_tokens": 1024}
+
+
 def test_known_providers_match_enum():
     """
     KNOWN_LLM_PROVIDERS must stay aligned with the LLMProvider dispatch enum so

--- a/docs/ollama_models.md
+++ b/docs/ollama_models.md
@@ -34,6 +34,6 @@ Any model not listed above is treated as unvalidated/experimental. If you choose
 If you notice that `cognify()` is running but your final queries yield empty search results or no nodes are created, check the following:
 
 1. **Verify your Model**: Ensure you are using one of the recommended models (e.g., `llama3.1:8b`).
-2. **Set Temperature to 0**: Keep `LLM_TEMPERATURE=0.0` (which is Cognee's default) to force deterministic output formatting.
+2. **Set Temperature to 0**: Set `LLM_TEMPERATURE=0.0` in your `.env` to force deterministic output formatting. When unset, the model's own default applies.
 3. **Verify API Connection**: Ensure Ollama is running and accessible (usually at `http://localhost:11434/v1`).
 4. **Inspect Logging**: Check the console log outputs. If Cognee catches validation errors during extraction, they will be reported as warnings.


### PR DESCRIPTION
## Description

`LLM_TEMPERATURE` was dead config, surfaced while investigating customer feedback about nondeterministic extraction hurting reproducibility:

- `llm_temperature` is defined in `LLMConfig` (default `0.0`) and documented in `docs/ollama_models.md` and `.env.template` as "Cognee's default" for deterministic output — but it was never plumbed to any adapter on the instructor or litellm-native paths. No adapter takes a temperature argument, so the provider default (OpenAI = 1.0) always applied. The only working path was the `LLM_ARGS='{"temperature": 0}'` escape hatch. (The BAML path wires its own `baml_llm_temperature` correctly.)
- There was also no seed support on the extraction path.

## Fix

One `model_validator` on `LLMConfig` folds `llm_temperature` and a new `llm_seed` field into `llm_args` — the dict every adapter already merges into each completion call (`{**self.llm_args, **kwargs}`). Both structured-output paths pick the values up with no adapter changes, and the instructor client cache key already includes `llm_args`, so differing temperatures cannot collide in the adapter cache.

Two deliberate semantics:
- **Temperature is folded only when explicitly set** (env var or kwarg). The default model `openai/gpt-5-mini` rejects any temperature other than 1, so silently sending the field's `0.0` default would break every default install.
- **Explicit `LLM_ARGS` keys win** over the dedicated fields, preserving existing workaround behavior.

Docs updated to stop claiming an unplumbed default; `.env.template` documents both knobs including the gpt-5 caveat.

## Verification

- 5 new unit tests in `test_llm_config.py` (unset not folded, kwarg/env folded, `LLM_ARGS` precedence, seed folding preserves keys).
- Verified end-to-end that with `LLM_TEMPERATURE=0.0 LLM_SEED=7`, both the instructor `OpenAIAdapter` and `NativeLiteLLMAdapter` carry `{"temperature": 0.0, "seed": 7}`.
- The two failures in `test_llm_config_rate_limit_defaults.py` are pre-existing on clean dev (verified via stash).

Fixes COG-6174

🤖 Generated with [Claude Code](https://claude.com/claude-code)