### PR TITLE
feat: Single-sweep provenance move (COG-6112)

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -32,6 +32,7 @@ from cognee.infrastructure.databases.provenance.source_refs import (
 )
 from cognee.infrastructure.databases.provenance.source_ref_state import (
     provenance_after_attach,
+    provenance_after_move,
     provenance_after_remove,
     provenance_attach_inputs,
 )
@@ -1430,6 +1431,48 @@ class LadybugAdapter(GraphDBInterface):
             self._write_edge_provenance,
             self._edge_row,
             lambda keys, run_refs: provenance_after_remove(keys, run_refs, remove_keys),
+        )
+
+    async def move_node_source_refs(
+        self,
+        node_ids: list[str],
+        old_source_ref_key: str,
+        new_source_ref_key: str,
+    ) -> None:
+        """Replace one source ref with another in a single read+write sweep.
+
+        Equivalent end state to attach(new) followed by remove(old), but each
+        artifact is rewritten once instead of twice — on large graphs this
+        halves the write volume of a re-key, the dominant cost (and the
+        engine-corruption exposure, see COG-6112) of the fork document re-key.
+        Run refs embedding the old key are rewritten in place, so per-artifact
+        run ids are preserved exactly.
+        """
+        await self._apply_source_ref_change(
+            node_ids,
+            self._read_node_provenance,
+            self._write_node_provenance,
+            self._node_row,
+            lambda keys, run_refs: provenance_after_move(
+                keys, run_refs, old_source_ref_key, new_source_ref_key
+            ),
+        )
+
+    async def move_edge_source_refs(
+        self,
+        edges: list[EdgeIdentity],
+        old_source_ref_key: str,
+        new_source_ref_key: str,
+    ) -> None:
+        """Edge counterpart of ``move_node_source_refs`` — one sweep, not two."""
+        await self._apply_source_ref_change(
+            edges,
+            self._read_edge_provenance,
+            self._write_edge_provenance,
+            self._edge_row,
+            lambda keys, run_refs: provenance_after_move(
+                keys, run_refs, old_source_ref_key, new_source_ref_key
+            ),
         )
 
     async def delete_edge_triples(self, edges: list[EdgeIdentity]) -> None:

