### PR TITLE
perf: Make Ladybug bulk writes use the primary-key index

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -66,6 +66,93 @@ logger = get_logger()
 _WRITE_CHUNK_SIZE = 2000
 
 
+# ── Bulk upsert statements (COG-6216) ────────────────────────────────────────
+#
+# Kuzu never plans ``MERGE`` through the ``Node.id`` primary-key index. EXPLAIN
+# on ``UNWIND $rows AS row MERGE (n:Node {id: row.id})`` returns
+# SCAN_NODE_TABLE + HASH_JOIN, so ONE statement costs a full scan of the node
+# table and a batch split into C chunks costs C scans:
+#
+#     total  ~  (rows / _WRITE_CHUNK_SIZE) * node_table_size    ->    O(N^2)
+#
+# ``MATCH`` does use the index — it plans as QUERY_PRIMARY_KEY_LOOKUP, a
+# per-row seek — so the upsert is spelled out as probe-existing /
+# CREATE-missing / SET-existing. Three index-driven statements per chunk beat
+# one scanning statement by ~20x at 40k nodes and, unlike MERGE, stay linear.
+#
+# The edge statements match their two endpoints in SEPARATE ``MATCH`` clauses.
+# A single comma-separated ``MATCH (a {id: ...}), (b {id: ...})`` plans as a
+# cartesian product of two scans; split clauses plan as two seeks.
+#
+# COG-6185 recorded that splitting the endpoints into two ``MATCH`` clauses
+# segfaults ladybug 0.19.x mid-write. That was observed with ``MERGE``, which
+# is gone from these statements: split ``MATCH`` + ``CREATE`` and split
+# ``MATCH`` + ``SET`` were exercised on 0.19.0 up to 40k edges, in-process and
+# through the subprocess worker, without a SIGSEGV. Keep ``MERGE`` out of the
+# split-MATCH shape.
+#
+# ``test_ladybug_write_query_plans.py`` asserts these plans against a real
+# database, so a Kuzu upgrade that changes the planner fails there rather than
+# silently reintroducing the quadratic.
+_NODE_PROBE_QUERY = """
+UNWIND $ids AS node_id
+MATCH (n:Node {id: node_id})
+RETURN n.id
+"""
+
+_NODE_CREATE_QUERY = """
+UNWIND $nodes AS node
+CREATE (n:Node {
+    id: node.id,
+    name: node.name,
+    type: node.type,
+    properties: node.properties,
+    created_at: TIMESTAMP(node.created_at),
+    updated_at: TIMESTAMP(node.updated_at)
+})
+"""
+
+_NODE_UPDATE_QUERY = """
+UNWIND $nodes AS node
+MATCH (n:Node {id: node.id})
+SET n.name = node.name,
+    n.type = node.type,
+    n.properties = node.properties,
+    n.updated_at = TIMESTAMP(node.updated_at)
+"""
+
+# Existing edges are found by expanding the source nodes' outgoing edges rather
+# than by matching both endpoints and the relationship in one pattern: the
+# latter plans as a scan even with both endpoints bound.
+_EDGE_PROBE_QUERY = """
+UNWIND $ids AS node_id
+MATCH (from:Node {id: node_id})-[r:EDGE]->(to:Node)
+RETURN from.id, to.id, r.relationship_name
+"""
+
+_EDGE_CREATE_QUERY = """
+UNWIND $edges AS edge
+MATCH (from:Node {id: edge.from_id})
+MATCH (to:Node {id: edge.to_id})
+CREATE (from)-[r:EDGE {
+    relationship_name: edge.relationship_name,
+    created_at: TIMESTAMP(edge.created_at),
+    updated_at: TIMESTAMP(edge.updated_at),
+    properties: edge.properties
+}]->(to)
+"""
+
+_EDGE_UPDATE_QUERY = """
+UNWIND $edges AS edge
+MATCH (from:Node {id: edge.from_id})
+MATCH (to:Node {id: edge.to_id})
+MATCH (from)-[r:EDGE]->(to)
+WHERE r.relationship_name = edge.relationship_name
+SET r.updated_at = TIMESTAMP(edge.updated_at),
+    r.properties = edge.properties
+"""
+
+
 DEFAULT_KUZU_BUFFER_POOL_SIZE = 1 << 35  # 32 GB (must be a power of 2 for Kuzu)
 DEFAULT_KUZU_MAX_DB_SIZE = 1 << 35  # 32 GB (must be a power of 2 for Kuzu)
 
