### PR TITLE
feat(slack): Add /cognee-remember and align command replies with cloud

### DIFF
--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -400,11 +400,15 @@ def get_datasets_router() -> APIRouter:
         if dataset_data is None:
             return []
 
+        # Dict literal, not dict(**data, dataset_id=...): Data now carries its
+        # own dataset_id column, and the kwarg form raises TypeError on the
+        # duplicate key. The requested dataset id still wins — the column is
+        # nullable, so the row's value cannot be relied on here.
         return [
-            dict(
+            {
                 **jsonable_encoder(data),
-                dataset_id=dataset_id,
-            )
+                "dataset_id": dataset_id,
+            }
             for data in dataset_data
         ]
 

--- a/cognee/modules/integrations/slack/handle_cognee_ask.py
+++ b/cognee/modules/integrations/slack/handle_cognee_ask.py
@@ -28,6 +28,7 @@ from uuid import UUID, uuid4
 
 from cognee.api.v1.search.search import search as cognee_search
 from cognee.infrastructure.databases.exceptions import EntityNotFoundError
+from cognee.modules.integrations.slack.handle_slack_link import NOT_LINKED_MESSAGE
 from cognee.modules.integrations.slack.persistence import (
     get_by_team,
     is_active,
@@ -128,13 +129,13 @@ async def handle_cognee_ask(raw_body: bytes) -> dict[str, Any]:
 
     owner_user_id = await resolve_owner_user_id(credential, team_id, invoking_slack_user_id)
     if owner_user_id is None:
-        return _ephemeral(
-            "Link your own Cognee account first: `/cognee-link <api_key>` "
-            "(create a key from your Cognee account's API Keys settings)."
-        )
+        return _ephemeral(NOT_LINKED_MESSAGE)
 
     if not text:
-        return _ephemeral("Usage: `/cognee-ask <your question>`")
+        return _ephemeral(
+            "Ask me something and I'll check what you know — "
+            "e.g. `/cognee-ask why did we choose Neon for v2?`"
+        )
 
     task = asyncio.create_task(_search_and_respond(response_url, team_id, owner_user_id, text))
     _pending_searches.add(task)
@@ -144,7 +145,7 @@ async def handle_cognee_ask(raw_body: bytes) -> dict[str, Any]:
     # on the answer that follows, so this ack (and the "<@user> used
     # /cognee-ask ..." invocation line an in_channel response would trigger)
     # must not leak the question either.
-    return _ephemeral(f'Searching your memory for: "{_preview(text)}"…')
+    return _ephemeral(f"🔎 Recalling: _{_preview(text)}_")
 
 
 def _preview(text: str) -> str:

--- a/cognee/modules/integrations/slack/handle_cognee_remember.py
+++ b/cognee/modules/integrations/slack/handle_cognee_remember.py
@@ -1,0 +1,144 @@
+"""Handle ``/cognee-remember`` slash command — save free text to memory.
+
+There are two ways to remember, and they answer different needs. The
+"Remember this" message shortcut covers what Slack already has on screen:
+the thing worth keeping was written by someone else, and retyping it is
+exactly the friction that stops anyone bothering. This command covers what
+Slack never saw — a decision from a call, a conclusion someone is recording
+after the fact.
+
+Slack's 3-second ack budget applies here as much as it does to
+``/cognee-ask``. ``cognee.remember`` resolves the target dataset before it
+returns even with ``run_in_background=True``, and on a first save that
+dataset does not exist yet, so the write runs detached and its confirmation
+arrives afterwards via ``response_url``.
+
+Every reply is ``ephemeral``. What someone chooses to commit to memory is
+between them and their graph — announcing it to the channel is not this
+app's call to make, the same reasoning that keeps ``/cognee-ask`` private
+until its asker clicks Share.
+"""
+
+import asyncio
+import logging
+from typing import Any
+from urllib.parse import parse_qs
+from uuid import UUID
+
+from cognee.modules.integrations.slack.handle_slack_link import NOT_LINKED_MESSAGE
+from cognee.modules.integrations.slack.persistence import (
+    get_by_team,
+    is_active,
+    resolve_owner_user_id,
+)
+from cognee.modules.integrations.slack.remember_message import remember_note
+from cognee.modules.integrations.slack.response_url import post_to_response_url
+
+logger = logging.getLogger(__name__)
+
+# asyncio.create_task() only holds a weak reference to its result — without a
+# strong one the save can be garbage-collected mid-flight the instant this
+# handler returns. Each task removes itself on completion. Same reasoning
+# (and same shape) as _pending_searches in handle_cognee_ask.
+_pending_saves: set = set()
+
+# Keep the ack readable even if someone pastes an essay.
+_NOTE_PREVIEW_MAX_CHARS = 200
+
+NOT_CONNECTED_MESSAGE = (
+    "This Slack workspace is not connected to Cognee. Connect it from your Integrations settings."
+)
+
+USAGE_MESSAGE = (
+    "Tell me what to remember — e.g. "
+    "`/cognee-remember we chose Neon for v2, branching is cheaper`.\n"
+    "To remember something already in Slack, use *Remember this* from a "
+    "message's ⋯ menu instead."
+)
+
+# "Recallable shortly", not "saved": ingestion keeps running after the write
+# returns, so asking for it back this second may legitimately find nothing.
+REMEMBERED_MESSAGE = "✅ Remembered — it'll be recallable shortly."
+
+SAVE_FAILED_MESSAGE = "Could not save that. Please try again."
+
+
+def _ephemeral(text: str, *, replace_original: bool = False) -> dict[str, Any]:
+    """Build a reply visible only to the person who ran the command."""
+    payload: dict[str, Any] = {"response_type": "ephemeral", "text": text}
+    if replace_original:
+        payload["replace_original"] = True
+    return payload
+
+
+def _preview(text: str) -> str:
+    if len(text) <= _NOTE_PREVIEW_MAX_CHARS:
+        return text
+    return text[:_NOTE_PREVIEW_MAX_CHARS] + "…"
+
+
+async def handle_cognee_remember(raw_body: bytes) -> dict[str, Any]:
+    """Ack ``/cognee-remember {text}`` within Slack's 3-second window.
+
+    The save itself is not this function's return value — it runs detached
+    and confirms via ``response_url``.
+    """
+    form = parse_qs(raw_body.decode())
+    team_id = (form.get("team_id") or [""])[0]
+    invoking_slack_user_id = (form.get("user_id") or [""])[0]
+    text = (form.get("text") or [""])[0].strip()
+    response_url = (form.get("response_url") or [""])[0]
+
+    credential = await get_by_team(team_id) if team_id else None
+    if not is_active(credential):
+        return _ephemeral(NOT_CONNECTED_MESSAGE)
+
+    # Which cognee account this lands in has to be settled before anything is
+    # written — a note saved into the installer's memory because the author
+    # never linked is worse than one refused with a reason.
+    owner_user_id = await resolve_owner_user_id(credential, team_id, invoking_slack_user_id)
+    if owner_user_id is None:
+        return _ephemeral(NOT_LINKED_MESSAGE)
+
+    if not text:
+        return _ephemeral(USAGE_MESSAGE)
+
+    task = asyncio.create_task(
+        _remember_and_confirm(
+            response_url,
+            team_id=team_id,
+            user_id=owner_user_id,
+            text=text,
+            slack_user_id=invoking_slack_user_id,
+        )
+    )
+    _pending_saves.add(task)
+    task.add_done_callback(_pending_saves.discard)
+
+    return _ephemeral(f"💾 Remembering: _{_preview(text)}_")
+
+
+async def _remember_and_confirm(
+    response_url: str,
+    *,
+    team_id: str,
+    user_id: UUID,
+    text: str,
+    slack_user_id: str,
+) -> None:
+    """Write the note and report the outcome via ``response_url``.
+
+    Never raises — this runs detached from the request/response cycle, so
+    there is no caller left to catch anything; a failure has to reach the
+    person as a message or it reaches them as silence.
+    """
+    try:
+        await remember_note(user_id, text=text, author_id=slack_user_id)
+    except Exception:  # noqa: BLE001 - a save failure must degrade to a chat message, not a crash
+        logger.exception("Remember failed for Slack team %s", team_id)
+        await post_to_response_url(
+            response_url, _ephemeral(SAVE_FAILED_MESSAGE, replace_original=True)
+        )
+        return
+
+    await post_to_response_url(response_url, _ephemeral(REMEMBERED_MESSAGE, replace_original=True))

--- a/cognee/modules/integrations/slack/handle_slack_command.py
+++ b/cognee/modules/integrations/slack/handle_slack_command.py
@@ -1,9 +1,11 @@
 """Slash command handling for the Slack app.
 
-``/cognee-ask`` and ``/cognee-link`` (per-member account linking — see
-handle_slack_link.py) are implemented today. ``/cognee-remember`` and
-``/cognee-forget`` (async ``response_url`` pattern) are natural follow-ons
-once this integration has an owner to prioritize them.
+``/cognee-ask``, ``/cognee-remember`` and ``/cognee-link`` (per-member
+account linking — see handle_slack_link.py) are implemented today, matching
+the commands the cloud integration exposes. ``/cognee-forget`` is not: cognee
+can delete a dataset, one data item, or everything, but not by description,
+so a command taking a description of a fact could not honour it — and a
+person believing otherwise is the worst outcome available.
 
 Slash command bodies are ``application/x-www-form-urlencoded`` — parsed here
 from the verified raw bytes, never via FastAPI form parameters (see
@@ -19,6 +21,7 @@ from typing import Any
 from urllib.parse import parse_qs
 
 from cognee.modules.integrations.slack.handle_cognee_ask import handle_cognee_ask
+from cognee.modules.integrations.slack.handle_cognee_remember import handle_cognee_remember
 from cognee.modules.integrations.slack.handle_slack_link import handle_cognee_link
 from cognee.modules.integrations.slack.persistence import get_by_team, is_active
 
@@ -52,6 +55,9 @@ async def handle_slack_command(raw_body: bytes) -> dict[str, Any]:
 
     if command == "/cognee-ask":
         return await handle_cognee_ask(raw_body)
+
+    if command == "/cognee-remember":
+        return await handle_cognee_remember(raw_body)
 
     if command == "/cognee-link":
         return await handle_cognee_link(raw_body)

--- a/cognee/modules/integrations/slack/handle_slack_interactive.py
+++ b/cognee/modules/integrations/slack/handle_slack_interactive.py
@@ -26,6 +26,7 @@ from cognee.modules.integrations.slack.handle_cognee_ask import (
     handle_cognee_ask_discard,
     handle_cognee_ask_share,
 )
+from cognee.modules.integrations.slack.handle_slack_link import NOT_LINKED_MESSAGE
 from cognee.modules.integrations.slack.persistence import (
     get_by_team,
     is_active,
@@ -106,13 +107,7 @@ async def _handle_remember_this(payload: dict[str, Any]) -> None:
     # installer" as a stopgap).
     owner_user_id = await resolve_owner_user_id(credential, team_id, invoking_slack_user_id)
     if owner_user_id is None:
-        await post_to_response_url(
-            response_url,
-            _ephemeral(
-                "Link your own Cognee account first: `/cognee-link <api_key>` "
-                "(create a key from your Cognee account's API Keys settings)."
-            ),
-        )
+        await post_to_response_url(response_url, _ephemeral(NOT_LINKED_MESSAGE))
         return
 
     message = payload.get("message") or {}

--- a/cognee/modules/integrations/slack/handle_slack_link.py
+++ b/cognee/modules/integrations/slack/handle_slack_link.py
@@ -34,6 +34,17 @@ from cognee.modules.integrations.slack.slack_settings import require
 # Distinct from PROVIDER ("slack") on purpose — see module docstring.
 MEMBER_LINK_PROVIDER = "slack_member"
 
+# Shown wherever resolve_owner_user_id comes back None. /cognee-ask,
+# /cognee-remember and the "Remember this" shortcut all reach that state, so
+# the wording lives here — with the command it names — instead of being
+# retyped per call site. It had already drifted that way: two copies told
+# people to run `/cognee-link <api_key>` and create a key first, neither of
+# which this command has ever taken or needed.
+NOT_LINKED_MESSAGE = (
+    "I don't know which Cognee account you are yet. "
+    "Run `/cognee-link` to connect yours, then try again."
+)
+
 # Long enough to open Slack, switch to the browser, and click Confirm;
 # short enough that a leaked link (pasted somewhere, sitting in a browser
 # history) is stale soon after.

--- a/cognee/modules/integrations/slack/remember_message.py
+++ b/cognee/modules/integrations/slack/remember_message.py
@@ -28,6 +28,17 @@ def _format_remembered_text(
     return f"In {channel}, {author} said: {text}"
 
 
+def _format_noted_text(text: str, *, author_id: Optional[str]) -> str:
+    """Provenance for a note nobody said in Slack — see :func:`remember_note`.
+
+    Deliberately "noted", not "said": the shortcut path quotes a real
+    message, this one records something that happened elsewhere, and
+    flattening the two would put words in someone's mouth in the graph.
+    """
+    author = f"<@{author_id}>" if author_id else "someone"
+    return f"In Slack, {author} noted: {text}"
+
+
 async def remember_message(
     user_id: UUID,
     *,
@@ -46,6 +57,29 @@ async def remember_message(
     enriched_text = _format_remembered_text(text, channel_name=channel_name, author_id=author_id)
     await cognee_remember(
         enriched_text,
+        dataset_name=SLACK_DATASET_NAME,
+        user=owner,
+        run_in_background=True,
+        node_set=SLACK_NODE_SET,
+    )
+
+
+async def remember_note(
+    user_id: UUID,
+    *,
+    text: str,
+    author_id: Optional[str] = None,
+) -> None:
+    """Store a free-text ``/cognee-remember`` note, attributed to ``user_id``.
+
+    The shortcut above covers what Slack already has on screen; this covers
+    what it never saw — a decision from a call, a conclusion someone records
+    after the fact. Same dataset and node_set on purpose, so both arrive as
+    one Slack-origin body of memory rather than two the graph can't relate.
+    """
+    owner = await get_user(user_id)
+    await cognee_remember(
+        _format_noted_text(text, author_id=author_id),
         dataset_name=SLACK_DATASET_NAME,
         user=owner,
         run_in_background=True,

--- a/cognee/tests/unit/modules/integrations/test_handle_cognee_ask.py
+++ b/cognee/tests/unit/modules/integrations/test_handle_cognee_ask.py
@@ -86,7 +86,8 @@ async def test_empty_query_returns_usage():
     ):
         response = await handle_cognee_ask(_body(text=""))
 
-    assert response["text"].startswith("Usage:")
+    # Worth more than "Usage: ..." — an example is what people copy.
+    assert "/cognee-ask" in response["text"]
     assert response["response_type"] == "ephemeral"
 
 

--- a/cognee/tests/unit/modules/integrations/test_handle_cognee_remember.py
+++ b/cognee/tests/unit/modules/integrations/test_handle_cognee_remember.py
@@ -1,0 +1,151 @@
+"""Unit tests for cognee.modules.integrations.slack.handle_cognee_remember.
+
+Credential lookup, owner resolution, the ingest call and the response_url
+delivery are all patched out — this is about the handler's contract, not
+about cognee.remember.
+
+Invariants: an unconnected workspace and an unlinked member are both refused
+before anything is written; empty text gets usage rather than an empty note;
+a valid call acks inside Slack's 3-second window and does the save detached,
+confirming (or reporting failure) afterwards via response_url.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from urllib.parse import urlencode
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.integrations.credentials import STATUS_ACTIVE
+from cognee.modules.integrations.slack.handle_cognee_remember import (
+    REMEMBERED_MESSAGE,
+    SAVE_FAILED_MESSAGE,
+    handle_cognee_remember,
+)
+
+MODULE = "cognee.modules.integrations.slack.handle_cognee_remember"
+
+
+def _body(text="we chose Neon for v2", team_id="T123", user_id="U1"):
+    return urlencode(
+        {
+            "command": "/cognee-remember",
+            "team_id": team_id,
+            "channel_id": "C1",
+            "user_id": user_id,
+            "text": text,
+            "response_url": "https://hooks.slack.test/response",
+        }
+    ).encode()
+
+
+def _credential():
+    return SimpleNamespace(provider_metadata={}, status=STATUS_ACTIVE)
+
+
+async def _drain_pending_saves():
+    """Let the detached save task run to completion before asserting on it."""
+    from cognee.modules.integrations.slack.handle_cognee_remember import _pending_saves
+
+    if _pending_saves:
+        await asyncio.gather(*list(_pending_saves), return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_unconnected_workspace_is_refused_without_writing():
+    with (
+        patch(f"{MODULE}.get_by_team", new=AsyncMock(return_value=None)),
+        patch(f"{MODULE}.remember_note", new=AsyncMock()) as note,
+    ):
+        response = await handle_cognee_remember(_body())
+
+    note.assert_not_awaited()
+    assert "not connected" in response["text"]
+
+
+@pytest.mark.asyncio
+async def test_unlinked_member_is_refused_without_writing():
+    with (
+        patch(f"{MODULE}.get_by_team", new=AsyncMock(return_value=_credential())),
+        patch(f"{MODULE}.resolve_owner_user_id", new=AsyncMock(return_value=None)),
+        patch(f"{MODULE}.remember_note", new=AsyncMock()) as note,
+    ):
+        response = await handle_cognee_remember(_body())
+
+    note.assert_not_awaited()
+    # The point of the message: name the command that fixes it.
+    assert "/cognee-link" in response["text"]
+
+
+@pytest.mark.asyncio
+async def test_empty_text_returns_usage_rather_than_saving_nothing():
+    with (
+        patch(f"{MODULE}.get_by_team", new=AsyncMock(return_value=_credential())),
+        patch(f"{MODULE}.resolve_owner_user_id", new=AsyncMock(return_value=uuid4())),
+        patch(f"{MODULE}.remember_note", new=AsyncMock()) as note,
+    ):
+        response = await handle_cognee_remember(_body(text="   "))
+
+    note.assert_not_awaited()
+    assert "/cognee-remember" in response["text"]
+    # Points at the other way in, which is the right answer more often.
+    assert "Remember this" in response["text"]
+
+
+@pytest.mark.asyncio
+async def test_valid_call_acks_immediately_and_saves_detached():
+    user_id = uuid4()
+    with (
+        patch(f"{MODULE}.get_by_team", new=AsyncMock(return_value=_credential())),
+        patch(f"{MODULE}.resolve_owner_user_id", new=AsyncMock(return_value=user_id)),
+        patch(f"{MODULE}.remember_note", new=AsyncMock()) as note,
+        patch(f"{MODULE}.post_to_response_url", new=AsyncMock()) as respond,
+    ):
+        response = await handle_cognee_remember(_body(text="we chose Neon for v2"))
+
+        # The ack is the return value; the save has not necessarily run yet.
+        assert response["response_type"] == "ephemeral"
+        assert "we chose Neon for v2" in response["text"]
+
+        await _drain_pending_saves()
+
+    note.assert_awaited_once()
+    assert note.await_args.kwargs["text"] == "we chose Neon for v2"
+    assert note.await_args.kwargs["author_id"] == "U1"
+
+    respond.assert_awaited_once()
+    assert respond.await_args.args[1]["text"] == REMEMBERED_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_save_failure_reports_back_instead_of_raising():
+    with (
+        patch(f"{MODULE}.get_by_team", new=AsyncMock(return_value=_credential())),
+        patch(f"{MODULE}.resolve_owner_user_id", new=AsyncMock(return_value=uuid4())),
+        patch(f"{MODULE}.remember_note", new=AsyncMock(side_effect=RuntimeError("boom"))),
+        patch(f"{MODULE}.post_to_response_url", new=AsyncMock()) as respond,
+    ):
+        await handle_cognee_remember(_body())
+        await _drain_pending_saves()
+
+    respond.assert_awaited_once()
+    assert respond.await_args.args[1]["text"] == SAVE_FAILED_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_long_note_is_truncated_in_the_ack_only():
+    long_text = "x" * 500
+    with (
+        patch(f"{MODULE}.get_by_team", new=AsyncMock(return_value=_credential())),
+        patch(f"{MODULE}.resolve_owner_user_id", new=AsyncMock(return_value=uuid4())),
+        patch(f"{MODULE}.remember_note", new=AsyncMock()) as note,
+        patch(f"{MODULE}.post_to_response_url", new=AsyncMock()),
+    ):
+        response = await handle_cognee_remember(_body(text=long_text))
+        await _drain_pending_saves()
+
+    assert len(response["text"]) < len(long_text)
+    # Truncation is presentation only — the note keeps every character.
+    assert note.await_args.kwargs["text"] == long_text

--- a/cognee/tests/unit/modules/integrations/test_handle_slack_command.py
+++ b/cognee/tests/unit/modules/integrations/test_handle_slack_command.py
@@ -99,6 +99,34 @@ async def test_cognee_link_dispatches_to_its_handler():
 
 
 @pytest.mark.asyncio
+async def test_cognee_remember_dispatches_to_its_handler():
+    credential = _credential(allowed_channel_ids=[])
+    with (
+        patch(f"{MODULE}.get_by_team", new=AsyncMock(return_value=credential)),
+        patch(
+            f"{MODULE}.handle_cognee_remember", new=AsyncMock(return_value={"remembered": True})
+        ) as remember,
+    ):
+        response = await handle_slack_command(
+            _body(command="/cognee-remember", text="we chose Neon for v2")
+        )
+    remember.assert_awaited_once()
+    assert response == {"remembered": True}
+
+
+@pytest.mark.asyncio
+async def test_cognee_remember_is_blocked_by_the_allowlist_like_every_command():
+    credential = _credential(allowed_channel_ids=["C1"])
+    with (
+        patch(f"{MODULE}.get_by_team", new=AsyncMock(return_value=credential)),
+        patch(f"{MODULE}.handle_cognee_remember", new=AsyncMock()) as remember,
+    ):
+        response = await handle_slack_command(_body(command="/cognee-remember", channel_id="C999"))
+    remember.assert_not_awaited()
+    assert "isn't enabled in this channel" in response["text"]
+
+
+@pytest.mark.asyncio
 async def test_unimplemented_command_still_honors_allowlist():
     credential = _credential(allowed_channel_ids=["C1"])
     with patch(f"{MODULE}.get_by_team", new=AsyncMock(return_value=credential)):

--- a/scripts/slack-app-manifest.sdk.yml
+++ b/scripts/slack-app-manifest.sdk.yml
@@ -1,0 +1,90 @@
+# Slack app manifest for testing the *SDK* Slack integration locally.
+#
+# This is NOT the cloud manifest. cognee-saas-backend/slack-app-manifest.yml
+# describes the control plane's app: 12 scopes, /cognee-recall, /cognee-remember,
+# app_mention, message.channels. The SDK implements none of that. Installing the
+# cloud manifest against an SDK server gives you an app whose buttons hit
+# handlers that do not exist.
+#
+# Create a SEPARATE Slack app for SDK testing — do not point the cloud app at
+# your laptop. Reusing one app means whoever else is testing has their events
+# routed to your ngrok tunnel.
+#
+# Replace <ngrok> with your tunnel host, e.g. abc123.ngrok-free.app
+#
+# ── First save will fail unless the server is already reachable ────────────
+# Slack POSTs a url_verification challenge to request_url the moment you save
+# event_subscriptions. Start the SDK server AND ngrok first, then create the
+# app from this manifest.
+
+display_information:
+  name: Cognee SDK (local)
+  description: Local SDK testing — not the production Cognee app.
+  background_color: "#6510F4"
+
+features:
+  bot_user:
+    display_name: cognee-sdk-local
+    always_online: false
+  # app_home_opened only fires when the Home tab is enabled. handle_slack_event
+  # publishes the view via home.py::publish_home_view on that event.
+  app_home:
+    home_tab_enabled: true
+    messages_tab_enabled: false
+  slash_commands:
+    # The only three commands handle_slack_command dispatches. Anything else
+    # falls through to its unknown-command reply.
+    #
+    # Adding a command here is not enough on its own: Slack does not grant a
+    # new slash command to an existing install, so the app must be REINSTALLED
+    # before it can be invoked. Until then Slack refuses it client-side and
+    # nothing reaches the server at all.
+    - command: /cognee-ask
+      url: https://<ngrok>/api/v1/slack/commands
+      description: Ask your memory a question
+      usage_hint: why did we choose Neon for v2?
+    - command: /cognee-remember
+      url: https://<ngrok>/api/v1/slack/commands
+      description: Save a decision or fact worth keeping
+      usage_hint: we chose Neon for v2, branching is cheaper
+    - command: /cognee-link
+      url: https://<ngrok>/api/v1/slack/commands
+      description: Link your Slack account to cognee
+  shortcuts:
+    # callback_id must be exactly remember_this — handle_slack_interactive
+    # matches on REMEMBER_THIS_CALLBACK_ID.
+    - name: Remember this
+      type: message
+      callback_id: remember_this
+      description: Save this message to your memory
+
+oauth_config:
+  redirect_urls:
+    # Must byte-match SLACK_REDIRECT_URI in your .env.
+    - https://<ngrok>/api/v1/integrations/slack/callback
+  scopes:
+    bot:
+      # Exactly _BOT_SCOPES in cognee/modules/integrations/slack/oauth.py.
+      # Adding more here without changing that constant does nothing: the
+      # authorize URL only requests what the constant lists.
+      - commands
+      - chat:write
+      - im:write
+      - channels:read
+
+settings:
+  event_subscriptions:
+    request_url: https://<ngrok>/api/v1/slack/events
+    bot_events:
+      # The three the SDK actually acts on. Deliberately no app_mention or
+      # message.channels — the SDK has no handler for either, and subscribing
+      # them just spams your tunnel with events that get a bare ack.
+      - app_home_opened
+      - app_uninstalled
+      - tokens_revoked
+  interactivity:
+    is_enabled: true
+    request_url: https://<ngrok>/api/v1/slack/interactive
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false

--- a/slack-app-manifest.yml
+++ b/slack-app-manifest.yml
@@ -29,8 +29,13 @@
 #      Confirm — no key to create or paste. This makes /cognee-ask and
 #      "Remember this" use your own memory, not just the workspace
 #      installer's.
-#   9. Run /cognee-ask <your question> in any channel the bot can see (or a
-#      DM with it) to test the full round-trip.
+#   9. Run /cognee-remember <a fact> to put something in memory, then
+#      /cognee-ask <your question> in any channel the bot can see (or a DM
+#      with it) to test the full round-trip. Asking before anything has been
+#      ingested fails on a missing vector collection, not an empty answer.
+#
+# NOTE: adding a slash command to an existing app requires reinstalling it to
+# each workspace — Slack does not grant new commands to an existing install.
 
 display_information:
   name: Cognee
@@ -57,6 +62,10 @@ features:
       url: https://<public-host>/api/v1/slack/commands
       description: Ask your Cognee memory a question — reviewed privately before you share it
       usage_hint: what do we know about the Q3 launch?
+    - command: /cognee-remember
+      url: https://<public-host>/api/v1/slack/commands
+      description: Save a decision or fact worth keeping — for things Slack never saw
+      usage_hint: we chose Neon for v2, branching is cheaper
     - command: /cognee-link
       url: https://<public-host>/api/v1/slack/commands
       description: Get a private link to connect this Slack account to your own Cognee memory


### PR DESCRIPTION
## What

Adds `/cognee-remember` to the SDK's Slack app and brings the two commands' replies in line with the cloud integration.

`/cognee-remember` fell through to *"Command `/cognee-remember` is not yet supported."* — remembering was reachable only through the **Remember this** message shortcut. That shortcut covers what Slack already has on screen; it cannot cover what Slack never saw, which is most of what's worth keeping: a decision from a call, a conclusion someone records after the fact.

## Changes

**New `/cognee-remember <text>`** (`handle_cognee_remember.py`)
- Writes to the same dataset and `node_set` as the shortcut, so both land as one Slack-origin body of memory rather than two the graph can't relate.
- Acks inside Slack's 3-second window and saves detached, confirming via `response_url`. `cognee.remember` resolves — and on a first save, creates — the dataset before returning even with `run_in_background=True`, so it can't run inline.
- Refuses an unconnected workspace and an unlinked member *before* writing: a note landing in the installer's memory because the author never linked is worse than one refused with a reason.
- Every reply is ephemeral, matching `/cognee-ask` — what someone commits to memory isn't the app's to announce.

**Fixed the not-linked reply**
`handle_cognee_ask.py` and `handle_slack_interactive.py` both told people to run `` `/cognee-link <api_key>` `` and create a key from their API Keys settings. That argument has never existed and the SDK flow uses no key — leftover from before linking became a magic link. The wording now lives in `handle_slack_link.py` beside the command it names, so the three call sites can't drift again.

**Empty-input replies now carry an example** instead of `Usage: ...`, and acks match cloud's `🔎 Recalling:` / `💾 Remembering:`.

**Manifest** gains the command, plus a note that adding a slash command to an existing app requires reinstalling it — Slack doesn't grant new commands to an existing install.

## Unrelated fix, folded in because it blocks verifying any of the above

`GET /datasets/{id}/data` raises `TypeError: dict() got multiple values for keyword argument 'dataset_id'`. `Data` carries its own `dataset_id` column now, so `dict(**jsonable_encoder(data), dataset_id=…)` collides with the encoded row on every call. **Every dataset detail view 500s — on `dev`, not just here.** A dict literal resolves the duplicate instead of raising; the requested id still wins, which matters because the column is nullable. Happy to split this out if you'd rather it land on its own.

## Testing

205 unit tests pass (was 197). New coverage for `/cognee-remember`: unconnected workspace, unlinked member, empty text, the ack/detached-save split, save failure reporting back rather than raising, and ack truncation not touching the stored note.

Manually verified end to end against a real Slack workspace over ngrok.

## Note

No `/cognee-forget`. cognee can delete a dataset, one item, or everything — not by description. A command taking a description of a fact couldn't honour it, and someone believing otherwise is the worst outcome available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit: the manifest that actually gets installed

`scripts/slack-app-manifest.sdk.yml` — the manifest people install from when testing the SDK locally — still listed only `/cognee-ask` and `/cognee-link`. Adding the command to the tracked `slack-app-manifest.yml` was not enough: an app created from the SDK manifest can't invoke `/cognee-remember` at all, because Slack refuses an unregistered command client-side and nothing ever reaches the backend. It looks exactly like a broken server.

This cost a full debugging session to find, which is the argument against keeping two manifests for one app. Worth deciding as part of this PR:

1. **Delete `scripts/slack-app-manifest.sdk.yml`** and drive local testing off the tracked manifest with a host substitution — one source of truth, drift impossible.
2. **Keep both** and add a test asserting the two files declare identical `slash_commands`, so CI catches the next divergence.

I've committed the fix plus a note about the reinstall requirement, but haven't picked between those — happy to do either.
