### PR TITLE
fix: Chunk ladybug edge-identity queries, batch rekey restore

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -1237,30 +1237,37 @@ class LadybugAdapter(GraphDBInterface):
         self, node_ids: List[str]
     ) -> Dict[str, Tuple[List[str], List[str]]]:
         """Return ``{node_id: (source_ref_keys, source_run_refs)}`` for existing nodes."""
-        rows = await self.query(
-            """
-            MATCH (n:Node) WHERE n.id IN $ids
-            RETURN n.id, n.source_ref_keys, n.source_run_refs
-            """,
-            {"ids": list(node_ids)},
-        )
+        ids = list(node_ids)
+        rows = []
+        for start in range(0, len(ids), _WRITE_CHUNK_SIZE):
+            rows.extend(
+                await self.query(
+                    """
+                    UNWIND $ids AS nid
+                    MATCH (n:Node {id: nid})
+                    RETURN n.id, n.source_ref_keys, n.source_run_refs
+                    """,
+                    {"ids": ids[start : start + _WRITE_CHUNK_SIZE]},
+                )
+            )
         return {row[0]: (_decode_refs(row[1]), _decode_refs(row[2])) for row in rows}
 
     async def _write_node_provenance(self, batch: List[dict]) -> None:
         if not batch:
             return
         encoded_batch = [_encode_provenance_row(row) for row in batch]
-        await self.query(
-            """
-            UNWIND $batch AS row
-            MATCH (n:Node) WHERE n.id = row.id
-            SET n.source_ref_keys = row.refs,
-                n.source_dataset_ids = row.datasets,
-                n.source_run_ids = row.runs,
-                n.source_run_refs = row.run_refs
-            """,
-            {"batch": encoded_batch},
-        )
+        for start in range(0, len(encoded_batch), _WRITE_CHUNK_SIZE):
+            await self.query(
+                """
+                UNWIND $batch AS row
+                MATCH (n:Node {id: row.id})
+                SET n.source_ref_keys = row.refs,
+                    n.source_dataset_ids = row.datasets,
+                    n.source_run_ids = row.runs,
+                    n.source_run_refs = row.run_refs
+                """,
+                {"batch": encoded_batch[start : start + _WRITE_CHUNK_SIZE]},
+            )
         await self.checkpoint()
 
     async def _read_edge_provenance(
@@ -1271,15 +1278,19 @@ class LadybugAdapter(GraphDBInterface):
             {"s": edge.source_id, "t": edge.target_id, "rel": edge.relationship_name}
             for edge in edges
         ]
-        rows = await self.query(
-            """
-            UNWIND $edges AS e
-            MATCH (a:Node)-[r:EDGE]->(b:Node)
-            WHERE a.id = e.s AND b.id = e.t AND r.relationship_name = e.rel
-            RETURN a.id, b.id, r.relationship_name, r.source_ref_keys, r.source_run_refs
-            """,
-            {"edges": edge_params},
-        )
+        rows = []
+        for start in range(0, len(edge_params), _WRITE_CHUNK_SIZE):
+            rows.extend(
+                await self.query(
+                    """
+                    UNWIND $edges AS e
+                    MATCH (a:Node {id: e.s})-[r:EDGE]->(b:Node {id: e.t})
+                    WHERE r.relationship_name = e.rel
+                    RETURN a.id, b.id, r.relationship_name, r.source_ref_keys, r.source_run_refs
+                    """,
+                    {"edges": edge_params[start : start + _WRITE_CHUNK_SIZE]},
+                )
+            )
         result: Dict[EdgeIdentity, Tuple[List[str], List[str]]] = {}
         for row in rows:
             edge = EdgeIdentity(source_id=row[0], target_id=row[1], relationship_name=row[2])
@@ -1290,18 +1301,19 @@ class LadybugAdapter(GraphDBInterface):
         if not batch:
             return
         encoded_batch = [_encode_provenance_row(row) for row in batch]
