### PR TITLE
feat(chunking): support nested JSON arrays with indexed context

### DIFF
--- a/cognee/modules/chunking/JsonListChunker.py
+++ b/cognee/modules/chunking/JsonListChunker.py
@@ -1,16 +1,183 @@
 import json
+import re
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass
 from os.path import basename
+from typing import TYPE_CHECKING, Any, TypeAlias
 from uuid import NAMESPACE_OID, uuid5
 
 from cognee.modules.chunking.Chunker import Chunker
 from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
 from cognee.shared.logging_utils import get_logger
 
+if TYPE_CHECKING:
+    from cognee.modules.data.processing.document_types.Document import Document
+
 logger = get_logger()
+
+PathToken: TypeAlias = str | int
+SelectorToken: TypeAlias = str | int | None
+
+
+@dataclass(frozen=True)
+class _ArrayOccurrence:
+    path: tuple[PathToken, ...]
+    items: list[Any]
+    context: dict[str, Any]
+
+
+def _format_json_path(path: tuple[PathToken, ...], *, normalized: bool = False) -> str:
+    """Render a tokenized JSON path without conflating object keys and array indexes."""
+    formatted = ""
+    for token in path:
+        if isinstance(token, int):
+            formatted += "[*]" if normalized else f"[{token}]"
+        else:
+            formatted += f".{token}" if formatted else token
+    return formatted
+
+
+def _scalar_context(container: dict[str, Any]) -> dict[str, Any]:
+    """Return scalar siblings that describe descendants of ``container``."""
+    return {key: value for key, value in container.items() if not isinstance(value, (dict, list))}
+
+
+def _find_arrays(
+    node: Any,
+    path: tuple[PathToken, ...] = (),
+    context: dict[str, Any] | None = None,
+) -> list[_ArrayOccurrence]:
+    """Find arrays at any depth while retaining scalar values from every ancestor."""
+    context = context or {}
+    occurrences: list[_ArrayOccurrence] = []
+
+    if isinstance(node, dict):
+        child_context = {**context, **_scalar_context(node)}
+        for key, value in node.items():
+            child_path = (*path, key)
+            if isinstance(value, list):
+                occurrences.append(_ArrayOccurrence(child_path, value, child_context))
+                occurrences.extend(_find_arrays(value, child_path, child_context))
+            elif isinstance(value, dict):
+                occurrences.extend(_find_arrays(value, child_path, child_context))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            occurrences.extend(_find_arrays(value, (*path, index), context))
+
+    return occurrences
+
+
+def _is_descendant(path: tuple[PathToken, ...], ancestor: tuple[PathToken, ...]) -> bool:
+    return len(path) > len(ancestor) and path[: len(ancestor)] == ancestor
+
+
+def _leaf_array_occurrences(occurrences: list[_ArrayOccurrence]) -> list[_ArrayOccurrence]:
+    """Exclude container arrays when they contain a more specific child array."""
+    return [
+        occurrence
+        for occurrence in occurrences
+        if not any(
+            _is_descendant(other.path, occurrence.path)
+            for other in occurrences
+            if other is not occurrence
+        )
+    ]
+
+
+def _parse_json_path(json_path: str) -> tuple[SelectorToken, ...]:
+    """Parse dotted object keys plus ``[index]`` or ``[*]`` array selectors."""
+    if not json_path:
+        raise ValueError("json_path must not be empty.")
+
+    tokens: list[SelectorToken] = []
+    for segment in json_path.split("."):
+        match = re.fullmatch(r"([^\[\].]+)((?:\[(?:\*|\d+)\])*)", segment)
+        if match is None:
+            raise ValueError(
+                f"json_path '{json_path}' must use dotted keys and optional [index] or [*] selectors."
+            )
+
+        tokens.append(match.group(1))
+        for array_selector in re.findall(r"\[(\*|\d+)\]", match.group(2)):
+            tokens.append(None if array_selector == "*" else int(array_selector))
+
+    return tuple(tokens)
+
+
+def _path_matches(selector: tuple[SelectorToken, ...], path: tuple[PathToken, ...]) -> bool:
+    return len(selector) == len(path) and all(
+        expected is None or expected == actual for expected, actual in zip(selector, path)
+    )
+
+
+def _select_array_occurrences(
+    data: dict[str, Any], json_path: str | None
+) -> list[_ArrayOccurrence]:
+    occurrences = _find_arrays(data)
+
+    if json_path is not None:
+        selector = _parse_json_path(json_path)
+        selected = [
+            occurrence for occurrence in occurrences if _path_matches(selector, occurrence.path)
+        ]
+        if not selected:
+            raise ValueError(
+                f"json_path '{json_path}' does not point to a JSON list in the document."
+            )
+        return selected
+
+    leaves = _leaf_array_occurrences(occurrences)
+    candidates: dict[str, list[_ArrayOccurrence]] = {}
+    for occurrence in leaves:
+        candidates.setdefault(_format_json_path(occurrence.path, normalized=True), []).append(
+            occurrence
+        )
+
+    if not candidates:
+        raise ValueError(
+            "JsonListChunker could not find any JSON list in the document. "
+            "Pass json_path explicitly to point at the array to chunk."
+        )
+    if len(candidates) > 1:
+        paths = ", ".join(f"'{path}'" for path in candidates)
+        raise ValueError(
+            "JsonListChunker found multiple leaf JSON lists in the document: "
+            f"{paths}. Pass json_path to specify which one to chunk."
+        )
+
+    return next(iter(candidates.values()))
+
+
+def _contextual_text(item: Any, context: dict[str, Any], array_path: str) -> str:
+    """Put source context and structural path in the indexed text, not metadata alone."""
+    return json.dumps(
+        {"_context": context, "_json_path": array_path, "_record": item},
+        ensure_ascii=False,
+        default=str,
+        sort_keys=True,
+    )
 
 
 class JsonListChunker(Chunker):
