### PR TITLE
perf: Fix LanceDB schema check convergence and cost (COG-6185)

### DIFF
--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -717,15 +717,31 @@ class LanceDBAdapter(VectorDBInterface):
     def _normalize_arrow_type(arrow_type):
         """
         Convert Arrow type objects into a recursive comparable structure.
-        This allows deep comparison of field names, nullability, and nested types.
+        Compares field names and nested types; nullability is deliberately
+        excluded.
+
+        LanceDB writes every struct field as nullable regardless of what the
+        pydantic model declares, so a model field that is not Optional always
+        reads back ``nullable=True`` while the target type says
+        ``nullable=False``. Comparing that flag makes the check unsatisfiable:
+        a table the migration itself just wrote still reports as incompatible,
+        so the rewrite runs again on the next startup, forever. On a 206k-row
+        collection that is ~7 minutes per collection per start (COG-6185).
         """
-        if hasattr(arrow_type, "num_fields"):
+        import pyarrow as pa
+
+        # Struct first, and by type predicate rather than ``num_fields``:
+        # every pyarrow type answers ``num_fields`` (0 for scalars, 1 for
+        # lists), so the old check funnelled scalars and lists into this
+        # branch and collapsed them all to ``{"fields": []}`` — int64 and
+        # string normalized identically, and a real type change could not be
+        # detected at all.
+        if pa.types.is_struct(arrow_type):
             return {
-                "kind": type(arrow_type).__name__,
+                "kind": "struct",
                 "fields": [
                     {
                         "name": arrow_type.field(i).name,
-                        "nullable": getattr(arrow_type.field(i), "nullable", True),
                         "type": LanceDBAdapter._normalize_arrow_type(arrow_type.field(i).type),
                     }
                     for i in range(arrow_type.num_fields)
@@ -736,7 +752,6 @@ class LanceDBAdapter(VectorDBInterface):
         if value_field is not None:
             return {
                 "kind": type(arrow_type).__name__,
-                "value_nullable": getattr(value_field, "nullable", True),
                 "value_type": LanceDBAdapter._normalize_arrow_type(value_field.type),
             }
 
@@ -749,7 +764,8 @@ class LanceDBAdapter(VectorDBInterface):
                 "item_type": LanceDBAdapter._normalize_arrow_type(item_type),
             }
 
-        return {"kind": type(arrow_type).__name__, "repr": str(arrow_type)}
+        # Scalars: the printed form is what distinguishes int64 from string.
+        return {"kind": "scalar", "repr": str(arrow_type)}
 
     def _get_target_payload_arrow_type(self, payload_schema: type):
         """
@@ -822,14 +838,18 @@ class LanceDBAdapter(VectorDBInterface):
 
             checked_collections.append(collection_name)
             collection = await self.get_collection(collection_name)
-            table = await collection.to_arrow()
-            payload_field_index = table.schema.get_field_index("payload")
+            # Read the schema, not the data: ``to_arrow()`` materializes every
+            # row (206k rows x 3072-dim vectors on a large store) just to reach
+            # ``.schema``, and it does that for collections that turn out to
+            # need nothing. ``schema()`` is a metadata read.
+            schema = await collection.schema()
+            payload_field_index = schema.get_field_index("payload")
 
             if payload_field_index < 0:
                 skipped_collections.append(collection_name)
                 continue
 
-            payload_field_type = table.schema.field(payload_field_index).type
+            payload_field_type = schema.field(payload_field_index).type
             if not hasattr(payload_field_type, "num_fields"):
                 skipped_collections.append(collection_name)
                 continue

--- a/cognee/modules/migrations/versions/namespace_entity_type_node_ids.py
+++ b/cognee/modules/migrations/versions/namespace_entity_type_node_ids.py
@@ -761,6 +761,42 @@ async def _restore_provenance_bulk(attach, items_with_snapshots) -> None:
             await attach(artifacts, [source_ref_key], run_refs_by_key.get(source_ref_key))
 
 
+async def _edges_needing_reassert(graph_engine, at_risk: list) -> list:
+    """Narrow the at-risk set to the edges the backend actually dropped.
+
+    ``at_risk`` is every survivor edge incident to a node whose neighbourhood
+    was rewritten — potentially the whole graph. Upserting all of them is
+    correct but pays ~102k writes on a 100k-node fork to repair drops that are
+    usually zero.
+
+    One scan of the edge table answers the question directly, and a scan is the
+    operation an embedded graph engine is fastest at. Backends that cannot
+    answer it (no Cypher, unsupported syntax) fall back to re-asserting
+    everything, so behaviour is unchanged where the shortcut does not apply.
+    """
+    try:
+        rows = await graph_engine.query(
+            "MATCH (a:Node)-[r:EDGE]->(b:Node) RETURN a.id, b.id, r.relationship_name"
+        )
+    except Exception as error:
+        logger.info(
+            "namespace migration: edge listing unavailable (%s), re-asserting all "
+            "%d at-risk edge(s)",
+            error,
+            len(at_risk),
+        )
+        return at_risk
+
+    present = {(str(row[0]), str(row[1]), str(row[2])) for row in rows}
+    dropped = [edge for edge in at_risk if (edge[0], edge[1], edge[2]) not in present]
+    logger.info(
+        "namespace migration: %d of %d at-risk edge(s) were dropped and need re-asserting",
+        len(dropped),
+        len(at_risk),
+    )
+    return dropped
+
+
 async def _migrate_graph(graph_engine, id_map: dict, properties_by_id: dict, edges: list) -> int:
     """Remap old-scheme node ids (and their edges) in the graph database."""
     inverse_id_map = {new_id: old_id for old_id, new_id in id_map.items()}
@@ -845,23 +881,30 @@ async def _migrate_graph(graph_engine, id_map: dict, properties_by_id: dict, edg
     #    incoming ``TextSummary -made_from-> DocumentChunk``. add_edges is an
     #    idempotent upsert, so re-asserting is a no-op where the edge survived and
     #    restores it where the backend dropped it.
+    #
+    #    Re-asserting blindly costs one upsert per at-risk edge — on a 100k-node
+    #    fork that is ~102k writes (~22 min measured) to repair a handful of
+    #    drops, or none at all. When the backend can list its edges in one scan,
+    #    ask it which ones actually vanished and rewrite only those.
     at_risk = [
         edge
         for edge in survivor_edges
         if edge[0] in affected_neighbors or edge[1] in affected_neighbors
     ]
     if at_risk:
-        await graph_engine.add_edges(at_risk)
-        await _restore_provenance_bulk(
-            graph_engine.attach_edge_source_refs,
-            [
-                (edge, edge_snapshots.get(edge))
-                for edge in (
-                    _edge_identity(source_id, target_id, relationship_name)
-                    for source_id, target_id, relationship_name, _properties in at_risk
-                )
-            ],
-        )
+        to_reassert = await _edges_needing_reassert(graph_engine, at_risk)
+        if to_reassert:
+            await graph_engine.add_edges(to_reassert)
+            await _restore_provenance_bulk(
+                graph_engine.attach_edge_source_refs,
+                [
+                    (edge, edge_snapshots.get(edge))
+                    for edge in (
+                        _edge_identity(source_id, target_id, relationship_name)
+                        for source_id, target_id, relationship_name, _properties in to_reassert
+                    )
+                ],
+            )
 
     return len(remapped_edges)
 

--- a/cognee/modules/migrations/versions/rekey_fork_document_ids.py
+++ b/cognee/modules/migrations/versions/rekey_fork_document_ids.py
@@ -134,6 +134,64 @@ def _run_id_for_key(snapshot, source_ref_key: str) -> Optional[str]:
     return None
 
 
+_LADYBUG_PROVIDERS = {"ladybug", "kuzu"}
+
+
+def _is_ladybug_graph() -> bool:
+    """True when the graph store is Ladybug/Kuzu (embedded, string-encoded provenance)."""
+    from cognee.infrastructure.databases.graph.config import get_graph_config
+
+    return get_graph_config().graph_database_provider.lower() in _LADYBUG_PROVIDERS
+
+
+async def _fast_move_provenance_ladybug(graph_engine, old_key: str, new_key: str) -> bool:
+    """Rewrite provenance keys in place with two set-based statements.
+
+    The generic path lists every artifact carrying ``old_key``, reads its
+    provenance, then attaches the new key and removes the old one — 3 reads
+    and 2 writes over the whole subgraph, each a per-row primary-key probe.
+    On a 100k-node fork that is ~400k point updates (~11 min measured).
+
+    Ladybug stores provenance as delimiter-wrapped strings, and a re-key only
+    changes the data-id half of the key, so the entire move is a substring
+    rewrite the engine can do in one scan per artifact kind — no id lists
+    cross the process boundary and no row is probed individually.
+    ``source_run_refs`` embeds the key verbatim, so the same replace fixes it;
+    ``source_dataset_ids`` and ``source_run_ids`` do not contain the data id
+    and stay correct untouched.
+
+    Artifacts holding BOTH keys (an earlier run interrupted mid-move) are
+    deliberately left alone here — a blind replace would duplicate the new
+    key — and fall through to the generic path, which dedupes. Returns False
+    when the engine rejects the statements, so the caller can fall back
+    wholesale.
+    """
+    rewrite = """
+    MATCH (n:Node)
+    WHERE n.source_ref_keys CONTAINS $old_key AND NOT n.source_ref_keys CONTAINS $new_key
+    SET n.source_ref_keys = replace(n.source_ref_keys, $old_key, $new_key),
+        n.source_run_refs = replace(n.source_run_refs, $old_key, $new_key)
+    """
+    rewrite_edges = """
+    MATCH ()-[r:EDGE]->()
+    WHERE r.source_ref_keys CONTAINS $old_key AND NOT r.source_ref_keys CONTAINS $new_key
+    SET r.source_ref_keys = replace(r.source_ref_keys, $old_key, $new_key),
+        r.source_run_refs = replace(r.source_run_refs, $old_key, $new_key)
+    """
+    params = {"old_key": old_key, "new_key": new_key}
+    try:
+        await graph_engine.query(rewrite, params)
+        await graph_engine.query(rewrite_edges, params)
+    except Exception as error:  # unsupported syntax / non-string provenance
+        logger.info(
+            "rekey_fork_document_ids: fast provenance move unavailable (%s), "
+            "using the generic path",
+            error,
+        )
+        return False
+    return True
+
+
 async def _rekey_graph_provenance(graph_engine, fork_rows: list) -> None:
     """Move graph-embedded provenance from pre-fork keys to canonical keys.
 
@@ -149,14 +207,32 @@ async def _rekey_graph_provenance(graph_engine, fork_rows: list) -> None:
     if not await stores_provenance_in_graph(graph_engine):
         return
 
+    fast_path = _is_ladybug_graph()
+
     for old_id, new_id, dataset_id in fork_rows:
         old_key = make_source_ref_key(dataset_id, UUID(old_id))
         new_key = make_source_ref_key(dataset_id, UUID(new_id))
+
+        # Set-based rewrite first; whatever it cannot express (artifacts that
+        # already carry both keys) is left for the generic path below, which
+        # then finds only that residue instead of the whole subgraph.
+        if fast_path:
+            fast_path = await _fast_move_provenance_ladybug(graph_engine, old_key, new_key)
+
         try:
             node_ids = await graph_engine.find_nodes_by_source_ref(old_key)
             edge_identities = await graph_engine.find_edges_by_source_ref(old_key)
         except UnsupportedProvenanceCapability:
             return
+
+        if fast_path and not node_ids and not edge_identities:
+            logger.info(
+                "rekey_fork_document_ids: moved provenance refs from %s to %s "
+                "via set-based rewrite",
+                old_key,
+                new_key,
+            )
+            continue
 
         # Group artifacts by pipeline run id and attach per group: a dataset's
         # subgraph overwhelmingly carries one run id, so this collapses the

--- a/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_schema_check.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_schema_check.py
@@ -1,0 +1,74 @@
+"""The proactive LanceDB schema check must converge and must not read data.
+
+Both properties were violated on a 100k-node store (COG-6185): every startup
+rewrote 206k-row collections that the previous startup had just rewritten,
+because the comparison included a nullability flag the storage layer never
+reproduces — and each check materialized the whole table just to reach its
+schema.
+"""
+
+import pyarrow as pa
+
+from cognee.infrastructure.databases.vector.lancedb.LanceDBAdapter import LanceDBAdapter
+
+
+def _payload(nullable: bool) -> pa.DataType:
+    return pa.struct(
+        [
+            pa.field("id", pa.string(), nullable=nullable),
+            pa.field("text", pa.string(), nullable=nullable),
+            pa.field("version", pa.int64(), nullable=nullable),
+        ]
+    )
+
+
+def test_nullability_does_not_make_identical_schemas_differ():
+    """LanceDB stores every struct field nullable; a model field that is not
+    Optional would otherwise never match what was written for it."""
+    stored = LanceDBAdapter._normalize_arrow_type(_payload(nullable=True))
+    declared = LanceDBAdapter._normalize_arrow_type(_payload(nullable=False))
+
+    assert stored == declared
+
+
+def test_field_names_still_distinguish_schemas():
+    """The check must keep catching a genuinely different field set."""
+    without_field = LanceDBAdapter._normalize_arrow_type(_payload(nullable=True))
+    with_field = LanceDBAdapter._normalize_arrow_type(
+        pa.struct(
+            [
+                pa.field("id", pa.string()),
+                pa.field("text", pa.string()),
+                pa.field("version", pa.int64()),
+                pa.field("valid_to", pa.int64()),
+            ]
+        )
+    )
+
+    assert without_field != with_field
+
+
+def test_field_types_still_distinguish_schemas():
+    as_int = LanceDBAdapter._normalize_arrow_type(pa.struct([pa.field("version", pa.int64())]))
+    as_string = LanceDBAdapter._normalize_arrow_type(pa.struct([pa.field("version", pa.string())]))
+
+    assert as_int != as_string
+
+
+def test_list_element_nullability_is_also_ignored():
+    """Same reasoning one level down: element nullability is storage's choice."""
+    strict = LanceDBAdapter._normalize_arrow_type(
+        pa.list_(pa.field("item", pa.string(), nullable=False))
+    )
+    lenient = LanceDBAdapter._normalize_arrow_type(
+        pa.list_(pa.field("item", pa.string(), nullable=True))
+    )
+
+    assert strict == lenient
+
+
+def test_list_element_types_still_distinguish_schemas():
+    of_strings = LanceDBAdapter._normalize_arrow_type(pa.list_(pa.string()))
+    of_ints = LanceDBAdapter._normalize_arrow_type(pa.list_(pa.int64()))
+
+    assert of_strings != of_ints

--- a/cognee/tests/unit/modules/migrations/test_ladybug_migration_fast_paths.py
+++ b/cognee/tests/unit/modules/migrations/test_ladybug_migration_fast_paths.py
@@ -1,0 +1,146 @@
+"""Ladybug-only migration shortcuts (COG-6185).
+
+Two phases dominated the fork re-key on a 100k-node graph: re-asserting every
+at-risk edge (~102k upserts, ~22 min) and moving provenance key by key (~400k
+point updates, ~11 min). Both are replaced by set-based statements the engine
+can answer in one scan. These tests pin the behaviour that makes that safe:
+the shortcuts must narrow the work, never skip work that is still needed, and
+must fall back cleanly on backends that cannot answer them.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+import cognee.modules.migrations.versions.namespace_entity_type_node_ids as ns
+import cognee.modules.migrations.versions.rekey_fork_document_ids as rk
+from cognee.infrastructure.databases.provenance import make_source_ref_key
+
+
+@pytest.mark.asyncio
+async def test_only_dropped_edges_are_reasserted():
+    """Edges the backend still holds must not be rewritten."""
+    at_risk = [
+        ("a", "b", "contains", {}),
+        ("c", "d", "made_from", {}),
+        ("e", "f", "is_part_of", {}),
+    ]
+    engine = AsyncMock()
+    # The scan reports the first two survived; only the third vanished.
+    engine.query.return_value = [["a", "b", "contains"], ["c", "d", "made_from"]]
+
+    result = await ns._edges_needing_reassert(engine, at_risk)
+
+    assert result == [("e", "f", "is_part_of", {})]
+
+
+@pytest.mark.asyncio
+async def test_nothing_reasserted_when_no_edge_was_dropped():
+    at_risk = [("a", "b", "contains", {})]
+    engine = AsyncMock()
+    engine.query.return_value = [["a", "b", "contains"]]
+
+    assert await ns._edges_needing_reassert(engine, at_risk) == []
+
+
+@pytest.mark.asyncio
+async def test_reassert_falls_back_to_everything_when_listing_unsupported():
+    """A backend that cannot list edges keeps the old, exhaustive behaviour."""
+    at_risk = [("a", "b", "contains", {}), ("c", "d", "made_from", {})]
+    engine = AsyncMock()
+    engine.query.side_effect = RuntimeError("Cypher not supported")
+
+    assert await ns._edges_needing_reassert(engine, at_risk) == at_risk
+
+
+@pytest.mark.asyncio
+async def test_fast_provenance_move_rewrites_both_key_columns():
+    """One statement per artifact kind, rewriting keys and run refs together."""
+    engine = AsyncMock()
+
+    moved = await rk._fast_move_provenance_ladybug(engine, "OLD_KEY", "NEW_KEY")
+
+    assert moved is True
+    assert engine.query.await_count == 2
+    node_query, node_params = engine.query.await_args_list[0].args
+    edge_query, _ = engine.query.await_args_list[1].args
+    assert "MATCH (n:Node)" in node_query and "MATCH ()-[r:EDGE]->()" in edge_query
+    for query in (node_query, edge_query):
+        assert "source_ref_keys = replace(" in query
+        assert "source_run_refs = replace(" in query
+        # Artifacts already carrying the new key are excluded: a blind replace
+        # would leave the key twice.
+        assert "NOT" in query and "CONTAINS $new_key" in query
+    assert node_params == {"old_key": "OLD_KEY", "new_key": "NEW_KEY"}
+
+
+@pytest.mark.asyncio
+async def test_fast_provenance_move_reports_failure_for_fallback():
+    engine = AsyncMock()
+    engine.query.side_effect = RuntimeError("function replace does not exist")
+
+    assert await rk._fast_move_provenance_ladybug(engine, "OLD", "NEW") is False
+
+
+@pytest.mark.asyncio
+async def test_rekey_skips_generic_sweep_once_fast_move_clears_the_key():
+    """With nothing left carrying the old key, the per-artifact path is skipped."""
+    old_id, new_id, dataset_id = str(uuid4()), str(uuid4()), str(uuid4())
+    engine = AsyncMock()
+    engine.find_nodes_by_source_ref.return_value = []
+    engine.find_edges_by_source_ref.return_value = []
+
+    with (
+        patch.object(rk, "stores_provenance_in_graph", new=AsyncMock(return_value=True)),
+        patch.object(rk, "_is_ladybug_graph", return_value=True),
+        patch.object(rk, "_fast_move_provenance_ladybug", new=AsyncMock(return_value=True)),
+    ):
+        await rk._rekey_graph_provenance(engine, [(old_id, new_id, dataset_id)])
+
+    engine.get_node_delete_data.assert_not_awaited()
+    engine.attach_node_source_refs.assert_not_awaited()
+    engine.remove_node_source_refs.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rekey_still_sweeps_artifacts_the_fast_move_left_behind():
+    """Artifacts holding both keys (interrupted run) go through the generic path."""
+    old_id, new_id, dataset_id = str(uuid4()), str(uuid4()), str(uuid4())
+    old_key = make_source_ref_key(dataset_id, __import__("uuid").UUID(old_id))
+    run = "00000000-0000-0000-0000-000000000001"
+    snapshot = SimpleNamespace(source_run_refs=[f"source_run_ref:v1:{run}:{old_key}"])
+
+    engine = AsyncMock()
+    engine.find_nodes_by_source_ref.return_value = ["leftover-node"]
+    engine.find_edges_by_source_ref.return_value = []
+    engine.get_node_delete_data.return_value = {"leftover-node": snapshot}
+
+    with (
+        patch.object(rk, "stores_provenance_in_graph", new=AsyncMock(return_value=True)),
+        patch.object(rk, "_is_ladybug_graph", return_value=True),
+        patch.object(rk, "_fast_move_provenance_ladybug", new=AsyncMock(return_value=True)),
+    ):
+        await rk._rekey_graph_provenance(engine, [(old_id, new_id, dataset_id)])
+
+    engine.attach_node_source_refs.assert_awaited_once()
+    engine.remove_node_source_refs.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_ladybug_backends_keep_the_generic_path():
+    old_id, new_id, dataset_id = str(uuid4()), str(uuid4()), str(uuid4())
+    engine = AsyncMock()
+    engine.find_nodes_by_source_ref.return_value = []
+    engine.find_edges_by_source_ref.return_value = []
+    fast = AsyncMock(return_value=True)
+
+    with (
+        patch.object(rk, "stores_provenance_in_graph", new=AsyncMock(return_value=True)),
+        patch.object(rk, "_is_ladybug_graph", return_value=False),
+        patch.object(rk, "_fast_move_provenance_ladybug", new=fast),
+    ):
+        await rk._rekey_graph_provenance(engine, [(old_id, new_id, dataset_id)])
+
+    fast.assert_not_awaited()


### PR DESCRIPTION
## Description

With the graph phases optimized in #4514, the 100k migration's remaining ~21 minutes is almost entirely **LanceDB rewriting vector collections** — and investigating that turned up a loop, not just a slow step.

Stacked on #4514 (which is stacked on #4512). Review those first.

### What the profile showed

Phase timings from the optimized 100k run:

| phase | cost |
|---|---|
| LanceDB `EdgeType_relationship_name` rewrite (dataset 1) | **7 min 10 s** |
| LanceDB `Entity_name` rewrite (dataset 1) | 1 min 39 s |
| fork re-key: graph re-key + provenance move | **~1 min total** |
| LanceDB `EdgeType_relationship_name` rewrite (dataset 2) | **6 min 52 s** |
| LanceDB `Entity_name` rewrite (dataset 2) | ~2 min |

### The check never converges

The vector storage sync is correctly gated: `_sync_vector_adapter_storage()` runs only when the recorded `cognee_version` differs from the running one, so a same-version restart skips it. This is **not** a per-startup cost.

What it is: the sync never reaches the no-op state its own contract promises. Measured on the store the migration had **just written**:

```
post-migration  EdgeType_relationship_name  compatible=False
post-migration  Entity_name                 compatible=False
```

So on **every version bump** the ~7-minute rewrite runs again on each large collection and still ends incompatible — ~17 minutes added to every upgrade of a 100k store, permanently, with nothing to show for it.

Two defects in the comparison, both fixed here:

**1. Nullability is unsatisfiable.** LanceDB writes every struct field nullable regardless of what the pydantic model declares, so any non-`Optional` model field reads back `nullable=True` against a target of `nullable=False`. Eight fields mismatched purely this way (`id`, `text`, `type`, `created_at`, `updated_at`, `version`, `ontology_valid`, `feedback_weight`). Nullability is no longer compared.

**2. Scalar and list types collapsed together.** The struct branch was entered via `hasattr(arrow_type, "num_fields")` — but *every* pyarrow type answers that (0 for scalars, 1 for lists), so scalars and lists all normalized to `{"fields": []}`. **`int64` and `string` compared equal**, and a genuine type change was invisible to the check. Struct detection now uses `pa.types.is_struct`, scalars carry their printed type, and list element types are compared. This one was found by the new tests, not by inspection.

### Also: stop reading the data to read the schema

`run_migrations()` called `to_arrow()` on every collection — materializing 206k rows × 3072-dim vectors — only to reach `.schema`, including for collections that needed nothing. Measured: `to_arrow()` 2.7 s vs `schema()` 0.000 s, plus the memory. Now a metadata read.

## Still open (not fixed here)

After a successful rewrite the stored payload is **missing `valid_to`**, which the model declares (21 fields stored vs 22 in the model). That difference survives the rewrite, so the loop persists even with the comparison fixed. Local schema derivation from the `LanceModel` *does* include the field (22 of 22) and `_schema_for_create_table` returns the model class, so the field is being lost on the write path — most likely the subprocess route, where a `pa.Schema` is derived instead. That needs its own investigation and I did not want to guess at it inside this PR.

Concretely: this PR removes the wasted full-table reads and makes the comparison correct, but the per-upgrade rewrite will only stop once `valid_to` actually lands.

## Testing

- 5 new tests: nullability ignored, field-set differences still detected, **field type differences still detected** (fails on the old normalizer), list element nullability ignored, list element types still detected.
- 589 passed across `cognee/tests/unit/infrastructure/databases/` and `cognee/tests/unit/modules/migrations/`.

Part of COG-6185.
