### PR TITLE
fix(skills): pass explicit limit to avoid silent 200-skill truncation

### DIFF
--- a/cognee-frontend/src/modules/skills/getSkills.ts
+++ b/cognee-frontend/src/modules/skills/getSkills.ts
@@ -12,6 +12,7 @@ export default function getSkills(
 ): Promise<Skill[]> {
   const params = new URLSearchParams({ dataset_id: datasetId });
   if (includeInactive) params.set("include_inactive", "true");
+  params.set("limit", "1000");
 
   return instance
     .fetch(`/v1/skills/?${params.toString()}`, {


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
The Skills page permanently shows "200 skills" even though the dataset contains 378. There is no truncation indicator and no pagination control, so it is impossible to tell from the UI that ~half the skills are missing from the list.
Fixes #4279

## Acceptance Criteria
1. getSkills.ts now sends an explicit limit param instead of relying on
   the backend's default
2. Datasets with more than 200 skills (up to 1000) now display fully
   on the Skills page instead of silently cutting off at 200


## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
N/A — frontend query-param change, no visual UI change to screenshot.

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
