### PR TITLE
fix: Lower add data_per_batch default to 100

### DIFF
--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -50,7 +50,12 @@ async def add(
     dataset_id: Optional[UUID] = None,
     preferred_loaders: Optional[List[Union[str, dict[str, dict[str, Any]]]]] = None,
     incremental_loading: bool = True,
-    data_per_batch: Optional[int] = 2000,
+    # 100, not unbounded: every in-flight item writes its Data row concurrently,
+    # and on the default SQLite backend hundreds of parallel read-then-write
+    # transactions hit WAL snapshot-upgrade conflicts ("database is locked"
+    # immediately, bypassing busy_timeout) — observed live at 448 concurrent
+    # items. 100 keeps ingestion fast while staying under that pressure.
+    data_per_batch: Optional[int] = 100,
     importance_weight: Optional[float] = 0.5,
     run_in_background: bool = False,
     llm_config: Optional[LLMConfig] = None,


### PR DESCRIPTION
## Description

`add()`'s `data_per_batch` default of 2000 effectively runs every item of a large add fully concurrently. Each in-flight item writes its `Data` row in parallel, and on the default SQLite backend hundreds of simultaneous read-then-write transactions hit WAL **snapshot-upgrade conflicts**: `database is locked` raised immediately, bypassing the existing 120s `busy_timeout`/WAL pragmas (issue #2717's mitigations don't cover this mode — the busy handler is not invoked for `SQLITE_BUSY_SNAPSHOT`).

Observed live: a 448-item directory add on SQLite failed 34 seconds in with a plain `INSERT INTO data` lock error, despite WAL + 120s timeouts being active. The same add at bounded concurrency completes cleanly.

This lowers the default to 100 — the single default all add surfaces inherit (SDK `add()`, the HTTP router, and `remember()` all flow through it). Callers can still pass a higher value explicitly. Postgres deployments are unaffected either way.

Note: deliberately **not** raising the SQLite timeouts — they are already 120s and the observed failure was not a timeout expiry; a bump would be a placebo for this failure mode.

## Testing
- Signature default verified (100), ruff clean.
- Live A/B on cognee's own repo directory (448 items incl. images through vision): 2000 → `database is locked` at 34s; bounded concurrency → clean completion. A confirmation run of this exact PR state on SQLite is in the PR conversation.

No Linear key attached yet — `linear-issue-check` will fail until one is added.