@@ -330,6 +417,11 @@ class LadybugAdapter(GraphDBInterface):
                 self._initialize_connection()
         self.LADYBUG_ASYNC_LOCK = asyncio.Lock()
         self._source_ref_change_lock = asyncio.Lock()
+        # Serializes the probe -> create -> update sequence in add_nodes /
+        # add_edges (see the bulk upsert statements above): those reads decide
+        # what the following writes do, so two concurrent callers must not
+        # interleave them.
+        self._bulk_write_lock = asyncio.Lock()
         self._connection_lock = asyncio.Lock()
         # Set when ``open_connections == 0``; used by transient teardown
         # paths (e.g. ``delete_graph``) to wait for in-flight queries to
@@ -1158,34 +1250,43 @@ class LadybugAdapter(GraphDBInterface):
                     }
                 )
 
+            # Deduplicate by id (last wins). MERGE absorbed repeats within one
+            # UNWIND batch; CREATE would raise a primary-key violation on them.
+            # Mirrors PostgresAdapter.add_nodes, which dedupes for ON CONFLICT.
+            node_params = list({node["id"]: node for node in node_params}.values())
+
             if node_params:
-                # Batch merge nodes
-                merge_query = """
-                UNWIND $nodes AS node
-                MERGE (n:Node {id: node.id})
-                ON CREATE SET
-                    n.name = node.name,
-                    n.type = node.type,
-                    n.properties = node.properties,
-                    n.created_at = TIMESTAMP(node.created_at),
-                    n.updated_at = TIMESTAMP(node.updated_at)
-                ON MATCH SET
-                    n.name = node.name,
-                    n.type = node.type,
-                    n.properties = node.properties,
-                    n.updated_at = TIMESTAMP(node.updated_at)
-                """
+                create_query = _NODE_CREATE_QUERY
+                update_query = _NODE_UPDATE_QUERY
                 extra_params = {}
                 if source_ref_key is not None:
-                    merge_query += _provenance_fold_clause("n")
+                    create_query += _provenance_fold_clause("n")
+                    update_query += _provenance_fold_clause("n")
                     extra_params = _provenance_fold_params(source_ref_key, pipeline_run_id)
 
                 total = len(node_params)
-                for start in range(0, total, _WRITE_CHUNK_SIZE):
-                    chunk = node_params[start : start + _WRITE_CHUNK_SIZE]
-                    await self.query(merge_query, {"nodes": chunk, **extra_params})
-                    if total > _WRITE_CHUNK_SIZE:
-                        logger.info("Merged nodes %d/%d", start + len(chunk), total)
+                # The probe -> create -> update sequence is a read-modify-write:
+                # serialize it per adapter instance so two concurrent writers
+                # cannot both see an id as missing and both CREATE it (which
+                # would raise a primary-key violation). Same rationale as
+                # ``_source_ref_change_lock``.
+                async with self._bulk_write_lock:
+                    for start in range(0, total, _WRITE_CHUNK_SIZE):
+                        chunk = node_params[start : start + _WRITE_CHUNK_SIZE]
+                        existing = {
+                            row[0]
+                            for row in await self.query(
+                                _NODE_PROBE_QUERY, {"ids": [node["id"] for node in chunk]}
+                            )
+                        }
+                        new_nodes = [node for node in chunk if node["id"] not in existing]
+                        old_nodes = [node for node in chunk if node["id"] in existing]
+                        if new_nodes:
+                            await self.query(create_query, {"nodes": new_nodes, **extra_params})
+                        if old_nodes:
+                            await self.query(update_query, {"nodes": old_nodes, **extra_params})
+                        if total > _WRITE_CHUNK_SIZE:
+                            logger.info("Merged nodes %d/%d", start + len(chunk), total)
                 await self.checkpoint()
                 logger.debug(f"Processed {total} nodes in batch")
 