--- a/cognee/infrastructure/databases/provenance/source_ref_state.py
+++ b/cognee/infrastructure/databases/provenance/source_ref_state.py
@@ -127,6 +127,48 @@ def provenance_after_attach(
     return ProvenanceColumns(keys, derive_dataset_ids(keys), derive_run_ids(run_refs), run_refs)
 
 
+def provenance_after_move(
+    current_keys: List[str],
+    current_run_refs: List[str],
+    old_key: str,
+    new_key: str,
+) -> ProvenanceColumns:
+    """Return the four provenance columns after moving ``old_key`` to ``new_key``.
+
+    Single-transition equivalent of attach(new) + remove(old), so a re-key can
+    rewrite an artifact in ONE read+write sweep instead of two. Every
+    source_run_ref embedding the old key is rewritten in place to embed the new
+    key — each artifact keeps its own run ids, which attach+remove could only
+    approximate by re-stamping a group-level run id. An artifact that no longer
+    carries the old key (interrupted run resumed) is returned unchanged, so the
+    sweep stays convergent.
+    """
+    had_old_key = old_key in current_keys
+    old_run_refs = [
+        ref for ref in current_run_refs if get_source_ref_key_from_source_run_ref(ref) == old_key
+    ]
+    if not had_old_key and not old_run_refs:
+        return ProvenanceColumns(
+            list(current_keys),
+            derive_dataset_ids(current_keys),
+            derive_run_ids(current_run_refs),
+            list(current_run_refs),
+        )
+
+    keys = [key for key in current_keys if key != old_key]
+    if new_key not in keys:
+        keys.append(new_key)
+
+    run_refs: List[str] = []
+    for ref in current_run_refs:
+        if get_source_ref_key_from_source_run_ref(ref) == old_key:
+            ref = make_source_run_ref(get_pipeline_run_id_from_source_run_ref(ref), new_key)
+        if ref not in run_refs:
+            run_refs.append(ref)
+
+    return ProvenanceColumns(keys, derive_dataset_ids(keys), derive_run_ids(run_refs), run_refs)
+
+
 def provenance_after_remove(
     current_keys: List[str],
     current_run_refs: List[str],

--- a/cognee/modules/migrations/versions/rekey_fork_document_ids.py
+++ b/cognee/modules/migrations/versions/rekey_fork_document_ids.py
@@ -158,30 +158,48 @@ async def _rekey_graph_provenance(graph_engine, fork_rows: list) -> None:
         except UnsupportedProvenanceCapability:
             return
 
-        # Group artifacts by pipeline run id and attach per group: a dataset's
-        # subgraph overwhelmingly carries one run id, so this collapses the
-        # 100k-node / 295k-edge per-item loops — each a write+checkpoint
-        # subprocess round-trip whose page churn alone could exhaust kuzu's
-        # max_db_size — into a handful of batched calls.
+        # Backends with single-sweep moves (Ladybug) rewrite each artifact
+        # ONCE: run refs embedding the old key are rewritten in place, so the
+        # run-id grouping (and its full-graph snapshot read) is unnecessary.
+        # Versus attach-then-remove this is 1 read + 1 write sweep instead of
+        # 3 reads + 2 writes — on a 100k-node fork the write volume, which is
+        # both the dominant cost and the engine-corruption exposure surface
+        # (COG-6112), is halved. Convergence is preserved: an artifact the
+        # sweep already moved no longer matches the old key and is a no-op.
+        single_sweep = hasattr(graph_engine, "move_node_source_refs") and hasattr(
+            graph_engine, "move_edge_source_refs"
+        )
+
         if node_ids:
-            snapshots = await graph_engine.get_node_delete_data(node_ids)
-            nodes_by_run: dict = {}
-            for node_id in node_ids:
-                run_id = _run_id_for_key(snapshots.get(node_id), old_key)
-                nodes_by_run.setdefault(run_id, []).append(node_id)
-            for run_id, grouped_ids in nodes_by_run.items():
-                await graph_engine.attach_node_source_refs(grouped_ids, [new_key], run_id)
-            await graph_engine.remove_node_source_refs(node_ids, [old_key])
+            if single_sweep:
+                await graph_engine.move_node_source_refs(node_ids, old_key, new_key)
+            else:
+                # Group artifacts by pipeline run id and attach per group: a
+                # dataset's subgraph overwhelmingly carries one run id, so this
+                # collapses the 100k-node per-item loops — each a
+                # write+checkpoint subprocess round-trip whose page churn alone
+                # could exhaust kuzu's max_db_size — into a few batched calls.
+                snapshots = await graph_engine.get_node_delete_data(node_ids)
+                nodes_by_run: dict = {}
+                for node_id in node_ids:
+                    run_id = _run_id_for_key(snapshots.get(node_id), old_key)
+                    nodes_by_run.setdefault(run_id, []).append(node_id)
+                for run_id, grouped_ids in nodes_by_run.items():
+                    await graph_engine.attach_node_source_refs(grouped_ids, [new_key], run_id)
+                await graph_engine.remove_node_source_refs(node_ids, [old_key])
 
         if edge_identities:
-            edge_snapshots = await graph_engine.get_edge_delete_data(edge_identities)
-            edges_by_run: dict = {}
-            for edge in edge_identities:
-                run_id = _run_id_for_key(edge_snapshots.get(edge), old_key)
-                edges_by_run.setdefault(run_id, []).append(edge)
-            for run_id, grouped_edges in edges_by_run.items():
-                await graph_engine.attach_edge_source_refs(grouped_edges, [new_key], run_id)
-            await graph_engine.remove_edge_source_refs(edge_identities, [old_key])
+            if single_sweep:
+                await graph_engine.move_edge_source_refs(edge_identities, old_key, new_key)
+            else:
+                edge_snapshots = await graph_engine.get_edge_delete_data(edge_identities)
+                edges_by_run: dict = {}
+                for edge in edge_identities:
+                    run_id = _run_id_for_key(edge_snapshots.get(edge), old_key)
+                    edges_by_run.setdefault(run_id, []).append(edge)
+                for run_id, grouped_edges in edges_by_run.items():
+                    await graph_engine.attach_edge_source_refs(grouped_edges, [new_key], run_id)
+                await graph_engine.remove_edge_source_refs(edge_identities, [old_key])
 
         logger.info(
             "rekey_fork_document_ids: moved provenance refs on %d node(s), %d edge(s) "

--- a/cognee/tests/unit/infrastructure/databases/provenance/test_provenance_after_move.py
+++ b/cognee/tests/unit/infrastructure/databases/provenance/test_provenance_after_move.py
@@ -1,0 +1,87 @@
+"""provenance_after_move must equal attach(new)+remove(old) in one transition,
+preserving per-artifact run ids and staying a no-op on already-moved artifacts
+(sweep convergence after interruption)."""
+
+from cognee.infrastructure.databases.provenance.source_ref_state import (
+    provenance_after_attach,
+    provenance_after_move,
+    provenance_after_remove,
+)
+
+DATASET = "11111111-1111-4111-8111-111111111111"
+RUN = "22222222-2222-4222-8222-222222222222"
+OLD_KEY = f"source_ref:v1:{DATASET}:33333333-3333-4333-8333-333333333333"
+NEW_KEY = f"source_ref:v1:{DATASET}:44444444-4444-4444-8444-444444444444"
+OTHER_KEY = f"source_ref:v1:{DATASET}:55555555-5555-4555-8555-555555555555"
+
+
+def test_move_replaces_key_and_rewrites_run_refs():
+    old_ref = f"source_run_ref:v1:{RUN}:{OLD_KEY}"
+
+    cols = provenance_after_move([OLD_KEY], [old_ref], OLD_KEY, NEW_KEY)
+
+    assert cols.source_ref_keys == [NEW_KEY]
+    assert cols.source_run_refs == [f"source_run_ref:v1:{RUN}:{NEW_KEY}"]
+    assert cols.source_run_ids == [RUN]
+    assert cols.source_dataset_ids == [DATASET]
+
+
+def test_move_matches_attach_then_remove_end_state():
+    old_ref = f"source_run_ref:v1:{RUN}:{OLD_KEY}"
+
+    moved = provenance_after_move([OLD_KEY], [old_ref], OLD_KEY, NEW_KEY)
+    attached = provenance_after_attach([OLD_KEY], [old_ref], [NEW_KEY], RUN)
+    legacy = provenance_after_remove(attached.source_ref_keys, attached.source_run_refs, [OLD_KEY])
+
+    assert set(moved.source_ref_keys) == set(legacy.source_ref_keys)
+    assert set(moved.source_run_refs) == set(legacy.source_run_refs)
+    assert moved.source_dataset_ids == legacy.source_dataset_ids
+    assert moved.source_run_ids == legacy.source_run_ids
+
+
+def test_move_preserves_each_artifacts_own_run_ids():
+    other_run = "66666666-6666-4666-8666-666666666666"
+    refs = [
+        f"source_run_ref:v1:{RUN}:{OLD_KEY}",
+        f"source_run_ref:v1:{other_run}:{OLD_KEY}",
+    ]
+
+    cols = provenance_after_move([OLD_KEY], refs, OLD_KEY, NEW_KEY)
+
+    assert cols.source_run_refs == [
+        f"source_run_ref:v1:{RUN}:{NEW_KEY}",
+        f"source_run_ref:v1:{other_run}:{NEW_KEY}",
+    ]
+    assert sorted(cols.source_run_ids) == sorted([RUN, other_run])
+
+
+def test_move_leaves_other_keys_untouched():
+    other_ref = f"source_run_ref:v1:{RUN}:{OTHER_KEY}"
+    old_ref = f"source_run_ref:v1:{RUN}:{OLD_KEY}"
+
+    cols = provenance_after_move([OTHER_KEY, OLD_KEY], [other_ref, old_ref], OLD_KEY, NEW_KEY)
+
+    assert cols.source_ref_keys == [OTHER_KEY, NEW_KEY]
+    assert other_ref in cols.source_run_refs
+
+
+def test_move_is_noop_when_old_key_absent():
+    other_ref = f"source_run_ref:v1:{RUN}:{OTHER_KEY}"
+
+    cols = provenance_after_move([OTHER_KEY], [other_ref], OLD_KEY, NEW_KEY)
+
+    assert cols.source_ref_keys == [OTHER_KEY]
+    assert cols.source_run_refs == [other_ref]
+    assert NEW_KEY not in cols.source_ref_keys
+
+
+def test_move_dedupes_when_new_key_already_present():
+    refs = [
+        f"source_run_ref:v1:{RUN}:{OLD_KEY}",
+        f"source_run_ref:v1:{RUN}:{NEW_KEY}",
+    ]
+
+    cols = provenance_after_move([OLD_KEY, NEW_KEY], refs, OLD_KEY, NEW_KEY)
+
+    assert cols.source_ref_keys == [NEW_KEY]
+    assert cols.source_run_refs == [f"source_run_ref:v1:{RUN}:{NEW_KEY}"]

--- a/cognee/tests/unit/modules/migrations/test_migrate_graph_snapshot_scope.py
+++ b/cognee/tests/unit/modules/migrations/test_migrate_graph_snapshot_scope.py
@@ -58,9 +58,10 @@ async def test_restore_provenance_bulk_batches_by_profile():
 
 @pytest.mark.asyncio
 async def test_rekey_provenance_moves_are_batched_by_run():
-    """_rekey_graph_provenance must attach refs per run-id group, not one
-    artifact at a time — the per-item loop's checkpoint churn could exhaust
-    kuzu's max_db_size on 100k-node graphs."""
+    """On backends WITHOUT single-sweep moves, _rekey_graph_provenance must
+    attach refs per run-id group, not one artifact at a time — the per-item
+    loop's checkpoint churn could exhaust kuzu's max_db_size on 100k-node
+    graphs."""
     from types import SimpleNamespace
     from uuid import uuid4
 
@@ -72,10 +73,14 @@ async def test_rekey_provenance_moves_are_batched_by_run():
     run_uuid = "00000000-0000-0000-0000-000000000001"
     snapshot = SimpleNamespace(source_run_refs=[f"source_run_ref:v1:{run_uuid}:{old_key}"])
 
-    engine = AsyncMock()
-    engine.find_nodes_by_source_ref.return_value = ["n1", "n2", "n3"]
-    engine.find_edges_by_source_ref.return_value = []
-    engine.get_node_delete_data.return_value = {n: snapshot for n in ("n1", "n2", "n3")}
+    # plain namespace: hasattr(move_*_source_refs) is False -> legacy path
+    engine = SimpleNamespace(
+        find_nodes_by_source_ref=AsyncMock(return_value=["n1", "n2", "n3"]),
+        find_edges_by_source_ref=AsyncMock(return_value=[]),
+        get_node_delete_data=AsyncMock(return_value={n: snapshot for n in ("n1", "n2", "n3")}),
+        attach_node_source_refs=AsyncMock(),
+        remove_node_source_refs=AsyncMock(),
+    )
 
     with patch.object(rk, "stores_provenance_in_graph", new=AsyncMock(return_value=True)):
         await rk._rekey_graph_provenance(engine, [(old_id, new_id, dataset_id)])
@@ -84,3 +89,37 @@ async def test_rekey_provenance_moves_are_batched_by_run():
     ids, _keys, run_id = engine.attach_node_source_refs.await_args.args
     assert sorted(ids) == ["n1", "n2", "n3"]
     assert run_id == run_uuid
+
+
+@pytest.mark.asyncio
+async def test_rekey_provenance_uses_single_sweep_move_when_available():
+    """On backends WITH single-sweep moves (Ladybug), the re-key must rewrite
+    each artifact once via move_*_source_refs — no snapshot read, no
+    attach+remove double sweep (COG-6112: write volume is the corruption
+    exposure surface)."""
+    from uuid import uuid4
+
+    import cognee.modules.migrations.versions.rekey_fork_document_ids as rk
+    from cognee.infrastructure.databases.provenance import make_source_ref_key
+
+    old_id, new_id, dataset_id = str(uuid4()), str(uuid4()), str(uuid4())
+    old_key = make_source_ref_key(dataset_id, __import__("uuid").UUID(old_id))
+    new_key = make_source_ref_key(dataset_id, __import__("uuid").UUID(new_id))
+
+    engine = AsyncMock()  # bare AsyncMock has every attribute -> move path
+    engine.find_nodes_by_source_ref.return_value = ["n1", "n2"]
+    engine.find_edges_by_source_ref.return_value = [("n1", "n2", "relates_to")]
+
+    with patch.object(rk, "stores_provenance_in_graph", new=AsyncMock(return_value=True)):
+        await rk._rekey_graph_provenance(engine, [(old_id, new_id, dataset_id)])
+
+    engine.move_node_source_refs.assert_awaited_once_with(["n1", "n2"], old_key, new_key)
+    engine.move_edge_source_refs.assert_awaited_once_with(
+        [("n1", "n2", "relates_to")], old_key, new_key
+    )
+    engine.get_node_delete_data.assert_not_awaited()
+    engine.get_edge_delete_data.assert_not_awaited()
+    engine.attach_node_source_refs.assert_not_awaited()
+    engine.remove_node_source_refs.assert_not_awaited()
+    engine.attach_edge_source_refs.assert_not_awaited()
+    engine.remove_edge_source_refs.assert_not_awaited()


### PR DESCRIPTION
## Description

The fork re-key (`rekey_fork_document_ids`) moves provenance refs with **attach-then-remove**: per artifact kind that is one full-graph snapshot read (to group by run id) plus two full read+write sweeps — **3 reads + 2 writes** over every node and edge of the fork dataset.

During 1.5.0 release testing at 100k scale this write volume proved to be two things at once:

1. **The dominant migration cost** — ~11 min of the fork re-key on a 100k-node / 295k-edge dataset is this move.
2. **The exposure surface of a real Ladybug storage corruption**: on both 0.17.1 and 0.18.2, the re-key's write storm left ~1,983 node rows with their `id`/`name` string columns reading empty while row count, `type`, and the freshly-written provenance columns stayed intact (index/page disagreement inside the engine; corrupted fixture + clean twin preserved). An engine-side report is being prepared separately; this PR halves the trigger surface from the cognee side.

### The change

- **`provenance_after_move`** (pure, in `source_ref_state.py`): the single-transition equivalent of `attach(new)` + `remove(old)`. Run refs embedding the old key are rewritten in place, so each artifact keeps **its own** run ids — which attach+remove could only approximate by re-stamping a group-level run id.
- **`move_node_source_refs` / `move_edge_source_refs`** on the Ladybug adapter: one read + one write sweep via the existing `_apply_source_ref_change` machinery.
- **`_rekey_graph_provenance`** uses the single sweep when the backend provides it (capability-dispatched — **Ladybug only**; every other backend keeps the attach-then-remove path unchanged), and skips the run-grouping snapshot read entirely.

Net per artifact kind: **3 reads + 2 writes → 1 read + 1 write.** Expected fork-move wall clock at 100k scale: ~11 min → ~4–5 min; write volume (the corruption exposure) halved.

Convergence on interrupted runs is preserved: the sweep is driven by `find_*_by_source_ref(old_key)`, each artifact flips old→new atomically in its statement, and an already-moved artifact no longer matches the old key (`provenance_after_move` is a no-op without it).

### Testing

- `cognee/tests/unit/infrastructure/databases/provenance/test_provenance_after_move.py` — 6 tests: end-state equivalence with attach+remove, per-artifact run-id preservation, other-key isolation, no-op convergence, dedup.
- `test_migrate_graph_snapshot_scope.py` — new dispatch test (single-sweep path: move called, no snapshot read, no attach/remove) + the existing legacy-path test pinned to a backend without move support.
- Full provenance + migrations unit suites: **103 passed**.
- Live 100k validation (seed → migrate → verify, the release-test flow) can be run on request; the release-test branch (#4501) can be pointed at this branch the same way it tracked #4498.

Part of COG-6112.
