### PR TITLE
chore: Set dev version marker to 1.5.0.dev1

### DIFF
--- a/.github/workflows/dev_canary_release.yml
+++ b/.github/workflows/dev_canary_release.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Publish to PyPI
         # Trusted Publishing (OIDC) — no API token. PEP 740 attestations are
         # generated and uploaded by default (attestations: true).
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2 (twine 7.0.0: accepts Metadata-Version 2.5)
         with:
           packages-dir: dist/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Publish ${{ github.ref_name }} release to PyPI
         # Trusted Publishing (OIDC) — no API token. The action generates and
         # uploads PEP 740 digital attestations by default (attestations: true).
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2 (twine 7.0.0: accepts Metadata-Version 2.5)
         with:
           packages-dir: dist/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cognee"
 
-version = "1.5.0.dev0"
+version = "1.5.0.dev1"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 authors = [
     { name = "Vasilije Markovic" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cognee"
 
-version = "1.5.0"
+version = "1.5.0.dev0"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 authors = [
     { name = "Vasilije Markovic" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,11 @@ Repository = "https://github.com/topoteretes/cognee"
 cognee-cli = "cognee.cli._cognee:main"
 
 [build-system]
-requires = ["hatchling"]
+# Pinned: the build backend decides the wheel's Metadata-Version, and the PyPI
+# publish action validates it with a pinned twine — an unpinned hatchling let
+# the emitted metadata drift to 2.5 and broke the release publish gate. Bump
+# this together with the gh-action-pypi-publish pin in the release workflows.
+requires = ["hatchling==1.32.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]

--- a/uv.lock
+++ b/uv.lock
@@ -1208,7 +1208,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.5.0.dev0"
+version = "1.5.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -1208,7 +1208,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.5.0"
+version = "1.5.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Description

Post-release-cut housekeeping (replaces #4493, which GitHub closed when the head branch was renamed): move dev's version off the 1.5.0 release value — `pyproject.toml` → **1.5.0.dev1** and `uv.lock` regenerated (single-line change; `uv lock --check` passes).

dev1 rather than dev0 because the earlier canary dispatch consumed `1.5.0.dev0`. The branch also carries the cherry-picked release-publish fix (#4495: gh-action-pypi-publish → v1.14.2, hatchling pinned) so the canary can be re-dispatched from it; that commit deduplicates on merge once #4495 lands in dev.

Note (also on #4493): per PEP 440, `1.5.0.devN` sorts *below* `1.5.0` — once 1.5.0 ships, dev builds compare older than the release. `1.5.1.dev0` is the alternative if any tooling compares versions.