@@ -1952,11 +2053,15 @@ class LadybugAdapter(GraphDBInterface):
         try:
             now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
 
+            # Endpoint ids are stringified here, not just handed to Kuzu as
+            # whatever the caller passed (usually UUID): the existing-edge probe
+            # compares them against ids read back from the STRING `Node.id`
+            # column, and UUID != str would make every edge look new.
             edge_params = [
                 {
-                    "from_id": from_node,
-                    "to_id": to_node,
-                    "relationship_name": relationship_name,
+                    "from_id": str(from_node),
+                    "to_id": str(to_node),
+                    "relationship_name": str(relationship_name),
                     "properties": json.dumps(properties, cls=JSONEncoder),
                     "created_at": now,
                     "updated_at": now,
@@ -1964,43 +2069,51 @@ class LadybugAdapter(GraphDBInterface):
                 for from_node, to_node, relationship_name, properties in edges
             ]
 
-            # Property-map matches (primary-key index seeks) instead of a
-            # cartesian MATCH + WHERE, which planned as a scan on large graphs.
-            #
-            # Both endpoints must be matched in ONE comma-separated clause.
-            # Splitting them into two MATCH clauses segfaults ladybug 0.19.x
-            # mid-write (SIGSEGV in the native engine, surfacing through the
-            # subprocess worker as "Subprocess exited unexpectedly (exit code
-            # -11)") — 0.19.0 introduced a row-driven primary-key lookup for
-            # MATCH (LadybugDB/ladybug#722) that this shape lands on. The comma
-            # form keeps the index seeks and is equally fast on 0.17.1, 0.18.2
-            # and 0.19.0 (~80s for 20k edges on all three), and writes an
-            # identical graph. See COG-6185.
-            query = """
-            UNWIND $edges AS edge
-            MATCH (from:Node {id: edge.from_id}), (to:Node {id: edge.to_id})
-            MERGE (from)-[r:EDGE {
-                relationship_name: edge.relationship_name
-            }]->(to)
-            ON CREATE SET
-                r.created_at = TIMESTAMP(edge.created_at),
-                r.updated_at = TIMESTAMP(edge.updated_at),
-                r.properties = edge.properties
-            ON MATCH SET
-                r.updated_at = TIMESTAMP(edge.updated_at),
-                r.properties = edge.properties
-            """
+            # Deduplicate by (from, to, relationship_name), last wins. MERGE
+            # absorbed repeats within one UNWIND batch; CREATE would write them
+            # twice. Mirrors PostgresAdapter.add_edges, which dedupes by the
+            # same composite key for ON CONFLICT.
+            edge_params = list(
+                {
+                    (edge["from_id"], edge["to_id"], edge["relationship_name"]): edge
+                    for edge in edge_params
+                }.values()
+            )
+
+            create_query = _EDGE_CREATE_QUERY
+            update_query = _EDGE_UPDATE_QUERY
             extra_params = {}
             if source_ref_key is not None:
-                query += _provenance_fold_clause("r")
+                create_query += _provenance_fold_clause("r")
+                update_query += _provenance_fold_clause("r")
                 extra_params = _provenance_fold_params(source_ref_key, pipeline_run_id)
 
             total = len(edge_params)
-            for start in range(0, total, _WRITE_CHUNK_SIZE):
-                chunk = edge_params[start : start + _WRITE_CHUNK_SIZE]
-                await self.query(query, {"edges": chunk, **extra_params})
-                if total > _WRITE_CHUNK_SIZE:
-                    logger.info("Merged edges %d/%d", start + len(chunk), total)
+            async with self._bulk_write_lock:
+                for start in range(0, total, _WRITE_CHUNK_SIZE):
+                    chunk = edge_params[start : start + _WRITE_CHUNK_SIZE]
+                    # Expand only the OUTGOING edges of this chunk's source
+                    # nodes. Cost is the sum of their out-degrees, not the node
+                    # table — and cognee's hub nodes (EntityType) are hubs by
+                    # in-degree, which this never touches.
+                    existing = {
+                        tuple(row)
+                        for row in await self.query(
+                            _EDGE_PROBE_QUERY,
+                            {"ids": sorted({edge["from_id"] for edge in chunk})},
+                        )
+                    }
+                    new_edges = []
+                    old_edges = []
+                    for edge in chunk:
+                        key = (edge["from_id"], edge["to_id"], edge["relationship_name"])
+                        (old_edges if key in existing else new_edges).append(edge)
+                    if new_edges:
+                        await self.query(create_query, {"edges": new_edges, **extra_params})
+                    if old_edges:
+                        await self.query(update_query, {"edges": old_edges, **extra_params})
+                    if total > _WRITE_CHUNK_SIZE:
+                        logger.info("Merged edges %d/%d", start + len(chunk), total)
             await self.checkpoint()
 
         except Exception as e:

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_write_chunking.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_write_chunking.py
@@ -1,8 +1,15 @@
 """Bulk node/edge writes must be chunked so no single statement can run past
 the subprocess engine's per-call deadline on large graphs (COG: ladybug
 ingestion of e.g. 30k-fact code graphs previously sent one statement for all
-rows and could never finish)."""
+rows and could never finish).
 
