### PR TITLE
fix(api): serve GET /datasets/graph-summary the dashboard calls (#4431)

### DIFF
--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pydantic import BaseModel, Field
 from typing import Any, Dict, List, Optional, Union
 from typing_extensions import Annotated
+from sqlalchemy import select, func
 from fastapi import status
 from fastapi import APIRouter
 from fastapi.encoders import jsonable_encoder
@@ -24,7 +25,8 @@ from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.modules.users.permissions.methods import get_all_user_permission_datasets
 from cognee.modules.graph.methods import get_formatted_graph_data
-from cognee.modules.pipelines.models import PipelineRunStatus
+from cognee.modules.data.models import GraphMetrics
+from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus
 from cognee.shared.utils import send_telemetry
 from cognee import __version__ as cognee_version
 
@@ -70,6 +72,17 @@ class GraphEdgeDTO(OutDTO):
 class GraphDTO(OutDTO):
     nodes: List[GraphNodeDTO]
     edges: List[GraphEdgeDTO]
+
+
+class GraphSummaryDTO(OutDTO):
+    dataset_id: UUID
+    pipeline_run_id: Optional[UUID] = None
+    num_nodes: int = 0
+    num_edges: int = 0
+    # ``None`` (while ``pipeline_run_id`` is null) means no metrics have been
+    # computed for the dataset yet. Serialized as ``computedAt`` for the
+    # dashboard's precomputed node/edge counts (frontend COG-5726).
+    computed_at: Optional[datetime] = None
 
 
 class DatasetCreationPayload(InDTO):
@@ -129,6 +142,117 @@ def get_datasets_router() -> APIRouter:
                 status_code=status.HTTP_418_IM_A_TEAPOT,
                 detail=f"Error retrieving datasets: {str(error)}",
             ) from error
