### PR TITLE
fix(mcp): Wire workspace UI to real backend tools

### DIFF
--- a/cognee-mcp/apps-src/src/main.tsx
+++ b/cognee-mcp/apps-src/src/main.tsx
@@ -324,8 +324,8 @@ function DatasetRail({
     setStatus(`Deleting '${name}'...`);
     try {
       const result = await app.callServerTool({
-        name: "delete_dataset",
-        arguments: { dataset_name: name },
+        name: "forget",
+        arguments: { dataset: name },
       });
       if (result.isError) {
         setStatus(`Error: ${textOf(result) ?? "delete failed"}`);
@@ -347,7 +347,7 @@ function DatasetRail({
     setStatus("Deleting data item...");
     try {
       const result = await app.callServerTool({
-        name: "delete",
+        name: "forget",
         arguments: { data_id: dataId, dataset_id: datasetId },
       });
       if (result.isError) {
@@ -568,11 +568,11 @@ function Composer({
     });
     try {
       const args: Record<string, string> = {
-        search_query: q,
+        query: q,
         search_type: searchType,
       };
       if (selectedDataset) args.datasets = selectedDataset;
-      const result = await app.callServerTool({ name: "search", arguments: args });
+      const result = await app.callServerTool({ name: "recall", arguments: args });
       const msg = textOf(result) ?? JSON.stringify(result.content);
       onSearchResult({
         type: searchType,
@@ -598,9 +598,12 @@ function Composer({
     setBusy(true);
     setStatus("Adding text…");
     try {
-      const args: Record<string, string> = { data };
+      // background: ingestion runs add + cognify and routinely exceeds the
+      // host's per-request timeout. The tool queues the work and returns a
+      // status message instead of blocking until the pipeline finishes.
+      const args: Record<string, string | boolean> = { data, background: true };
       if (selectedDataset) args.dataset_name = selectedDataset;
-      const result = await app.callServerTool({ name: "cognify", arguments: args });
+      const result = await app.callServerTool({ name: "remember", arguments: args });
       const msg = textOf(result) ?? JSON.stringify(result.content);
       setStatus(result.isError ? `Error: ${msg}` : msg);
       if (!result.isError) {
@@ -626,7 +629,13 @@ function Composer({
     setStatus(`Uploading ${file.name}…`);
     try {
       const content_base64 = arrayBufferToBase64(await file.arrayBuffer());
-      const args: Record<string, string> = { filename: file.name, content_base64 };
+      // background: same timeout constraint as text ingest, and more acute —
+      // a multi-megabyte document takes far longer than the host will wait.
+      const args: Record<string, string | boolean> = {
+        filename: file.name,
+        content_base64,
+        background: true,
+      };
       if (selectedDataset) args.dataset_name = selectedDataset;
       const result = await app.callServerTool({
         name: "remember",

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -732,19 +732,36 @@ class CogneeClient:
         self,
         dataset: Optional[str] = None,
         everything: bool = False,
+        data_id: Optional[UUID] = None,
+        dataset_id: Optional[UUID] = None,
     ) -> Dict[str, Any]:
-        """Delete data via forget()."""
+        """Delete data via forget().
+
+        Mirrors cognee.forget()'s targeting options rather than a subset of
+        them: whole-dataset (by name or id), a single data item, or
+        everything. The single-item path is what the workspace UI's per-item
+        delete needs; without it the UI has no way to remove one document.
+        """
         if self.use_api:
             endpoint = f"{self.api_url}/api/v1/forget"
             payload = {"everything": everything}
             if dataset:
                 payload["dataset"] = dataset
+            if data_id:
+                payload["data_id"] = str(data_id)
+            if dataset_id:
+                payload["dataset_id"] = str(dataset_id)
             response = await self.client.post(endpoint, json=payload, headers=self._get_headers())
             response.raise_for_status()
             return response.json()
         else:
             with redirect_stdout(sys.stderr):
-                return await self.cognee.forget(dataset=dataset, everything=everything)
+                return await self.cognee.forget(
+                    dataset=dataset,
+                    everything=everything,
+                    data_id=data_id,
+                    dataset_id=dataset_id,
+                )
 
     async def improve(
         self,

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1146,6 +1146,7 @@ async def remember(
     dataset_name: str = None,
     session_id: str = None,
     custom_prompt: str = None,
+    background: bool = False,
 ) -> list:
     """Store data in memory.
 
@@ -1180,6 +1181,12 @@ async def remember(
         Session ID. When set, stores in session cache only.
     custom_prompt : str, optional
         Custom prompt for entity extraction (permanent mode only).
+    background : bool
+        Queue permanent ingestion as a background task and return immediately
+        instead of waiting for the pipeline. Use when the caller has a request
+        deadline shorter than ingestion takes. Ignored with session_id, which
+        is already fast. Errors surface via cognify_status, not the return
+        value.
     """
     if content_base64 and data:
         return [
@@ -1217,6 +1224,46 @@ async def remember(
             ]
 
     dataset_name = dataset_name or _agent_scoped_default_dataset()
+
+    # Permanent-memory ingestion runs add + cognify (+ improve), which routinely
+    # outruns an MCP host's per-request deadline — the same constraint the
+    # cognify tool documents as "background process launched due to MCP timeout
+    # limitations". Callers that can't block (the workspace UI) pass
+    # background=True and poll cognify_status instead. Session-cache writes are
+    # fast, so they always run inline.
+    if background and not session_id:
+
+        async def remember_task_wrapper(**kwargs):
+            """Wrapper that captures errors from the background task."""
+            try:
+                await cognee_client.remember(**kwargs)
+            except Exception as e:
+                _record_task_error(dataset_name, str(e))
+                logger.error(f"Background remember task failed for dataset '{dataset_name}': {e}")
+
+        _track_background(
+            remember_task_wrapper(
+                data=data,
+                filename=filename,
+                content_base64=content_base64,
+                dataset_name=dataset_name,
+                session_id=None,
+                custom_prompt=custom_prompt,
+            )
+        )
+        queued = f"'{filename}'" if content_base64 else "text"
+        return [
+            types.TextContent(
+                type="text",
+                text=(
+                    f"Background process launched due to MCP timeout limitations.\n"
+                    f"Queued {queued} for dataset '{dataset_name}'.\n"
+                    f"Check progress with cognify_status, or the log file at: "
+                    f"{get_log_file_location()}"
+                ),
+            )
+        ]
+
     with redirect_stdout(sys.stderr):
         try:
             result = await cognee_client.remember(
@@ -1309,11 +1356,14 @@ async def recall(
 async def forget(
     dataset: str = None,
     everything: bool = False,
+    data_id: str = None,
+    dataset_id: str = None,
 ) -> list:
     """Delete data from memory.
 
-    Can target a specific dataset or delete everything the user owns.
-    Removes data from the relational DB, graph DB, and vector DB.
+    Can target a single data item, a specific dataset (by name or id), or
+    everything the user owns. Removes data from the relational DB, graph DB,
+    and vector DB.
 
     Parameters
     ----------
@@ -1321,22 +1371,57 @@ async def forget(
         Dataset name to delete entirely.
     everything : bool
         If true, delete ALL data across all datasets.
+    data_id : str, optional
+        UUID of a single data item to delete. Must be paired with `dataset`
+        or `dataset_id` so the owning dataset is unambiguous.
+    dataset_id : str, optional
+        UUID of the dataset to delete entirely, or to scope `data_id`.
     """
     with redirect_stdout(sys.stderr):
         try:
-            if not dataset and not everything:
+            if not dataset and not everything and not data_id and not dataset_id:
                 return [
                     types.TextContent(
                         type="text",
-                        text="Error: Specify 'dataset' name or set 'everything' to true.",
+                        text=(
+                            "Error: Specify 'dataset' name or set 'everything' to true. "
+                            "To remove a single item, pass 'data_id' with 'dataset' or "
+                            "'dataset_id'."
+                        ),
                     )
                 ]
-            result = await cognee_client.forget(dataset=dataset, everything=everything)
+            if data_id and not dataset and not dataset_id:
+                return [
+                    types.TextContent(
+                        type="text",
+                        text="Error: 'data_id' requires 'dataset' or 'dataset_id'.",
+                    )
+                ]
+
+            # The UI passes ids as strings over JSON; cognee.forget() wants UUIDs.
+            # Parse here so a malformed id is a clear message rather than a
+            # cognee-internal traceback.
+            from uuid import UUID
+
+            try:
+                parsed_data_id = UUID(data_id) if data_id else None
+                parsed_dataset_id = UUID(dataset_id) if dataset_id else None
+            except ValueError as e:
+                return [types.TextContent(type="text", text=f"Error: invalid UUID ({e}).")]
+
+            result = await cognee_client.forget(
+                dataset=dataset,
+                everything=everything,
+                data_id=parsed_data_id,
+                dataset_id=parsed_dataset_id,
+            )
             status = result.get("status", "unknown") if isinstance(result, dict) else "completed"
             if everything:
                 text = f"All data deleted (status={status})."
+            elif parsed_data_id:
+                text = f"Data item '{data_id}' deleted (status={status})."
             else:
-                text = f"Dataset '{dataset}' deleted (status={status})."
+                text = f"Dataset '{dataset or dataset_id}' deleted (status={status})."
             return [types.TextContent(type="text", text=text)]
         except Exception as e:
             error_msg = f"Forget failed: {str(e)}"
@@ -1396,6 +1481,14 @@ async def improve(
 # ---------------------------------------------------------------------------
 
 
+@registry.tool(
+    tags={"workspace", "status"},
+    description=(
+        "Check the progress of background ingestion started by remember(background=True). "
+        "Reports active and completed pipeline jobs for a dataset, including failures that "
+        "a backgrounded call could not return inline."
+    ),
+)
 @log_usage(function_name="MCP cognify_status", log_type="mcp_tool")
 async def cognify_status(
     dataset_name: str = None,

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -133,6 +133,10 @@ WORKSPACE_INTERNAL_TOOLS = {
     "list_dataset_data_json",
     "create_dataset_json",
     "get_client_info_json",
+    # Ingestion is queued (remember(background=True)) because it outruns the
+    # host's request deadline, so progress and failures are only observable
+    # through a status call.
+    "cognify_status",
 }
 EXPECTED_TOOLS = MEMORY_API_TOOLS | WORKSPACE_UI_ENTRY_TOOLS | WORKSPACE_INTERNAL_TOOLS
 

--- a/cognee-mcp/tests/test_workspace_ui_contract.py
+++ b/cognee-mcp/tests/test_workspace_ui_contract.py
@@ -1,0 +1,97 @@
+"""Pins the workspace UI's tool calls against the server's real tool surface.
+
+The UI is TypeScript calling MCP tools by string name, so nothing at build time
+or import time connects the two. When ``b52fcc335`` narrowed the server to the
+memory tools, the UI kept calling ``cognify``/``search``/``delete``/
+``delete_dataset`` and every one of those buttons raised "Unknown tool" — for
+five months, because no test crossed the language boundary.
+
+These tests parse the UI source and check it against ``server.registry``, which
+is the only place the two sides can be compared automatically.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+MCP_ROOT = Path(__file__).resolve().parents[1]  # cognee-mcp/
+if str(MCP_ROOT) not in sys.path:
+    sys.path.insert(0, str(MCP_ROOT))
+
+UI_SOURCE = MCP_ROOT / "apps-src" / "src" / "main.tsx"
+
+# `name: "some_tool"` inside a callServerTool({...}) argument object.
+TOOL_NAME_RE = re.compile(r'name:\s*"([a-z_]+)"')
+
+
+def _registered_tool_names() -> set[str]:
+    server = importlib.import_module("src.server")
+    return set(server.registry.tags)
+
+
+def _ui_tool_calls() -> set[str]:
+    source = UI_SOURCE.read_text(encoding="utf-8")
+    # Only the names passed to callServerTool matter; the regex is broad enough
+    # to also catch `name:` keys in unrelated object literals, so intersect with
+    # the set of strings that appear near a callServerTool call.
+    calls = set()
+    for match in re.finditer(r"callServerTool\(\s*\{(.{0,400}?)\}\s*\)", source, re.DOTALL):
+        calls.update(TOOL_NAME_RE.findall(match.group(1)))
+    return calls
+
+
+def test_ui_source_is_present():
+    """The contract tests below are vacuous if the source moved."""
+    assert UI_SOURCE.is_file(), f"workspace UI source not found at {UI_SOURCE}"
+
+
+def test_ui_calls_only_registered_tools():
+    """Every tool the workspace UI calls must exist in the server registry.
+
+    A failure here means a workspace button is dead in the host: the call
+    returns "Unknown tool" and the UI surfaces it as a generic error.
+    """
+    ui_calls = _ui_tool_calls()
+    assert ui_calls, "parsed no callServerTool names — the regex or the UI shape changed"
+
+    unregistered = sorted(ui_calls - _registered_tool_names())
+    assert not unregistered, (
+        f"workspace UI calls unregistered tools: {unregistered}. "
+        "Either register them with @registry.tool or point the UI at a tool that exists."
+    )
+
+
+@pytest.mark.parametrize(
+    "tool_name, required_params",
+    [
+        # The UI's argument names, which must match the tool signatures. These
+        # broke silently once already (the UI sent `search_query` to a `query`
+        # parameter), so they are pinned rather than assumed.
+        # `background` is load-bearing: ingestion outruns the host's request
+        # deadline, so the UI must be able to queue rather than block.
+        ("remember", {"data", "dataset_name", "filename", "content_base64", "background"}),
+        ("recall", {"query", "search_type", "datasets"}),
+        ("forget", {"dataset", "data_id", "dataset_id"}),
+        ("list_dataset_data_json", {"dataset_id"}),
+        ("create_dataset_json", {"name"}),
+        ("visualize_graph_ui", {"dataset_name"}),
+    ],
+)
+def test_tool_accepts_ui_argument_names(tool_name, required_params):
+    """Tools must accept the argument names the UI actually sends."""
+    import inspect
+
+    server = importlib.import_module("src.server")
+    func = getattr(server, tool_name)
+    accepted = set(inspect.signature(func).parameters)
+
+    missing = sorted(required_params - accepted)
+    assert not missing, (
+        f"{tool_name}() does not accept {missing}, which the workspace UI sends. "
+        f"Accepted parameters: {sorted(accepted)}."
+    )


### PR DESCRIPTION
## Description
Upon first test, the MCP workspace UI for cognee was broken (text and file ingestion would error out.) This was no issue with the backend: the frontend was completely unwired to the current state of the backend. This PR fixes the frontend and confirmed works for file + text ingestion.

## Acceptance Criteria
Text and files appear in the graph as exposed by the UI.

## Type of Change
<!-- Please check the relevant option -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
Screenshot of it working after the fixes (I ingested a random screenshot and the word "test")
<img width="752" height="651" alt="Screenshot 2026-08-14 at 2 54 58 PM" src="https://github.com/user-attachments/assets/fbbe5129-1031-4e37-bda0-c92d42f58d78" />

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [X] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [X] **This PR contains minimal changes necessary to address the issue/feature**
- [X] My code follows the project's coding standards and style guidelines
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if applicable)
- [X] All new and existing tests pass
- [X] I have searched existing PRs to ensure this change hasn't been submitted already
- [X] I have linked any relevant issues in the description
- [X] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.