+Each chunk is an upsert spelled out as probe / CREATE-missing / SET-existing
+rather than one MERGE, because Kuzu never plans MERGE through the primary-key
+index (COG-6216). The plans themselves are asserted against a real database in
+``test_ladybug_write_query_plans.py``; these tests cover chunking and the
+statement shapes."""
+
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -14,11 +21,21 @@ from cognee.infrastructure.databases.graph.ladybug.adapter import (
 )
 
 
-def _adapter_with_mocked_writes():
+def _adapter_with_mocked_writes(existing_rows=None):
+    """Adapter whose queries are mocked. ``existing_rows`` is what the
+    existing-row probe returns, so a test can drive the CREATE path (default:
+    nothing exists yet) or the SET path.
+    """
     adapter = object.__new__(LadybugAdapter)
-    adapter.query = AsyncMock(return_value=[])
+    adapter.query = AsyncMock(return_value=existing_rows or [])
     adapter.checkpoint = AsyncMock()
+    adapter._bulk_write_lock = asyncio.Lock()
     return adapter
+
+
+def _write_calls(adapter, param_key):
+    """Query calls carrying ``param_key`` — i.e. the writes, not the probe."""
+    return [call for call in adapter.query.await_args_list if param_key in call.args[1]]
 
 
 def _fake_nodes(count):
@@ -38,19 +55,50 @@ async def test_add_nodes_chunks_large_batches():
 
     await adapter.add_nodes(_fake_nodes(total))
 
-    assert adapter.query.await_count == 3
-    chunk_sizes = [len(call.args[1]["nodes"]) for call in adapter.query.await_args_list]
-    assert chunk_sizes == [_WRITE_CHUNK_SIZE, _WRITE_CHUNK_SIZE, 1]
+    # Nothing exists yet, so every chunk is probe + CREATE and none update.
+    expected = [_WRITE_CHUNK_SIZE, _WRITE_CHUNK_SIZE, 1]
+    assert [len(call.args[1]["ids"]) for call in _write_calls(adapter, "ids")] == expected
+    assert [len(call.args[1]["nodes"]) for call in _write_calls(adapter, "nodes")] == expected
     adapter.checkpoint.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_add_nodes_small_batch_is_single_statement():
+async def test_add_nodes_small_batch_is_one_probe_and_one_write():
     adapter = _adapter_with_mocked_writes()
 
     await adapter.add_nodes(_fake_nodes(5))
 
-    assert adapter.query.await_count == 1
+    assert len(_write_calls(adapter, "ids")) == 1
+    assert len(_write_calls(adapter, "nodes")) == 1
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_updates_rows_the_probe_found():
+    """Ids the probe returns take the SET path. Sending them to CREATE would
+    raise a primary-key violation on every re-ingest."""
+    adapter = _adapter_with_mocked_writes(existing_rows=[("node-0",), ("node-1",)])
+
+    await adapter.add_nodes(_fake_nodes(3))
+
+    by_kind = {
+        ("CREATE" if "CREATE (n:Node" in call.args[0] else "SET"): [
+            node["id"] for node in call.args[1]["nodes"]
+        ]
+        for call in _write_calls(adapter, "nodes")
+    }
+    assert by_kind["SET"] == ["node-0", "node-1"]
+    assert by_kind["CREATE"] == ["node-2"]
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_deduplicates_ids_within_a_batch():
+    """MERGE absorbed repeated ids inside one UNWIND; CREATE would raise."""
+    adapter = _adapter_with_mocked_writes()
+    duplicated = [SimpleNamespace(id="node-0", name=f"n{i}", type="Node") for i in range(3)]
+
+    await adapter.add_nodes(duplicated)
+
+    assert [len(call.args[1]["nodes"]) for call in _write_calls(adapter, "nodes")] == [1]
 
 
 @pytest.mark.asyncio
@@ -60,42 +108,57 @@ async def test_add_edges_chunks_large_batches():
 
     await adapter.add_edges(_fake_edges(total))
 
-    assert adapter.query.await_count == 2
-    chunk_sizes = [len(call.args[1]["edges"]) for call in adapter.query.await_args_list]
-    assert chunk_sizes == [_WRITE_CHUNK_SIZE, 1]
+    assert [len(call.args[1]["edges"]) for call in _write_calls(adapter, "edges")] == [
+        _WRITE_CHUNK_SIZE,
+        1,
+    ]
     adapter.checkpoint.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_add_edges_matches_endpoints_by_primary_key():
-    """The edge MERGE must seek endpoints via property-map matches (index
-    lookups), not a cartesian MATCH + WHERE that plans as a scan."""
+async def test_add_edges_deduplicates_within_a_batch():
     adapter = _adapter_with_mocked_writes()
 
-    await adapter.add_edges(_fake_edges(1))
+    await adapter.add_edges(_fake_edges(1) * 3)
 
-    query = adapter.query.await_args_list[0].args[0]
-    assert "MATCH (from:Node {id: edge.from_id}), (to:Node {id: edge.to_id})" in query
-    assert "MATCH (from:Node), (to:Node)" not in query
+    assert [len(call.args[1]["edges"]) for call in _write_calls(adapter, "edges")] == [1]
 
 
 @pytest.mark.asyncio
-async def test_add_edges_matches_both_endpoints_in_one_clause():
-    """Both endpoints must be bound by a single comma-separated MATCH.
+async def test_add_edges_stringifies_endpoint_ids():
+    """Endpoint ids arrive as UUIDs. The probe compares them against ids read
+    back from the STRING id column, so unless they are stringified every edge
+    looks new and gets written again on each ingest."""
+    import uuid
 
