### PR TITLE
perf: Skip re-embedding in fork-rekey payload sync; add PGVector.upsert_raw_vectors

### DIFF
--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
@@ -450,6 +450,59 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
                     await session.execute(insert_statement)
                 await session.commit()
 
+    async def upsert_raw_vectors(
+        self,
+        collection_name: str,
+        points: list[dict],
+        payload_schema: Optional[Any] = None,
+    ) -> None:
+        """Upsert caller-supplied vectors + payloads without invoking the embedding engine.
+
+        For small, system-owned vector state (truth-subspace centroids, migration
+        re-keys) where re-embedding from text would be wrong or wasteful. Unlike
+        ``create_data_points``, the vector comes from the caller and BOTH the vector
+        and payload are refreshed on id conflict. The payload dict is stored as-is,
+        so no fields are dropped; ``payload_schema`` is accepted for interface
+        symmetry with LanceDB but is not needed here (Postgres stores JSON directly).
+        """
+        if not points:
+            return
+
+        if not await self.has_collection(collection_name):
+            await self.create_collection(collection_name)
+        table = await self.get_table(collection_name)
+
+        rows = []
+        for point in points:
+            point_id = point.get("id")
+            vector = point.get("vector")
+            if point_id is None:
+                raise ValueError("Raw vector point is missing id")
+            if not isinstance(vector, list):
+                raise ValueError("Raw vector point vector must be a list")
+            rows.append(
+                {
+                    "id": str(point_id),
+                    "payload": sanitize_relational_payload(serialize_data(point.get("payload"))),
+                    "vector": vector,
+                }
+            )
+
+        async with self._get_write_lock(collection_name):
+            async with self.get_async_session() as session:
+                for start_index in range(0, len(rows), QUERY_BATCH_SIZE):
+                    batch = rows[start_index : start_index + QUERY_BATCH_SIZE]
+                    statement = insert(table).values(batch)
+                    statement = statement.on_conflict_do_update(
+                        index_elements=["id"],
+                        set_={
+                            "vector": statement.excluded.vector,
+                            "payload": statement.excluded.payload,
+                        },
+                    )
+                    await session.execute(statement)
+                await session.commit()
+
     async def create_vector_index(self, index_name: str, index_property_name: str):
         """Create the underlying index collection (table) for the given name/property pair."""
         await self.create_collection(f"{index_name}_{index_property_name}")

--- a/cognee/modules/migrations/versions/_vector_rekey.py
+++ b/cognee/modules/migrations/versions/_vector_rekey.py
@@ -216,3 +216,55 @@ async def rekey_native(vector_engine, collection: str, id_map: dict) -> bool:
         await rekey_pgvector(vector_engine, collection, id_map)
         return True
     return False
+
+
+async def resync_document_id_native(vector_engine, collection: str, chunk_targets: dict) -> bool:
+    """Repoint the ``document_id`` payload scalar on existing chunk vector rows
+    WITHOUT re-embedding — the point id and chunk text are unchanged, so the
+    stored vector is already correct; only the reference scalar moves.
+
+    ``chunk_targets`` maps ``chunk point id -> new document id``. Returns ``True``
+    when a native path handled it (nothing re-embedded); ``False`` means the
+    caller must fall back to the generic re-embed path (``index_data_points``).
+
+    Re-embedding purely to change a payload scalar is wasted embedding spend and,
+    on a large fork, is exactly what trips a provider's per-request token cap.
+    PGVector stores the payload as a plain JSON column, so it is updated in place.
+    Backends whose vector rows cannot be updated without re-embedding (e.g.
+    LanceDB's columnar store, whose payload arrow schema is not a plain map)
+    return ``False`` and take the re-embed fallback.
+    """
+    if not chunk_targets:
+        return True
+
+    adapter = vector_engine.__class__.__name__
+    if adapter == "PGVectorAdapter":
+        await _resync_pgvector_document_id(vector_engine, collection, chunk_targets)
+        return True
+    return False
+
+
+async def _resync_pgvector_document_id(vector_engine, collection: str, chunk_targets: dict) -> None:
+    """PGVector: update the ``document_id`` payload key in place (vector untouched)."""
+    from sqlalchemy import select, update
+
+    from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
+
+    try:
+        table = await vector_engine.get_table(collection)
+    except CollectionNotFoundError:
+        return
+
+    ids = [str(chunk_id) for chunk_id in chunk_targets]
+    async with vector_engine.get_async_session() as session:
+        rows = (
+            await session.execute(select(table.c.id, table.c.payload).where(table.c.id.in_(ids)))
+        ).all()
+        for row in rows:
+            new_document_id = str(chunk_targets[str(row.id)])
+            payload = dict(row.payload or {})
+            if payload.get("document_id") == new_document_id:
+                continue  # idempotent: already re-keyed
+            payload["document_id"] = new_document_id
+            await session.execute(update(table).where(table.c.id == row.id).values(payload=payload))
+        await session.commit()

