### PR TITLE
fix: Raise on pinned-id re-add with changed content

### DIFF
--- a/cognee/modules/ingestion/exceptions/__init__.py
+++ b/cognee/modules/ingestion/exceptions/__init__.py
@@ -5,5 +5,6 @@ This module defines a set of exceptions for handling various ingestion errors
 """
 
 from .exceptions import (
+    DataContentConflictError,
     IngestionError,
 )

--- a/cognee/modules/ingestion/exceptions/exceptions.py
+++ b/cognee/modules/ingestion/exceptions/exceptions.py
@@ -10,3 +10,20 @@ class IngestionError(CogneeValidationError):
         status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
     ):
         super().__init__(message, name, status_code)
+
+
+class DataContentConflictError(CogneeValidationError):
+    """A pinned data_id already holds different content in the dataset.
+
+    Raised by the incremental add pre-check instead of silently keeping the
+    stale record: the caller must choose between updating the existing
+    document, ingesting under a different identity, or forcing re-ingestion.
+    """
+
+    def __init__(
+        self,
+        message: str = "Data id already exists with different content.",
+        name: str = "DataContentConflictError",
+        status_code=status.HTTP_409_CONFLICT,
+    ):
+        super().__init__(message, name, status_code)

--- a/cognee/modules/pipelines/operations/run_tasks_data_item.py
+++ b/cognee/modules/pipelines/operations/run_tasks_data_item.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 
 import cognee.modules.ingestion as ingestion
 from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.ingestion.exceptions import DataContentConflictError
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
 from cognee.shared.logging_utils import get_logger
 from cognee.modules.users.models import User
@@ -28,6 +29,25 @@ from cognee.modules.pipelines.operations.run_tasks_with_telemetry import run_tas
 from ..tasks.task import Task
 
 logger = get_logger("run_tasks_data_item")
+
+
+async def _pinned_item_content_hash(data_item) -> Optional[str]:
+    """Content hash of a pinned DataItem's incoming payload, or None.
+
+    Pinned items skip content classification on the fast path, but the
+    already-completed short-circuit needs the hash to tell an idempotent
+    re-add apart from a changed one. Uses the same save+classify path as
+    unpinned ingestion so the formula matches the stored Data.content_hash
+    exactly. Returns None for anything that is not a pinned DataItem —
+    unpinned identities derive from content, so they can never conflict.
+    """
+    from cognee.tasks.ingestion.data_item import DataItem as DataItemType
+
+    if not isinstance(data_item, DataItemType) or data_item.data_id is None:
+        return None
+    file_path = await save_data_item_to_storage(data_item)
+    async with open_data_file(file_path) as file:
+        return ingestion.classify(file).get_metadata()["content_hash"]
 
 
 async def run_tasks_data_item_incremental(
@@ -94,6 +114,27 @@ async def run_tasks_data_item_incremental(
                 data_point.pipeline_status.get(pipeline_name, {}).get(str(dataset.id))
                 == DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED
             ):
+                # A pinned id that resurfaces with DIFFERENT content must not
+                # be silently skipped: the stored record (and everything
+                # derived from it) would go stale with no signal. Fail loudly
+                # with the ways out instead. Same content keeps the cheap
+                # idempotent skip.
+                incoming_hash = await _pinned_item_content_hash(data_item)
+                if (
+                    incoming_hash is not None
+                    and data_point.content_hash is not None
+                    and str(data_point.content_hash) != str(incoming_hash)
+                ):
+                    raise DataContentConflictError(
+                        message=(
+                            f"Data id {data_id} already exists in dataset {dataset.id} "
+                            "with different content. To update the existing document, "
+                            "use the update pipeline (update()). To ingest this content "
+                            "as a separate item, use a different data_id (or none, so "
+                            "content derives it). To force re-ingestion in place, "
+                            "re-add with incremental_loading=False and data_cache=False."
+                        )
+                    )
                 yield {
                     "run_info": PipelineRunAlreadyCompleted(
                         pipeline_run_id=pipeline_run_id,

--- a/cognee/tasks/ingestion/resolve_dlt_sources.py
+++ b/cognee/tasks/ingestion/resolve_dlt_sources.py
@@ -372,9 +372,11 @@ async def _build_source_manifest_item(
     # The data_id is STABLE — seeded from (dataset, source name) with no
     # content hash — so a changed source updates its Data row in place instead
     # of orphaning it (which left the source absent from the graph between add
-    # and cognify). add() is idempotent: a re-add of the same source — changed
-    # or not — keeps the completed record as-is. Updating an existing source
-    # is update()'s job (explicit UUID), or an explicit re-ingest via
+    # and cognify). add() is idempotent for unchanged content: a re-add of
+    # the same source keeps the completed record as-is; a re-add with CHANGED
+    # content raises DataContentConflictError instead of silently keeping the
+    # stale record. Updating an existing source is update()'s job (explicit
+    # UUID), or an explicit re-ingest via
     # add(..., incremental_loading=False, data_cache=False). Renaming a source (or dataset)
     # changes this identity and is remove + add — a one-time full rebuild,
     # by design.

--- a/cognee/tests/unit/modules/pipelines/test_pinned_content_conflict.py
+++ b/cognee/tests/unit/modules/pipelines/test_pinned_content_conflict.py
@@ -1,0 +1,121 @@
+"""A pinned data_id resurfacing with different content must fail loudly.
+
+The incremental pre-check used to short-circuit on "pipeline already
+completed" before any content comparison, silently keeping the stale record
+(observed live: a changed code-repo manifest kept its old file_count). Now:
+same content -> the cheap idempotent skip stays; different content ->
+DataContentConflictError naming the ways out; non-pinned items are untouched
+(their identity derives from content, so they cannot conflict).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+import cognee.modules.pipelines.operations.run_tasks_data_item as rtdi
+from cognee.modules.ingestion.exceptions import DataContentConflictError
+from cognee.modules.pipelines.models.DataItemStatus import DataItemStatus
+from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunAlreadyCompleted
+from cognee.tasks.ingestion.data_item import DataItem
+
+PIPELINE = "add_pipeline"
+
+
+def _dataset():
+    return SimpleNamespace(id=uuid4(), name="conflict_ds", owner_id=uuid4())
+
+
+def _completed_record(dataset, content_hash="hash-v1"):
+    return SimpleNamespace(
+        pipeline_status={
+            PIPELINE: {str(dataset.id): DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED}
+        },
+        content_hash=content_hash,
+    )
+
+
+def _fake_engine(data_point):
+    session = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = data_point
+    session.execute = AsyncMock(return_value=result)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    engine = MagicMock()
+    engine.get_async_session.return_value = ctx
+    return engine
+
+
+def _run(data_item, dataset, engine, incoming_hash):
+    return rtdi.run_tasks_data_item_incremental(
+        data_item=data_item,
+        dataset=dataset,
+        tasks=[],
+        pipeline_name=PIPELINE,
+        pipeline_id="pid",
+        pipeline_run_id=uuid4(),
+        ctx=None,
+        user=SimpleNamespace(id=uuid4(), tenant_id=None),
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_content_keeps_the_idempotent_skip():
+    dataset = _dataset()
+    item = DataItem(data="manifest v1", data_id=uuid4())
+    with (
+        patch.object(
+            rtdi, "get_relational_engine", return_value=_fake_engine(_completed_record(dataset))
+        ),
+        patch.object(rtdi, "_pinned_item_content_hash", new=AsyncMock(return_value="hash-v1")),
+    ):
+        results = [step async for step in _run(item, dataset, None, "hash-v1")]
+
+    assert len(results) == 1
+    assert isinstance(results[0]["run_info"], PipelineRunAlreadyCompleted)
+
+
+@pytest.mark.asyncio
+async def test_changed_content_raises_conflict_with_remedies():
+    dataset = _dataset()
+    item = DataItem(data="manifest v2 CHANGED", data_id=uuid4())
+    with (
+        patch.object(
+            rtdi, "get_relational_engine", return_value=_fake_engine(_completed_record(dataset))
+        ),
+        patch.object(rtdi, "_pinned_item_content_hash", new=AsyncMock(return_value="hash-v2")),
+    ):
+        with pytest.raises(DataContentConflictError) as excinfo:
+            async for _step in _run(item, dataset, None, "hash-v2"):
+                pass
+
+    message = str(excinfo.value)
+    assert "update()" in message
+    assert "different data_id" in message
+    assert "incremental_loading=False and data_cache=False" in message
+
+
+@pytest.mark.asyncio
+async def test_undeterminable_hash_keeps_legacy_skip():
+    """Items whose incoming hash cannot be computed (e.g. already-persisted
+    Data instances) keep the pre-existing silent skip - no false conflicts."""
+    dataset = _dataset()
+    item = DataItem(data="anything", data_id=uuid4())
+    with (
+        patch.object(
+            rtdi, "get_relational_engine", return_value=_fake_engine(_completed_record(dataset))
+        ),
+        patch.object(rtdi, "_pinned_item_content_hash", new=AsyncMock(return_value=None)),
+    ):
+        results = [step async for step in _run(item, dataset, None, None)]
+
+    assert isinstance(results[0]["run_info"], PipelineRunAlreadyCompleted)
+
+
+@pytest.mark.asyncio
+async def test_hash_helper_returns_none_for_unpinned_items():
+    assert await rtdi._pinned_item_content_hash("plain text") is None
+    assert await rtdi._pinned_item_content_hash(DataItem(data="text", data_id=None)) is None

--- a/cognee/tests/unit/tasks/ingestion/test_dlt_stable_manifest_id.py
+++ b/cognee/tests/unit/tasks/ingestion/test_dlt_stable_manifest_id.py
@@ -4,9 +4,10 @@ The manifest Data id is seeded from (dataset, source name) — no content hash �
 so re-adding a source resolves to the SAME record instead of orphaning it
 between add and cognify. Two invariants keep that safe:
 
-1. add() is idempotent: a completed item keeps the fast skip on re-add,
-   changed content or not. Updating an existing source is update()'s job
-   (explicit UUID), or an explicit re-ingest via
+1. add() is idempotent for UNCHANGED content: a completed item keeps the
+   fast skip on re-add. CHANGED content raises DataContentConflictError
+   instead of silently keeping the stale record — updating an existing
+   source is update()'s job (explicit UUID), or an explicit re-ingest via
    add(..., incremental_loading=False, data_cache=False).
 2. Two sources resolving to one identity in one add() fail loudly instead of
    last-write-wins.
@@ -83,16 +84,35 @@ def _incremental_run(monkeypatch, completed=True):
 
 
 @pytest.mark.asyncio
-async def test_completed_stable_id_item_keeps_the_fast_skip(monkeypatch):
-    """add() is idempotent: a completed item is skipped on re-add, changed
-    content or not — update() (explicit UUID) or turning off both
-    data_cache and incremental_loading are the sanctioned refresh paths."""
+async def test_completed_stable_id_item_with_unchanged_content_keeps_the_fast_skip(monkeypatch):
+    """add() is idempotent for unchanged content: the completed item is
+    skipped on re-add with no error and no reprocessing."""
+    monkeypatch.setattr(
+        item_module, "_pinned_item_content_hash", AsyncMock(return_value="stored-hash")
+    )
     collect = _incremental_run(monkeypatch, completed=True)
     events = await collect()
 
     run_infos = [e["run_info"] for e in events if isinstance(e, dict) and "run_info" in e]
     assert any(isinstance(info, PipelineRunAlreadyCompleted) for info in run_infos)
     assert not any(isinstance(info, PipelineRunCompleted) for info in run_infos)
+
+
+@pytest.mark.asyncio
+async def test_completed_stable_id_item_with_changed_content_raises(monkeypatch):
+    """A completed item resurfacing with different content must fail loudly —
+    silently keeping the stale record left graphs describing old data.
+    update() (explicit UUID) or incremental_loading=False + data_cache=False
+    are the sanctioned refresh paths, named in the error."""
+    from cognee.modules.ingestion.exceptions import DataContentConflictError
+
+    monkeypatch.setattr(
+        item_module, "_pinned_item_content_hash", AsyncMock(return_value="different-hash")
+    )
+    collect = _incremental_run(monkeypatch, completed=True)
+
+    with pytest.raises(DataContentConflictError, match="update"):
+        await collect()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Items ingested with a **pinned, stable `data_id`** (DLT source manifests; code-repo manifests once #4481 lands) were silently dropped on re-add even when their content had changed: the incremental pre-check in `run_tasks_data_item_incremental` short-circuited on *pipeline already completed* **before any content comparison**, so the stored record — and every graph artifact derived from it — went stale with no signal.

**Observed live** (2026-08-14, cognee repo ingestion): a repository manifest re-added after the tree gained 19 files kept its old `file_count=2453` while detection logged 2,472 covered files; cognify then skipped it, and the graph kept describing the pre-change repository.

## The change

The completed short-circuit now computes the incoming item's content hash first (the same save+classify formula that produced the stored `Data.content_hash`, so the comparison is exact):

- **Unchanged content** → the cheap idempotent skip stays (re-running an unchanged sync is quiet and free).
- **Changed content** → new `DataContentConflictError` (HTTP 409) naming all three ways out: `update()` for an in-place update, a different `data_id` to ingest as a separate item, or `add(..., incremental_loading=False, data_cache=False)` to force re-ingestion in place.
- **Unpinned items are untouched** by construction — their identity derives from content, so changed content is a new id and no conflict can occur.

This narrows DLT's documented idempotency contract (was: *re-add keeps the completed record, changed or not*): re-syncing **changed** data now fails loudly instead of no-opping. The contract comment in `resolve_dlt_sources.py` and its invariant tests are updated accordingly.

## Testing

- New `test_pinned_content_conflict.py`: same hash → `PipelineRunAlreadyCompleted` skip; different hash → `DataContentConflictError` with all three remedies in the message; undeterminable hash → legacy skip (no false conflicts); helper returns None for unpinned items.
- `test_dlt_stable_manifest_id.py` updated to the narrowed contract (unchanged → fast skip; changed → raise).
- Live end-to-end through the real `add()` pipeline: v1 add → unchanged re-add silently skipped (hash proven identical) → changed re-add raised 409 with the record verifiably untouched → `incremental_loading=False, data_cache=False` refreshed the record in place (content_hash changed, same single record) → two unpinned adds with different content created two records, no conflict.
- Pipelines + tasks + data unit suites: 448 passed.

Found while validating #4481's repo manifests; fixes the mechanism for both manifest families. One caveat surfaced during testing and encoded in the message: `incremental_loading=False` alone does **not** bypass the pre-check — `data_cache` also selects it, so the escape hatch is both flags (matching DLT's existing documentation).

No Linear key attached yet — `linear-issue-check` will fail until one is added.