### PR TITLE
docs(examples): fix broken script links in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,25 +4,24 @@ This directory contains 60+ runnable example scripts that demonstrate cognee's
 features end-to-end. They double as the smoke-test corpus that the team uses
 to verify behaviour across the SDK.
 
-> **New here?** Start with [`demos/simple_cognee_example.py`](demos/simple_cognee_example.py) (the canonical `remember → recall` flow), then follow the quickstart map below.
+> **New here?** Start with [`guides/simple_cognee_example.py`](guides/simple_cognee_example.py) (the canonical `remember → recall` flow), then follow the quickstart map below.
 
 ## 🚀 Quickstart map (5 examples to start with)
 
 | Example | What you'll learn |
 |---|---|
-| [`demos/simple_cognee_example.py`](demos/simple_cognee_example.py) | Canonical `remember → recall` pipeline |
+| [`guides/simple_cognee_example.py`](guides/simple_cognee_example.py) | Canonical `remember → recall` pipeline |
 | [`advanced_guides/remember_recall_improve_example.py`](advanced_guides/remember_recall_improve_example.py) | The v1.0 memory API (`remember`, `recall`, `improve`, `forget`) |
 | [`guides/agent_memory_quickstart.py`](guides/agent_memory_quickstart.py) | Wrap an LLM agent with cognee memory |
 | [`guides/graph_visualization.py`](guides/graph_visualization.py) | Render the resulting knowledge graph |
-| [`demos/start_local_ui_frontend_example.py`](demos/start_local_ui_frontend_example.py) | Launch the cognee UI alongside the API server |
+| [`guides/start_local_ui_frontend_example.py`](guides/start_local_ui_frontend_example.py) | Launch the cognee UI alongside the API server |
 
 ## 📁 Top-level layout
 
 | Folder | Purpose | Count |
 |---|---|---|
-| [`configurations/`](configurations/) | Database & permissions configuration recipes | 8 |
+| [`configurations/`](configurations/) | Permissions & multi-tenancy recipes | 4 |
 | [`custom_pipelines/`](custom_pipelines/) | Build your own pipeline / extend `cognify` | 7 |
-| [`database_examples/`](database_examples/) | Smoke tests per supported backend | 5 |
 | [`demos/`](demos/) | Feature demos — broadest coverage | 22 |
 | [`guides/`](guides/) | Short focused how-to guides | 13 |
 | [`integrations/`](integrations/) | Data-source connectors — installed from cognee-community | 1 |
@@ -31,15 +30,7 @@ to verify behaviour across the SDK.
 
 Most runnable demos and backend examples use the v1.0 memory API (`remember`, `recall`, `forget`, `improve`). The lower-level `add`, `cognify`, `search`, and `prune` calls are intentionally kept in examples that demonstrate pipeline internals, permissions, relational migrations, or research POCs.
 
-## 🔧 `configurations/` — backend & permissions setup
-
-### Database configuration
-| Script | Demonstrates |
-|---|---|
-| [`database_examples/ladybug_graph_database_configuration.py`](configurations/database_examples/ladybug_graph_database_configuration.py) | Ladybug (default) graph backend |
-| [`database_examples/neo4j_graph_database_configuration.py`](configurations/database_examples/neo4j_graph_database_configuration.py) | Neo4j graph backend |
-| [`database_examples/neptune_analytics_aws_database_configuration.py`](configurations/database_examples/neptune_analytics_aws_database_configuration.py) | AWS Neptune Analytics graph backend |
-| [`database_examples/pgvector_postgres_vector_database_configuration.py`](configurations/database_examples/pgvector_postgres_vector_database_configuration.py) | Postgres + pgvector hybrid (vector + relational in one) |
+## 🔧 `configurations/` — permissions & multi-tenancy setup
 
 ### Permissions / multi-tenancy (set `ENABLE_BACKEND_ACCESS_CONTROL=True`)
 | Script | Demonstrates |
