### PR TITLE
ci: Fix release publish gate for Metadata-Version 2.5

### DIFF
--- a/.github/workflows/dev_canary_release.yml
+++ b/.github/workflows/dev_canary_release.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Publish to PyPI
         # Trusted Publishing (OIDC) — no API token. PEP 740 attestations are
         # generated and uploaded by default (attestations: true).
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2 (twine 7.0.0: accepts Metadata-Version 2.5)
         with:
           packages-dir: dist/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Publish ${{ github.ref_name }} release to PyPI
         # Trusted Publishing (OIDC) — no API token. The action generates and
         # uploads PEP 740 digital attestations by default (attestations: true).
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2 (twine 7.0.0: accepts Metadata-Version 2.5)
         with:
           packages-dir: dist/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,11 @@ Repository = "https://github.com/topoteretes/cognee"
 cognee-cli = "cognee.cli._cognee:main"
 
 [build-system]
-requires = ["hatchling"]
+# Pinned: the build backend decides the wheel's Metadata-Version, and the PyPI
+# publish action validates it with a pinned twine — an unpinned hatchling let
+# the emitted metadata drift to 2.5 and broke the release publish gate. Bump
+# this together with the gh-action-pypi-publish pin in the release workflows.
+requires = ["hatchling==1.32.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]


### PR DESCRIPTION
## Description

Fixes the failed `cognee-1.5.0.dev0` publish ([run](https://github.com/topoteretes/cognee/actions/runs/31807256287/job/94789294624)): `InvalidDistribution: '2.5' is not a valid metadata version`.

**Root cause — builder/checker version skew:** `[build-system]` had an unpinned `hatchling`, so `uv build` resolves a fresh backend every release; current hatchling stamps **Metadata-Version 2.5** into the wheel. The publish action was pinned to `gh-action-pypi-publish` v1.14.0 (Feb 2026), whose bundled twine predates 2.5 and rejects the wheel at the `verify-metadata` gate — before upload, so nothing reached PyPI. The 1.4.2 release passed only because hatchling still emitted ≤2.4 back then; the pipeline changed underneath with zero repo changes.

**Fix (both ends):**
- **Repin `gh-action-pypi-publish` → v1.14.2** (`dc37677b2e1c63e2034f94d8a5b11f265b73ba33`) in `release.yml` and `dev_canary_release.yml`. Its `requirements/runtime.txt` pins **twine 7.0.0**.
- **Pin `hatchling==1.32.0`** in `[build-system]` with a comment tying the two pins together — the emitted metadata version now changes only deliberately.

**Verified locally:** wheel built with the pinned hatchling carries `Metadata-Version: 2.5`, and `twine check` with exactly twine 7.0.0 (what v1.14.2 bundles) reports **PASSED**. `uv lock --check` unaffected (build-system deps aren't in the lock).

No workflow was executed — validation was entirely local.