--- a/cognee/modules/migrations/versions/rekey_fork_document_ids.py
+++ b/cognee/modules/migrations/versions/rekey_fork_document_ids.py
@@ -41,11 +41,14 @@ un-migrated stores: a fork delete there fails fast (DocumentSubgraphNotFoundErro
 instead of mutating stores the migration has not touched.
 
 Deliberate boundary: chunk POINT ids are untouched — nothing recomputes them
-from the document id on this code line. The payload sync goes through
-``index_data_points`` (cognify's own write path), batched the same way
-(``index_data_points_batched``), so the stored row shape matches production
-writes on every vector backend; text is unchanged, so the re-embedded vector
-is equivalent.
+from the document id on this code line. Only the ``document_id`` reference
+scalar in the chunk's payload moves. Because the point id and chunk text are
+unchanged, the stored vector is already correct, so a backend that can update
+the payload in place does exactly that (``resync_document_id_native``: PGVector
+via a SQL payload update, no re-embed). Backends without a native path fall back
+to re-embedding through ``index_data_points`` (``index_data_points_batched``);
+re-embedding purely to change a scalar is wasted spend and, on a large fork, is
+what trips a provider's per-request embedding token cap.
 
 Fork rows are rare (same user, identical content, several datasets, before
 the upgrade), so this is cheap: one indexed relational query in the common
@@ -70,7 +73,7 @@ from cognee.modules.data.models import Data
 from cognee.modules.migrations.migration import MigrationContext
 from cognee.shared.logging_utils import get_logger
 
-from ._vector_rekey import index_data_points_batched
+from ._vector_rekey import index_data_points_batched, resync_document_id_native
 from .namespace_entity_type_node_ids import _make_node, _migrate_graph
 
 logger = get_logger(__name__)
@@ -259,7 +262,12 @@ async def _sync_chunk_vector_payloads(
 
     if not await vector_engine.has_collection("DocumentChunk_text"):
         return
-    await index_data_points_batched(vector_engine, "DocumentChunk", "text", carriers)
+    # Only the document_id reference scalar moves — the chunk text and point id
+    # are unchanged, so the stored vector is already correct. Repoint it in place
+    # on backends that can (no re-embedding); re-embed only where they cannot.
+    chunk_targets = {str(carrier.id): str(carrier.document_id) for carrier in carriers}
+    if not await resync_document_id_native(vector_engine, "DocumentChunk_text", chunk_targets):
+        await index_data_points_batched(vector_engine, "DocumentChunk", "text", carriers)
     logger.info(
         "rekey_fork_document_ids: synced document_id payload on %d chunk vector row(s)",
         len(carriers),

--- a/cognee/tests/unit/modules/migrations/test_resync_document_id_native.py
+++ b/cognee/tests/unit/modules/migrations/test_resync_document_id_native.py
@@ -1,0 +1,53 @@
+"""Tests for the vector-preserving ``document_id`` re-key path used by the
+fork-document rekey migration (``resync_document_id_native``).
+
+Repointing the ``document_id`` payload scalar must NOT re-embed: the chunk text
+and point id are unchanged, so the stored vector is already correct. PGVector
+updates the JSON payload in place; backends without a native path (LanceDB,
+etc.) return False so the caller re-embeds through the existing path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognee.modules.migrations.versions import _vector_rekey
+from cognee.modules.migrations.versions._vector_rekey import resync_document_id_native
+
+
+def _named_engine(class_name: str):
+    # The dispatch keys on ``vector_engine.__class__.__name__``.
+    return type(class_name, (), {})()
+
+
+@pytest.mark.asyncio
+async def test_empty_targets_is_noop_and_native():
+    # Nothing to do -> treated as handled, so the caller never re-embeds.
+    assert await resync_document_id_native(_named_engine("PGVectorAdapter"), "C", {}) is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pgvector_uses_native_path(monkeypatch):
+    called = AsyncMock()
+    monkeypatch.setattr(_vector_rekey, "_resync_pgvector_document_id", called)
+    engine = _named_engine("PGVectorAdapter")
+    assert await resync_document_id_native(engine, "DocumentChunk_text", {"a": "b"}) is True
+    called.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lancedb_falls_back_to_reembed():
+    # LanceDB's columnar payload schema can't take an in-place scalar update,
+    # so it returns False and the caller re-embeds (current behavior).
+    assert (
+        await resync_document_id_native(_named_engine("LanceDBAdapter"), "C", {"a": "b"}) is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_unsupported_adapter_falls_back():
+    assert (
+        await resync_document_id_native(_named_engine("SomeOtherAdapter"), "C", {"a": "b"}) is False
+    )


### PR DESCRIPTION
# Description

The `rekey_fork_document_ids` migration re-keys a fork document's identity. For the
document's **chunk vector rows**, the only thing that changes is the `document_id`
reference scalar in the payload — the **point id and chunk text are unchanged**, so
the stored vector is already correct. Yet the migration re-embedded every fork chunk
(through `index_data_points` → `create_data_points`) purely to rewrite that scalar.

Two problems with that:
1. **Wasted embedding spend.** The recomputed vector is discarded — `create_data_points`'
   `ON CONFLICT DO UPDATE` only refreshes the payload, never the vector column. So the
   migration pays a real embedding API call whose result is thrown away.
2. **A hard failure mode at scale.** On a large fork with a big `EMBEDDING_BATCH_SIZE`,
   batching all the chunk texts into one embedding request overflows OpenAI's
   `max_tokens_per_request` cap (300k tokens) → `BadRequestError`, and the per-dataset
   migration stalls.

This was found running the full-scale (100k-node) War & Peace migration on an
all-Postgres, access-control-on stack.

## What changed

- **`rekey_fork_document_ids` no longer re-embeds to move `document_id`.** It calls a new
  `resync_document_id_native(vector_engine, collection, chunk_targets)` helper that repoints
  the scalar in place where the backend allows it, and only falls back to the existing
  re-embed path where it can't:
  - **PGVector** updates the `document_id` key in the JSON payload column via SQL — the
    vector is never touched, nothing is embedded. (Idempotent: rows already canonical are
    skipped.)
  - **Other backends** (LanceDB, etc.) return `False` → the caller re-embeds exactly as
    before. LanceDB's columnar payload arrow-schema can't take an in-place scalar update
    cleanly, so a native path there is left as a follow-up (behavior is unchanged for it).

- **New `PGVectorAdapter.upsert_raw_vectors`** (mirrors `LanceDBAdapter`): writes
  caller-supplied vectors + payloads without invoking the embedding engine, refreshing both
  vector and payload on id conflict. Beyond this migration, it **unblocks
  `truth_subspace` centroids on PGVector** — `upsert_centroids` calls `upsert_raw_vectors`,
  which previously raised the interface's `NotImplementedError` on every non-LanceDB backend.

## Tests

- `test_resync_document_id_native.py`: dispatch (PGVector → native, empty → no-op) and
  fallback (LanceDB and unknown adapters → `False` so the caller re-embeds).
- Existing migration + `upsert_raw_vectors` + centroid suites still pass (46 tests).
- Live-verified against real Postgres: `upsert_raw_vectors` insert + on-conflict (updates
  both vector and payload), and `resync_document_id_native` repointing `document_id` while
  leaving the stored vector byte-for-byte intact.

## Notes

- No behavior change for the graph/relational parts of the rekey, or for any backend that
  currently re-embeds — this only removes the embed where it was provably unnecessary.
- Needs a `COG-xxxx` Linear key in the title/branch for the required `linear-issue-check`.
