### PR TITLE
fix: Make ladybug dependency unconditional

### DIFF
--- a/cognee/tests/unit/test_ladybug_requirement.py
+++ b/cognee/tests/unit/test_ladybug_requirement.py
@@ -1,0 +1,38 @@
+"""Guards the ladybug dependency against environment-marker regressions.
+
+The old macOS-gating marker (``platform_release >= '24.'``) could not be
+expressed correctly across installer generations: packaging <= 24.x needed the
+invalid ``'24.'`` literal to avoid crashing on Linux kernel strings, while
+packaging >= 25 (vendored in current pip) dropped the string-ordering fallback,
+evaluated the marker False on macOS, and **silently skipped ladybug** — a
+pip-installed cognee then failed at ``import cognee``. The dependency is
+therefore unconditional; anyone reintroducing a marker must consciously delete
+this test and re-verify against every packaging generation.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _ladybug_requirement() -> str:
+    text = (REPO_ROOT / "pyproject.toml").read_text()
+    matches = re.findall(r'"(ladybug[^"]*)"', text)
+    assert len(matches) == 1, f"expected exactly one ladybug dependency, found {matches}"
+    return matches[0]
+
+
+def test_ladybug_dependency_has_no_environment_marker():
+    requirement = _ladybug_requirement()
+    assert ";" not in requirement, (
+        f"ladybug requirement {requirement!r} carries an environment marker — "
+        "markers on this dependency have silently skipped installation on "
+        "macOS under packaging >= 25; see the comment in pyproject.toml"
+    )
+
+
+def test_ladybug_dependency_keeps_a_bounded_range():
+    requirement = _ladybug_requirement()
+    assert re.search(r">=\s*[\d.]+", requirement), "ladybug range lost its floor"
+    assert re.search(r"<=?\s*[\d.]+", requirement), "ladybug range lost its ceiling"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cognee"
 
-version = "1.5.0.dev1"
+version = "1.5.0.dev2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 authors = [
     { name = "Vasilije Markovic" },
@@ -57,16 +57,20 @@ dependencies = [
     "structlog>=25.2.0,<26",
     "pympler>=1.1,<2.0.0",
     "pylance>=0.22.0,<=0.36.0",
-    # ladybug 0.18.x publishes only macosx_15_0 wheels and its sdist needs C++20
-    # std::atomic_ref, which Apple Clang's libc++ on macOS <= 14 lacks — so the
-    # source-build fallback hard-fails there. Darwin 24 == macOS 15: older Macs
-    # stay on 0.17.x (storage code 41; the ladybug_migrate worker upgrades the
-    # on-disk format when they later move to 0.18). The '24.' (trailing dot) is
-    # deliberate: it is not a valid PEP 440 version, which forces PEP 508's
-    # string-comparison fallback — packaging evaluates BOTH sides of and/or, and
-    # version-comparing platform_release crashes pip on Linux kernels like
-    # "6.8.0-45-generic" (packaging.version.InvalidVersion).
-    "ladybug>=0.16.0,<=0.18.2 ; sys_platform != 'darwin' or platform_release >= '24.'",
+    # Unconditional on purpose — do NOT add an environment marker (guarded by
+    # cognee/tests/unit/test_ladybug_requirement.py). The old macOS-version
+    # marker (platform_release >= '24.') cannot be expressed correctly across
+    # installer generations: packaging <= 24.x string-compares the invalid
+    # '24.' literal (works) but crashes on valid literals against Linux kernel
+    # strings, while packaging >= 25 (vendored in current pip) dropped the
+    # string-ordering fallback, evaluated the marker False on macOS, and
+    # silently skipped ladybug — pip-installed cognee then failed at import.
+    # Consequence of no marker: macOS <= 14 (ladybug 0.18.x ships only
+    # macosx_15_0 wheels; its sdist needs C++20 std::atomic_ref that old Apple
+    # Clang lacks) now fails ladybug's sdist build at install time instead of
+    # being skipped. Escape hatch for those users: pre-install
+    # `ladybug==0.17.1` (macosx_13_0 wheels, satisfies this range) first.
+    "ladybug>=0.16.0,<=0.18.2",
     "python-magic-bin<0.5 ; platform_system == 'Windows'", # Only needed for Windows
     "networkx>=3.4.2,<4",
     "uvicorn>=0.34.0,<1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1208,7 +1208,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.5.0.dev1"
+version = "1.5.0.dev2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1228,7 +1228,7 @@ dependencies = [
     { name = "gunicorn" },
     { name = "instructor" },
     { name = "jinja2" },
-    { name = "ladybug", marker = "platform_release >= '24.' or sys_platform != 'darwin'" },
+    { name = "ladybug" },
     { name = "lancedb" },
     { name = "langdetect" },
     { name = "limits" },
@@ -1470,7 +1470,7 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=20.1.0,<24" },
     { name = "instructor", specifier = ">=1.9.1,<1.15.3" },
     { name = "jinja2", specifier = ">=3.1.3,<4" },
-    { name = "ladybug", marker = "platform_release >= '24.' or sys_platform != 'darwin'", specifier = ">=0.16.0,<=0.18.2" },
+    { name = "ladybug", specifier = ">=0.16.0,<=0.18.2" },
     { name = "lancedb", specifier = ">=0.24.3,<1.0.0" },
     { name = "langchain-aws", marker = "extra == 'neptune'", specifier = ">=0.2.22" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.2.5" },


### PR DESCRIPTION
## Description

Fixes the bug found while testing `cognee-1.5.0.dev1` from PyPI: **on macOS with a current pip, `pip install cognee` silently skips ladybug and `import cognee` fails with `ModuleNotFoundError`**. Also bumps the dev version marker to **1.5.0.dev2**.

### Root cause

The ladybug dependency carried `; sys_platform != 'darwin' or platform_release >= '24.'`. The trailing-dot literal was a deliberate 2024-era trick relying on PEP 508's string-comparison fallback. That fallback semantics changed in packaging >= 25 (vendored in current pip): ordering comparisons on non-version literals now degrade to equality (`>=` → `==`, `>` → hardcoded False), so `'24.0.0' >= '24.'` became False and the marker silently excluded ladybug on every macOS. Verified against both generations side by side — and the obvious fix (a valid `'24'` literal) **crashes packaging <= 24.x on Linux** (`InvalidVersion` on kernel strings like `6.8.0-45-generic`; both sides of `or` are evaluated). The gate is not expressible correctly across installer generations.

### Fix

Drop the marker; the dependency becomes unconditional `ladybug>=0.16.0,<=0.18.2`. The pyproject comment documents the policy trade-off, and a new guard test (`cognee/tests/unit/test_ladybug_requirement.py`) pins the requirement markerless so the trick cannot quietly return.

**Cost, accepted deliberately**: macOS <= 14 (ladybug 0.18.x ships only `macosx_15_0` wheels; its sdist needs C++20 `std::atomic_ref`) now fails ladybug's sdist build *loudly at install time* instead of being cleanly skipped — arguably better than today's silent success-then-import-crash. Escape hatch (documented in the comment): pre-install `ladybug==0.17.1` (macosx_13_0 wheels, satisfies the unchanged range).

### Verification (local only)

- Built wheel's `Requires-Dist: ladybug<=0.18.2,>=0.16.0` — markerless.
- From-scratch dry-run resolution (`pip install --dry-run --ignore-installed --report`) of the built wheel selects **ladybug==0.18.2**: with **pip 26.2.1 / packaging 26.2** (the generation that skipped it) and **pip 25.1 / packaging 25.0**. packaging <= 24 has nothing left to evaluate.
- `uv lock` regenerates cleanly (marker lines drop out of the lock); `uv lock --check` passes; guard tests + pre-commit green.

### Follow-ups worth their own PRs

- Release-workflow smoke test: bare-venv `pip install dist/*.whl && python -c 'import cognee'` on macOS + Ubuntu runners — would have caught this and the Metadata-2.5 bug.
- Upstream ask to ladybug: restore macOS 13/14 wheels for 0.18+, which would delete even the documented trade-off.
- Note: released `1.4.2` on PyPI carries the broken marker too — macOS users with current pip are affected until a release ships with this fix.