### PR TITLE
feat: Report search timings per search type

### DIFF
--- a/.github/scripts/build_nightly_slack_blocks.py
+++ b/.github/scripts/build_nightly_slack_blocks.py
@@ -29,16 +29,36 @@ import sys
 # `p50`, preserved verbatim from the hand-written YAML this replaced: the
 # columns do not line up (add/cognify/tenant end at 9, search/total at 11), and
 # reproducing that exactly is what lets the migration be diffed to zero.
-ROWS = [("add", 6), ("cognify", 2), ("search", 5), ("total", 6)]
+ROWS_BEFORE_SEARCH = [("add", 6), ("cognify", 2)]
+ROWS_AFTER_SEARCH = [("total", 6)]
 TENANT_ROW = ("tenant", 3)
-# Metric rows read `<key>.p50` etc. from the arm's metrics object; the tenant
-# row is the one whose label differs from its JSON key.
-METRIC_KEY = {"tenant": "tenant_create"}
+# Search rows, in render order. The Python and cloud arms time each search type
+# separately (`search_graph` / `search_hybrid`); the Rust SDK arm still reports
+# a single `search`. search_rows() picks whichever the arm actually carries.
+SEARCH_ROWS = [("search", 5), ("search graph", 3), ("search hybrid", 2)]
+# Metric rows read `<key>.p50` etc. from the arm's metrics object; these are the
+# rows whose label differs from its JSON key.
+METRIC_KEY = {
+    "tenant": "tenant_create",
+    "search graph": "search_graph",
+    "search hybrid": "search_hybrid",
+}
 PERCENTILES = ("p50", "p90", "p99")
 
 
 def section(text):
     return {"type": "section", "text": {"type": "mrkdwn", "text": text}}
+
+
+def search_rows(metrics):
+    """The search rows this arm reports.
+
+    A failed job produces `{}`, which matches none of them — fall back to the
+    single legacy row so the arm still renders a search line with blank
+    numbers rather than silently losing it.
+    """
+    rows = [row for row in SEARCH_ROWS if METRIC_KEY.get(row[0], row[0]) in metrics]
+    return rows or [SEARCH_ROWS[0]]
 
 
 def metric_row(metrics, label, pad):
@@ -57,7 +77,7 @@ def arm_block(emoji, title, result, metrics_json, url):
         metrics = {}
 
     rows = [TENANT_ROW] if "tenant_create" in metrics else []
-    rows += ROWS
+    rows += ROWS_BEFORE_SEARCH + search_rows(metrics) + ROWS_AFTER_SEARCH
 
     lines = [f"*{emoji} {title}* (`{result}`)  •  runs `{metrics.get('success', '')}`"]
     lines += [metric_row(metrics, label, pad) for label, pad in rows]

--- a/.github/workflows/performance_report.yml
+++ b/.github/workflows/performance_report.yml
@@ -42,13 +42,13 @@ on:
         default: ''
     outputs:
       file_based_metrics:
-        description: "File-based run: success + add/cognify/search/total p50/p90/p99."
+        description: "File-based run: success + add/cognify/search (GRAPH_COMPLETION + HYBRID_COMPLETION)/total p50/p90/p99."
         value: ${{ jobs.file_based.outputs.metrics }}
       file_based_html_key:
         description: "File-based run: S3 object key of the HTML report."
         value: ${{ jobs.file_based.outputs.html_key }}
       postgres_metrics:
-        description: "Postgres run: success + add/cognify/search/total p50/p90/p99."
+        description: "Postgres run: success + add/cognify/search (GRAPH_COMPLETION + HYBRID_COMPLETION)/total p50/p90/p99."
         value: ${{ jobs.postgres.outputs.metrics }}
       postgres_html_key:
         description: "Postgres run: S3 object key of the HTML report."
@@ -161,7 +161,8 @@ jobs:
             success: "\(.succeeded)/\(.num_runs)",
             add:     {p50: .stats.add_time_s.p50,          p90: .stats.add_time_s.p90,          p99: .stats.add_time_s.p99},
             cognify: {p50: .stats.cognify_time_s.p50,      p90: .stats.cognify_time_s.p90,      p99: .stats.cognify_time_s.p99},