-    Two separate MATCH clauses hit the row-driven primary-key lookup added in
-    ladybug 0.19.0 (LadybugDB/ladybug#722) and segfault the engine mid-write
-    (COG-6185). The comma form is equally fast and writes an identical graph,
-    so this is the only shape allowed here.
+    adapter = _adapter_with_mocked_writes()
+    source, target = uuid.uuid4(), uuid.uuid4()
+
+    await adapter.add_edges([(source, target, "relates_to", {})])
+
+    written = _write_calls(adapter, "edges")[0].args[1]["edges"][0]
+    assert written["from_id"] == str(source)
+    assert written["to_id"] == str(target)
+
+
+@pytest.mark.asyncio
+async def test_add_edges_matches_endpoints_in_separate_clauses():
+    """Both endpoints in ONE comma-separated MATCH plans as a cartesian product
+    of two table scans; separate MATCH clauses plan as two index seeks.
+
+    COG-6185 recorded that separate clauses segfault ladybug 0.19.x mid-write,
+    but that was with MERGE, which these statements no longer use — CREATE and
+    SET were exercised on 0.19.0 up to 40k edges through the subprocess worker
+    without a SIGSEGV. Keeping MERGE out of the split shape is the invariant.
     """
     adapter = _adapter_with_mocked_writes()
 
     await adapter.add_edges(_fake_edges(1))
 
-    query = adapter.query.await_args_list[0].args[0]
-    match_clauses = [line for line in query.splitlines() if line.strip().startswith("MATCH ")]
-    assert len(match_clauses) == 1, f"endpoints must bind in one MATCH clause, got: {match_clauses}"
-    assert "MATCH (to:Node {id: edge.to_id})" not in query
+    query = _write_calls(adapter, "edges")[0].args[0]
+    assert "MATCH (from:Node {id: edge.from_id})\nMATCH (to:Node {id: edge.to_id})" in query
+    assert "MATCH (from:Node {id: edge.from_id}), (to:Node {id: edge.to_id})" not in query
+    assert "MERGE" not in query
 
 
 def _fake_edge_identities(count):

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_write_query_plans.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_write_query_plans.py
@@ -1,0 +1,128 @@
+"""The bulk-write statements must reach nodes through the primary-key index.
+
+This is the test that would have caught COG-6216. ``Node.id`` is declared
+``STRING PRIMARY KEY``, so the writes look like index seeks — but Kuzu plans
+``MERGE`` as SCAN_NODE_TABLE + HASH_JOIN and ignores the index entirely. One
+scanning statement per 2000-row chunk turns a bulk ingest into O(N^2): the
+100k-node nightly performance suite ran for over three hours without
+finishing, while the same graph on Postgres took seven minutes.
+
+Wall-clock assertions cannot catch this — on a small graph a scan and a seek
+are indistinguishable, which is exactly the regime unit tests run in. So
+assert the PLAN instead. A Kuzu upgrade that changes the planner fails here
+rather than silently reintroducing the quadratic.
+"""
+
+import re
+
+import pytest
+
+from cognee.infrastructure.databases.graph.ladybug.adapter import (
+    LadybugAdapter,
+    _EDGE_CREATE_QUERY,
+    _EDGE_PROBE_QUERY,
+    _EDGE_UPDATE_QUERY,
+    _NODE_CREATE_QUERY,
+    _NODE_PROBE_QUERY,
+    _NODE_UPDATE_QUERY,
+)
+
+NOW = "2026-01-01 00:00:00.000000"
+IDS = [f"00000000-0000-0000-0000-{index:012d}" for index in range(20)]
+NODES = [
+    {
+        "id": node_id,
+        "name": "n",
+        "type": "T",
+        "properties": "{}",
+        "created_at": NOW,
+        "updated_at": NOW,
+    }
+    for node_id in IDS
+]
+EDGES = [
+    {
+        "from_id": IDS[index],
+        "to_id": IDS[index + 1],
+        "relationship_name": "rel",
+        "properties": "{}",
+        "created_at": NOW,
+        "updated_at": NOW,
+    }
+    for index in range(0, len(IDS) - 1, 2)
+]
+
+
+@pytest.fixture
+def adapter(tmp_path):
+    return LadybugAdapter(str(tmp_path / "graph_db"))
+
+
+async def _plan(adapter, query, params):
+    rows = await adapter.query("EXPLAIN " + query, params)
+    return "\n".join(str(cell) for row in rows for cell in row)
+
+
+def _count(plan, operator):
+    # Guard the prefix so SCAN_NODE_TABLE does not also match
+    # PRIMARY_KEY_SCAN_NODE_TABLE.
+    return len(re.findall(rf"(?<![A-Z_]){operator}\[", plan))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name, query, params",
+    [
+        ("node probe", _NODE_PROBE_QUERY, {"ids": IDS}),
+        ("node update", _NODE_UPDATE_QUERY, {"nodes": NODES}),
+        ("edge create", _EDGE_CREATE_QUERY, {"edges": EDGES}),
+    ],
+)
+async def test_node_lookups_are_primary_key_seeks(adapter, name, query, params):
+    plan = await _plan(adapter, query, params)
+
+    assert _count(plan, "QUERY_PRIMARY_KEY_LOOKUP") > 0, f"{name} lost the index:\n{plan}"
+    assert _count(plan, "SCAN_NODE_TABLE") == 0, f"{name} scans the node table:\n{plan}"
+
+
+@pytest.mark.asyncio
+async def test_node_create_touches_no_node_table(adapter):
+    """A pure insert needs neither a seek nor a scan."""
+    plan = await _plan(adapter, _NODE_CREATE_QUERY, {"nodes": NODES})
+
+    assert _count(plan, "SCAN_NODE_TABLE") == 0, plan
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query", [_NODE_CREATE_QUERY, _NODE_UPDATE_QUERY, _EDGE_CREATE_QUERY, _EDGE_UPDATE_QUERY]
+)
+async def test_writes_never_use_merge(query):
+    """MERGE is the operator that drops the primary-key index. Keeping it out
+    of the write statements is the whole fix, so state it directly — a plan
+    assertion alone would not explain the failure to whoever reintroduces it.
+    """
+    assert "MERGE" not in query
+
+
+@pytest.mark.asyncio
+async def test_edge_endpoints_use_separate_match_clauses(adapter):
+    """One comma-separated MATCH of both endpoints plans as a cartesian product
+    of two scans; separate clauses plan as two seeks."""
+    plan = await _plan(adapter, _EDGE_CREATE_QUERY, {"edges": EDGES})
+
+    assert _count(plan, "QUERY_PRIMARY_KEY_LOOKUP") == 2, plan
+    assert _count(plan, "CROSS_PRODUCT") == 0, plan
+
+
+@pytest.mark.asyncio
+async def test_edge_probe_expands_outgoing_edges_only(adapter):
+    """The probe walks the source nodes' outgoing edges instead of matching
+    both endpoints plus the relationship, which plans as a scan even with both
+    endpoints bound. Cost is the sum of those out-degrees — and cognee's hub
+    nodes (EntityType, via `is_a`) are hubs by IN-degree, which this never
+    touches.
+    """
+    assert "-[r:EDGE]->(to:Node)" in _EDGE_PROBE_QUERY
+    plan = await _plan(adapter, _EDGE_PROBE_QUERY, {"ids": IDS})
+    assert _count(plan, "SCAN_REL_TABLE") <= 1, plan


