### PR TITLE
fix(database): use portable UUID type for SQLite

### DIFF
--- a/cognee/modules/data/models/Data.py
+++ b/cognee/modules/data/models/Data.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from uuid import uuid4
-from sqlalchemy import UUID, Column, DateTime, Index, String, JSON, Integer, Float
+from sqlalchemy import Uuid, Column, DateTime, Index, String, JSON, Integer, Float
 from sqlalchemy.ext.mutable import MutableDict
 
 from cognee.infrastructure.databases.relational import Base
@@ -16,7 +16,7 @@ class Data(Base):
         Index("data_dataset_content_lookup", "dataset_id", "owner_id", "content_hash"),
     )
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
     label = Column(String, nullable=True)
     name = Column(String)
     extension = Column(String)
@@ -26,21 +26,21 @@ class Data(Base):
     loader_engine = Column(String)
     raw_data_location = Column(String)
     original_data_location = Column(String)
-    owner_id = Column(UUID, index=True)
-    tenant_id = Column(UUID, index=True, nullable=True)
+    owner_id = Column(Uuid, index=True)
+    tenant_id = Column(Uuid, index=True, nullable=True)
     # Dataset that owns this content row. Rows are dataset-scoped: the same
     # content in two datasets is two rows with two ids, so updating one
     # document can never touch another dataset's data. Nullable only for the
     # upgrade window: the startup backfill (alembic d6e8f0a2b4c6) stamps every
     # legacy row's dataset (splitting rows shared by several datasets), so no
     # NULL rows exist after it runs.
-    dataset_id = Column(UUID, index=True, nullable=True)
+    dataset_id = Column(Uuid, index=True, nullable=True)
     # The pre-refactor data_id this row's identity descends from. Written by
     # exactly one thing — the backfill split of a shared legacy row — and only
     # preserved afterwards (update() re-ingests under the row's own id), so
     # alias chains cannot form and every id ever issued keeps resolving.
     # NULL for rows whose id never changed.
-    legacy_id = Column(UUID, index=True, nullable=True)
+    legacy_id = Column(Uuid, index=True, nullable=True)
     content_hash = Column(String)
     raw_content_hash = Column(String)
     external_metadata = Column(JSON)

--- a/cognee/modules/data/models/Dataset.py
+++ b/cognee/modules/data/models/Dataset.py
@@ -2,22 +2,22 @@ from uuid import uuid4
 from typing import List
 from datetime import datetime, timezone
 from sqlalchemy.orm import relationship, Mapped
-from sqlalchemy import Column, Text, DateTime, UUID
+from sqlalchemy import Column, Text, DateTime, Uuid
 from cognee.infrastructure.databases.relational import Base
 
 
 class Dataset(Base):
     __tablename__ = "datasets"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
 
     name = Column(Text)
 
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime(timezone=True), onupdate=lambda: datetime.now(timezone.utc))
 