-            search:  {p50: .stats.search_time.p50,         p90: .stats.search_time.p90,         p99: .stats.search_time.p99},
+            search_graph:  {p50: .stats.search_time_graph_completion.p50,  p90: .stats.search_time_graph_completion.p90,  p99: .stats.search_time_graph_completion.p99},
+            search_hybrid: {p50: .stats.search_time_hybrid_completion.p50, p90: .stats.search_time_hybrid_completion.p90, p99: .stats.search_time_hybrid_completion.p99},
             total:   {p50: .stats.total_ingest_time_s.p50, p90: .stats.total_ingest_time_s.p90, p99: .stats.total_ingest_time_s.p99}
           }' "$JSON_PATH")"
           echo "metrics=$METRICS" >> "$GITHUB_OUTPUT"
@@ -312,7 +313,8 @@ jobs:
             success: "\(.succeeded)/\(.num_runs)",
             add:     {p50: .stats.add_time_s.p50,          p90: .stats.add_time_s.p90,          p99: .stats.add_time_s.p99},
             cognify: {p50: .stats.cognify_time_s.p50,      p90: .stats.cognify_time_s.p90,      p99: .stats.cognify_time_s.p99},
-            search:  {p50: .stats.search_time.p50,         p90: .stats.search_time.p90,         p99: .stats.search_time.p99},
+            search_graph:  {p50: .stats.search_time_graph_completion.p50,  p90: .stats.search_time_graph_completion.p90,  p99: .stats.search_time_graph_completion.p99},
+            search_hybrid: {p50: .stats.search_time_hybrid_completion.p50, p90: .stats.search_time_hybrid_completion.p90, p99: .stats.search_time_hybrid_completion.p99},
             total:   {p50: .stats.total_ingest_time_s.p50, p90: .stats.total_ingest_time_s.p90, p99: .stats.total_ingest_time_s.p99}
           }' "$JSON_PATH")"
           echo "metrics=$METRICS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/performance_report_cloud.yml
+++ b/.github/workflows/performance_report_cloud.yml
@@ -40,7 +40,7 @@ on:
         type: string
     outputs:
       cloud_metrics:
-        description: "Cloud run: success + add/cognify/search/total p50/p90/p99."
+        description: "Cloud run: success + add/cognify/search (GRAPH_COMPLETION + HYBRID_COMPLETION)/total p50/p90/p99."
         value: ${{ jobs.cloud.outputs.metrics }}
       cloud_html_key:
         description: "Cloud run: S3 object key of the HTML report."
@@ -148,7 +148,8 @@ jobs:
             tenant_create: {p50: .stats.tenant_create_time_s.p50, p90: .stats.tenant_create_time_s.p90, p99: .stats.tenant_create_time_s.p99},
             add:     {p50: .stats.add_time_s.p50,          p90: .stats.add_time_s.p90,          p99: .stats.add_time_s.p99},
             cognify: {p50: .stats.cognify_time_s.p50,      p90: .stats.cognify_time_s.p90,      p99: .stats.cognify_time_s.p99},
-            search:  {p50: .stats.search_time.p50,         p90: .stats.search_time.p90,         p99: .stats.search_time.p99},
+            search_graph:  {p50: .stats.search_time_graph_completion.p50,  p90: .stats.search_time_graph_completion.p90,  p99: .stats.search_time_graph_completion.p99},
+            search_hybrid: {p50: .stats.search_time_hybrid_completion.p50, p90: .stats.search_time_hybrid_completion.p90, p99: .stats.search_time_hybrid_completion.p99},
             total:   {p50: .stats.total_ingest_time_s.p50, p90: .stats.total_ingest_time_s.p90, p99: .stats.total_ingest_time_s.p99}
           }' "$JSON_PATH")"
           echo "metrics=$METRICS" >> "$GITHUB_OUTPUT"

--- a/cognee/tests/performance/statistics_percentile/bench_cognee.py
+++ b/cognee/tests/performance/statistics_percentile/bench_cognee.py
@@ -48,6 +48,17 @@ DEFAULT_EMBEDDING_PROVIDER = "openai"
 DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
 DEFAULT_EMBEDDING_DIMS = 1536
 DATASET_NAME = "bench_memories"