-    """Chunk a JSON list document into one stringified item per chunk."""
+    """Chunk a JSON list or a selected nested JSON array into record chunks."""
+
+    json_path: str | None = None
+
+    def __init__(
+        self,
+        document: "Document",
+        get_text: Callable[[], AsyncIterator[str | None]],
+        max_chunk_size: int,
+        json_path: str | None = None,
+    ):
+        super().__init__(document, get_text, max_chunk_size)
+        self.json_path = json_path if json_path is not None else type(self).json_path
+
+    @classmethod
+    def with_json_path(cls, json_path: str) -> type["JsonListChunker"]:
+        """Return a chunker class usable by ``cognify(chunker=...)`` with a path selector."""
+        _parse_json_path(json_path)
+        return type(f"{cls.__name__}AtPath", (cls,), {"json_path": json_path})
 
     async def read(self):
         document_id = str(self.document.id)
@@ -21,41 +188,71 @@ class JsonListChunker(Chunker):
             if content_text is not None:
                 content += content_text
 
-        items = json.loads(content)
-        if not isinstance(items, list):
-            raise ValueError("JsonListChunker expects the document content to be a JSON list.")
+        data = json.loads(content)
+        if isinstance(data, list):
+            occurrences = [_ArrayOccurrence((), data, {})]
+        elif isinstance(data, dict):
+            occurrences = _select_array_occurrences(data, self.json_path)
+        else:
+            raise ValueError(
+                "JsonListChunker expects the document content to be a JSON list "
+                "or a JSON object containing one."
+            )
 
         max_observed_chunk_size = 0