-    owner_id = Column(UUID, index=True)
-    tenant_id = Column(UUID, index=True, nullable=True)
+    owner_id = Column(Uuid, index=True)
+    tenant_id = Column(Uuid, index=True, nullable=True)
 
     acls = relationship("ACL", back_populates="dataset", cascade="all, delete-orphan")
     configuration = relationship(

--- a/cognee/modules/data/models/DatasetConfiguration.py
+++ b/cognee/modules/data/models/DatasetConfiguration.py
@@ -1,7 +1,7 @@
 from uuid import uuid4
 from datetime import datetime, timezone
 from sqlalchemy.orm import relationship
-from sqlalchemy import Column, ForeignKey, DateTime, Text, UUID
+from sqlalchemy import Column, ForeignKey, DateTime, Text, Uuid
 from sqlalchemy.types import JSON as GenericJSON
 from cognee.infrastructure.databases.relational import Base
 
@@ -9,9 +9,9 @@ from cognee.infrastructure.databases.relational import Base
 class DatasetConfiguration(Base):
     __tablename__ = "dataset_configurations"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
     dataset_id = Column(
-        UUID, ForeignKey("datasets.id", ondelete="CASCADE"), unique=True, nullable=False
+        Uuid, ForeignKey("datasets.id", ondelete="CASCADE"), unique=True, nullable=False
     )
 
     graph_schema = Column(GenericJSON, nullable=True)

--- a/cognee/modules/data/models/GraphMetrics.py
+++ b/cognee/modules/data/models/GraphMetrics.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from sqlalchemy.sql import func
 
-from sqlalchemy import Column, DateTime, Float, Integer, JSON, UUID
+from sqlalchemy import Column, DateTime, Float, Integer, JSON, Uuid
 
 from cognee.infrastructure.databases.relational import Base
 from uuid import uuid4
@@ -11,7 +11,7 @@ class GraphMetrics(Base):
     __tablename__ = "graph_metrics"
 
     # TODO: Change ID to reflect unique id of graph database
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
     num_tokens = Column(Integer, nullable=True)
     num_nodes = Column(Integer, nullable=True)
     num_edges = Column(Integer, nullable=True)

--- a/cognee/modules/data/models/answers_data.py
+++ b/cognee/modules/data/models/answers_data.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from uuid import uuid4
-from sqlalchemy import Column, DateTime, JSON, UUID
+from sqlalchemy import Column, DateTime, JSON, Uuid
 
 from cognee.modules.data.models.answers_base import AnswersBase
 
@@ -8,7 +8,7 @@ from cognee.modules.data.models.answers_base import AnswersBase
 class Answers(AnswersBase):
     __tablename__ = "eval_answers"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
 
     payload = Column(JSON, nullable=False)
 

--- a/cognee/modules/data/models/metrics_data.py
+++ b/cognee/modules/data/models/metrics_data.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from uuid import uuid4
-from sqlalchemy import Column, DateTime, JSON, UUID
+from sqlalchemy import Column, DateTime, JSON, Uuid
 
 from cognee.modules.data.models.metrics_base import MetricsBase
 
@@ -8,7 +8,7 @@ from cognee.modules.data.models.metrics_base import MetricsBase
 class Metrics(MetricsBase):
     __tablename__ = "eval_metrics"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
 
     payload = Column(JSON, nullable=False)
 

--- a/cognee/modules/data/models/questions_data.py
+++ b/cognee/modules/data/models/questions_data.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from uuid import uuid4
-from sqlalchemy import Column, DateTime, JSON, UUID
+from sqlalchemy import Column, DateTime, JSON, Uuid
 
 from cognee.modules.data.models.questions_base import QuestionsBase
 
@@ -8,7 +8,7 @@ from cognee.modules.data.models.questions_base import QuestionsBase
 class Questions(QuestionsBase):
     __tablename__ = "eval_questions"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
 
     payload = Column(JSON, nullable=False)
 

--- a/cognee/modules/graph/legacy/GraphRelationshipLedger.py
+++ b/cognee/modules/graph/legacy/GraphRelationshipLedger.py
@@ -1,6 +1,6 @@
 from uuid import uuid5, NAMESPACE_OID
 from datetime import datetime, timezone
-from sqlalchemy import UUID, Column, DateTime, String, Index
+from sqlalchemy import Uuid, Column, DateTime, String, Index
 
 from cognee.infrastructure.databases.relational import Base
 
@@ -9,12 +9,12 @@ class GraphRelationshipLedger(Base):
     __tablename__ = "graph_relationship_ledger"
 
     id = Column(
-        UUID,
+        Uuid,
         primary_key=True,
         default=lambda: uuid5(NAMESPACE_OID, f"{datetime.now(timezone.utc).timestamp()}"),
     )
-    source_node_id = Column(UUID, nullable=False)
-    destination_node_id = Column(UUID, nullable=False)
+    source_node_id = Column(Uuid, nullable=False)
+    destination_node_id = Column(Uuid, nullable=False)
     creator_function = Column(String, nullable=False)
     # TODO(security): node_label stores readable entity names (e.g. "Apple", "John").
     #   Evaluate whether this needs hashing/minimization for SOC2 compliance.
@@ -22,7 +22,7 @@ class GraphRelationshipLedger(Base):
     node_label = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     deleted_at = Column(DateTime(timezone=True), nullable=True)
-    user_id = Column(UUID, nullable=True)
+    user_id = Column(Uuid, nullable=True)
 
     # Create indexes
     __table_args__ = (

--- a/cognee/modules/graph/models/Edge.py
+++ b/cognee/modules/graph/models/Edge.py
@@ -1,9 +1,11 @@
 from datetime import datetime, timezone
+from uuid import UUID
+
 from sqlalchemy import (
     # event,
     DateTime,
     JSON,
-    UUID,
+    Uuid,
     Text,
 )
 
@@ -16,21 +18,21 @@ from cognee.infrastructure.databases.relational import Base
 class Edge(Base):
     __tablename__ = "edges"
 
-    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
 
-    slug: Mapped[UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    slug: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), nullable=False)
 
-    user_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    user_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), nullable=False)
 
-    data_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), index=True, nullable=False)
+    data_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), index=True, nullable=False)
 
-    dataset_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), index=True, nullable=False)
+    dataset_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), index=True, nullable=False)
     pipeline_run_id: Mapped[UUID | None] = mapped_column(
-        UUID(as_uuid=True), index=True, nullable=True
+        Uuid(as_uuid=True), index=True, nullable=True
     )
 
-    source_node_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
-    destination_node_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    source_node_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), nullable=False)
+    destination_node_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), nullable=False)
 
     relationship_name: Mapped[str] = mapped_column(Text, nullable=False)
 