@@ -61,45 +52,42 @@ Most runnable demos and backend examples use the v1.0 memory API (`remember`, `r
 | [`organizational_hierarchy/organizational_hierarchy_pipeline_example.py`](custom_pipelines/organizational_hierarchy/organizational_hierarchy_pipeline_example.py) | Org-chart ingestion (high-level API) |
 | [`organizational_hierarchy/organizational_hierarchy_pipeline_low_level_example.py`](custom_pipelines/organizational_hierarchy/organizational_hierarchy_pipeline_low_level_example.py) | Same dataset via the low-level Task API |
 
-## 🗄️ `database_examples/` — smoke tests per backend
+## 🗄️ Backend examples
 
-| Script | Demonstrates |
-|---|---|
-| [`ladybug_example.py`](database_examples/ladybug_example.py) | Ladybug (default) — graph |
-| [`neo4j_example.py`](database_examples/neo4j_example.py) | Neo4j — graph |
-| [`neptune_analytics_example.py`](database_examples/neptune_analytics_example.py) | Neptune Analytics — graph |
-| [`chromadb_example.py`](database_examples/chromadb_example.py) | ChromaDB — vector |
-| [`pgvector_example.py`](database_examples/pgvector_example.py) | pgvector — vector + relational |
+The per-backend smoke scripts now live in [`guides/`](guides/):
+[`ladybug_example.py`](guides/ladybug_example.py) (default graph),
+[`neo4j_example.py`](guides/neo4j_example.py),
+[`neptune_analytics_example.py`](guides/neptune_analytics_example.py), and
+[`pgvector_example.py`](guides/pgvector_example.py) (vector + relational).
 
 ## 🎯 `demos/` — feature breadth
 
 | Script | Demonstrates |
 |---|---|
-| [`simple_cognee_example.py`](demos/simple_cognee_example.py) | Canonical `remember → recall` pipeline (start here) |
+| [`simple_cognee_example.py`](guides/simple_cognee_example.py) | Canonical `remember → recall` pipeline (start here) |
 | [`comprehensive_example/cognee_comprehensive_example.py`](demos/comprehensive_example/cognee_comprehensive_example.py) | End-to-end with most features stitched together |
 | [`remember_recall_improve_example.py`](advanced_guides/remember_recall_improve_example.py) | v1.0 memory API (`remember`, `recall`, `improve`, `forget`) |
 | [`conversation_session_persistence_example.py`](advanced_guides/conversation_session_persistence_example.py) | Session memory persisted across runs |
 | [`session_feedback_example.py`](demos/session_feedback_example.py) | Capturing thumbs-up/down feedback on retrieval |
 | [`session_feedback_lifecycle_demo/backend/app.py`](demos/session_feedback_lifecycle_demo/backend/app.py) | Full feedback-loop backend (FastAPI + cognee) |
 | [`feedback_score_shifting_example.py`](demos/feedback_score_shifting_example.py) | How feedback nudges retrieval scores |
-| [`references_example.py`](demos/references_example.py) | Search answers with lightweight evidence references |
+| [`references_example.py`](guides/references_example.py) | Search answers with lightweight evidence references |
 | [`custom_graph_model_entity_schema_definition.py`](demos/custom_graph_model_entity_schema_definition.py) | Define your own entity schema for graph extraction |
 | [`custom_pipeline_single_object_example.py`](demos/custom_pipeline_single_object_example.py) | Run a custom pipeline on a single object |
 | [`dynamic_multiple_weighted_edges_example.py`](demos/dynamic_multiple_weighted_edges_example.py) | Many-to-many edges with per-edge weights |
-| [`nodeset_grouping_example.py`](demos/nodeset_grouping_example.py) | Group nodes into named sets for filtered retrieval |
+| [`nodeset_grouping_example.py`](guides/nodeset_grouping_example.py) | Group nodes into named sets for filtered retrieval |
 | [`temporal_awareness_example/temporal_awareness_example.py`](advanced_guides/temporal_awareness_example/temporal_awareness_example.py) | Time-aware retrieval (`Event` model) |
 | [`ontology_reference_vocabulary/ontology_as_reference_vocabulary_example.py`](advanced_guides/ontology_reference_vocabulary/ontology_as_reference_vocabulary_example.py) | Ontology as a constraining vocabulary for extraction |
-| [`web_url_content_ingestion_example.py`](demos/web_url_content_ingestion_example.py) | Crawl a URL and cognify the content |
+| [`web_url_content_ingestion_example.py`](guides/web_url_content_ingestion_example.py) | Crawl a URL and cognify the content |
 | [`dlt_ingestion_example.py`](demos/dlt_ingestion_example.py) | Ingest via [dlt](https://dlthub.com/) sources |
-| [`multimedia_processing/multimedia_audio_image_processing_example.py`](demos/multimedia_processing/multimedia_audio_image_processing_example.py) | Audio + image ingestion |
+| [`multimedia_audio_image_processing_example.py`](guides/multimedia_audio_image_processing_example.py) | Audio + image ingestion |
 | [`simple_document_qa/simple_document_qa_demo.py`](advanced_guides/simple_document_qa/simple_document_qa_demo.py) | Q&A over a single document |
 | [`simple_relational_database_migration_example/simple_relational_database_migration_example.py`](demos/simple_relational_database_migration_example/simple_relational_database_migration_example.py) | SQL → graph (small schema) |
 | [`complex_relational_database_migration_example/complex_relational_database_migration_example.py`](demos/complex_relational_database_migration_example/complex_relational_database_migration_example.py) | SQL → graph (richer schema) |
-| [`schema_inventory_demo.py`](demos/schema_inventory_demo.py) | Schema and entity inventory visualization |
-| [`memory_provenance_demo.py`](demos/memory_provenance_demo.py) | Memory provenance projection and visualization |
-| [`sync_local_to_cloud_example.py`](demos/sync_local_to_cloud_example.py) | Sync a local dataset to Cognee Cloud |
+| [`schema_inventory.py`](guides/schema_inventory.py) | Schema and entity inventory visualization |
+| [`memory_provenance.py`](guides/memory_provenance.py) | Memory provenance projection and visualization |
 | [`pipeline_api_proposal.py`](demos/pipeline_api_proposal.py) | Proposal-style API exploration |
-| [`start_local_ui_frontend_example.py`](demos/start_local_ui_frontend_example.py) | Spin up cognee UI + backend |
+| [`start_local_ui_frontend_example.py`](guides/start_local_ui_frontend_example.py) | Spin up cognee UI + backend |
 
 ## 📘 `guides/` — focused how-tos
 
@@ -160,8 +148,8 @@ Same scripts, indexed by what they demonstrate.
 - [`guides/ontology_quickstart.py`](guides/ontology_quickstart.py)
 
 ### Multimedia & non-text ingestion
-- [`demos/multimedia_processing/multimedia_audio_image_processing_example.py`](demos/multimedia_processing/multimedia_audio_image_processing_example.py)
-- [`demos/web_url_content_ingestion_example.py`](demos/web_url_content_ingestion_example.py)
+- [`guides/multimedia_audio_image_processing_example.py`](guides/multimedia_audio_image_processing_example.py)
+- [`guides/web_url_content_ingestion_example.py`](guides/web_url_content_ingestion_example.py)
 - [`demos/dlt_ingestion_example.py`](demos/dlt_ingestion_example.py)
 
 ### Connectors / Integrations
@@ -190,17 +178,16 @@ Same scripts, indexed by what they demonstrate.
 - [`configurations/permissions_example/`](configurations/permissions_example/) (4 scripts)
 
 ### Backends
-- [`database_examples/`](database_examples/) — 5 backends end-to-end
-- [`configurations/database_examples/`](configurations/database_examples/) — 4 graph + 1 hybrid configurations
+- [`guides/`](guides/) backend guides — Ladybug, Neo4j, Neptune Analytics, pgvector
 
 ### Visualization & UI
 - [`guides/graph_visualization.py`](guides/graph_visualization.py)
-- [`demos/schema_inventory_demo.py`](demos/schema_inventory_demo.py)
-- [`demos/memory_provenance_demo.py`](demos/memory_provenance_demo.py)
-- [`demos/start_local_ui_frontend_example.py`](demos/start_local_ui_frontend_example.py)
+- [`guides/schema_inventory.py`](guides/schema_inventory.py)
+- [`guides/memory_provenance.py`](guides/memory_provenance.py)
+- [`guides/start_local_ui_frontend_example.py`](guides/start_local_ui_frontend_example.py)
 
 ### References / evidence
-- [`demos/references_example.py`](demos/references_example.py)
+- [`guides/references_example.py`](guides/references_example.py)
 
 ### Storage backends
 - [`guides/s3_storage.py`](guides/s3_storage.py)
@@ -222,7 +209,7 @@ cp .env.template .env
 # edit .env: set LLM_API_KEY (your OpenAI key) at minimum
 
 # Run any example
-uv run python examples/demos/simple_cognee_example.py
+uv run python examples/guides/simple_cognee_example.py
 ```
 
 For non-OpenAI providers (Anthropic, Bedrock, Ollama, fastembed, …) see


### PR DESCRIPTION
## Summary

20 relative links in `examples/README.md` are broken on `dev` after the examples restructure moved or removed their targets. This PR retargets them so the index matches reality.

### Changes

- Retarget scripts that moved into `guides/`: `simple_cognee_example.py`, `start_local_ui_frontend_example.py`, `references_example.py`, `nodeset_grouping_example.py`, `web_url_content_ingestion_example.py`, `schema_inventory.py` (was `schema_inventory_demo.py`), `memory_provenance.py` (was `memory_provenance_demo.py`), `multimedia_audio_image_processing_example.py`, and the backend smoke scripts (`ladybug` / `neo4j` / `neptune_analytics` / `pgvector`).
- Remove entries whose targets no longer exist anywhere: `database_examples/` folder (section, layout-table row, cross-index), `configurations/database_examples/` subsection, `chromadb_example.py`, `sync_local_to_cloud_example.py`.
- Update the `configurations/` layout row (permissions-only now) and the `Running` example path (`examples/guides/simple_cognee_example.py`).

### Test results

Relative-link check before and after (every markdown link resolved against the repo tree):

```text
before: 20 broken links
after:   0 broken links
```

Docs-only change; no Python surface touched.

---

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin
