### PR TITLE
fix: Restore data_per_batch default to 20

### DIFF
--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -55,7 +55,7 @@ async def add(
     # transactions hit WAL snapshot-upgrade conflicts ("database is locked"
     # immediately, bypassing busy_timeout) — observed live at 448 concurrent
     # items. 100 keeps ingestion fast while staying under that pressure.
-    data_per_batch: Optional[int] = 100,
+    data_per_batch: Optional[int] = 20,
     importance_weight: Optional[float] = 0.5,
     run_in_background: bool = False,
     llm_config: Optional[LLMConfig] = None,

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -66,7 +66,7 @@ async def cognify(
     custom_prompt: Optional[str] = None,
     temporal_cognify: bool = False,
     functional_relationships: Optional[Collection[str]] = None,
-    data_per_batch: int = 2000,
+    data_per_batch: int = 20,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
     data_cache: bool = True,

--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -110,8 +110,8 @@ class CognifyPayloadDTO(InDTO):
         ),
     )
     data_per_batch: Optional[int] = Field(
-        default=2000,
-        examples=[2000],
+        default=20,
+        examples=[20],
         description="Maximum number of data items to process concurrently within a dataset.",
     )
 
@@ -157,7 +157,7 @@ def get_cognify_router() -> APIRouter:
           a size from the configured LLM and embedding limits.
         - **ontology_key** (Optional[List[str]]): Reference to one or more previously uploaded ontology files to use for knowledge graph construction.
         - **chunks_per_batch** (Optional[int]): Number of chunks to process per task batch in Cognify. Uses the pipeline default when omitted.
-        - **data_per_batch** (Optional[int]): Maximum number of data items to process concurrently within a dataset. Defaults to 2000.
+        - **data_per_batch** (Optional[int]): Maximum number of data items to process concurrently within a dataset. Defaults to 20.
 
         ## Response
         - **Blocking execution**: Complete pipeline run information with entity counts, processing duration, and success/failure status


### PR DESCRIPTION
## Description

Restores the `data_per_batch` default to **20** for add / cognify / remember. The default had drifted upward by mistake — `cognify()` to 2000 (came in with #4444) and `add()` to 100 — while the pipeline layer (`pipeline.py`, `run_tasks.py`, `run_custom_pipeline.py`) kept 20 all along.

Changes:
- `cognee/api/v1/cognify/cognify.py`: `data_per_batch` 2000 → 20
- `cognee/api/v1/add/add.py`: `data_per_batch` 100 → 20
- `cognee/api/v1/cognify/routers/get_cognify_router.py`: request field default/examples + endpoint docs 2000 → 20

`remember()` has no default of its own — it passes `data_per_batch` through to add/cognify, so it inherits the restored value. The similarly named `chunks_per_batch` fallback (2000 in `cognify.py`) is a different knob and is deliberately untouched.