+SEARCH_QUERY = "What is in the document"
+
+# Search types timed in Phase 3, in run order: `(metric suffix, SearchType name)`.
+# Each gets its own metric so the nightly report can compare retrieval
+# strategies side by side — GRAPH_COMPLETION is the default graph traversal,
+# HYBRID_COMPLETION the chunk+entity blend. Both the local and the cloud
+# benchmark iterate this list, so the two modes always report the same types.
+BENCHMARKED_SEARCH_TYPES = (
+    ("graph_completion", "GRAPH_COMPLETION"),
+    ("hybrid_completion", "HYBRID_COMPLETION"),
+)
 
 ENV_FILE = Path(__file__).resolve().parents[4] / ".env"
 
@@ -227,14 +238,14 @@ async def run_benchmark(
         "db_setup": "success",
         "add": "success",
         "cognify": "success",
-        "search": "success",
         "dataset_delete": "success",
+        **{f"search_{key}": "success" for key, _ in BENCHMARKED_SEARCH_TYPES},
     }
     t_prune = 0.0
     t_db_setup = 0.0
     t_add = 0.0
     t_cognify = 0.0
-    t_search = 0.0
+    t_search = {key: 0.0 for key, _ in BENCHMARKED_SEARCH_TYPES}
     t_dataset_delete = 0.0
 
     # ── Prune (clean slate) ──────────────────────────────────────────────