+
+    @router.get("/graph-summary", response_model=list[GraphSummaryDTO])
+    async def get_datasets_graph_summary(
+        dataset_ids: Annotated[
+            List[UUID],
+            Query(
+                alias="dataset_ids",
+                description=(
+                    "Dataset UUIDs to summarize (from GET /api/v1/datasets)."
+                    " Omit to summarize every dataset you can read; foreign or"
+                    " unknown ids are silently omitted from the response."
+                ),
+                examples=[["b8a7c3de-4f5a-4b6c-8d9e-0f1a2b3c4d5e"]],
+            ),
+        ] = [],
+        user: User = Depends(get_authenticated_user),
+    ):
+        """
+        Get precomputed node/edge counts for one or more datasets.
+
+        Backed by the cached ``GraphMetrics`` a cognify run writes, this is
+        orders of magnitude cheaper than ``/{dataset_id}/graph`` (which walks
+        the whole graph) and powers the dashboard's graph-size display.
+
+        ## Query Parameters
+        - **dataset_ids** (List[UUID], optional): Datasets to summarize. If
+          omitted, returns a summary for every dataset the user can read.
+          Foreign/unknown ids are silently dropped.
+
+        ## Response
+        Returns a list of per-dataset summaries containing:
+        - **dataset_id**: The dataset UUID
+        - **pipeline_run_id**: The run whose metrics are reported (``null`` if
+          no metrics have been computed for the dataset yet)
+        - **num_nodes** / **num_edges**: Cached counts (``0`` when uncomputed)
+        - **computed_at**: When the reported metrics were computed (``null``
+          when uncomputed)
+        """
+        send_telemetry(
+            "Datasets API Endpoint Invoked",
+            user.id,
+            additional_properties={
+                "endpoint": "GET /v1/datasets/graph-summary",
+                "cognee_version": cognee_version,
+            },
+        )
+
+        datasets = await get_authorized_existing_datasets(
+            dataset_ids or None, "read", user
+        )
+        authorized_ids = [dataset.id for dataset in datasets]
+
+        if not authorized_ids:
+            return []
+
+        # ``pipeline_run_id`` is not unique in ``pipeline_runs`` (there is one
+        # row per status transition), so collapse to a distinct run->dataset
+        # map before joining the metrics to avoid a fan-out.
+        run_datasets = (
+            select(
+                PipelineRun.pipeline_run_id.label("pipeline_run_id"),
+                PipelineRun.dataset_id.label("dataset_id"),
+            )
+            .filter(PipelineRun.dataset_id.in_(authorized_ids))
+            .distinct()
+            .subquery()
+        )
+
+        ranked = (
+            select(
+                run_datasets.c.dataset_id.label("dataset_id"),
+                GraphMetrics.id.label("pipeline_run_id"),
+                GraphMetrics.num_nodes.label("num_nodes"),
+                GraphMetrics.num_edges.label("num_edges"),
+                GraphMetrics.created_at.label("computed_at"),
+                func.row_number()
+                .over(
+                    partition_by=run_datasets.c.dataset_id,
+                    order_by=GraphMetrics.created_at.desc(),
+                )
+                .label("rn"),
+            )
+            .join(GraphMetrics, GraphMetrics.id == run_datasets.c.pipeline_run_id)
+            .subquery()
+        )
+
+        db_engine = get_relational_engine()
+        async with db_engine.get_async_session() as session:
+            rows = (
+                await session.execute(select(ranked).filter(ranked.c.rn == 1))
+            ).all()
+
+        metrics_by_dataset = {row.dataset_id: row for row in rows}
+
+        summaries: list[GraphSummaryDTO] = []
+        for dataset_id in authorized_ids:
+            row = metrics_by_dataset.get(dataset_id)
+            if row is None:
+                summaries.append(GraphSummaryDTO(dataset_id=dataset_id))
+            else:
+                summaries.append(
+                    GraphSummaryDTO(
+                        dataset_id=dataset_id,
+                        pipeline_run_id=row.pipeline_run_id,
+                        num_nodes=row.num_nodes or 0,
+                        num_edges=row.num_edges or 0,
+                        computed_at=row.computed_at,
+                    )
+                )
+
+        return summaries
 
     @router.post("", response_model=DatasetDTO)
     async def create_new_dataset(


### PR DESCRIPTION
## What & why

Fixes #4431. On a stock `v1.4.2` deployment the dashboard calls `GET /api/v1/datasets/graph-summary`, but that route doesn't exist. The path matches the dynamic `DELETE /{dataset_id}` route, so a `GET` returns **405 Method Not Allowed** and floods the browser console on every dashboard load.

## Fix

Adds the missing `GET /api/v1/datasets/graph-summary` route. It returns the precomputed node/edge counts the frontend already expects (`getDatasetGraphSummary.ts` / `useGraphSummary.ts`, COG-5726) instead of the frontend having to walk the full graph via `/{dataset_id}/graph`.

Everything it needs already exists on `main`:

- **Counts** come from the cached `GraphMetrics` rows a cognify run writes in `get_pipeline_run_metrics.py`, keyed by `GraphMetrics.id == pipeline_run_id`.
- **Latest-per-dataset** selection reuses the same `row_number() OVER (partition_by dataset_id ORDER BY created_at DESC)` pattern as `get_pipeline_status.py`. Because `pipeline_run_id` is not unique in `pipeline_runs` (one row per status transition), the run→dataset map is collapsed with `DISTINCT` before the metrics join to avoid a fan-out.
- **Authorization** reuses `get_authorized_existing_datasets(dataset_ids or None, "read", user)`: omit `dataset_ids` → every dataset the caller can read; foreign/unknown ids are silently dropped — exactly the behavior the frontend TS documents.
- **Serialization** uses an `OutDTO`, so `dataset_id/pipeline_run_id/num_nodes/num_edges/computed_at` are emitted as `datasetId/pipelineRunId/numNodes/numEdges/computedAt`, matching the `DatasetGraphSummary` interface.

Datasets with no metrics computed yet report `numNodes/numEdges = 0` with a `null` `pipelineRunId`/`computedAt`.

## Note for maintainers

The response contract is inferred from the frontend `DatasetGraphSummary` interface (the current consumer only sums `numNodes`/`numEdges`). If COG-5726 intended different degraded-case semantics for `computedAt` when a run exists but its metrics row is missing, happy to adjust — but the core fix (serving the route so the `405` stops) stands regardless. This is a single-file, read-only endpoint with no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