### PR DESCRIPTION
## The bug

`Node.id` is declared `STRING PRIMARY KEY`, so the bulk writes in `LadybugAdapter` looked like index seeks. They were not. `EXPLAIN` on the statements this adapter actually ran:

| statement | plan |
|---|---|
| `MATCH (n:Node {id: $id})` — scalar param | `PRIMARY_KEY_SCAN_NODE_TABLE`, `Index: HASH` ✅ |
| `UNWIND $nodes AS node MERGE (n:Node {id: node.id})` — `add_nodes` | `SCAN_NODE_TABLE` + 2× `HASH_JOIN` ❌ |
| `UNWIND $edges … MATCH (a {id: …}), (b {id: …}) MERGE (a)-[r:EDGE]->(b)` — `add_edges` | **3×** `SCAN_NODE_TABLE` + 4× `HASH_JOIN` + `SCAN_REL_TABLE` ❌ |

**Kuzu never plans `MERGE` through the primary-key index.** `MATCH` does. So one statement costs a full scan of the node table, and a batch split into C chunks of `_WRITE_CHUNK_SIZE` costs C scans:

```
total  ~  (rows / _WRITE_CHUNK_SIZE) * node_table_size    ->    O(N^2)
```

Confirmed directly — writing the **same 10,000 edges** into a bigger node table:

