### PR TITLE
fix: avoid mutating datapoint metadata during indexing

### DIFF
--- a/cognee/tasks/storage/index_data_points.py
+++ b/cognee/tasks/storage/index_data_points.py
@@ -1,9 +1,9 @@
 import asyncio
 
-from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.vector.embeddings.config import get_embedding_context_config
 from cognee.infrastructure.engine import DataPoint
+from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("index_data_points")
 
@@ -50,7 +50,7 @@ async def index_data_points(data_points: list[DataPoint], vector_engine=None):
                 await vector_engine.create_vector_index(type_name, field_name)
                 data_points_by_type[type_name][field_name] = []
 
-            indexed_data_point = data_point.model_copy()
+            indexed_data_point = data_point.model_copy(deep=True)
             indexed_data_point.metadata["index_fields"] = [field_name]
             data_points_by_type[type_name][field_name].append(indexed_data_point)
 

--- a/cognee/tests/unit/infrastructure/databases/test_index_data_points.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_data_points.py
@@ -1,21 +1,23 @@
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
-from cognee.tasks.storage.index_data_points import index_data_points
+
 from cognee.infrastructure.engine import DataPoint
+from cognee.tasks.storage.index_data_points import index_data_points
 
 
 class TestDataPoint(DataPoint):
     name: str
-    metadata: dict = {"index_fields": ["name"]}
+    description: str = "test description"
 
 
 @pytest.mark.asyncio
 async def test_index_data_points_calls_vector_engine():
     """Test that index_data_points creates vector index and indexes data."""
     data_points = [TestDataPoint(name="test1")]
+    data_points[0].metadata["index_fields"] = ["name"]
 
     mock_vector_engine = AsyncMock()
     mock_vector_engine.embedding_engine.get_batch_size = MagicMock(return_value=100)
@@ -66,6 +68,8 @@ async def _run_and_measure_peak_concurrency(data_points, batch_size, max_concurr
 async def test_concurrency_derived_from_max_concurrent_data_points():
     """Concurrent batches = max_concurrent_data_points // batch_size (6 // 2 = 3)."""
     data_points = [TestDataPoint(name=f"point{i}") for i in range(20)]
+    for data_point in data_points:
+        data_point.metadata["index_fields"] = ["name"]
 
     peak = await _run_and_measure_peak_concurrency(
         data_points, batch_size=2, max_concurrent_data_points=6
@@ -78,9 +82,33 @@ async def test_concurrency_derived_from_max_concurrent_data_points():
 async def test_concurrency_floors_at_one_when_batch_size_exceeds_limit():
     """batch_size > max_concurrent_data_points must still run one batch, not deadlock."""
     data_points = [TestDataPoint(name=f"point{i}") for i in range(10)]
+    for data_point in data_points:
+        data_point.metadata["index_fields"] = ["name"]
 
     peak = await _run_and_measure_peak_concurrency(
         data_points, batch_size=100, max_concurrent_data_points=6
     )
 
     assert peak == 1
+
+
+@pytest.mark.asyncio
+async def test_index_data_points_does_not_mutate_metadata():
+    data_point = TestDataPoint(name="test")
+    data_point.metadata["index_fields"] = ["name", "description"]
+
+    original_index_fields = list(data_point.metadata["index_fields"])
+
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.embedding_engine.get_batch_size = MagicMock(return_value=100)
+
+    async def _get_vector_engine():
+        return mock_vector_engine
+
+    with patch.dict(
+        index_data_points.__globals__,
+        {"get_vector_engine_async": _get_vector_engine},
+    ):
+        await index_data_points([data_point])
+
+    assert data_point.metadata["index_fields"] == original_index_fields


### PR DESCRIPTION
## Description

`index_data_points()` uses `DataPoint.model_copy()` before modifying
`metadata["index_fields"]`. Since `model_copy()` performs a shallow copy by
default, the copied `DataPoint` and the original `DataPoint` share the same
mutable `metadata` object.

When a data point contains multiple index fields, modifying the metadata of
the indexed copy can therefore mutate the original data point's metadata.

This change uses `model_copy(deep=True)` so that the indexed data point receives
an independent copy of its nested metadata before `index_fields` is modified.

A regression test has also been added to verify that the original
`metadata["index_fields"]` remains unchanged after indexing.

## Acceptance Criteria

- `index_data_points()` must not mutate the original `DataPoint` metadata.
- The indexed copy must be able to modify `metadata["index_fields"]` without
  affecting the caller's `DataPoint`.
- Existing vector indexing behavior must remain unchanged.
- A regression test must verify that the caller's metadata is preserved.
- Existing indexing and concurrency tests must continue to pass.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Local unit tests passing:

![Unit tests passing]
<img width="1355" height="692" alt="Screenshot 2026-08-14 at 6 17 28 PM" src="https://github.com/user-attachments/assets/36a43368-3aa8-486d-b4e6-37d072be8d4b" />


## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.