### PR TITLE
chore: Remove stale data_per_batch comment

### DIFF
--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -50,11 +50,6 @@ async def add(
     dataset_id: Optional[UUID] = None,
     preferred_loaders: Optional[List[Union[str, dict[str, dict[str, Any]]]]] = None,
     incremental_loading: bool = True,
-    # 100, not unbounded: every in-flight item writes its Data row concurrently,
-    # and on the default SQLite backend hundreds of parallel read-then-write
-    # transactions hit WAL snapshot-upgrade conflicts ("database is locked"
-    # immediately, bypassing busy_timeout) — observed live at 448 concurrent
-    # items. 100 keeps ingestion fast while staying under that pressure.
     data_per_batch: Optional[int] = 20,
     importance_weight: Optional[float] = 0.5,
     run_in_background: bool = False,


### PR DESCRIPTION
## Description

Removes the comment above `data_per_batch` in `cognee/api/v1/add/add.py` that explained the interim 100 default (SQLite WAL snapshot-upgrade rationale). Since #4490 restored the value to 20, the comment no longer matches the line beneath it.

Comment-only change. Once merged, `release-v1.5.0` gets a final dev sync to pick it up.