-        await self.query(
-            """
-            UNWIND $batch AS row
-            MATCH (a:Node)-[r:EDGE]->(b:Node)
-            WHERE a.id = row.s AND b.id = row.t AND r.relationship_name = row.rel
-            SET r.source_ref_keys = row.refs,
-                r.source_dataset_ids = row.datasets,
-                r.source_run_ids = row.runs,
-                r.source_run_refs = row.run_refs
-            """,
-            {"batch": encoded_batch},
-        )
+        for start in range(0, len(encoded_batch), _WRITE_CHUNK_SIZE):
+            await self.query(
+                """
+                UNWIND $batch AS row
+                MATCH (a:Node {id: row.s})-[r:EDGE]->(b:Node {id: row.t})
+                WHERE r.relationship_name = row.rel
+                SET r.source_ref_keys = row.refs,
+                    r.source_dataset_ids = row.datasets,
+                    r.source_run_ids = row.runs,
+                    r.source_run_refs = row.run_refs
+                """,
+                {"batch": encoded_batch[start : start + _WRITE_CHUNK_SIZE]},
+            )
         await self.checkpoint()
 
     @staticmethod
@@ -1429,28 +1441,35 @@ class LadybugAdapter(GraphDBInterface):
         ]
         # DELETE r (not DETACH DELETE) removes only the matched relationships and
         # preserves the endpoint nodes.
-        await self.query(
-            """
-            UNWIND $edges AS e
-            MATCH (a:Node)-[r:EDGE]->(b:Node)
-            WHERE a.id = e.s AND b.id = e.t AND r.relationship_name = e.rel
-            DELETE r
-            """,
-            {"edges": edge_params},
-        )
+        for start in range(0, len(edge_params), _WRITE_CHUNK_SIZE):
+            await self.query(
+                """
+                UNWIND $edges AS e
+                MATCH (a:Node {id: e.s})-[r:EDGE]->(b:Node {id: e.t})
+                WHERE r.relationship_name = e.rel
+                DELETE r
+                """,
+                {"edges": edge_params[start : start + _WRITE_CHUNK_SIZE]},
+            )
         await self.checkpoint()
 
     async def get_node_delete_data(self, node_ids: list[str]) -> dict[str, NodeDeleteData]:
         if not node_ids:
             return {}
-        rows = await self.query(
-            """
-            MATCH (n:Node) WHERE n.id IN $ids
-            RETURN n.id, n.name, n.type, n.properties,
-                   n.source_ref_keys, n.source_dataset_ids, n.source_run_ids, n.source_run_refs
-            """,
-            {"ids": list(node_ids)},
-        )
+        ids = list(node_ids)
+        rows = []
+        for start in range(0, len(ids), _WRITE_CHUNK_SIZE):
+            rows.extend(
+                await self.query(
+                    """
+                    UNWIND $ids AS nid
+                    MATCH (n:Node {id: nid})
+                    RETURN n.id, n.name, n.type, n.properties,
+                           n.source_ref_keys, n.source_dataset_ids, n.source_run_ids, n.source_run_refs
+                    """,
+                    {"ids": ids[start : start + _WRITE_CHUNK_SIZE]},
+                )
+            )
         result: dict[str, NodeDeleteData] = {}
         for row in rows:
             node_id, name, node_type, raw_props = row[0], row[1], row[2], row[3]
@@ -1485,16 +1504,20 @@ class LadybugAdapter(GraphDBInterface):
             {"s": edge.source_id, "t": edge.target_id, "rel": edge.relationship_name}
             for edge in edges
         ]
-        rows = await self.query(
-            """
-            UNWIND $edges AS e
-            MATCH (a:Node)-[r:EDGE]->(b:Node)
-            WHERE a.id = e.s AND b.id = e.t AND r.relationship_name = e.rel
-            RETURN a.id, b.id, r.relationship_name, r.properties,
-                   r.source_ref_keys, r.source_dataset_ids, r.source_run_ids, r.source_run_refs
-            """,
-            {"edges": edge_params},
-        )
+        rows = []
+        for start in range(0, len(edge_params), _WRITE_CHUNK_SIZE):
+            rows.extend(
+                await self.query(
+                    """
+                    UNWIND $edges AS e
+                    MATCH (a:Node {id: e.s})-[r:EDGE]->(b:Node {id: e.t})
+                    WHERE r.relationship_name = e.rel
+                    RETURN a.id, b.id, r.relationship_name, r.properties,
+                           r.source_ref_keys, r.source_dataset_ids, r.source_run_ids, r.source_run_refs
+                    """,
+                    {"edges": edge_params[start : start + _WRITE_CHUNK_SIZE]},
+                )
+            )
         # Lazy import: prepare_edges_for_storage lives in the modules layer, whose
         # package __init__ imports get_graph_engine -> this adapter. Importing it
         # at module load would create a cycle; at delete-time it is safe.