--- a/cognee/modules/graph/models/Node.py
+++ b/cognee/modules/graph/models/Node.py
@@ -1,11 +1,13 @@
 from datetime import datetime, timezone
+from uuid import UUID
+
 from sqlalchemy import (
     DateTime,
     Index,
     # event,
     Text,
     JSON,
-    UUID,
+    Uuid,
 )
 
 # from sqlalchemy.schema import DDL
@@ -17,17 +19,17 @@ from cognee.infrastructure.databases.relational import Base
 class Node(Base):
     __tablename__ = "nodes"
 
-    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
 
-    slug: Mapped[UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    slug: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), nullable=False)
 
-    user_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    user_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), nullable=False)
 
-    data_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    data_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), nullable=False)
 
-    dataset_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), index=True, nullable=False)
+    dataset_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), index=True, nullable=False)
     pipeline_run_id: Mapped[UUID | None] = mapped_column(
-        UUID(as_uuid=True), index=True, nullable=True
+        Uuid(as_uuid=True), index=True, nullable=True
     )
 
     label: Mapped[str | None] = mapped_column(Text)

--- a/cognee/modules/integrations/models/IntegrationCredential.py
+++ b/cognee/modules/integrations/models/IntegrationCredential.py
@@ -3,8 +3,7 @@ from typing import Optional
 from uuid import UUID, uuid4
 
 from cognee.infrastructure.databases.relational.ModelBase import Base
-from sqlalchemy import JSON, DateTime, Index, LargeBinary, SmallInteger, String
-from sqlalchemy import UUID as SAUUID
+from sqlalchemy import JSON, DateTime, Index, LargeBinary, SmallInteger, String, Uuid
 from sqlalchemy.orm import Mapped, mapped_column
 
 
@@ -45,13 +44,13 @@ class IntegrationCredential(Base):
         ),
     )
 
-    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
 
-    user_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False, index=True)
+    user_id: Mapped[UUID] = mapped_column(Uuid, nullable=False, index=True)
 
     # Optional second owner dimension — see the class docstring. No FK: a
     # plain opaque id, same as user_id.
-    workspace_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True, index=True)
+    workspace_id: Mapped[Optional[UUID]] = mapped_column(Uuid, nullable=True, index=True)
 
     provider: Mapped[str] = mapped_column(String, nullable=False)
     provider_account_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)

--- a/cognee/modules/pipelines/models/Pipeline.py
+++ b/cognee/modules/pipelines/models/Pipeline.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 from datetime import datetime, timezone
-from sqlalchemy import Column, DateTime, String, Text, UUID
+from sqlalchemy import Column, DateTime, String, Text, Uuid
 from sqlalchemy.orm import relationship, Mapped
 from cognee.infrastructure.databases.relational import Base
 from .PipelineTask import PipelineTask
@@ -10,7 +10,7 @@ from .Task import Task
 class Pipeline(Base):
     __tablename__ = "pipelines"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
 
     name = Column(String)
     description = Column(Text, nullable=True)

--- a/cognee/modules/pipelines/models/PipelineRun.py
+++ b/cognee/modules/pipelines/models/PipelineRun.py
@@ -1,7 +1,7 @@
 import enum
 from uuid import uuid4
 from datetime import datetime, timezone
-from sqlalchemy import Column, DateTime, JSON, Enum, UUID, String
+from sqlalchemy import Column, DateTime, JSON, Enum, Uuid, String
 from cognee.infrastructure.databases.relational import Base
 
 
@@ -15,13 +15,13 @@ class PipelineRunStatus(enum.Enum):
 class PipelineRun(Base):
     __tablename__ = "pipeline_runs"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
 
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     status = Column(Enum(PipelineRunStatus))
-    pipeline_run_id = Column(UUID, index=True)
+    pipeline_run_id = Column(Uuid, index=True)
     pipeline_name = Column(String)
-    pipeline_id = Column(UUID, index=True)
-    dataset_id = Column(UUID, index=True)
+    pipeline_id = Column(Uuid, index=True)
+    dataset_id = Column(Uuid, index=True)
     run_info = Column(JSON)

--- a/cognee/modules/pipelines/models/PipelineTask.py
+++ b/cognee/modules/pipelines/models/PipelineTask.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from sqlalchemy import Column, DateTime, ForeignKey, UUID
+from sqlalchemy import Column, DateTime, ForeignKey, Uuid
 from cognee.infrastructure.databases.relational import Base
 
 
@@ -8,5 +8,5 @@ class PipelineTask(Base):
 
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
-    pipeline_id = Column("pipeline", UUID, ForeignKey("pipeline.id"), primary_key=True)
-    task_id = Column("task", UUID, ForeignKey("task.id"), primary_key=True)
+    pipeline_id = Column("pipeline", Uuid, ForeignKey("pipeline.id"), primary_key=True)
+    task_id = Column("task", Uuid, ForeignKey("task.id"), primary_key=True)

