### PR TITLE
fix: Raise litellm embedding attempt deadline to 300s

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -187,13 +187,10 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
 
                     # Ensure each attempt does not hang indefinitely. The
                     # deadline is TOTAL per attempt and starts before any
-                    # network I/O — under high cognify concurrency a request
-                    # can spend most of it queued in the local HTTP connection
-                    # pool, so 30s starved queued-but-healthy requests
-                    # (observed live on a 421-item run: 3,336 timeout retries,
-                    # then failure). 120s absorbs local queueing while still
-                    # catching a genuinely unreachable endpoint; the
-                    # OpenAI-compatible engine uses 300s for the same guard.
+                    # network I/O, so under large loads a request can spend
+                    # most of it queued client-side; 300s absorbs that while
+                    # still catching a genuinely hung request (matches the
+                    # OpenAI-compatible engine's deadline).
                     response = await asyncio.wait_for(
                         litellm.aembedding(**embedding_kwargs),
                         timeout=300.0,

--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -185,10 +185,18 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
                     if self.dimensions is not None:
                         embedding_kwargs["dimensions"] = self.dimensions
 
-                    # Ensure each attempt does not hang indefinitely
+                    # Ensure each attempt does not hang indefinitely. The
+                    # deadline is TOTAL per attempt and starts before any
+                    # network I/O — under high cognify concurrency a request
+                    # can spend most of it queued in the local HTTP connection
+                    # pool, so 30s starved queued-but-healthy requests
+                    # (observed live on a 421-item run: 3,336 timeout retries,
+                    # then failure). 120s absorbs local queueing while still
+                    # catching a genuinely unreachable endpoint; the
+                    # OpenAI-compatible engine uses 300s for the same guard.
                     response = await asyncio.wait_for(
                         litellm.aembedding(**embedding_kwargs),
-                        timeout=30.0,
+                        timeout=300.0,
                     )
 
                 embedding_response = [data["embedding"] for data in response.data]


### PR DESCRIPTION
## Description

`LiteLLMEmbeddingEngine.embed_text` wraps each attempt in `asyncio.wait_for(litellm.aembedding(...), timeout=30.0)`. That deadline is **total per attempt and starts before any network I/O** — everything counts against it: waiting for a free connection in the local HTTP pool, event-loop scheduling under load, and the provider's response time.

Under high cognify concurrency this starves healthy requests. Observed live (421-item cognify of the cognee repo at the default `data_per_batch`, OpenAI `text-embedding-3-large`): requests spent most of their 30s budget queued client-side, producing **3,336 timeout retries** and ultimately a failed run after 64 minutes — while the log shows only **2** genuine provider `RateLimitError`s. The requests were healthy; the deadline was charging them for standing in our own queue.

This raises the deadline to **300s**, matching `OpenAICompatibleEmbeddingEngine`, which already uses 300s for the identical `wait_for` guard — the 30s value was the outlier between the two engines. A genuinely hung request is still caught; a queued one gets time to drain.

Related: bounding concurrency is the other half of the fix (#4482 did this for `add()`; cognify's own default is a candidate for the same treatment) — but the deadline should not punish queueing regardless.

## Testing
- Embedding unit tests (fallbacks, rate limiting, auth fastfail, sanitize): 44 passed.
- Live evidence for the failure mode is in the description; the same workload's add phase completes cleanly, isolating the issue to sustained embedding pressure.

No Linear key attached yet — `linear-issue-check` will fail until one is added.