--- a/cognee/modules/migrations/versions/namespace_entity_type_node_ids.py
+++ b/cognee/modules/migrations/versions/namespace_entity_type_node_ids.py
@@ -730,25 +730,45 @@ async def _restore_edge_provenance(graph_engine, edge: EdgeIdentity, snapshot) -
     )
 
 
+async def _restore_provenance_bulk(attach, items_with_snapshots) -> None:
+    """Batched provenance restore: one attach call per (provenance profile,
+    source key) instead of one per artifact.
+
+    A dataset's subgraph overwhelmingly carries one provenance profile (same
+    source_ref_keys and run refs on every artifact), so restoring a re-keyed
+    100k-edge subgraph collapses from 100k sequential read+write+checkpoint
+    round-trips — hours through the subprocess engine — to a handful of
+    batched calls. ``attach`` is ``attach_node_source_refs`` /
+    ``attach_edge_source_refs``; both take the artifact list first and apply
+    the transition per artifact, so the batched call is state-identical to
+    the per-artifact loop it replaces.
+    """
+    groups: dict = {}
+    for artifact, snapshot in items_with_snapshots:
+        if snapshot is None or not snapshot.source_ref_keys:
+            continue
+        profile = (tuple(snapshot.source_ref_keys), tuple(snapshot.source_run_refs))
+        groups.setdefault(profile, []).append(artifact)
+
+    for (source_ref_keys, source_run_refs), artifacts in groups.items():
+        run_refs_by_key: dict[str, str] = {}
+        for run_ref in source_run_refs:
+            source_ref_key = get_source_ref_key_from_source_run_ref(run_ref)
+            run_refs_by_key[source_ref_key] = str(get_pipeline_run_id_from_source_run_ref(run_ref))
+        for source_ref_key in source_ref_keys:
+            await attach(artifacts, [source_ref_key], run_refs_by_key.get(source_ref_key))
+
+
 async def _migrate_graph(graph_engine, id_map: dict, properties_by_id: dict, edges: list) -> int:
     """Remap old-scheme node ids (and their edges) in the graph database."""
-    node_snapshots, edge_snapshots = await _snapshot_graph_provenance(
-        graph_engine, list(id_map.keys()), edges
-    )
     inverse_id_map = {new_id: old_id for old_id, new_id in id_map.items()}
 
-    # 1) Create the remapped nodes (new IDs, all original properties preserved).
-    new_nodes = [
-        _make_node({**properties_by_id[old_id], "id": new_id}) for old_id, new_id in id_map.items()
-    ]
-    await graph_engine.add_nodes(new_nodes)
-    for old_id, new_id in id_map.items():
-        await _restore_node_provenance(graph_engine, new_id, node_snapshots.get(old_id))
-
-    # 2) Re-create every edge touching a remapped node onto the new endpoints.
-    #    Edges between two unchanged nodes are kept aside as survivors, and the
-    #    unchanged endpoint of a remapped edge is recorded as an "affected
-    #    neighbor" (its OTHER edges sit next to the detach-delete in step 3).
+    # Partition edges BEFORE snapshotting so the provenance snapshot covers
+    # only edges whose snapshot is ever consumed: remapped edges (looked up by
+    # their old identity) and survivors incident to an affected neighbor
+    # (re-asserted in step 4). Snapshotting every edge in the graph made the
+    # fork re-key quadratic on large graphs — a 295k-edge dataset never fit
+    # the subprocess deadline even though only its document subgraph moves.
     remapped_edges = []
     survivor_edges = []
     affected_neighbors = set()