--- a/cognee/modules/pipelines/models/Task.py
+++ b/cognee/modules/pipelines/models/Task.py
@@ -1,15 +1,15 @@
 from uuid import uuid4
 from datetime import datetime, timezone
 from sqlalchemy.orm import relationship, Mapped
-from sqlalchemy import Column, String, DateTime, Text
-from cognee.infrastructure.databases.relational import Base, UUID
+from sqlalchemy import Column, String, DateTime, Text, Uuid
+from cognee.infrastructure.databases.relational import Base
 from .PipelineTask import PipelineTask
 
 
 class Task(Base):
     __tablename__ = "tasks"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
 
     name = Column(String)
     description = Column(Text, nullable=True)

--- a/cognee/modules/pipelines/models/TaskRun.py
+++ b/cognee/modules/pipelines/models/TaskRun.py
@@ -1,13 +1,13 @@
 from uuid import uuid4
 from datetime import datetime, timezone
-from sqlalchemy import Column, DateTime, String, JSON
-from cognee.infrastructure.databases.relational import Base, UUID
+from sqlalchemy import Column, DateTime, String, JSON, Uuid
+from cognee.infrastructure.databases.relational import Base
 
 
 class TaskRun(Base):
     __tablename__ = "task_runs"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
 
     task_name = Column(String)
 

--- a/cognee/modules/search/models/Query.py
+++ b/cognee/modules/search/models/Query.py
@@ -1,23 +1,23 @@
 from uuid import uuid4
 from datetime import datetime, timezone
-from sqlalchemy import Column, DateTime, String, UUID
+from sqlalchemy import Column, DateTime, String, Uuid
 from cognee.infrastructure.databases.relational import Base
 
 
 class Query(Base):
     __tablename__ = "queries"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
 
     text = Column(String)
     query_type = Column(String)
-    user_id = Column(UUID, index=True)
+    user_id = Column(Uuid, index=True)
 
     # Dataset the search was scoped to, recorded only when it resolved to
     # exactly one. A search can fan out over several datasets (or every
     # dataset the user can read), and those have no single dataset to
     # attribute the query to, so they stay NULL.
-    dataset_id = Column(UUID, index=True, nullable=True)
+    dataset_id = Column(Uuid, index=True, nullable=True)
 
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True

--- a/cognee/modules/search/models/Result.py
+++ b/cognee/modules/search/models/Result.py
@@ -1,21 +1,21 @@
 from datetime import datetime, timezone
 from uuid import uuid4
-from sqlalchemy import Column, DateTime, Text, UUID
+from sqlalchemy import Column, DateTime, Text, Uuid
 from cognee.infrastructure.databases.relational import Base
 
 
 class Result(Base):
     __tablename__ = "results"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
 
     value = Column(Text)
-    query_id = Column(UUID)
-    user_id = Column(UUID, index=True)
+    query_id = Column(Uuid)
+    user_id = Column(Uuid, index=True)
 
     # Mirrors ``Query.dataset_id`` for the query this result answers, so
     # history can be filtered by dataset without joining back to queries.
-    dataset_id = Column(UUID, index=True, nullable=True)
+    dataset_id = Column(Uuid, index=True, nullable=True)
 
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True

--- a/cognee/modules/session_lifecycle/models.py
+++ b/cognee/modules/session_lifecycle/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, Float, Integer, String, Text, UUID
+from sqlalchemy import Column, DateTime, Float, Integer, String, Text, Uuid
 
 from cognee.infrastructure.databases.relational import Base
 
@@ -29,9 +29,9 @@ class SessionRecord(Base):
     # from the Claude Code plugin). Scoped per user — same string from
     # two users is two different sessions.
     session_id = Column(String, primary_key=True)
-    user_id = Column(UUID, primary_key=True, index=True)
+    user_id = Column(Uuid, primary_key=True, index=True)
 
-    dataset_id = Column(UUID, nullable=True, index=True)
+    dataset_id = Column(Uuid, nullable=True, index=True)
 
     # Stored status. "abandoned" is the only value inferred at read
     # time instead of being stored — everything else (running,
@@ -99,7 +99,7 @@ class SessionModelUsage(Base):
     __tablename__ = "session_model_usage"
 
     session_id = Column(String, primary_key=True)
-    user_id = Column(UUID, primary_key=True, index=True)
+    user_id = Column(Uuid, primary_key=True, index=True)
     model = Column(Text, primary_key=True)
 
     tokens_in = Column(Integer, nullable=False, default=0)