| nodes | edges written | add_edges |
|---|---|---|
| 10,005 | 10,000 | 1.76s |
| 20,000 | 10,000 | 5.35s |
| 40,000 | 10,000 | 19.36s |
| 80,000 | 10,000 | 77.29s |

Identical work, ~4× slower per doubling of a table it never needed to read.

This is why the `war_and_peace_large` (100k nodes / 206k edges) nightly arm has **never** completed on the file-based backend — killed at 3h50m and 3h02m on consecutive nights — while the same graph on Postgres, where `id` is a real indexed primary key with `INSERT … ON CONFLICT`, finishes cognify in 457s.

The existing comment claiming the comma-`MATCH` form "keeps the index seeks" was wrong; so was the test asserting it.

## The fix

Spell the upsert out so every statement is index-driven:

- **nodes** — probe existing ids (`MATCH`, seek) → `CREATE` the missing → `SET` the existing (`MATCH`, seek).
- **edges** — probe the source nodes' outgoing edges → `CREATE` the missing → `SET` the existing, with the two endpoints in **separate** `MATCH` clauses (one comma-separated clause plans as a cartesian product of two scans; split clauses plan as two seeks).

Supporting changes:
- Endpoint ids are stringified. They arrive as `UUID`, and the probe compares them against ids read back from the `STRING` id column — without this every edge looks new and is rewritten on each ingest. (Caught by the idempotency check below, not by inspection.)
- Batches are deduplicated by id / `(from, to, relationship_name)`. `MERGE` absorbed repeats inside one `UNWIND`; `CREATE` would raise or duplicate. Mirrors what `PostgresAdapter` already does for `ON CONFLICT`.
- `_bulk_write_lock` serializes the probe→write sequence per adapter instance, same rationale as the existing `_source_ref_change_lock`: it is a read-modify-write and two callers must not interleave.

