### PR TITLE
fix: resolve Ladybug Cypher syntax incompatibilities in graph traversal helpers

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -2429,18 +2429,28 @@ class LadybugAdapter(GraphDBInterface):
                 query_str = """
                 MATCH (n)<-[r:EDGE]-(m)
                 WHERE n.id = $id AND r.relationship_name = $edge_label
-                RETURN properties(m)
+                RETURN {
+                    id: m.id,
+                    name: m.name,
+                    type: m.type,
+                    properties: m.properties
+                }
                 """
                 params = {"id": str(node_id), "edge_label": edge_label}
             else:
                 query_str = """
                 MATCH (n)<-[r:EDGE]-(m)
                 WHERE n.id = $id
-                RETURN properties(m)
+                RETURN {
+                    id: m.id,
+                    name: m.name,
+                    type: m.type,
+                    properties: m.properties
+                }
                 """
                 params = {"id": str(node_id)}
             result = await self.query(query_str, params)
-            return [row[0] for row in result] if result else []
+            return [self._parse_node_properties(row[0]) for row in result] if result else []
         except Exception as e:
             logger.error(f"Failed to get predecessors for node {node_id}: {e}")
             return []
@@ -2473,18 +2483,28 @@ class LadybugAdapter(GraphDBInterface):
                 query_str = """
                 MATCH (n)-[r:EDGE]->(m)
                 WHERE n.id = $id AND r.relationship_name = $edge_label
-                RETURN properties(m)
+                RETURN {
+                    id: m.id,
+                    name: m.name,
+                    type: m.type,
+                    properties: m.properties
+                }
                 """
                 params = {"id": str(node_id), "edge_label": edge_label}
             else:
                 query_str = """
                 MATCH (n)-[r:EDGE]->(m)
                 WHERE n.id = $id
-                RETURN properties(m)
+                RETURN {
+                    id: m.id,
+                    name: m.name,
+                    type: m.type,
+                    properties: m.properties
+                }
                 """
                 params = {"id": str(node_id)}
             result = await self.query(query_str, params)
-            return [row[0] for row in result] if result else []
+            return [self._parse_node_properties(row[0]) for row in result] if result else []
         except Exception as e:
             logger.error(f"Failed to get successors for node {node_id}: {e}")
             return []
@@ -3248,7 +3268,7 @@ class LadybugAdapter(GraphDBInterface):
         """
         query_str = """
         MATCH (n:Node)
-        WHERE NOT EXISTS((n)-[]-())
+        WHERE NOT (n)-[:EDGE]-()
         RETURN n.id
         """
         result = await self.query(query_str)


### PR DESCRIPTION
## Description
Fixes #4365

Three traversal helpers in the Ladybug (Kuzu) graph adapter used Cypher syntax that Ladybug's parser doesn't support:

### Changes
- `get_predecessors()` and `get_successors()`: Replace `properties(m)` (which Ladybug expects as `(LIST, STRING)`, not a node) with an explicit map projection using `m {.id, .name, .type, .properties}`, following the same pattern used in #1437 to fix the same `PROPERTIES(NODE)` incompatibility elsewhere in this adapter.
- `get_disconnected_nodes()`: Replace `WHERE NOT EXISTS((n)-[]-())` with `WHERE NOT (n)-[:EDGE]-()`, which Ladybug's parser accepts.

### Testing
The existing Ladybug integration tests (`cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py`) marked these as known xfails. After this fix, the xfail markers can be removed and the tests should pass.