--- a/cognee/modules/sync/models/SyncOperation.py
+++ b/cognee/modules/sync/models/SyncOperation.py
@@ -6,7 +6,7 @@ from sqlalchemy import (
     Column,
     Text,
     DateTime,
-    UUID as SQLAlchemy_UUID,
+    Uuid,
     Integer,
     Enum as SQLEnum,
     JSON,
@@ -36,7 +36,7 @@ class SyncOperation(Base):
     __tablename__ = "sync_operations"
 
     # Primary identifiers
-    id = Column(SQLAlchemy_UUID, primary_key=True, default=uuid4, doc="Database primary key")
+    id = Column(Uuid, primary_key=True, default=uuid4, doc="Database primary key")
     run_id = Column(Text, unique=True, index=True, doc="Public run ID returned to users")
 
     # Status and progress tracking
@@ -48,7 +48,7 @@ class SyncOperation(Base):
     # Operation metadata
     dataset_ids = Column(JSON, doc="Array of dataset IDs being synced")
     dataset_names = Column(JSON, doc="Array of dataset names being synced")
-    user_id = Column(SQLAlchemy_UUID, index=True, doc="ID of the user who initiated the sync")
+    user_id = Column(Uuid, index=True, doc="ID of the user who initiated the sync")
 
     # Timing information
     created_at = Column(

--- a/cognee/modules/tools/models/ToolConnection.py
+++ b/cognee/modules/tools/models/ToolConnection.py
@@ -2,8 +2,7 @@ from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID, uuid4
 
-from sqlalchemy import JSON, DateTime, LargeBinary, SmallInteger, String, UniqueConstraint
-from sqlalchemy import UUID as SAUUID
+from sqlalchemy import JSON, DateTime, LargeBinary, SmallInteger, String, UniqueConstraint, Uuid
 from sqlalchemy.orm import Mapped, mapped_column
 
 from cognee.infrastructure.databases.relational.ModelBase import Base
@@ -29,9 +28,9 @@ class ToolConnection(Base):
 
     __table_args__ = (UniqueConstraint("user_id", "name", name="uq_tool_connections_user_name"),)
 
-    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
 
-    user_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False, index=True)
+    user_id: Mapped[UUID] = mapped_column(Uuid, nullable=False, index=True)
     name: Mapped[str] = mapped_column(String, nullable=False)
 
     # "postgres" | "sqlite" in v1; inferred from the DSN at registration.

--- a/cognee/modules/tools/models/ToolWriteProposal.py
+++ b/cognee/modules/tools/models/ToolWriteProposal.py
@@ -2,8 +2,7 @@ from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID, uuid4
 
-from sqlalchemy import JSON, DateTime, Integer, String, Text
-from sqlalchemy import UUID as SAUUID
+from sqlalchemy import JSON, DateTime, Integer, String, Text, Uuid
 from sqlalchemy.orm import Mapped, mapped_column
 
 from cognee.infrastructure.databases.relational.ModelBase import Base
@@ -25,9 +24,9 @@ class ToolWriteProposal(Base):
 
     __tablename__ = "tool_write_proposals"
 
-    id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
 
-    user_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False, index=True)
+    user_id: Mapped[UUID] = mapped_column(Uuid, nullable=False, index=True)
     connection_name: Mapped[str] = mapped_column(String, nullable=False)
 
     status: Mapped[str] = mapped_column(String, nullable=False, default="proposed", index=True)

--- a/cognee/modules/users/models/ACL.py
+++ b/cognee/modules/users/models/ACL.py
@@ -1,21 +1,21 @@
 from uuid import uuid4
 from datetime import datetime, timezone
 from sqlalchemy.orm import relationship
-from sqlalchemy import Column, ForeignKey, DateTime, UUID
+from sqlalchemy import Column, ForeignKey, DateTime, Uuid
 from cognee.infrastructure.databases.relational import Base
 
 
 class ACL(Base):
     __tablename__ = "acls"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
 
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime(timezone=True), onupdate=lambda: datetime.now(timezone.utc))
 
-    principal_id = Column(UUID, ForeignKey("principals.id"))
-    permission_id = Column(UUID, ForeignKey("permissions.id"))
-    dataset_id = Column(UUID, ForeignKey("datasets.id", ondelete="CASCADE"))
+    principal_id = Column(Uuid, ForeignKey("principals.id"))
+    permission_id = Column(Uuid, ForeignKey("permissions.id"))
+    dataset_id = Column(Uuid, ForeignKey("datasets.id", ondelete="CASCADE"))
 
     principal = relationship("Principal")
     permission = relationship("Permission")

--- a/cognee/modules/users/models/DatasetDatabase.py
+++ b/cognee/modules/users/models/DatasetDatabase.py
@@ -1,15 +1,15 @@
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, String, UUID, ForeignKey, JSON, text
+from sqlalchemy import Column, DateTime, String, Uuid, ForeignKey, JSON, text
 from cognee.infrastructure.databases.relational import Base
 
 
 class DatasetDatabase(Base):
     __tablename__ = "dataset_database"
 