### On COG-6185

That issue recorded separate `MATCH` clauses segfaulting ladybug 0.19.x mid-write. **That was observed with `MERGE`**, which these statements no longer use. Split `MATCH` + `CREATE` and split `MATCH` + `SET` were executed on 0.19.0 up to 40k edges, in-process and through the subprocess worker, with no SIGSEGV. The comment and the test now say to keep `MERGE` out of the split shape rather than banning the split shape.

## Results

ladybug 0.19.0, through the subprocess worker (as CI runs it), hub-shaped graph of n nodes + 2n edges:

| nodes | edges | add_nodes before | after | add_edges before | after |
|---|---|---|---|---|---|
| 10,005 | 20,000 | 0.53s | 0.39s | 3.47s | **0.69s** |
| 20,005 | 40,000 | 1.25s | 0.72s | 21.26s | **1.47s** |
| 40,005 | 80,000 | — | 1.46s | — | **3.39s** |
| 80,005 | 160,000 | — | 3.01s | — | **8.43s** |

Linear where it was quadratic — ~2.1× per doubling. At 20k nodes that is 14×; extrapolating the old curve to 80k/160k it is roughly two orders of magnitude.

## Verification

- **Correctness / idempotency**: at 10k, 20k, 40k and 80k nodes, a second identical `add_nodes` + `add_edges` leaves node and edge counts unchanged and preserves properties. Isolated edge-shape benchmarks also confirmed idempotency across passes (`IDEMPOTENT` at every size).
- **End-to-end**: `statistics_percentile_report.py --runs 1 --mock-llm` — full add → cognify → search → dataset-delete, 1/1 success.
- **Unit**: `cognee/tests/unit/infrastructure/databases/graph/` 100 passed; `cognee/tests/unit/modules/graph/` 127 passed; `cognee/tests/unit/tasks/storage/` 41 passed.
- **Provenance on a real ladybug DB**: `test_graph_provenance_delete_default_stack.py` 3 passed — this matters because the provenance fold clause now attaches to `CREATE` and `SET` separately instead of to one `MERGE`.
- `pre-commit run --files <changed>` clean.

### New guard: `test_ladybug_write_query_plans.py`

The test that would have caught this. It `EXPLAIN`s the write statements against a real database and asserts `QUERY_PRIMARY_KEY_LOOKUP` with no `SCAN_NODE_TABLE`. Wall-clock assertions cannot catch a lost index — on a small graph a scan and a seek are indistinguishable, which is exactly the regime unit tests run in. A Kuzu upgrade that changes the planner now fails here instead of silently reintroducing the quadratic.

## Known limits

- `_EDGE_PROBE_QUERY` and `_EDGE_UPDATE_QUERY` still contain a `SCAN_NODE_TABLE` in their plans, so the **re-ingest** path is ~n^1.15 rather than exactly linear (rewrite of 160k edges: 16.7s). First ingest — the path that was failing in CI — is linear. Worth a follow-up, not a blocker.
- Not benchmarked against the real 100k `war_and_peace_large` fixture; that lives in S3 and only runs in nightly CI. The nightly arm is the real proof.
- Unrelated: `cognee/tests/unit/infrastructure/databases/` (the whole directory) hangs partway through on my machine — reproduced on clean `dev`, so it is pre-existing and not from this change. The `graph/` subdirectory runs clean.