### PR TITLE
fix: rollback must not clear cognify markers of already-completed data

### DIFF
--- a/cognee/modules/cognify/rollback.py
+++ b/cognee/modules/cognify/rollback.py
@@ -14,6 +14,7 @@ from cognee.modules.graph.legacy.has_edges_in_legacy_ledger import has_edges_in_
 from cognee.modules.graph.legacy.has_nodes_in_legacy_ledger import has_nodes_in_legacy_ledger
 from cognee.modules.graph.methods.delete_from_graph_and_vector import delete_from_graph_and_vector
 from cognee.modules.graph.models import Edge, Node
+from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunAlreadyCompleted
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("cognify.rollback")
@@ -29,12 +30,31 @@ def _to_uuid(value: Any) -> Optional[UUID]:
 
 
 def _extract_data_ids(data_ingestion_info: Any) -> set[UUID]:
+    """Data ids the failed run actually processed, read from its per-item results.
+
+    Entries reporting ``PipelineRunAlreadyCompleted`` are deliberately EXCLUDED.
+    That status means an earlier run had already extracted the item and this run
+    skipped it (``run_tasks_data_item`` short-circuits on the completed marker and
+    still yields a ``data_id``), so the run being rolled back neither produced its
+    graph artifacts nor owns its cognify marker.
+
+    Including them is what makes one unprocessable document cost a whole dataset:
+    ``run_tasks`` raises as soon as any item errors and hands the rollback *every*
+    result, so a single bad file clears the markers of every record in the dataset,
+    including ones extracted successfully weeks earlier. Those records keep their
+    nodes — the node/edge deletion below is correctly scoped by ``pipeline_run_id``
+    and never touches an earlier run's rows — so the two halves of the rollback end
+    up disagreeing: the marker says "not extracted", the graph says otherwise, and
+    the next ``cognify`` re-extracts the lot at full LLM cost.
+    """
     if not isinstance(data_ingestion_info, list):
         return set()
 
     data_ids: set[UUID] = set()
     for entry in data_ingestion_info:
         if not isinstance(entry, dict):
+            continue
+        if isinstance(entry.get("run_info"), PipelineRunAlreadyCompleted):
             continue
         maybe_data_id = _to_uuid(entry.get("data_id"))
         if maybe_data_id:

--- a/cognee/tests/unit/modules/cognify/test_rollback.py
+++ b/cognee/tests/unit/modules/cognify/test_rollback.py
@@ -4,6 +4,11 @@ from uuid import uuid4
 import pytest
 
 from cognee.modules.cognify import rollback as rollback_module
+from cognee.modules.pipelines.models.PipelineRunInfo import (
+    PipelineRunAlreadyCompleted,
+    PipelineRunCompleted,
+    PipelineRunErrored,
+)
 
 
 class _FakeScalarsResult:
@@ -234,3 +239,89 @@ async def test_cognify_rollback_keeps_relational_rows_if_graph_delete_fails(monk
         )
 
     assert engine.calls == 1