-    owner_id = Column(UUID, ForeignKey("principals.id", ondelete="CASCADE"), index=True)
+    owner_id = Column(Uuid, ForeignKey("principals.id", ondelete="CASCADE"), index=True)
     dataset_id = Column(
-        UUID, ForeignKey("datasets.id", ondelete="CASCADE"), primary_key=True, index=True
+        Uuid, ForeignKey("datasets.id", ondelete="CASCADE"), primary_key=True, index=True
     )
 
     vector_database_name = Column(String, unique=False, nullable=False)

--- a/cognee/modules/users/models/Permission.py
+++ b/cognee/modules/users/models/Permission.py
@@ -1,14 +1,14 @@
 from uuid import uuid4
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, String, UUID
+from sqlalchemy import Column, DateTime, String, Uuid
 from cognee.infrastructure.databases.relational import Base
 
 
 class Permission(Base):
     __tablename__ = "permissions"
 
-    id = Column(UUID, primary_key=True, index=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, index=True, default=uuid4)
 
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime(timezone=True), onupdate=lambda: datetime.now(timezone.utc))

--- a/cognee/modules/users/models/Principal.py
+++ b/cognee/modules/users/models/Principal.py
@@ -1,13 +1,13 @@
 from uuid import uuid4
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, DateTime, UUID
+from sqlalchemy import Column, String, DateTime, Uuid
 from cognee.infrastructure.databases.relational import Base
 
 
 class Principal(Base):
     __tablename__ = "principals"
 
-    id = Column(UUID, primary_key=True, index=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, index=True, default=uuid4)
 
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime(timezone=True), onupdate=lambda: datetime.now(timezone.utc))

--- a/cognee/modules/users/models/PrincipalConfiguration.py
+++ b/cognee/modules/users/models/PrincipalConfiguration.py
@@ -1,6 +1,6 @@
 from sqlalchemy import ForeignKey
 from datetime import datetime, timezone
-from sqlalchemy import UUID, Column, DateTime, String, JSON
+from sqlalchemy import Uuid, Column, DateTime, String, JSON
 from sqlalchemy.ext.mutable import MutableDict
 from uuid import uuid4
 
@@ -10,9 +10,9 @@ from cognee.infrastructure.databases.relational import Base
 class PrincipalConfiguration(Base):
     __tablename__ = "principal_configuration"
 
-    id = Column(UUID, primary_key=True, default=uuid4)
+    id = Column(Uuid, primary_key=True, default=uuid4)
 
-    owner_id = Column(UUID, ForeignKey("principals.id", ondelete="CASCADE"), index=True)
+    owner_id = Column(Uuid, ForeignKey("principals.id", ondelete="CASCADE"), index=True)
 
     name = Column(String, unique=False, nullable=False)
 

--- a/cognee/modules/users/models/Role.py
+++ b/cognee/modules/users/models/Role.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import relationship, Mapped
-from sqlalchemy import Column, String, ForeignKey, UUID, UniqueConstraint
+from sqlalchemy import Column, String, ForeignKey, Uuid, UniqueConstraint
 from .Principal import Principal
 from .UserRole import UserRole
 
@@ -7,7 +7,7 @@ from .UserRole import UserRole
 class Role(Principal):
     __tablename__ = "roles"
 
-    id = Column(UUID, ForeignKey("principals.id", ondelete="CASCADE"), primary_key=True)
+    id = Column(Uuid, ForeignKey("principals.id", ondelete="CASCADE"), primary_key=True)
 
     name = Column(String, nullable=False, index=True)
 
@@ -18,7 +18,7 @@ class Role(Principal):
     )
 
     # Foreign key to Tenant (Many-to-One relationship)
-    tenant_id = Column(UUID, ForeignKey("tenants.id"), nullable=False)
+    tenant_id = Column(Uuid, ForeignKey("tenants.id"), nullable=False)
 
     # Relationship to Tenant
     tenant = relationship("Tenant", back_populates="roles", foreign_keys=[tenant_id])

--- a/cognee/modules/users/models/RoleDefaultPermissions.py
+++ b/cognee/modules/users/models/RoleDefaultPermissions.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from sqlalchemy import Column, ForeignKey, DateTime, UUID
+from sqlalchemy import Column, ForeignKey, DateTime, Uuid
 from cognee.infrastructure.databases.relational import Base
 
 