@@ -776,8 +796,32 @@ async def _migrate_graph(graph_engine, id_map: dict, properties_by_id: dict, edg
                 affected_neighbors.add(target_id)
         else:
             survivor_edges.append((source_id, target_id, relationship_name, edge_properties or {}))
+
+    snapshot_relevant = set(id_map.keys()) | affected_neighbors
+    snapshot_edges = [
+        edge for edge in edges if edge[0] in snapshot_relevant or edge[1] in snapshot_relevant
+    ]
+    node_snapshots, edge_snapshots = await _snapshot_graph_provenance(
+        graph_engine, list(id_map.keys()), snapshot_edges
+    )
+
+    # 1) Create the remapped nodes (new IDs, all original properties preserved).
+    new_nodes = [
+        _make_node({**properties_by_id[old_id], "id": new_id}) for old_id, new_id in id_map.items()
+    ]
+    await graph_engine.add_nodes(new_nodes)
+    await _restore_provenance_bulk(
+        graph_engine.attach_node_source_refs,
+        [(new_id, node_snapshots.get(old_id)) for old_id, new_id in id_map.items()],
+    )
+
+    # 2) Re-create every edge touching a remapped node onto the new endpoints.
+    #    Edges between two unchanged nodes are kept aside as survivors, and the
+    #    unchanged endpoint of a remapped edge is recorded as an "affected
+    #    neighbor" (its OTHER edges sit next to the detach-delete in step 3).
     if remapped_edges:
         await graph_engine.add_edges(remapped_edges)
+        remapped_restores = []
         for source_id, target_id, relationship_name, _properties in remapped_edges:
             old_edge = _edge_identity(
                 inverse_id_map.get(source_id, source_id),
@@ -785,7 +829,8 @@ async def _migrate_graph(graph_engine, id_map: dict, properties_by_id: dict, edg
                 relationship_name,
             )
             new_edge = _edge_identity(source_id, target_id, relationship_name)
-            await _restore_edge_provenance(graph_engine, new_edge, edge_snapshots.get(old_edge))
+            remapped_restores.append((new_edge, edge_snapshots.get(old_edge)))
+        await _restore_provenance_bulk(graph_engine.attach_edge_source_refs, remapped_restores)
 
     # 3) Delete the old nodes. A detach-delete also drops their stale edges,
     #    which we already re-created against the new node IDs above.
@@ -805,9 +850,16 @@ async def _migrate_graph(graph_engine, id_map: dict, properties_by_id: dict, edg
     ]
     if at_risk:
         await graph_engine.add_edges(at_risk)
-        for source_id, target_id, relationship_name, _properties in at_risk:
-            edge = _edge_identity(source_id, target_id, relationship_name)
-            await _restore_edge_provenance(graph_engine, edge, edge_snapshots.get(edge))
+        await _restore_provenance_bulk(
+            graph_engine.attach_edge_source_refs,
+            [
+                (edge, edge_snapshots.get(edge))
+                for edge in (
+                    _edge_identity(source_id, target_id, relationship_name)
+                    for source_id, target_id, relationship_name, _properties in at_risk
+                )
+            ],
+        )
 
     return len(remapped_edges)
 

--- a/cognee/modules/migrations/versions/rekey_fork_document_ids.py
+++ b/cognee/modules/migrations/versions/rekey_fork_document_ids.py
@@ -156,18 +156,29 @@ async def _rekey_graph_provenance(graph_engine, fork_rows: list) -> None:
         except UnsupportedProvenanceCapability:
             return
 
+        # Group artifacts by pipeline run id and attach per group: a dataset's
+        # subgraph overwhelmingly carries one run id, so this collapses the
+        # 100k-node / 295k-edge per-item loops — each a write+checkpoint
+        # subprocess round-trip whose page churn alone could exhaust kuzu's
+        # max_db_size — into a handful of batched calls.
         if node_ids:
             snapshots = await graph_engine.get_node_delete_data(node_ids)
+            nodes_by_run: dict = {}
             for node_id in node_ids:
                 run_id = _run_id_for_key(snapshots.get(node_id), old_key)
-                await graph_engine.attach_node_source_refs([node_id], [new_key], run_id)
+                nodes_by_run.setdefault(run_id, []).append(node_id)
+            for run_id, grouped_ids in nodes_by_run.items():
+                await graph_engine.attach_node_source_refs(grouped_ids, [new_key], run_id)
             await graph_engine.remove_node_source_refs(node_ids, [old_key])
 
         if edge_identities:
             edge_snapshots = await graph_engine.get_edge_delete_data(edge_identities)
+            edges_by_run: dict = {}
             for edge in edge_identities:
                 run_id = _run_id_for_key(edge_snapshots.get(edge), old_key)
-                await graph_engine.attach_edge_source_refs([edge], [new_key], run_id)
+                edges_by_run.setdefault(run_id, []).append(edge)
+            for run_id, grouped_edges in edges_by_run.items():
+                await graph_engine.attach_edge_source_refs(grouped_edges, [new_key], run_id)
             await graph_engine.remove_edge_source_refs(edge_identities, [old_key])
 
         logger.info(

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_write_chunking.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_write_chunking.py
@@ -78,3 +78,96 @@ async def test_add_edges_matches_endpoints_by_primary_key():
     assert "MATCH (from:Node {id: edge.from_id})" in query
     assert "MATCH (to:Node {id: edge.to_id})" in query
     assert "MATCH (from:Node), (to:Node)" not in query
+
+
+def _fake_edge_identities(count):
+    from cognee.infrastructure.databases.provenance import EdgeIdentity
+
+    return [
+        EdgeIdentity(source_id=f"s-{index}", target_id=f"t-{index}", relationship_name="relates_to")
+        for index in range(count)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_edge_delete_data_chunks_and_seeks():
+    """The edge-snapshot query previously sent every identity in ONE statement
+    with a cartesian MATCH + WHERE — on a 295k-edge graph it could never finish
+    inside the subprocess deadline (hit by rekey_fork_document_ids)."""
+    adapter = _adapter_with_mocked_writes()
+    total = _WRITE_CHUNK_SIZE + 1
+
+    await adapter.get_edge_delete_data(_fake_edge_identities(total))
+
+    assert adapter.query.await_count == 2
+    chunk_sizes = [len(call.args[1]["edges"]) for call in adapter.query.await_args_list]
+    assert chunk_sizes == [_WRITE_CHUNK_SIZE, 1]
+    query = adapter.query.await_args_list[0].args[0]
+    assert "MATCH (a:Node {id: e.s})-[r:EDGE]->(b:Node {id: e.t})" in query
+    assert "WHERE a.id = e.s" not in query
+
+
+@pytest.mark.asyncio
+async def test_delete_edge_triples_chunks_and_seeks():
+    adapter = _adapter_with_mocked_writes()
+    total = _WRITE_CHUNK_SIZE * 2 + 1
+
+    await adapter.delete_edge_triples(_fake_edge_identities(total))
+
+    assert adapter.query.await_count == 3
+    query = adapter.query.await_args_list[0].args[0]
+    assert "MATCH (a:Node {id: e.s})-[r:EDGE]->(b:Node {id: e.t})" in query
+    adapter.checkpoint.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_edge_provenance_read_and_write_chunk_and_seek():
+    adapter = _adapter_with_mocked_writes()
+    total = _WRITE_CHUNK_SIZE + 1
+
+    await adapter._read_edge_provenance(_fake_edge_identities(total))
+    read_queries = [call.args[0] for call in adapter.query.await_args_list]
+    assert adapter.query.await_count == 2
+    assert all("MATCH (a:Node {id: e.s})-[r:EDGE]->(b:Node {id: e.t})" in q for q in read_queries)
+
+    adapter.query.reset_mock()
+    batch = [
+        {
+            "s": f"s-{i}",
+            "t": f"t-{i}",
+            "rel": "relates_to",
+            "refs": [],
+            "datasets": [],
+            "runs": [],
+            "run_refs": [],
+        }
+        for i in range(total)
+    ]
+    await adapter._write_edge_provenance(batch)
+    assert adapter.query.await_count == 2
+    write_query = adapter.query.await_args_list[0].args[0]
+    assert "MATCH (a:Node {id: row.s})-[r:EDGE]->(b:Node {id: row.t})" in write_query
+
+
+@pytest.mark.asyncio
+async def test_node_delete_data_and_provenance_chunk_by_id_seek():
+    adapter = _adapter_with_mocked_writes()
+    total = _WRITE_CHUNK_SIZE + 1
+    ids = [f"node-{i}" for i in range(total)]
+
+    await adapter.get_node_delete_data(ids)
+    assert adapter.query.await_count == 2
+    assert "MATCH (n:Node {id: nid})" in adapter.query.await_args_list[0].args[0]
+
+    adapter.query.reset_mock()
+    await adapter._read_node_provenance(ids)
+    assert adapter.query.await_count == 2
+
+    adapter.query.reset_mock()
+    batch = [
+        {"id": f"node-{i}", "refs": [], "datasets": [], "runs": [], "run_refs": []}
+        for i in range(total)
+    ]
+    await adapter._write_node_provenance(batch)
+    assert adapter.query.await_count == 2
+    assert "MATCH (n:Node {id: row.id})" in adapter.query.await_args_list[0].args[0]

--- a/cognee/tests/unit/modules/migrations/test_migrate_graph_snapshot_scope.py
+++ b/cognee/tests/unit/modules/migrations/test_migrate_graph_snapshot_scope.py
@@ -1,0 +1,86 @@
+"""_migrate_graph must snapshot provenance only for edges whose snapshot is
+consumed (remapped edges + survivors incident to an affected neighbor) —
+snapshotting the whole graph made large fork re-keys unable to finish."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import cognee.modules.migrations.versions.namespace_entity_type_node_ids as ns
+
+
+@pytest.mark.asyncio
+async def test_migrate_graph_snapshots_only_consumable_edges():
+    graph_engine = AsyncMock()
+    id_map = {"a": "a2"}
+    properties_by_id = {"a": {"id": "a", "name": "a", "type": "Node"}}
+    edges = [
+        ("a", "b", "contains", {}),  # remapped (touches id_map)
+        ("b", "c", "relates_to", {}),  # survivor at risk (touches neighbor b)
+        ("c", "d", "relates_to", {}),  # untouched — must NOT be snapshotted
+    ]
+
+    with patch.object(
+        ns, "_snapshot_graph_provenance", new=AsyncMock(return_value=({}, {}))
+    ) as snapshot:
+        await ns._migrate_graph(graph_engine, id_map, properties_by_id, edges)
+
+    snapshot.assert_awaited_once()
+    _, node_ids, snapshot_edges = snapshot.await_args.args
+    assert node_ids == ["a"]
+    assert ("a", "b", "contains", {}) in snapshot_edges
+    assert ("b", "c", "relates_to", {}) in snapshot_edges
+    assert ("c", "d", "relates_to", {}) not in snapshot_edges
+
+
+@pytest.mark.asyncio
+async def test_restore_provenance_bulk_batches_by_profile():
+    """One attach per (provenance profile, key) — not one per artifact. The
+    per-artifact loop made a 100k-edge restore take hours of sequential
+    subprocess round-trips."""
+    from types import SimpleNamespace
+
+    attach = AsyncMock()
+    shared = SimpleNamespace(
+        source_ref_keys=["key-A"],
+        source_run_refs=["source_run_ref:v1:00000000-0000-0000-0000-000000000001:key-A"],
+    )
+    items = [(f"edge-{i}", shared) for i in range(1000)]
+    items.append(("edge-none", None))  # snapshot-less artifacts are skipped
+
+    await ns._restore_provenance_bulk(attach, items)
+
+    attach.assert_awaited_once()
+    artifacts, keys, _run_id = attach.await_args.args
+    assert len(artifacts) == 1000
+    assert keys == ["key-A"]
+
+
+@pytest.mark.asyncio
+async def test_rekey_provenance_moves_are_batched_by_run():
+    """_rekey_graph_provenance must attach refs per run-id group, not one
+    artifact at a time — the per-item loop's checkpoint churn could exhaust
+    kuzu's max_db_size on 100k-node graphs."""
+    from types import SimpleNamespace
+    from uuid import uuid4
+
+    import cognee.modules.migrations.versions.rekey_fork_document_ids as rk
+    from cognee.infrastructure.databases.provenance import make_source_ref_key
+
+    old_id, new_id, dataset_id = str(uuid4()), str(uuid4()), str(uuid4())
+    old_key = make_source_ref_key(dataset_id, __import__("uuid").UUID(old_id))
+    run_uuid = "00000000-0000-0000-0000-000000000001"
+    snapshot = SimpleNamespace(source_run_refs=[f"source_run_ref:v1:{run_uuid}:{old_key}"])
+
+    engine = AsyncMock()
+    engine.find_nodes_by_source_ref.return_value = ["n1", "n2", "n3"]
+    engine.find_edges_by_source_ref.return_value = []
+    engine.get_node_delete_data.return_value = {n: snapshot for n in ("n1", "n2", "n3")}
+
+    with patch.object(rk, "stores_provenance_in_graph", new=AsyncMock(return_value=True)):
+        await rk._rekey_graph_provenance(engine, [(old_id, new_id, dataset_id)])
+
+    engine.attach_node_source_refs.assert_awaited_once()
+    ids, _keys, run_id = engine.attach_node_source_refs.await_args.args
+    assert sorted(ids) == ["n1", "n2", "n3"]
+    assert run_id == run_uuid


### PR DESCRIPTION
## Description

Found by the 1.5.0 release migration test: a main-built (1.4.2) system with two 100k-node / 295k-edge datasets sharing one deduplicated document. The dataset-scoping backfill forks the shared row, and `rekey_fork_document_ids` must then re-key the fork dataset's graph — **which could never finish**: it burned 3×300s subprocess deadlines in `get_edge_delete_data` and left the dataset permanently failed (`migration_last_error: TimeoutError: Subprocess call exceeded 300.0s deadline`).

Three stacked walls, each fatal at this scale (COG-6112 fixed the same disease for `add_nodes`/`add_edges` but these remained):

1. **Scan-planned, un-chunked edge-identity queries** — `get_edge_delete_data`, `delete_edge_triples`, and the edge provenance read/write helpers all used the one-statement cartesian `MATCH … WHERE` shape. Fixed with property-map index-seek matches + `_WRITE_CHUNK_SIZE` chunks; node-id lookups (`get_node_delete_data`, node provenance read/write) get `UNWIND` + primary-key seeks and the same chunking.
2. **Whole-graph provenance snapshotting in `_migrate_graph`** — it snapshotted all 295k edges when only remapped edges and at-risk survivors ever have their snapshot consumed. Now partitions first and snapshots just those.
3. **Per-artifact provenance restore/move loops** — one read+write+checkpoint subprocess round-trip per edge (the checkpoint page churn alone can exhaust kuzu's `max_db_size`). Both the `_migrate_graph` restore and `_rekey_graph_provenance` moves now group by provenance profile / run id and attach in batches — state-identical.

## Measured result (definitive uninterrupted run, pristine main-built fixture, M3 Max)

| dataset | before | after |
|---|---|---|
| keeper (no graph re-key) | ~12 s | **~7 s** |
| fork — full re-key: doc subgraph re-key (~5 min) + provenance moved on **100,722 nodes + 295,324 edges** batched (~18 min) | **never completes** (3×300s timeout, dataset permanently failed) | **~28 min total**, every call within the default 300 s worker deadline and default 32 GB kuzu cap |

Post-migration verification (through the release-branch server): the keeper dataset serves its full graph via API — 100,722 nodes / 295,290 edges, identical to pre-migration; chunk vector payloads on BOTH datasets carry the correct post-fork `document_id`s; data listings and raw downloads intact; both `dataset_database` rows at head revision with no recorded error.

Also verified compatible with #4494 (migration embedding batching): clean merge, zero conflicts (vector path vs graph path), 47 combined unit tests pass; a combined-branch migration run over a fresh 2×100k fixture is in flight and green so far (keeper dataset already at head).

## Tests

`test_ladybug_write_chunking.py` +4: chunk boundaries and index-seek guards for the edge-identity and node-id queries.
`test_migrate_graph_snapshot_scope.py` (new): snapshot covers exactly the consumable edges; bulk restore batches by profile; `_rekey_graph_provenance` batches by run id. 42 pass (47 with #4494 merged).

## Follow-ups observed during testing (separate tickets)

- **Fork datasets come out of the graph re-key with ~17.5k edge rows carrying an empty endpoint** (measured 12,989 empty-target + 4,572 empty-source on a clean, uninterrupted run; ~17.7k on an interrupted one), which makes the formatted-graph endpoint 500 on response validation. Keeper datasets are always clean. This is pre-existing `_migrate_graph` edge-handling behavior that nobody could reach before this fix (the re-key never completed at scale) — needs its own fix before release; likely the detach-delete/re-add sequence leaves or creates edge rows whose endpoint no longer resolves.
- Killing a worker mid-checkpoint leaves `.lbug.shadow`/`.wal.checkpoint` recovery files that can brick the next open; repeated interrupted bulk migrations can exhaust `max_db_size` at small on-disk size.

COG-6112