+
+
+def test_extract_data_ids_skips_already_completed_items():
+    """An item skipped as already-completed belongs to an EARLIER run, so the run
+    being rolled back must not claim its marker."""
+    completed_id = uuid4()
+    errored_id = uuid4()
+    skipped_id = uuid4()
+    run_info_fields = {
+        "pipeline_run_id": uuid4(),
+        "dataset_id": uuid4(),
+        "dataset_name": "some-dataset",
+    }
+
+    data_ingestion_info = [
+        {"run_info": PipelineRunCompleted(**run_info_fields), "data_id": completed_id},
+        {"run_info": PipelineRunAlreadyCompleted(**run_info_fields), "data_id": skipped_id},
+        {
+            "run_info": PipelineRunErrored(**run_info_fields, payload="boom"),
+            "data_id": errored_id,
+        },
+    ]
+
+    assert rollback_module._extract_data_ids(data_ingestion_info) == {completed_id, errored_id}
+
+
+@pytest.mark.asyncio
+async def test_rollback_preserves_markers_of_previously_extracted_data(monkeypatch):
+    """One unprocessable document must not cost the whole dataset its markers.
+
+    ``run_tasks`` raises as soon as any item errors and passes the rollback EVERY
+    per-item result, including the already-completed ones an earlier run extracted.
+    Clearing those markers strands records whose nodes are still in the graph — the
+    node/edge deletion is scoped by pipeline_run_id and never removes them — so the
+    next cognify re-extracts them at full LLM cost.
+    """
+    pipeline_run_id = uuid4()
+    dataset_id = uuid4()
+    errored_id = uuid4()
+    previously_extracted_id = uuid4()
+
+    # No nodes or edges from this run: the run died before writing any, so the only
+    # source of target ids is data_ingestion_info — which is where the bug lived.
+    session_discovery = _FakeSession([_FakeExecuteResult([]), _FakeExecuteResult([])])
+    session_mutation = _FakeSession([])
+    engine = _FakeEngine([session_discovery, session_mutation])
+
+    reset_calls = []
+
+    async def _capture_reset(_session, target_data_ids, _dataset_id):
+        reset_calls.append(set(target_data_ids))
+
+    async def _get_unified_engine():
+        return SimpleNamespace(supports_graph_provenance_delete=lambda: False)
+
+    monkeypatch.setattr(rollback_module, "get_unified_engine", _get_unified_engine)
+    monkeypatch.setattr(rollback_module, "get_relational_engine", lambda: engine)
+    monkeypatch.setattr(rollback_module, "multi_user_support_possible", lambda: False)
+    monkeypatch.setattr(rollback_module, "_reset_pipeline_status", _capture_reset)
+
+    await rollback_module.cognify_rollback_handler(
+        pipeline_run_id=pipeline_run_id,
+        dataset=SimpleNamespace(id=dataset_id),
+        data_ingestion_info=[
+            {
+                "run_info": PipelineRunErrored(
+                    pipeline_run_id=pipeline_run_id,
+                    dataset_id=dataset_id,
+                    dataset_name="some-dataset",
+                    payload="boom",
+                ),
+                "data_id": errored_id,
+            },
+            {
+                "run_info": PipelineRunAlreadyCompleted(
+                    pipeline_run_id=pipeline_run_id,
+                    dataset_id=dataset_id,
+                    dataset_name="some-dataset",
+                ),
+                "data_id": previously_extracted_id,
+            },
+        ],
+    )
+
+    assert reset_calls == [{errored_id}]
+    assert previously_extracted_id not in reset_calls[0]


### PR DESCRIPTION
## The problem

`cognify_rollback_handler` clears the cognify marker of records the failed run never processed. One unprocessable document costs the **whole dataset** its markers.

The path, on current `dev`:

1. **`run_tasks_data_item.py`** — an item already extracted by an earlier run is skipped, and yields `{"run_info": PipelineRunAlreadyCompleted(...), "data_id": ...}`. Note it still carries a `data_id`.
2. **`run_tasks.py`** — appends that to `results`, raises `PipelineRunFailedError` if *any* item errored, then hands the rollback `data_ingestion_info=results` — the whole list, errored and skipped alike.
3. **`rollback.py`** — `_extract_data_ids` walks every entry and takes `data_id` **without inspecting `run_info`**. `_reset_pipeline_status` then deletes `pipeline_status["cognify_pipeline"][dataset_id]` for all of them.

## Why it's a bug rather than a deliberate choice

The graph and vector deletion in the same handler **is** correctly scoped by `pipeline_run_id`, so it only removes the failed run's own nodes and edges. The marker reset is not scoped at all.

The two halves therefore disagree. Records extracted by an earlier run keep their graph artifacts but lose their markers: the marker says "not extracted", the graph says otherwise, and the next `cognify` re-extracts them at full LLM cost. Nothing detects it, because the run reports a rollback rather than corruption.

We hit this on a 400-record dataset. A single unprocessable document cleared markers for all 400; 260 were still present in the graph and were re-extracted on the following run.

## The fix

Skip `PipelineRunAlreadyCompleted` entries in `_extract_data_ids`, restoring the invariant that a rollback clears markers only for data the run actually touched. `PipelineRunCompleted` and `PipelineRunErrored` entries are still collected, so a genuine partial failure still rolls back fully.

The graph-provenance branch gets the same benefit, since it unions this helper's result with the ids read from provenance.

Three lines of behaviour change; the rest of the diff is the explanatory comment and tests.

## Tests

Two cases added to `cognee/tests/unit/modules/cognify/test_rollback.py`:

- `test_extract_data_ids_skips_already_completed_items` — the helper directly.
- `test_rollback_preserves_markers_of_previously_extracted_data` — through `cognify_rollback_handler`, with no nodes or edges from the failed run so `data_ingestion_info` is the only source of target ids.

Both **fail on current `dev` and pass with the fix**. The three existing rollback tests pass either way.

```
5 passed
```

## Notes

- Verified against `dev` (`3aba120`); `rollback.py` is byte-identical in `v1.4.2` and `v1.5.0`, so this affects both released versions.
- Related to #4233, which fixed a different problem in the same area (the memory-fragment projection). The rollback trap itself was never addressed — #4233 removed a common *trigger*, not the trap.