@@ -9,12 +9,12 @@ class RoleDefaultPermissions(Base):
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     role_id = Column(
-        UUID,
+        Uuid,
         ForeignKey("roles.id", ondelete="CASCADE"),  # cascade deletion when Role is deleted
         primary_key=True,
     )
     permission_id = Column(
-        UUID,
+        Uuid,
         ForeignKey(
             "permissions.id", ondelete="CASCADE"
         ),  # cascade deletion when Permission is deleted

--- a/cognee/modules/users/models/Tenant.py
+++ b/cognee/modules/users/models/Tenant.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import relationship, Mapped
-from sqlalchemy import Column, String, ForeignKey, UUID
+from sqlalchemy import Column, String, ForeignKey, Uuid
 from .Principal import Principal
 from .UserTenant import UserTenant
 from .Role import Role
@@ -8,10 +8,10 @@ from .Role import Role
 class Tenant(Principal):
     __tablename__ = "tenants"
 
-    id = Column(UUID, ForeignKey("principals.id"), primary_key=True)
+    id = Column(Uuid, ForeignKey("principals.id"), primary_key=True)
     name = Column(String, unique=False, nullable=False, index=True)
 
-    owner_id = Column(UUID, index=True)
+    owner_id = Column(Uuid, index=True)
 
     users: Mapped[list["User"]] = relationship(  # noqa: F821
         "User",

--- a/cognee/modules/users/models/TenantDefaultPermissions.py
+++ b/cognee/modules/users/models/TenantDefaultPermissions.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from sqlalchemy import Column, ForeignKey, DateTime, UUID
+from sqlalchemy import Column, ForeignKey, DateTime, Uuid
 from cognee.infrastructure.databases.relational import Base
 
 
@@ -8,10 +8,10 @@ class TenantDefaultPermissions(Base):
 
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
-    tenant_id = Column(UUID, ForeignKey("tenants.id", ondelete="CASCADE"), primary_key=True)
+    tenant_id = Column(Uuid, ForeignKey("tenants.id", ondelete="CASCADE"), primary_key=True)
 
     permission_id = Column(
-        UUID,
+        Uuid,
         ForeignKey(
             "permissions.id", ondelete="CASCADE"
         ),  # cascade deletion when Permission is deleted

--- a/cognee/modules/users/models/User.py
+++ b/cognee/modules/users/models/User.py
@@ -2,7 +2,7 @@ from typing import Optional
 from uuid import UUID as uuid_UUID
 from fastapi_users import schemas
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID
-from sqlalchemy import ForeignKey, Column, UUID
+from sqlalchemy import ForeignKey, Column, Uuid
 from sqlalchemy.orm import relationship, Mapped
 
 from .Principal import Principal
@@ -15,14 +15,14 @@ from .Tenant import Tenant
 class User(SQLAlchemyBaseUserTableUUID, Principal):
     __tablename__ = "users"
 
-    id = Column(UUID, ForeignKey("principals.id", ondelete="CASCADE"), primary_key=True)
+    id = Column(Uuid, ForeignKey("principals.id", ondelete="CASCADE"), primary_key=True)
 
     # Foreign key to current Tenant (Many-to-One relationship)
-    tenant_id = Column(UUID, ForeignKey("tenants.id"))
+    tenant_id = Column(Uuid, ForeignKey("tenants.id"))
 
     # Parent user — when an agent/service user creates datasets, the parent
     # inherits full permissions automatically. Null for regular human users.
-    parent_user_id = Column(UUID, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    parent_user_id = Column(Uuid, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
 
     # Many-to-Many Relationship with Roles
     roles: Mapped[list["Role"]] = relationship(

--- a/cognee/modules/users/models/UserApiKey.py
+++ b/cognee/modules/users/models/UserApiKey.py
@@ -1,6 +1,6 @@
-from uuid import uuid4
+from uuid import UUID, uuid4
 from typing import Optional
-from sqlalchemy import UUID, ForeignKey
+from sqlalchemy import ForeignKey, Uuid
 from sqlalchemy.orm import Mapped, mapped_column
 from cognee.infrastructure.databases.relational.ModelBase import Base
 
@@ -8,9 +8,9 @@ from cognee.infrastructure.databases.relational.ModelBase import Base
 class UserApiKey(Base):
     __tablename__ = "user_api_key"
 
-    id: Mapped[UUID] = mapped_column(UUID, primary_key=True, default=uuid4)
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
     user_id: Mapped[UUID] = mapped_column(
-        UUID, ForeignKey("principals.id", ondelete="CASCADE"), nullable=False, index=True
+        Uuid, ForeignKey("principals.id", ondelete="CASCADE"), nullable=False, index=True
     )
     api_key: Mapped[str] = mapped_column(nullable=False)
     label: Mapped[Optional[str]] = mapped_column(nullable=True)

--- a/cognee/modules/users/models/UserDefaultPermissions.py
+++ b/cognee/modules/users/models/UserDefaultPermissions.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from sqlalchemy import Column, ForeignKey, DateTime, UUID
+from sqlalchemy import Column, ForeignKey, DateTime, Uuid
 from cognee.infrastructure.databases.relational import Base
 
 
@@ -8,9 +8,9 @@ class UserDefaultPermissions(Base):
 
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
-    user_id = Column(UUID, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    user_id = Column(Uuid, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
     permission_id = Column(
-        UUID,
+        Uuid,
         ForeignKey(
             "permissions.id", ondelete="CASCADE"
         ),  # cascade deletion when Permission is deleted

--- a/cognee/modules/users/models/UserRole.py
+++ b/cognee/modules/users/models/UserRole.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from sqlalchemy import Column, ForeignKey, DateTime, UUID
+from sqlalchemy import Column, ForeignKey, DateTime, Uuid
 from cognee.infrastructure.databases.relational import Base
 
 
@@ -8,5 +8,5 @@ class UserRole(Base):
 
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
-    user_id = Column(UUID, ForeignKey("users.id"), primary_key=True)
-    role_id = Column(UUID, ForeignKey("roles.id"), primary_key=True)
+    user_id = Column(Uuid, ForeignKey("users.id"), primary_key=True)
+    role_id = Column(Uuid, ForeignKey("roles.id"), primary_key=True)

--- a/cognee/modules/users/models/UserTenant.py
+++ b/cognee/modules/users/models/UserTenant.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from sqlalchemy import Column, ForeignKey, DateTime, UUID
+from sqlalchemy import Column, ForeignKey, DateTime, Uuid
 from cognee.infrastructure.databases.relational import Base
 
 
@@ -8,5 +8,5 @@ class UserTenant(Base):
 
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
-    user_id = Column(UUID, ForeignKey("users.id"), primary_key=True)
-    tenant_id = Column(UUID, ForeignKey("tenants.id"), primary_key=True)
+    user_id = Column(Uuid, ForeignKey("users.id"), primary_key=True)
+    tenant_id = Column(Uuid, ForeignKey("tenants.id"), primary_key=True)

--- a/cognee/tests/unit/modules/graph/test_relational_upserts.py
+++ b/cognee/tests/unit/modules/graph/test_relational_upserts.py
@@ -1,16 +1,22 @@
+from datetime import datetime, timezone
 from importlib import import_module
-from uuid import uuid4
+from uuid import UUID, uuid4
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.orm import Session
 
 from cognee.infrastructure.engine import DataPoint
 from cognee.modules.graph.methods.sanitize_relational_payload import sanitize_relational_payload
 from cognee.modules.graph.methods.upsert_edges import upsert_edges
 from cognee.modules.graph.methods.upsert_nodes import upsert_nodes
+from cognee.modules.graph.models import Edge
 
 upsert_nodes_module = import_module("cognee.modules.graph.methods.upsert_nodes")
 upsert_edges_module = import_module("cognee.modules.graph.methods.upsert_edges")
+
+NUMERIC_LOOKING_UUID = UUID("123e4567890123456789012345678901")
 
 
 class RelationalPoint(DataPoint):
@@ -32,6 +38,39 @@ class FakeInsertStatement:
     def on_conflict_do_nothing(self, index_elements):
         self.index_elements = index_elements
         return self
+
+
+def test_edge_uuid_columns_keep_numeric_looking_values_as_text_in_sqlite():
+    engine = create_engine("sqlite://")
+    Edge.__table__.create(engine)
+
+    edge = Edge(
+        id=NUMERIC_LOOKING_UUID,
+        slug=uuid4(),
+        user_id=uuid4(),
+        data_id=uuid4(),
+        dataset_id=uuid4(),
+        source_node_id=uuid4(),
+        destination_node_id=uuid4(),
+        relationship_name="contains",
+        created_at=datetime.now(timezone.utc),
+    )
+
+    with Session(engine) as session:
+        session.add(edge)
+        session.commit()
+        session.expire_all()
+        stored_edge = session.scalar(select(Edge).where(Edge.id == NUMERIC_LOOKING_UUID))
+
+    with engine.connect() as connection:
+        table_sql = connection.scalar(
+            text("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'edges'")
+        )
+        storage_type = connection.scalar(text("SELECT typeof(id) FROM edges"))
+
+    assert "CHAR(32)" in table_sql
+    assert storage_type == "text"
+    assert stored_edge.id == NUMERIC_LOOKING_UUID
 
 
 def test_sanitize_relational_payload_strips_null_bytes_recursively():


### PR DESCRIPTION
## Summary

- replace SQLAlchemy's exact-name `UUID` type with backend-agnostic `Uuid` across relational models
- make newly created SQLite UUID columns use `CHAR(32)` text affinity while PostgreSQL continues using native `UUID`
- add a deterministic regression test proving a numeric-looking UUID round-trips as text through the real `Edge` model

This fixes an issue for SQLite when the first UUID element would not contain any characters it could interpret the whole column as a float type..

## Scope

This PR intentionally includes **no Alembic migration**. Existing SQLite tables declared as `UUID` are unchanged and existing malformed UUID values are not repaired. This prevents the issue for databases created after the model change only.

## Verification

- `44 passed`: relational database unit tests plus `test_relational_upserts.py`
- `ruff check .`
- `ruff format --check` on all changed Python files
- Python compilation checks on all changed Python files
- verified `Edge.id` compiles to `CHAR(32)` on SQLite and native `UUID` on PostgreSQL