@@ -289,15 +300,23 @@ async def run_benchmark(
     t_total = t_add + t_cognify
 
     # ── Phase 3: cognee.search() ─────────────────────────────────────────
+    # One timing per benchmarked search type. `only_context=True` keeps every
+    # number a measure of retrieval rather than answer generation, so the types
+    # stay comparable to each other and to the previous single-search metric.
     print("\nPhase 3: Running search queries...")
-    try:
+    for metric_key, search_type in BENCHMARKED_SEARCH_TYPES:
         t_q_start = time.time()
-        await cognee.search(query_text="What is in the document", only_context=True)
-        t_search = time.time() - t_q_start
-    except Exception as e:
-        t_search = time.time() - t_q_start
-        status["search"] = f"failed: {e}"
-        print(f"  Search FAILED: {e}")
+        try:
+            await cognee.search(
+                query_text=SEARCH_QUERY,
+                query_type=cognee.SearchType[search_type],
+                only_context=True,
+            )
+            t_search[metric_key] = time.time() - t_q_start
+        except Exception as e:
+            t_search[metric_key] = time.time() - t_q_start
+            status[f"search_{metric_key}"] = f"failed: {_err(e)}"
+            print(f"  Search {search_type} FAILED: {_err(e)}")
 
     # ── Phase 4: dataset delete (populated) ──────────────────────────────
     # Deleting the dataset AFTER the graph is built measures the meaningful
@@ -331,7 +350,7 @@ async def run_benchmark(
         "total_ingest_time_s": round(t_total, 3),
         "prune_time_s": round(t_prune, 3),
         "db_setup_time_s": round(t_db_setup, 3),
-        "search_time": t_search,
+        **{f"search_time_{key}": t_search[key] for key, _ in BENCHMARKED_SEARCH_TYPES},
         "dataset_delete_time_s": round(t_dataset_delete, 3),
         "status": status,
         "success": all_ok,
@@ -354,7 +373,11 @@ async def run_benchmark(
     print(f"  cognee.add() time : {t_add:.2f}s  ({t_add / n:.2f}s per memory)  [{status['add']}]")
     print(f"  cognify() time    : {t_cognify:.2f}s  [{status['cognify']}]")
     print(f"  Total ingest time : {t_total:.2f}s  ({t_total / n:.2f}s per memory)")
-    print(f"  Search total      : {t_search:.2f}s  [{status['search']}]")
+    for metric_key, search_type in BENCHMARKED_SEARCH_TYPES:
+        print(
+            f"  Search {search_type:<18}: {t_search[metric_key]:.2f}s  "
+            f"[{status[f'search_{metric_key}']}]"
+        )
     print(f"  DB setup time     : {t_db_setup:.2f}s  [{status['db_setup']}]")
     print(f"  Prune time        : {t_prune:.2f}s  [{status['prune']}]")
     print(f"  Dataset delete    : {t_dataset_delete:.2f}s  [{status['dataset_delete']}]")
@@ -514,12 +537,12 @@ async def run_benchmark_cloud(
         "db_setup": "success",  # server-side, nothing to set up from the client
         "add": "success",
         "cognify": "success",
-        "search": "success",
+        **{f"search_{key}": "success" for key, _ in BENCHMARKED_SEARCH_TYPES},
     }
     t_prune = 0.0
     t_add = 0.0
     t_cognify = 0.0
-    t_search = 0.0
+    t_search = {key: 0.0 for key, _ in BENCHMARKED_SEARCH_TYPES}
     t_tenant_create = 0.0
     t_tenant_delete = 0.0
     t_dataset_delete = 0.0
@@ -550,7 +573,10 @@ async def run_benchmark_cloud(
             # skew failed-run percentiles low).
             t_tenant_create = time.time() - t_tenant_create_start
             status["tenant_create"] = f"failed: {_err(e)}"
-            for phase in ("prune", "add", "cognify", "search"):
+            skipped_phases = ("prune", "add", "cognify") + tuple(
+                f"search_{key}" for key, _ in BENCHMARKED_SEARCH_TYPES
+            )
+            for phase in skipped_phases:
                 status[phase] = "skipped"
             tenant_ready = False
             print(f"  Tenant creation FAILED: {_err(e)}")
@@ -606,19 +632,24 @@ async def run_benchmark_cloud(
             print(f"  Cognify FAILED: {_err(e)}")
 
         # ── Phase 3: search ──────────────────────────────────────────────
+        # One timing per benchmarked search type, matching the local mode.
         # Scoped to this suite's dataset so a concurrently-running suite on
         # the same tenant cannot contaminate the search timing or results.
-        print("\nPhase 3: Running remote search query...")
-        t_q_start = time.time()
-        try:
-            await client.search(
-                "What is in the document", datasets=[dataset_name], only_context=True
-            )
-            t_search = time.time() - t_q_start
-        except Exception as e:
-            t_search = time.time() - t_q_start
-            status["search"] = f"failed: {_err(e)}"
-            print(f"  Search FAILED: {_err(e)}")
+        print("\nPhase 3: Running remote search queries...")
+        for metric_key, search_type in BENCHMARKED_SEARCH_TYPES:
+            t_q_start = time.time()
+            try:
+                await client.search(
+                    SEARCH_QUERY,
+                    search_type=search_type,
+                    datasets=[dataset_name],
+                    only_context=True,
+                )
+                t_search[metric_key] = time.time() - t_q_start
+            except Exception as e:
+                t_search[metric_key] = time.time() - t_q_start
+                status[f"search_{metric_key}"] = f"failed: {_err(e)}"
+                print(f"  Search {search_type} FAILED: {_err(e)}")
 
         # ── Phase 4 (cloud-only metric): delete the POPULATED dataset ────
         # Only meaningful with a graph in it, hence after cognify/search and
@@ -664,7 +695,7 @@ async def run_benchmark_cloud(
         "total_ingest_time_s": round(t_total, 3),
         "prune_time_s": round(t_prune, 3),
         "db_setup_time_s": 0.0,
-        "search_time": t_search,
+        **{f"search_time_{key}": t_search[key] for key, _ in BENCHMARKED_SEARCH_TYPES},
         "status": status,
         "success": all_ok,
         "config": {
@@ -700,7 +731,11 @@ async def run_benchmark_cloud(
     print(f"  add time          : {t_add:.2f}s  ({t_add / n:.2f}s per memory)  [{status['add']}]")
     print(f"  cognify time      : {t_cognify:.2f}s  [{status['cognify']}]")
     print(f"  Total ingest time : {t_total:.2f}s  ({t_total / n:.2f}s per memory)")
-    print(f"  Search total      : {t_search:.2f}s  [{status['search']}]")
+    for metric_key, search_type in BENCHMARKED_SEARCH_TYPES:
+        print(
+            f"  Search {search_type:<18}: {t_search[metric_key]:.2f}s  "
+            f"[{status[f'search_{metric_key}']}]"
+        )
     print(f"  Prune time        : {t_prune:.2f}s  [{status['prune']}]")
     print(f"  Overall           : {'ALL OK' if all_ok else 'SOME FAILURES'}")
     print("=" * 60)

--- a/cognee/tests/performance/statistics_percentile_report.py
+++ b/cognee/tests/performance/statistics_percentile_report.py
@@ -31,7 +31,12 @@ METRICS = [
     "add_time_s",
     "cognify_time_s",
     "total_ingest_time_s",
+    # Python + cloud runs time each search type separately; the Rust SDK bench
+    # still reports a single `search_time`. build_report keeps whichever the
+    # runs actually produced, so all three shapes report correctly.
     "search_time",
+    "search_time_graph_completion",
+    "search_time_hybrid_completion",
     "prune_time_s",
     "db_setup_time_s",
     # Local + cloud --create-tenant modes (populated-dataset deletion).
@@ -47,6 +52,8 @@ LABELS = {
     "cognify_time_s": "cognee.cognify()",
     "total_ingest_time_s": "Total ingest",
     "search_time": "Search",
+    "search_time_graph_completion": "Search GRAPH_COMPLETION",
+    "search_time_hybrid_completion": "Search HYBRID_COMPLETION",
     "prune_time_s": "Prune",
     "db_setup_time_s": "DB setup",
     "tenant_create_time_s": "Tenant create (cloud)",
@@ -135,13 +142,13 @@ def print_report(stats: dict, num_runs: int, config: dict, runs: list[dict]):
     print(f"  Success rate     : {succeeded}/{num_runs} ({failed} failed)")
     print()
 
-    header = f"  {'Metric':<22} {'min':>8} {'p50':>8} {'p75':>8} {'p90':>8} {'p95':>8} {'p99':>8} {'max':>8} {'mean':>8}"
+    header = f"  {'Metric':<26} {'min':>8} {'p50':>8} {'p75':>8} {'p90':>8} {'p95':>8} {'p99':>8} {'max':>8} {'mean':>8}"
     print(header)
     print("  " + "-" * (len(header) - 2))
 
     for metric, entry in stats.items():
         label = LABELS.get(metric, metric)
-        parts = [f"  {label:<22}"]
+        parts = [f"  {label:<26}"]
         for key in ["min", "p50", "p75", "p90", "p95", "p99", "max", "mean"]:
             parts.append(f"{entry[key]:>7.2f}s")
         print(" ".join(parts))


### PR DESCRIPTION
## Description

The nightly performance report timed a single `search()` call, so the search number described whatever `SearchType` the default happened to be, and there was no way to compare retrieval strategies against each other as the graph grows.

The **Python** (`file_based` + `postgres`) and **cloud** benchmarks now time `GRAPH_COMPLETION` and `HYBRID_COMPLETION` separately and report each one in the format we already use — p50/p90/p99, in the text report, the HTML report, and the nightly Slack message.

Both searches keep `only_context=True`, so they measure retrieval rather than answer generation and the new `GRAPH_COMPLETION` number stays directly comparable to the single `search_time` it replaces.

## Changes

- `bench_cognee.py` — `BENCHMARKED_SEARCH_TYPES` drives Phase 3 in both the local and cloud benchmarks; results carry `search_time_graph_completion` / `search_time_hybrid_completion` and a per-type `status` entry.
- `statistics_percentile_report.py` — both metrics added to `METRICS` / `LABELS`; label column widened to fit.
- `performance_report.yml` / `performance_report_cloud.yml` — headline `metrics` output now carries `search_graph` and `search_hybrid`.
- `build_nightly_slack_blocks.py` — renders one search row per reported type.

The **Rust SDK** bench is untouched and still emits a single `search_time`. `build_report` filters metrics by what a run actually produced and the Slack renderer picks the rows an arm carries, so all three shapes (Python, cloud, Rust) render correctly — as does a failed arm, which still shows a blank search row.

The MotherDuck ETL unnests `$.stats` generically, so the new keys land in `ci_analytics.nightly` with no change.

## Verification

- `statistics_percentile_report.py --runs 1 --mock-llm --num-memories 5` — green, both rows present in the text and HTML reports:
  ```
  Search GRAPH_COMPLETION       0.07s  ...
  Search HYBRID_COMPLETION      0.06s  ...
  ```
- The workflows' `jq` run against that report JSON yields `search_graph` and `search_hybrid`.
- `build_nightly_slack_blocks.py` exercised with sample Python / cloud / Rust / failed arms.
- `pre-commit run --files <changed>` clean.

## Note

The cloud arm's numbers are not verified against a live tenant — that path only runs in nightly CI.