-        for index, item in enumerate(items):
-            text = str(item)
-            chunk_size = len(text.split())
-            max_observed_chunk_size = max(max_observed_chunk_size, chunk_size)
-
-            if chunk_size > self.max_chunk_size:
-                logger.warning(
-                    "JsonListChunker item exceeds max_chunk_size",
-                    chunk_index=index,
-                    chunk_size=chunk_size,
-                    max_chunk_size=self.max_chunk_size,
-                    document_name=document_name,
+        chunk_index = 0
+        for occurrence in occurrences:
+            array_path = _format_json_path(occurrence.path, normalized=True)
+            for json_list_index, item in enumerate(occurrence.items):
+                item_path = (*occurrence.path, json_list_index)
+                formatted_item_path = _format_json_path(item_path)
+                is_nested = bool(occurrence.path)
+                text = (
+                    _contextual_text(item, occurrence.context, array_path)
+                    if is_nested
+                    else str(item)
                 )
+                chunk_size = len(text.split())
+                max_observed_chunk_size = max(max_observed_chunk_size, chunk_size)
 
-            yield DocumentChunk(
-                id=uuid5(NAMESPACE_OID, f"{document_id}-{index}"),
-                text=text,
-                chunk_size=chunk_size,
-                is_part_of=self.document,
-                chunk_index=index,
-                cut_type="json_list_item",
-                contains=[],
-                importance_weight=self.document.importance_weight,
-                document_id=document_id,
-                document_name=document_name,
-                metadata={
+                if chunk_size > self.max_chunk_size:
+                    logger.warning(
+                        "JsonListChunker item exceeds max_chunk_size",
+                        chunk_index=chunk_index,
+                        chunk_size=chunk_size,
+                        max_chunk_size=self.max_chunk_size,
+                        document_name=document_name,
+                    )
+
+                metadata = {
                     "index_fields": ["text"],
-                    "json_list_index": index,
-                },
-            )
+                    "json_list_index": json_list_index,
+                    "json_path": formatted_item_path,
+                }
+                if is_nested:
+                    metadata["json_array_path"] = array_path
+                    if occurrence.context:
+                        metadata["json_context"] = occurrence.context
+
+                yield DocumentChunk(
+                    id=uuid5(
+                        NAMESPACE_OID,
+                        f"{document_id}-{formatted_item_path}"
+                        if is_nested
+                        else f"{document_id}-{json_list_index}",
+                    ),
+                    text=text,
+                    chunk_size=chunk_size,
+                    is_part_of=self.document,
+                    chunk_index=chunk_index,
+                    cut_type="json_list_item",
+                    contains=[],
+                    importance_weight=self.document.importance_weight,
+                    document_id=document_id,
+                    document_name=document_name,
+                    metadata=metadata,
+                )
+                chunk_index += 1
 
         if max_observed_chunk_size > self.max_chunk_size:
             logger.warning(

--- a/cognee/tests/unit/modules/chunking/test_json_list_chunker.py
+++ b/cognee/tests/unit/modules/chunking/test_json_list_chunker.py
@@ -1,0 +1,190 @@
+import json
+from uuid import NAMESPACE_OID, uuid4, uuid5
+
+import pytest
+
+from cognee.modules.chunking.JsonListChunker import JsonListChunker
+from cognee.modules.data.processing.document_types import TextDocument
+from cognee.modules.data.processing.document_types.Document import Document
+
+
+def make_document() -> Document:
+    return Document(
+        id=uuid4(),
+        name="test_document",
+        raw_data_location="/test/path",
+        external_metadata=None,
+        mime_type="application/json",
+    )
+
+
+def make_text_generator(*texts: str):
+    async def get_text():
+        for text in texts:
+            yield text
+
+    return get_text
+
+
+async def collect_chunks(chunker: JsonListChunker):
+    return [chunk async for chunk in chunker.read()]
+
+
+@pytest.mark.asyncio
+async def test_flat_list_preserves_text_and_legacy_ids():
+    document = make_document()
+    chunker = JsonListChunker(
+        document,
+        make_text_generator(json.dumps([{"name": "Alice"}, {"name": "Bob"}])),
+        max_chunk_size=512,
+    )
+
+    chunks = await collect_chunks(chunker)
+
+    assert [chunk.text for chunk in chunks] == ["{'name': 'Alice'}", "{'name': 'Bob'}"]
+    assert [chunk.id for chunk in chunks] == [
+        uuid5(NAMESPACE_OID, f"{document.id}-0"),
+        uuid5(NAMESPACE_OID, f"{document.id}-1"),
+    ]
+    assert [chunk.metadata["json_path"] for chunk in chunks] == ["[0]", "[1]"]
+    assert "json_context" not in chunks[0].metadata
+
+
+@pytest.mark.asyncio
+async def test_single_nested_array_includes_ancestor_context_in_indexed_text():
+    data = {
+        "tenant": "ACME",
+        "records": {"batch_id": "B01", "items": [{"value": 123}]},
+    }
+    chunker = JsonListChunker(make_document(), make_text_generator(json.dumps(data)), 512)
+
+    [chunk] = await collect_chunks(chunker)
+
+    assert chunk.metadata["json_path"] == "records.items[0]"
+    assert chunk.metadata["json_array_path"] == "records.items"
+    assert chunk.metadata["json_context"] == {"tenant": "ACME", "batch_id": "B01"}
+    assert json.loads(chunk.text) == {
+        "_context": {"tenant": "ACME", "batch_id": "B01"},
+        "_json_path": "records.items",
+        "_record": {"value": 123},
+    }
+
+
+@pytest.mark.asyncio
+async def test_auto_detection_traverses_lists_and_normalizes_repeated_leaf_paths():
+    data = {
+        "tenant": "ACME",
+        "records": [
+            {"source": "sensor-A", "items": [{"value": 10}]},
+            {"source": "sensor-B", "items": [{"value": 20}]},
+        ],
+    }
+    chunker = JsonListChunker(make_document(), make_text_generator(json.dumps(data)), 512)
+
+    chunks = await collect_chunks(chunker)
+
+    assert [chunk.metadata["json_path"] for chunk in chunks] == [
+        "records[0].items[0]",
+        "records[1].items[0]",
+    ]
+    assert [chunk.metadata["json_array_path"] for chunk in chunks] == [
+        "records[*].items",
+        "records[*].items",
+    ]
+    assert [json.loads(chunk.text)["_context"] for chunk in chunks] == [
+        {"tenant": "ACME", "source": "sensor-A"},
+        {"tenant": "ACME", "source": "sensor-B"},
+    ]
+    assert chunks[0].id != chunks[1].id
+
+
+@pytest.mark.asyncio
+async def test_auto_detection_requires_a_selector_for_distinct_leaf_arrays():
+    data = {"users": [{"name": "Alice"}], "orders": [{"id": "order-1"}]}
+    chunker = JsonListChunker(make_document(), make_text_generator(json.dumps(data)), 512)
+
+    with pytest.raises(ValueError, match="'users', 'orders'"):
+        await collect_chunks(chunker)
+
+
+@pytest.mark.asyncio
+async def test_nested_array_indexes_its_structural_path_without_scalar_context():
+    data = {"records": {"items": [{"value": 123}]}}
+    chunker = JsonListChunker(make_document(), make_text_generator(json.dumps(data)), 512)
+
+    [chunk] = await collect_chunks(chunker)
+
+    assert json.loads(chunk.text) == {
+        "_context": {},
+        "_json_path": "records.items",
+        "_record": {"value": 123},
+    }
+
+
+@pytest.mark.asyncio
+async def test_explicit_path_can_select_a_container_array():
+    data = {"tenant": "ACME", "records": [{"items": [{"value": 10}]}]}
+    chunker = JsonListChunker(
+        make_document(), make_text_generator(json.dumps(data)), 512, json_path="records"
+    )
+
+    [chunk] = await collect_chunks(chunker)
+
+    assert chunk.metadata["json_path"] == "records[0]"
+    assert chunk.metadata["json_array_path"] == "records"
+    assert json.loads(chunk.text) == {
+        "_context": {"tenant": "ACME"},
+        "_json_path": "records",
+        "_record": {"items": [{"value": 10}]},
+    }
+
+
+@pytest.mark.asyncio
+async def test_selector_factory_works_through_document_read(tmp_path):
+    data_file = tmp_path / "records.json"
+    data_file.write_text(
+        json.dumps(
+            {
+                "tenant": "ACME",
+                "records": [
+                    {"items": [{"id": 1}]},
+                    {"items": [{"id": 2}]},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    document = TextDocument(
+        id=uuid4(),
+        name="records",
+        raw_data_location=str(data_file),
+        external_metadata=None,
+        mime_type="application/json",
+    )
+
+    chunks = [
+        chunk
+        async for chunk in document.read(
+            chunker_cls=JsonListChunker.with_json_path("records[*].items"), max_chunk_size=512
+        )
+    ]
+
+    assert [json.loads(chunk.text)["_record"] for chunk in chunks] == [{"id": 1}, {"id": 2}]
+
+
+@pytest.mark.asyncio
+async def test_invalid_selector_is_rejected():
+    chunker = JsonListChunker(
+        make_document(),
+        make_text_generator(json.dumps({"records": [{"id": 1}]})),
+        512,
+        json_path="records[*].items",
+    )
+
+    with pytest.raises(ValueError, match="does not point to a JSON list"):
+        await collect_chunks(chunker)
+
+
+def test_selector_factory_rejects_invalid_path_syntax():
+    with pytest.raises(ValueError, match="dotted keys"):
+        JsonListChunker.with_json_path("records..items")

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Cognee Examples
 
-Runnable example scripts demonstrating cognee end-to-end — 64 scripts across three folders.
+Runnable example scripts demonstrating cognee end-to-end — 65 scripts across three folders.
 They double as the smoke-test corpus the team uses to verify behaviour across the SDK.
 
 > **New here?** Start with [`guides/simple_cognee_example.py`](guides/simple_cognee_example.py)
@@ -20,7 +20,7 @@ They double as the smoke-test corpus the team uses to verify behaviour across th
 
 | Folder | What lives there | Count |
 |---|---|---|
-| [`guides/`](guides/) | One feature per script: concise, self-contained how-tos | 31 |
+| [`guides/`](guides/) | One feature per script: concise, self-contained how-tos | 32 |
 | [`advanced_guides/`](advanced_guides/) | Deeper takes on topics a guide already covers | 8 |
 | [`demos/`](demos/) | Multiple features stitched into use cases, grouped by topic | 25 |
 
@@ -70,6 +70,7 @@ features.** See [Contributing](#-contributing-a-new-example) for the precise cat
 | Script | Demonstrates |
 |---|---|
 | [`web_url_content_ingestion_example.py`](guides/web_url_content_ingestion_example.py) | Ingesting a URL with `preferred_loaders` (needs network) |
+| [`nested_json_chunking.py`](guides/nested_json_chunking.py) | Selecting repeated nested arrays with `JsonListChunker.with_json_path()` |
 | [`multimedia_audio_image_processing_example.py`](guides/multimedia_audio_image_processing_example.py) | Audio + image ingestion (bundled assets) |
 | [`image_ocr_extraction.py`](guides/image_ocr_extraction.py) | Vision transcription + OCR text for an image |
 | [`code_graph_example.py`](guides/code_graph_example.py) | Code-graph pipeline + `SearchType.CODE` |

--- a/examples/guides/nested_json_chunking.py
+++ b/examples/guides/nested_json_chunking.py
@@ -1,0 +1,34 @@
+"""Select repeated nested JSON arrays when building a knowledge graph."""
+
+import asyncio
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import cognee
+
+from cognee.modules.chunking.JsonListChunker import JsonListChunker
+
+
+async def main():
+    data = {
+        "tenant": "ACME",
+        "records": [
+            {"source": "sensor-A", "items": [{"temperature": 21.4}]},
+            {"source": "sensor-B", "items": [{"temperature": 22.1}]},
+        ],
+    }
+
+    with TemporaryDirectory() as directory:
+        data_path = Path(directory) / "readings.json"
+        data_path.write_text(json.dumps(data), encoding="utf-8")
+
+        await cognee.add(str(data_path), dataset_name="nested_json_example")
+        await cognee.cognify(
+            datasets="nested_json_example",
+            chunker=JsonListChunker.with_json_path("records[*].items"),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Description

Fixes #4236.

`JsonListChunker` currently accepts only a flat top-level JSON list. Nested record schemas therefore cannot be chunked through the normal ingestion path, and parent context kept only in metadata does not become part of the indexed `text` field.

This change:

- recursively discovers arrays through dictionaries and list-contained objects
- auto-selects one normalized leaf-array schema and requires an explicit selector for distinct ambiguous arrays
- supports dotted keys plus `[index]` and `[*]` selectors
- exposes `JsonListChunker.with_json_path(...)` so selectors work through the existing class-based ingestion API
- carries scalar context from every ancestor and includes it, together with the normalized array path, in indexed chunk text
- records exact item paths in metadata and uses source paths for deterministic nested-record IDs
- preserves legacy text and IDs for flat top-level lists
- adds a runnable nested JSON chunking guide and links it from `examples/README.md`

For example, `{"tenant":"ACME","records":[{"source":"sensor-A","items":[...]}]}` can emit one chunk per `items` record with `tenant`, `source`, and `records[*].items` present in the indexed text.

## Relationship to existing work

#4254 addresses the same issue but currently targets `main`. This is an independent implementation against `dev` and additionally covers arrays below list-contained dictionaries, a selector usable through the existing ingestion API, full ancestor context, and context/path inclusion in the indexed field.

## Validation

- `python -m pytest cognee/tests/unit/modules/chunking/ -v --tb=short` — **37 passed, 1 skipped**
- `python -m pytest cognee/tests/integration/documents/TextDocument_test.py cognee/tests/unit/modules/chunking/test_json_list_chunker.py::test_selector_factory_works_through_document_read -v --tb=short` — **3 passed**
- `UV_CACHE_DIR=/private/tmp/cognee-uv-cache uv lock --check` — passed
- `UV_CACHE_DIR=/private/tmp/cognee-uv-cache uv run ruff check .` — passed
- `UV_CACHE_DIR=/private/tmp/cognee-uv-cache uv run ruff format --check .` — passed
- `git diff --check` — passed

The focused public-path run covers the existing `TextDocument` integration boundary plus a real `TextDocument.read()` call using `JsonListChunker.with_json_path("records[*].items")`. It is not presented as the full external-service integration suite.

A broader local documents run was not reported as passing: 16 tests passed and one test required the optional `unstructured` dependency, which is not installed in the local environment. A broader Community Tests subset was also incomplete because Ladybug could not download its JSON extension in the local network environment. Neither environment limitation entered the four-file patch.

GitHub workflows currently show `action_required` while the fork-based runs wait for maintainer approval. Focused local validation and the required screenshots are complete; full upstream CI remains pending maintainer approval.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Code refactoring
- [ ] Other

## Screenshots

### Unit tests

<img width="1600" alt="Cognee PR 4503 local unit test evidence: 37 passed and 1 skipped" src="https://github.com/user-attachments/assets/9e34d971-20ae-4ab6-a514-3ce86e4fc375" />

### Focused public-path integration tests

<img width="1600" alt="Cognee PR 4503 local public-path integration evidence: 3 passed" src="https://github.com/user-attachments/assets/4a3e028b-d8da-4e44-b393-f05ab4213dcf" />

Both images were rendered from machine-captured local PTY transcripts at commit `bc9e3beb9`; local filesystem paths were omitted. The integration image is explicitly scoped to the `TextDocument` boundary and selector path, not the full external-service suite.

## Pre-submission Checklist

- [x] This PR contains the minimal changes necessary to address the feature
- [x] The code follows the project's style guidelines
- [x] Tests were added for the new behavior
- [x] Existing PRs were checked and the relationship to #4254 is documented
- [x] The relevant issue is linked
- [x] The commit message is clear and DCO-signed
- [x] Focused unit and public-path integration screenshots are attached
- [ ] Full external-service integration suite verified by upstream CI

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
