### PR TITLE
fix: Add checkout to notify-failure job (SDK-412)

### DIFF
--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -376,6 +376,9 @@ jobs:
     if: ${{ failure() }}
     runs-on: ubuntu-22.04
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
       - name: Send failure email
         env:
           SMTP_SERVER: ${{ secrets.SMTP_SERVER }}


### PR DESCRIPTION
## Description

The `notify-failure` job in `.github/workflows/dev_previous_day_commits.yml` fails with:

```
python3: can't open file '/home/runner/work/cognee/cognee/tools/send_failure_email.py': [Errno 2] No such file or directory
```

The email-sending code used to be inline in the workflow (heredoc), so it needed no repo files. Commit 9a4a93c85 extracted it into `tools/send_failure_email.py` but never added a checkout step to the `notify-failure` job, so the script is absent on the runner and the failure notification email is never sent.

This adds `actions/checkout@v6` as the first step of the job, matching the other jobs in the workflow.

Example failing run: https://github.com/topoteretes/cognee/actions/runs/31549644217/job/93970519229

Fixes SDK-412

🤖 Generated with [Claude Code](https://claude.com/claude-code)