### PR TITLE
Single-port gateway for frontend, backend and MCP

### DIFF
--- a/cognee/api/v1/ui/gateway.py
+++ b/cognee/api/v1/ui/gateway.py
@@ -1,0 +1,415 @@
+"""
+ASGI reverse proxy that serves cognee's frontend, backend and MCP server behind one port.
+
+Each service runs as its own process assuming it owns the root path of its own origin. The
+gateway matches a request against the longest configured prefix, strips it, and forwards to
+that upstream — so the upstreams keep routing on the paths they already know. Responses
+stream through unbuffered, and WebSockets are proxied too.
+
+A stripped prefix is invisible to the upstream, so anything it says about its own paths
+comes back unprefixed and has to be corrected on the way out: redirect targets here, and
+the callback URL MCP advertises when opening an SSE stream. The backend is told its prefix
+directly through uvicorn's --root-path instead.
+"""
+
+import asyncio
+import threading
+from typing import List, Optional, Tuple
+
+import httpx
+import uvicorn
+import websockets
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
+# Headers that describe a single transport hop and must not be forwarded to the next one.
+# Content-Length is dropped too: the response is re-chunked as it streams through.
+HOP_BY_HOP_HEADERS = frozenset(
+    [
+        b"connection",
+        b"content-length",
+        b"keep-alive",
+        b"proxy-authenticate",
+        b"proxy-authorization",
+        b"te",
+        b"trailer",
+        b"transfer-encoding",
+        b"upgrade",
+    ]
+)
+
+
+# Headers the gateway's own server regenerates for its own hop. Relaying the upstream's
+# copy as well emits each one twice, and Date is a singleton field that may not repeat.
+ORIGIN_HEADERS = frozenset([b"date", b"server"])
+
+
+def normalize_prefix(prefix: str) -> str:
+    """
+    Normalize a path prefix to "/" or to "/name" with no trailing slash.
+    """
+    return "/" + prefix.strip("/")
+
+
+def _filter_headers(
+    headers: List[Tuple[bytes, bytes]], drop: frozenset = HOP_BY_HOP_HEADERS
+) -> List[Tuple[bytes, bytes]]:
+    return [(name, value) for name, value in headers if name.lower() not in drop]
+
+
+class SubpathGateway:
+    """
+    Route requests to upstream services by path prefix.
+
+    Args:
+        routes: (path_prefix, upstream_base_url) pairs, for example
+            [("/backend", "http://localhost:8000"), ("/", "http://localhost:3000")].
+            Order does not matter — matching is always longest-prefix-first.
+    """
+
+    def __init__(self, routes: List[Tuple[str, str]]):
+        normalized = [
+            (normalize_prefix(prefix), upstream.rstrip("/")) for prefix, upstream in routes
+        ]
+        # Longest prefix first so "/backend" wins over a "/" catch-all.
+        self.routes = sorted(normalized, key=lambda route: len(route[0]), reverse=True)
+        self._client: Optional[httpx.AsyncClient] = None
+
+    def match(self, path: str) -> Optional[Tuple[str, str, str]]:
+        """
+        Return (prefix, upstream, remaining_path) for the first matching route.
+
+        The remaining path is what the upstream will see: the request path with the prefix
+        removed. A request for the prefix itself ("/backend") maps to the upstream root.
+        """
+        for prefix, upstream in self.routes:
+            if prefix == "/":
+                return prefix, upstream, path
+            if path == prefix:
+                return prefix, upstream, "/"
+            if path.startswith(prefix + "/"):
+                return prefix, upstream, path[len(prefix) :]
+
+        return None
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            await self._handle_lifespan(receive, send)
+        elif scope["type"] == "http":
+            await self._proxy_http(scope, receive, send)
+        elif scope["type"] == "websocket":
+            await self._proxy_websocket(scope, receive, send)
+
+    async def _handle_lifespan(self, receive, send):
+        while True:
+            message = await receive()
+
+            if message["type"] == "lifespan.startup":
+                # One client for the whole gateway: connection pooling matters here, and
+                # redirects must reach the browser rather than being followed internally.
+                self._client = httpx.AsyncClient(timeout=None, follow_redirects=False)
+                await send({"type": "lifespan.startup.complete"})
+            elif message["type"] == "lifespan.shutdown":
+                if self._client is not None:
+                    await self._client.aclose()
+                    self._client = None
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+
+    def _build_forwarded_headers(self, scope, prefix: str) -> List[Tuple[bytes, bytes]]:
+        headers = _filter_headers(scope["headers"])
+
+        scheme = scope.get("scheme", "http")
+        # Websocket schemes describe the client hop; the forwarded header describes the
+        # original request scheme, for which http/https is what upstreams expect.
+        forwarded_proto = {"ws": "http", "wss": "https"}.get(scheme, scheme)
+        host = dict(scope["headers"]).get(b"host", b"")
+        client = scope.get("client")
+
+        headers.append((b"x-forwarded-proto", forwarded_proto.encode()))
+        if host:
+            headers.append((b"x-forwarded-host", host))
+        if client:
+            headers.append((b"x-forwarded-for", str(client[0]).encode()))
+        if prefix != "/":
+            headers.append((b"x-forwarded-prefix", prefix.encode()))
+
+        return headers
+
+    def _rewrite_location(self, location: bytes, prefix: str) -> bytes:
+        """
+        Put the prefix back on a root-relative redirect target.
+
+        The upstream answers in its own path space, so a "Location: /login" would send the
+        browser out of the prefix and into whichever service owns the gateway root.
+        Absolute URLs are left alone — they already name their destination.
+        """
+        if prefix == "/" or not location.startswith(b"/") or location.startswith(b"//"):
+            return location
+
+        return prefix.encode() + location
+
+    async def _proxy_http(self, scope, receive, send):
+        match = self.match(scope["path"])
+
+        if match is None or self._client is None:
+            await self._send_plain_response(send, 502, b"No upstream configured for this path.")
+            return
+
+        prefix, upstream, upstream_path = match
+        url = upstream + upstream_path
+        if scope.get("query_string"):
+            url += "?" + scope["query_string"].decode("latin-1")
+
+        request = self._client.build_request(
+            scope["method"],
+            url,
+            headers=self._build_forwarded_headers(scope, prefix),
+            content=_request_body_stream(receive),
+        )
+
+        try:
+            response = await self._client.send(request, stream=True)
+        except httpx.HTTPError as error:
+            logger.error(f"Gateway could not reach {upstream}: {error}")
+            await self._send_plain_response(send, 502, b"Upstream service is unavailable.")
+            return
+
+        try:
+            headers = []
+            for name, value in _filter_headers(
+                response.headers.raw, HOP_BY_HOP_HEADERS | ORIGIN_HEADERS
+            ):
+                if name.lower() == b"location":
+                    value = self._rewrite_location(value, prefix)
+                headers.append((name, value))
+
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": response.status_code,
+                    "headers": headers,
+                }
+            )
+
+            # aiter_raw keeps the upstream's own framing, so streamed responses (SSE, large
+            # downloads) reach the client as they arrive instead of being buffered whole.
+            body = response.aiter_raw()
+
+            if prefix != "/" and _is_event_stream(response.headers):
+                body = _rewrite_sse_endpoint_event(body, prefix)
+
+            async for chunk in body:
+                await send({"type": "http.response.body", "body": chunk, "more_body": True})
+
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
+        finally:
+            await response.aclose()
+
+    async def _send_plain_response(self, send, status: int, body: bytes):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [(b"content-type", b"text/plain; charset=utf-8")],
+            }
+        )
+        await send({"type": "http.response.body", "body": body, "more_body": False})
+
+    async def _proxy_websocket(self, scope, receive, send):
+        # The connect message has to be consumed before the gateway answers at all, so it
+        # is taken here rather than after dialling — the failure paths below reply too.
+        await receive()
+
+        match = self.match(scope["path"])
+
+        if match is None:
+            await send({"type": "websocket.close", "code": 1008})
+            return
+
+        prefix, upstream, upstream_path = match
+        url = upstream.replace("http://", "ws://", 1).replace("https://", "wss://", 1)
+        url += upstream_path
+        if scope.get("query_string"):
+            url += "?" + scope["query_string"].decode("latin-1")
+
+        # The handshake headers the client library sets itself would collide with the ones
+        # copied from the incoming request.
+        forwarded = [
+            (name.decode("latin-1"), value.decode("latin-1"))
+            for name, value in self._build_forwarded_headers(scope, prefix)
+            if name.lower() not in (b"host", b"sec-websocket-key", b"sec-websocket-version")
+        ]
+        subprotocols = scope.get("subprotocols") or None
+
+        try:
+            upstream_socket = await websockets.connect(
+                url,
+                additional_headers=forwarded,
+                subprotocols=subprotocols,
+                open_timeout=10,
+            )
+        except Exception as error:
+            logger.debug(f"Gateway could not open a WebSocket to {url}: {error}")
+            await send({"type": "websocket.close", "code": 1011})
+            return
+
+        await send({"type": "websocket.accept", "subprotocol": upstream_socket.subprotocol})
+
+        # When one side goes away the other pump is mid-await on a connection that will
+        # never deliver another frame, and raises. That is the ordinary way a proxied
+        # socket ends — a closed tab, or Next.js cycling its hot-reload socket — so it is
+        # logged rather than propagated.
+        async def relay(direction, pump):
+            try:
+                await pump()
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                logger.debug(f"WebSocket {direction} ended: {type(error).__name__}: {error}")
+
+        async def client_to_upstream():
+            while True:
+                message = await receive()
+
+                if message["type"] == "websocket.disconnect":
+                    await upstream_socket.close()
+                    return
+                if message.get("text") is not None:
+                    await upstream_socket.send(message["text"])
+                elif message.get("bytes") is not None:
+                    await upstream_socket.send(message["bytes"])
+
+        async def upstream_to_client():
+            async for message in upstream_socket:
+                if isinstance(message, str):
+                    await send({"type": "websocket.send", "text": message})
+                else:
+                    await send({"type": "websocket.send", "bytes": message})
+
+        pumps = [
+            asyncio.create_task(relay("client->upstream", client_to_upstream)),
+            asyncio.create_task(relay("upstream->client", upstream_to_client)),
+        ]
+
+        try:
+            # Either direction closing ends the connection; the other pump is then dead
+            # weight waiting on a socket that will never produce another frame.
+            done, pending = await asyncio.wait(pumps, return_when=asyncio.FIRST_COMPLETED)
+            for task in pending:
+                task.cancel()
+            # Consume the finished task's result so a failure can never surface later as
+            # an unretrieved task exception.
+            for task in done:
+                task.result()
+        finally:
+            await upstream_socket.close()
+            try:
+                await send({"type": "websocket.close", "code": 1000})
+            except Exception:
+                # The client is already gone — nothing left to tell it.
+                pass
+
+
+def _is_event_stream(headers) -> bool:
+    return headers.get("content-type", "").split(";")[0].strip() == "text/event-stream"
+
+
+async def _rewrite_sse_endpoint_event(chunks, prefix: str):
+    """
+    Put the prefix back on the callback path an SSE "endpoint" event advertises.
+
+    This is the same correction applied to a root-relative Location header, in a response
+    body instead: the upstream names a path in its own root space, and the client is about
+    to request it against the gateway, where that path belongs to another service. MCP's
+    SSE transport opens exactly this way — it answers the stream with the URL the client
+    must post messages to, and unprefixed that URL lands on whatever owns the gateway root.
+
+    Only the one event is touched, and only until it has been seen; everything else streams
+    through untouched.
+    """
+    prefixed = prefix.encode()
+    pending = b""
+    last_event = None
+    rewritten = False
+
+    async for chunk in chunks:
+        if rewritten:
+            yield chunk
+            continue
+
+        pending += chunk
+        out = b""
+
+        # Rewriting is only safe on a whole line, so a partial trailing one stays buffered.
+        while b"\n" in pending:
+            line, _, pending = pending.partition(b"\n")
+
+            if line.startswith(b"event:"):
+                last_event = line[len(b"event:") :].strip()
+            elif line.startswith(b"data:") and last_event == b"endpoint":
+                path = line[len(b"data:") :].strip()
+                # A protocol-relative or absolute URL already names its destination.
+                if path.startswith(b"/") and not path.startswith(b"//"):
+                    line = b"data: " + prefixed + path
+                    rewritten = True
+
+            out += line + b"\n"
+
+        if out:
+            yield out
+
+    if pending:
+        yield pending
+
+
+async def _request_body_stream(receive):
+    """
+    Yield the request body as it arrives, so uploads are not buffered in the gateway.
+    """
+    while True:
+        message = await receive()
+
+        if message["type"] == "http.disconnect":
+            return
+
+        body = message.get("body", b"")
+        if body:
+            yield body
+        if not message.get("more_body", False):
+            return
+
+
+def start_gateway(
+    gateway_port: int,
+    routes: List[Tuple[str, str]],
+    host: str = "0.0.0.0",
+) -> threading.Thread:
+    """
+    Serve the gateway on gateway_port in a background thread.
+
+    start_ui() is synchronous and must return the frontend process to its caller, so the
+    gateway cannot own the main thread. The thread is a daemon: it goes away with the
+    process the CLI already supervises and shuts down.
+
+    Args:
+        gateway_port: Port to bind the gateway on
+        routes: (path_prefix, upstream_base_url) pairs
+        host: Interface to bind (default: all, since this is the public listener)
+
+    Returns:
+        Thread running the server
+    """
+    app = SubpathGateway(routes)
+    config = uvicorn.Config(app, host=host, port=gateway_port, log_level="warning")
+    server = uvicorn.Server(config)
+
+    thread = threading.Thread(target=server.run, daemon=True, name="cognee-gateway")
+    thread.start()
+
+    for prefix, upstream in app.routes:
+        logger.info(f"✓ Gateway route {prefix} -> {upstream}")
+
+    return thread

--- a/cognee/api/v1/ui/ui.py
+++ b/cognee/api/v1/ui/ui.py
@@ -421,6 +421,50 @@ def prompt_user_for_download() -> bool:
         return False
 
 
+# TODO(subpath-deployment): support serving frontend, backend, and MCP behind one
+# port, reachable at a single domain.
+# Currently, start_ui() always serves the frontend, backend, and MCP server on three
+# separate ports, each assuming it owns the root path ("/") of its own origin.
+# This makes it impossible to expose all three under a single public domain,
+# since none of them can be reached at a distinguishing path prefix.
+#
+# Proposed signature:
+#
+# def start_ui(
+#     pid_callback: Callable[[int], None],
+#     port: int = 3000,
+#     open_browser: bool = True,
+#     auto_download: bool = False,
+#     start_backend: bool = False,
+#     backend_port: int = 8000,
+#     start_mcp: bool = False,
+#     mcp_port: int = 8001,
+#     gateway_port: Optional[int] = None,
+#     frontend_path: str = "/frontend",
+#     backend_path: str = "/backend",
+#     mcp_path: str = "/mcp",
+# ) -> Optional[subprocess.Popen]:
+#
+# Default behavior (gateway_port=None): unchanged from current behavior. The frontend, backend,
+# and MCP server each run independently on their own port (port, backend_port,
+# mcp_port), with no awareness of any path prefix.
+#
+# New behavior (gateway_port=<int>): a single ASGI gateway app is started on
+# gateway_port, exposing all three services under one public port and domain,
+# distinguished by path prefix:
+#   - backend_path  -> the FastAPI backend app, mounted in-process
+#   - mcp_path      -> the MCP ASGI app, mounted in-process
+#   - frontend_path -> proxied through to the Next.js subprocess, which still runs
+#                       on its own internal port (a separate JS runtime cannot be
+#                       mounted in-process)
+# port, backend_port, and mcp_port then become internal bind ports behind the
+# gateway rather than publicly reachable addresses.
+#
+# Intended use case: reaching all of cognee's stack at a single domain, by putting
+# everything behind one port with no external reverse proxy required. The gateway
+# mounts the backend and MCP app in-process, and proxies requests to the frontend
+# internally since Next.js runs as a separate process that can't be mounted the
+# same way.
 def start_ui(
     pid_callback: Callable[[int], None],
     port: int = 3000,

--- a/cognee/api/v1/ui/ui.py
+++ b/cognee/api/v1/ui/ui.py
@@ -421,50 +421,6 @@ def prompt_user_for_download() -> bool:
         return False
 
 
-# TODO(subpath-deployment): support serving frontend, backend, and MCP behind one
-# port, reachable at a single domain.
-# Currently, start_ui() always serves the frontend, backend, and MCP server on three
-# separate ports, each assuming it owns the root path ("/") of its own origin.
-# This makes it impossible to expose all three under a single public domain,
-# since none of them can be reached at a distinguishing path prefix.
-#
-# Proposed signature:
-#
-# def start_ui(
-#     pid_callback: Callable[[int], None],
-#     port: int = 3000,
-#     open_browser: bool = True,
-#     auto_download: bool = False,
-#     start_backend: bool = False,
-#     backend_port: int = 8000,
-#     start_mcp: bool = False,
-#     mcp_port: int = 8001,
-#     gateway_port: Optional[int] = None,
-#     frontend_path: str = "/frontend",
-#     backend_path: str = "/backend",
-#     mcp_path: str = "/mcp",
-# ) -> Optional[subprocess.Popen]:
-#
-# Default behavior (gateway_port=None): unchanged from current behavior. The frontend, backend,
-# and MCP server each run independently on their own port (port, backend_port,
-# mcp_port), with no awareness of any path prefix.
-#
-# New behavior (gateway_port=<int>): a single ASGI gateway app is started on
-# gateway_port, exposing all three services under one public port and domain,
-# distinguished by path prefix:
-#   - backend_path  -> the FastAPI backend app, mounted in-process
-#   - mcp_path      -> the MCP ASGI app, mounted in-process
-#   - frontend_path -> proxied through to the Next.js subprocess, which still runs
-#                       on its own internal port (a separate JS runtime cannot be
-#                       mounted in-process)
-# port, backend_port, and mcp_port then become internal bind ports behind the
-# gateway rather than publicly reachable addresses.
-#
-# Intended use case: reaching all of cognee's stack at a single domain, by putting
-# everything behind one port with no external reverse proxy required. The gateway
-# mounts the backend and MCP app in-process, and proxies requests to the frontend
-# internally since Next.js runs as a separate process that can't be mounted the
-# same way.
 def start_ui(
     pid_callback: Callable[[int], None],
     port: int = 3000,
@@ -474,6 +430,10 @@ def start_ui(
     backend_port: int = 8000,
     start_mcp: bool = False,
     mcp_port: int = 8001,
+    gateway_port: Optional[int] = None,
+    frontend_path: str = "/",
+    backend_path: str = "/backend",
+    mcp_path: str = "/mcp",
 ) -> Optional[subprocess.Popen]:
     """
     Start the cognee frontend UI server, optionally with the backend API server and MCP server.
@@ -485,7 +445,8 @@ def start_ui(
     4. Check if Node.js and npm are available (for development mode)
     5. Install dependencies if needed (development mode)
     6. Start the frontend server
-    7. Optionally open the browser
+    7. Optionally start a gateway serving all of the above behind a single port
+    8. Optionally open the browser
 
     Args:
         pid_callback: Callback to notify with PID of each spawned process
@@ -496,6 +457,26 @@ def start_ui(
         backend_port: Port to run the backend server on (default: 8000)
         start_mcp: If True, also start the cognee MCP server (default: False)
         mcp_port: Port to run the MCP server on (default: 8001)
+        gateway_port: If set, serve every started service behind this single port,
+            distinguished by path prefix (default: None, meaning no gateway)
+        frontend_path: Gateway path prefix for the frontend (default: "/")
+        backend_path: Gateway path prefix for the backend API (default: "/backend")
+        mcp_path: Gateway path prefix for the MCP server (default: "/mcp")
+
+    Gateway mode:
+        Without gateway_port the three services each own a port and a root path, and all
+        three ports have to be publicly reachable — which a deployment with a single
+        domain cannot do.
+
+        With gateway_port set, one gateway is bound on that port and forwards to the
+        services by path prefix; port, backend_port and mcp_port become internal bind
+        addresses behind it. Reaching all of cognee at a single domain then only takes
+        that one port, with no external reverse proxy involved.
+
+        The frontend keeps the gateway root by default, since Next.js is only aware of a
+        path prefix if it is built with a matching basePath. The backend is told about its
+        prefix through uvicorn's --root-path, so the URLs it generates stay correct, and
+        it is reached from the browser as a same-origin path rather than a second origin.
 
     Returns:
         subprocess.Popen object representing the running frontend server, or None if failed
@@ -517,10 +498,45 @@ def start_ui(
         >>> server = cognee.start_ui(dummy_callback, start_mcp=True)
         >>> # UI will be available at http://localhost:3000
         >>> # MCP server will be available at http://127.0.0.1:8001/sse
+        >>>
+        >>> # Serve everything behind a single port
+        >>> server = cognee.start_ui(
+        ...     dummy_callback, start_backend=True, start_mcp=True, gateway_port=9000
+        ... )
+        >>> # UI will be available at http://localhost:9000/
+        >>> # API will be available at http://localhost:9000/backend
+        >>> # MCP server will be available at http://localhost:9000/mcp
         >>> # To stop all servers later:
         >>> server.terminate()
     """
     logger.info("Starting cognee UI...")
+
+    if gateway_port:
+        # Imported here rather than at module scope: cognee/__init__.py imports start_ui,
+        # so a top-level import would put uvicorn on the path of every `import cognee`,
+        # including scripts that never start a server.
+        from .gateway import normalize_prefix
+
+        frontend_path = normalize_prefix(frontend_path)
+        backend_path = normalize_prefix(backend_path)
+        mcp_path = normalize_prefix(mcp_path)
+
+        if frontend_path != "/":
+            logger.warning(
+                f"Serving the frontend under '{frontend_path}' requires the frontend to be "
+                f"built with a matching Next.js basePath, otherwise its assets will 404. "
+                f"Use frontend_path='/' unless you have configured one."
+            )
+
+        if start_mcp:
+            logger.warning(
+                f"The MCP server is routed at '{mcp_path}', but it runs the SSE transport, "
+                f"whose handshake hands the client a message URL relative to the server "
+                f"root — which does not account for the prefix. Reaching MCP through the "
+                f"gateway also needs the public host in MCP_ALLOWED_HOSTS, since FastMCP "
+                f"rejects a Host header it does not recognise. Until MCP moves to the "
+                f"streamable-HTTP transport, reach it on port {mcp_port} directly."
+            )
 
     ports_to_check = [(port, "Frontend UI")]
 
@@ -529,6 +545,9 @@ def start_ui(
 
     if start_mcp:
         ports_to_check.append((mcp_port, "MCP Server"))
+
+    if gateway_port:
+        ports_to_check.append((gateway_port, "Gateway"))
 
     logger.info("Checking port availability...")
     all_ports_available, unavailable_services = _check_required_ports(ports_to_check)
@@ -631,17 +650,26 @@ def start_ui(
         try:
             import sys
 
+            backend_command = [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                "cognee.api.client:app",
+                "--host",
+                "localhost",
+                "--port",
+                str(backend_port),
+            ]
+
+            if gateway_port and backend_path != "/":
+                # The gateway strips the prefix before forwarding, so the app still routes
+                # on the paths it already knows. root_path is how it learns the prefix
+                # anyway, so the URLs it generates — redirects, OpenAPI servers — remain
+                # valid at the publicly reachable address.
+                backend_command.extend(["--root-path", backend_path])
+
             backend_process = subprocess.Popen(
-                [
-                    sys.executable,
-                    "-m",
-                    "uvicorn",
-                    "cognee.api.client:app",
-                    "--host",
-                    "localhost",
-                    "--port",
-                    str(backend_port),
-                ],
+                backend_command,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 preexec_fn=os.setsid if hasattr(os, "setsid") else None,
@@ -666,17 +694,18 @@ def start_ui(
             logger.error(f"Failed to start backend server: {str(e)}")
             return None
 
-    # Find frontend directory
-    frontend_path = find_frontend_path()
+    # Find frontend directory. Note this is a filesystem path, distinct from the
+    # frontend_path parameter above, which is the URL prefix the gateway serves it under.
+    frontend_dir = find_frontend_path()
 
-    if not frontend_path:
+    if not frontend_dir:
         logger.info("Frontend not found locally. This is normal for pip-installed cognee.")
 
         # Offer to download the frontend
         if auto_download or prompt_user_for_download():
             if download_frontend_assets():
-                frontend_path = find_frontend_path()
-                if not frontend_path:
+                frontend_dir = find_frontend_path()
+                if not frontend_dir:
                     logger.error(
                         "Download succeeded but frontend still not found. This is unexpected."
                     )
@@ -699,7 +728,7 @@ def start_ui(
     logger.debug(f"Environment check passed: {node_message}")
 
     # Install dependencies if needed
-    if not install_frontend_dependencies(frontend_path):
+    if not install_frontend_dependencies(frontend_dir):
         logger.error("Failed to install frontend dependencies")
         return None
 
@@ -710,6 +739,13 @@ def start_ui(
     # The shared frontend defaults to cloud mode; this launcher always runs
     # against the local backend, so opt into local mode unless overridden.
     env.setdefault("NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT", "false")
+
+    if gateway_port and start_backend:
+        # A relative API URL keeps the browser on whatever origin it loaded the UI from,
+        # which is the point of the single-domain deployment: the API is reachable at the
+        # same host as the UI, whatever that host turns out to be. It also makes every
+        # call same-origin, so CORS never enters the picture.
+        env.setdefault("NEXT_PUBLIC_LOCAL_API_URL", backend_path)
 
     # If nvm is installed, ensure it's available in the environment
     nvm_path = get_nvm_sh_path()
@@ -736,7 +772,7 @@ def start_ui(
         if platform.system() == "Windows":
             process = subprocess.Popen(
                 ["npm", "run", "dev"],
-                cwd=frontend_path,
+                cwd=frontend_dir,
                 env=env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -748,7 +784,7 @@ def start_ui(
                 # Use bash to source nvm and run npm
                 process = subprocess.Popen(
                     ["bash", "-c", f"source {nvm_path} && npm run dev"],
-                    cwd=frontend_path,
+                    cwd=frontend_dir,
                     env=env,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
@@ -757,7 +793,7 @@ def start_ui(
             else:
                 process = subprocess.Popen(
                     ["npm", "run", "dev"],
-                    cwd=frontend_path,
+                    cwd=frontend_dir,
                     env=env,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
@@ -778,13 +814,29 @@ def start_ui(
             logger.error("Frontend server failed to start - check the logs above for details")
             return None
 
+        # The gateway is started last: every service it forwards to is listening by now,
+        # so the first request through it cannot race a still-booting upstream.
+        public_url = f"http://localhost:{port}"
+
+        if gateway_port:
+            from .gateway import start_gateway
+
+            routes = [(frontend_path, f"http://localhost:{port}")]
+            if start_backend:
+                routes.append((backend_path, f"http://localhost:{backend_port}"))
+            if start_mcp:
+                routes.append((mcp_path, f"http://localhost:{mcp_port}"))
+
+            start_gateway(gateway_port, routes)
+            public_url = f"http://localhost:{gateway_port}{frontend_path.rstrip('/')}"
+
         # Open browser if requested
         if open_browser:
 
             def open_browser_delayed():
                 time.sleep(5)  # Give Next.js time to fully start
                 try:
-                    webbrowser.open(f"http://localhost:{port}")
+                    webbrowser.open(public_url)
                 except Exception as e:
                     logger.warning(f"Could not open browser automatically: {e}")
 
@@ -792,7 +844,7 @@ def start_ui(
             browser_thread.start()
 
         logger.info("✓ Cognee UI is starting up...")
-        logger.info(f"✓ Open your browser to: http://localhost:{port}")
+        logger.info(f"✓ Open your browser to: {public_url}")
         logger.info("✓ The UI will be available once Next.js finishes compiling")
 
         return process

--- a/cognee/cli/_cognee.py
+++ b/cognee/cli/_cognee.py
@@ -152,6 +152,13 @@ def _create_parser() -> tuple[argparse.ArgumentParser, Dict[str, SupportsCliComm
         help="Start the cognee web UI interface",
     )
     parser.add_argument(
+        "--gateway-port",
+        type=int,
+        default=None,
+        help="Serve the UI, API backend and MCP server behind this single port, so the whole "
+        "stack is reachable at one domain. Without it each runs on its own port.",
+    )
+    parser.add_argument(
         "--user-id",
         default=None,
         help="User/agent UUID for multi-agent isolation. Each unique ID gets its own session history and permissions. Omit to use the default user.",
@@ -343,6 +350,7 @@ def main() -> int:
             frontend_port = 3000
             start_backend, backend_port = True, 8000
             start_mcp, mcp_port = True, 8001
+            gateway_port = getattr(args, "gateway_port", None)
             server_process = start_ui(
                 pid_callback=pid_callback,
                 port=frontend_port,
@@ -352,15 +360,26 @@ def main() -> int:
                 backend_port=backend_port,
                 start_mcp=start_mcp,
                 mcp_port=mcp_port,
+                gateway_port=gateway_port,
             )
 
             if server_process:
                 fmt.success("UI server started successfully!")
-                fmt.echo(f"The interface is available at: http://localhost:{frontend_port}")
-                if start_backend:
-                    fmt.echo(f"The API backend is available at: http://localhost:{backend_port}")
-                if start_mcp:
-                    fmt.echo(f"The MCP server is available at: http://localhost:{mcp_port}")
+                if gateway_port:
+                    base_url = f"http://localhost:{gateway_port}"
+                    fmt.echo(f"The interface is available at: {base_url}")
+                    if start_backend:
+                        fmt.echo(f"The API backend is available at: {base_url}/backend")
+                    if start_mcp:
+                        fmt.echo(f"The MCP server is available at: {base_url}/mcp")
+                else:
+                    fmt.echo(f"The interface is available at: http://localhost:{frontend_port}")
+                    if start_backend:
+                        fmt.echo(
+                            f"The API backend is available at: http://localhost:{backend_port}"
+                        )
+                    if start_mcp:
+                        fmt.echo(f"The MCP server is available at: http://localhost:{mcp_port}")
                 fmt.note("Press Ctrl+C to stop the server...")
 
                 try:

--- a/cognee/tests/unit/api/v1/ui/test_gateway.py
+++ b/cognee/tests/unit/api/v1/ui/test_gateway.py
@@ -1,0 +1,637 @@
+"""Tests for the single-port gateway in cognee.api.v1.ui.gateway and its start_ui wiring."""
+
+import asyncio
+import gc
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from cognee.api.v1.ui.gateway import (
+    HOP_BY_HOP_HEADERS,
+    ORIGIN_HEADERS,
+    SubpathGateway,
+    _filter_headers,
+    normalize_prefix,
+)
+
+
+async def call_gateway(gateway, path, method="GET", query=b"", headers=None, body=b""):
+    """Drive the gateway's ASGI interface once and collect what it sends back."""
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "query_string": query,
+        "scheme": "http",
+        "headers": headers if headers is not None else [(b"host", b"cognee.example")],
+        "client": ("203.0.113.7", 51234),
+    }
+
+    incoming = [{"type": "http.request", "body": body, "more_body": False}]
+    sent = []
+
+    async def receive():
+        return incoming.pop(0)
+
+    async def send(message):
+        sent.append(message)
+
+    await gateway(scope, receive, send)
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    payload = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+
+    return start, payload, sent
+
+
+def attach_upstream(gateway, upstream_app):
+    """Point the gateway at an in-process ASGI app instead of a real socket."""
+    gateway._client = httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=upstream_app),
+        timeout=None,
+        follow_redirects=False,
+    )
+
+
+class TestNormalizePrefix:
+    """Prefixes are accepted in whatever shape the caller wrote them."""
+
+    def test_variants_collapse_to_one_form(self):
+        assert normalize_prefix("/backend") == "/backend"
+        assert normalize_prefix("backend") == "/backend"
+        assert normalize_prefix("/backend/") == "/backend"
+        assert normalize_prefix("backend/") == "/backend"
+        assert normalize_prefix("/") == "/"
+        assert normalize_prefix("") == "/"
+
+
+class TestHeaderFiltering:
+    """Headers scoped to a single connection must not be relayed to the next one."""
+
+    def test_hop_by_hop_headers_are_dropped(self):
+        headers = [
+            (b"host", b"cognee.example"),
+            (b"connection", b"keep-alive"),
+            (b"keep-alive", b"timeout=5"),
+            (b"transfer-encoding", b"chunked"),
+            (b"content-length", b"12"),
+            (b"upgrade", b"websocket"),
+            (b"te", b"trailers"),
+            (b"trailer", b"Expires"),
+            (b"proxy-authenticate", b"Basic"),
+            (b"proxy-authorization", b"Basic hop"),
+            (b"authorization", b"Bearer token"),
+            (b"cookie", b"auth_token=abc"),
+        ]
+
+        assert _filter_headers(headers) == [
+            (b"host", b"cognee.example"),
+            (b"authorization", b"Bearer token"),
+            (b"cookie", b"auth_token=abc"),
+        ]
+
+    def test_origin_headers_are_dropped_from_responses(self):
+        # The gateway's own server emits Date and Server for its hop; relaying the
+        # upstream's copies too would send each twice, and Date may not repeat.
+        headers = [
+            (b"date", b"Mon, 17 Aug 2026 11:11:38 GMT"),
+            (b"server", b"uvicorn"),
+            (b"content-type", b"application/json"),
+        ]
+
+        assert _filter_headers(headers, HOP_BY_HOP_HEADERS | ORIGIN_HEADERS) == [
+            (b"content-type", b"application/json"),
+        ]
+
+
+class TestRouteMatching:
+    """The gateway picks an upstream by longest prefix and strips that prefix."""
+
+    def setup_method(self):
+        self.gateway = SubpathGateway(
+            [
+                ("/", "http://localhost:3000"),
+                ("/backend", "http://localhost:8000"),
+                ("/mcp", "http://localhost:8001"),
+            ]
+        )
+
+    def test_longest_prefix_wins_over_root_catch_all(self):
+        prefix, upstream, path = self.gateway.match("/backend/api/v1/datasets")
+
+        assert prefix == "/backend"
+        assert upstream == "http://localhost:8000"
+        assert path == "/api/v1/datasets"
+
+    def test_bare_prefix_maps_to_upstream_root(self):
+        assert self.gateway.match("/backend")[2] == "/"
+
+    def test_prefix_only_matches_on_a_segment_boundary(self):
+        # "/backendish" is a frontend route, not a mistyped backend one.
+        prefix, upstream, path = self.gateway.match("/backendish")
+
+        assert prefix == "/"
+        assert upstream == "http://localhost:3000"
+        assert path == "/backendish"
+
+    def test_unmatched_paths_fall_through_to_the_frontend(self):
+        for path in ["/", "/dashboard", "/_next/static/chunk.js"]:
+            assert self.gateway.match(path)[1] == "http://localhost:3000"
+
+    def test_no_match_without_a_root_route(self):
+        gateway = SubpathGateway([("/backend", "http://localhost:8000")])
+
+        assert gateway.match("/dashboard") is None
+
+
+class TestHttpProxying:
+    """Requests reach the upstream unchanged apart from the stripped prefix."""
+
+    def setup_method(self):
+        self.seen = {}
+
+        async def upstream(scope, receive, send):
+            body = b""
+            while True:
+                message = await receive()
+                body += message.get("body", b"")
+                if not message.get("more_body", False):
+                    break
+
+            self.seen["path"] = scope["path"]
+            self.seen["method"] = scope["method"]
+            self.seen["query_string"] = scope["query_string"]
+            self.seen["headers"] = dict(scope["headers"])
+            self.seen["body"] = body
+
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 201,
+                    "headers": [(b"content-type", b"application/json")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b'{"ok":true}'})
+
+        self.gateway = SubpathGateway(
+            [("/", "http://frontend"), ("/backend", "http://backend")],
+        )
+        attach_upstream(self.gateway, upstream)
+
+    @pytest.mark.asyncio
+    async def test_prefix_is_stripped_before_the_upstream_sees_it(self):
+        start, payload, _ = await call_gateway(self.gateway, "/backend/api/v1/datasets")
+
+        assert self.seen["path"] == "/api/v1/datasets"
+        assert start["status"] == 201
+        assert payload == b'{"ok":true}'
+
+    @pytest.mark.asyncio
+    async def test_method_query_string_and_body_survive_the_hop(self):
+        await call_gateway(
+            self.gateway,
+            "/backend/api/v1/search",
+            method="POST",
+            query=b"top_k=5",
+            body=b'{"query":"hello"}',
+        )
+
+        assert self.seen["method"] == "POST"
+        assert self.seen["query_string"] == b"top_k=5"
+        assert self.seen["body"] == b'{"query":"hello"}'
+
+    @pytest.mark.asyncio
+    async def test_forwarded_headers_describe_the_original_request(self):
+        await call_gateway(self.gateway, "/backend/health")
+
+        headers = self.seen["headers"]
+        assert headers[b"x-forwarded-proto"] == b"http"
+        assert headers[b"x-forwarded-host"] == b"cognee.example"
+        assert headers[b"x-forwarded-for"] == b"203.0.113.7"
+        assert headers[b"x-forwarded-prefix"] == b"/backend"
+
+    @pytest.mark.asyncio
+    async def test_no_forwarded_prefix_for_the_root_route(self):
+        await call_gateway(self.gateway, "/dashboard")
+
+        assert b"x-forwarded-prefix" not in self.seen["headers"]
+
+    @pytest.mark.asyncio
+    async def test_hop_by_hop_headers_are_not_forwarded(self):
+        await call_gateway(
+            self.gateway,
+            "/backend/health",
+            headers=[
+                (b"host", b"cognee.example"),
+                (b"transfer-encoding", b"chunked"),
+                (b"proxy-authorization", b"Basic hop"),
+                (b"te", b"trailers"),
+                (b"authorization", b"Bearer token"),
+            ],
+        )
+
+        headers = self.seen["headers"]
+        # These describe the client's hop to the gateway, not the gateway's to the upstream.
+        # transfer-encoding and connection are not asserted here: httpx sets its own for
+        # the outgoing hop, so what arrives is its framing rather than a copied header.
+        assert b"proxy-authorization" not in headers
+        assert b"te" not in headers
+        # End-to-end headers must still get through.
+        assert headers[b"authorization"] == b"Bearer token"
+
+    @pytest.mark.asyncio
+    async def test_unreachable_upstream_answers_502(self):
+        gateway = SubpathGateway([("/backend", "http://127.0.0.1:1")])
+        gateway._client = httpx.AsyncClient(timeout=1, follow_redirects=False)
+
+        start, payload, _ = await call_gateway(gateway, "/backend/health")
+
+        assert start["status"] == 502
+        assert b"unavailable" in payload
+
+    @pytest.mark.asyncio
+    async def test_unroutable_path_answers_502(self):
+        gateway = SubpathGateway([("/backend", "http://backend")])
+        attach_upstream(gateway, lambda scope, receive, send: None)
+
+        start, _, _ = await call_gateway(gateway, "/nowhere")
+
+        assert start["status"] == 502
+
+
+class ChunkStream(httpx.AsyncByteStream):
+    """A response body that arrives in distinct chunks, the way an SSE endpoint answers."""
+
+    def __init__(self, chunks):
+        self.chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self.chunks:
+            yield chunk
+
+
+class ChunkedTransport(httpx.AsyncBaseTransport):
+    def __init__(self, chunks):
+        self.chunks = chunks
+
+    async def handle_async_request(self, request):
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=ChunkStream(self.chunks),
+        )
+
+
+class TestStreaming:
+    """Chunks reach the client as they are produced, not buffered into one response.
+
+    Server-sent events are how the MCP server and the cognify progress endpoint report,
+    so a gateway that waited for the last chunk would stall them indefinitely.
+    """
+
+    @pytest.mark.asyncio
+    async def test_chunks_are_relayed_individually(self):
+        chunks = [b"data: 0\n\n", b"data: 1\n\n", b"data: 2\n\n"]
+        gateway = SubpathGateway([("/mcp", "http://mcp")])
+        gateway._client = httpx.AsyncClient(
+            transport=ChunkedTransport(chunks), timeout=None, follow_redirects=False
+        )
+
+        _, payload, sent = await call_gateway(gateway, "/mcp/sse")
+
+        assert payload == b"".join(chunks)
+        body_messages = [m for m in sent if m["type"] == "http.response.body" and m.get("body")]
+        assert len(body_messages) == len(chunks), "streamed chunks were buffered into one response"
+
+
+class TestSseEndpointRewriting:
+    """MCP's SSE handshake advertises the path the client must post messages to.
+
+    It is written relative to the server root, so behind a prefix it names a path the
+    gateway routes to a different service entirely — the same defect as a root-relative
+    Location header, in a body instead of a header.
+    """
+
+    def _sse_gateway(self, chunks):
+        gateway = SubpathGateway([("/", "http://frontend"), ("/mcp", "http://mcp")])
+        gateway._client = httpx.AsyncClient(
+            transport=ChunkedTransport(chunks), timeout=None, follow_redirects=False
+        )
+        return gateway
+
+    @pytest.mark.asyncio
+    async def test_endpoint_path_gains_the_prefix(self):
+        gateway = self._sse_gateway(
+            [b"event: endpoint\ndata: /messages/?session_id=abc123\n\n"],
+        )
+
+        _, payload, _ = await call_gateway(gateway, "/mcp/sse")
+
+        assert b"data: /mcp/messages/?session_id=abc123" in payload
+
+    @pytest.mark.asyncio
+    async def test_endpoint_split_across_chunks_is_still_rewritten(self):
+        # The rewrite must not depend on the frame arriving in one piece.
+        gateway = self._sse_gateway(
+            [b"event: endp", b"oint\ndata: /messa", b"ges/?session_id=abc123\n\n"],
+        )
+
+        _, payload, _ = await call_gateway(gateway, "/mcp/sse")
+
+        assert b"data: /mcp/messages/?session_id=abc123" in payload
+
+    @pytest.mark.asyncio
+    async def test_later_data_frames_are_left_alone(self):
+        # Only the handshake names a path; message payloads must stream through verbatim.
+        gateway = self._sse_gateway(
+            [
+                b"event: endpoint\ndata: /messages/?session_id=abc\n\n",
+                b'event: message\ndata: {"jsonrpc":"2.0","result":"/not/a/path"}\n\n',
+            ],
+        )
+
+        _, payload, _ = await call_gateway(gateway, "/mcp/sse")
+
+        assert b'data: {"jsonrpc":"2.0","result":"/not/a/path"}' in payload
+
+    @pytest.mark.asyncio
+    async def test_absolute_endpoint_is_left_alone(self):
+        gateway = self._sse_gateway(
+            [b"event: endpoint\ndata: https://mcp.example/messages/\n\n"],
+        )
+
+        _, payload, _ = await call_gateway(gateway, "/mcp/sse")
+
+        assert b"data: https://mcp.example/messages/" in payload
+
+    @pytest.mark.asyncio
+    async def test_root_route_is_never_rewritten(self):
+        gateway = self._sse_gateway([b"event: endpoint\ndata: /messages/\n\n"])
+
+        _, payload, _ = await call_gateway(gateway, "/stream")
+
+        assert b"data: /messages/" in payload
+        assert b"/mcp/messages" not in payload
+
+    @pytest.mark.asyncio
+    async def test_non_sse_bodies_are_not_inspected(self):
+        async def upstream(scope, receive, send):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"application/json")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b'{"data": "/messages/"}'})
+
+        gateway = SubpathGateway([("/mcp", "http://mcp")])
+        attach_upstream(gateway, upstream)
+
+        _, payload, _ = await call_gateway(gateway, "/mcp/info")
+
+        assert payload == b'{"data": "/messages/"}'
+
+
+class TestWebSocketTeardown:
+    """A socket dying mid-relay is how proxied WebSockets normally end, not a failure.
+
+    Next.js cycles its hot-reload socket constantly, so this is the common case rather
+    than an edge one, and it must not surface as an unhandled task exception.
+    """
+
+    @pytest.mark.asyncio
+    async def test_client_vanishing_mid_stream_is_handled(self):
+        import websockets
+
+        gateway = SubpathGateway([("/backend", "http://backend")])
+
+        class Upstream:
+            subprotocol = None
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                return "frame"
+
+            async def close(self):
+                pass
+
+        sent = []
+
+        async def send(message):
+            sent.append(message)
+            # The browser is gone; uvicorn raises on any further send.
+            if message["type"] == "websocket.send":
+                raise RuntimeError("ClientDisconnected")
+
+        async def receive():
+            await asyncio.sleep(0.05)
+            return {"type": "websocket.disconnect", "code": 1001}
+
+        scope = {
+            "type": "websocket",
+            "path": "/backend/ws",
+            "query_string": b"",
+            "scheme": "ws",
+            "headers": [(b"host", b"cognee.example")],
+            "client": ("203.0.113.7", 51234),
+            "subprotocols": [],
+        }
+
+        # "Task exception was never retrieved" is reported to the loop handler when the
+        # abandoned task is collected, so that is what this has to watch.
+        unretrieved = []
+        asyncio.get_running_loop().set_exception_handler(
+            lambda loop, context: unretrieved.append(context)
+        )
+
+        with patch.object(websockets, "connect", return_value=_awaitable(Upstream())):
+            # Must return rather than raise, and must not leave a task exception behind.
+            await asyncio.wait_for(gateway(scope, receive, send), timeout=5)
+
+        gc.collect()
+        await asyncio.sleep(0)
+
+        assert any(m["type"] == "websocket.accept" for m in sent)
+        assert not unretrieved, f"pump left an unhandled exception: {unretrieved}"
+
+
+def _awaitable(value):
+    async def _coro():
+        return value
+
+    return _coro()
+
+
+class TestRedirectHandling:
+    """Redirects reach the browser, and root-relative ones stay inside the prefix."""
+
+    def setup_method(self):
+        async def upstream(scope, receive, send):
+            location = scope["path"].encode().replace(b"/redirect", b"") or b"/login"
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 307,
+                    "headers": [(b"location", location)],
+                }
+            )
+            await send({"type": "http.response.body", "body": b""})
+
+        self.gateway = SubpathGateway([("/", "http://frontend"), ("/backend", "http://backend")])
+        attach_upstream(self.gateway, upstream)
+
+    def _location(self, start):
+        return dict(start["headers"])[b"location"]
+
+    @pytest.mark.asyncio
+    async def test_root_relative_location_is_rewritten_under_the_prefix(self):
+        start, _, _ = await call_gateway(self.gateway, "/backend/redirect/login")
+
+        # 307 rather than a followed redirect: the browser must see it, not the gateway.
+        assert start["status"] == 307
+        assert self._location(start) == b"/backend/login"
+
+    @pytest.mark.asyncio
+    async def test_root_route_locations_are_left_alone(self):
+        start, _, _ = await call_gateway(self.gateway, "/redirect/login")
+
+        assert self._location(start) == b"/login"
+
+    @pytest.mark.asyncio
+    async def test_absolute_location_is_left_alone(self):
+        async def upstream(scope, receive, send):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 302,
+                    "headers": [(b"location", b"https://auth.example/callback")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b""})
+
+        gateway = SubpathGateway([("/backend", "http://backend")])
+        attach_upstream(gateway, upstream)
+
+        start, _, _ = await call_gateway(gateway, "/backend/login")
+
+        assert self._location(start) == b"https://auth.example/callback"
+
+
+class TestStartUiGatewayWiring:
+    """start_ui only changes how it launches the services when a gateway is asked for."""
+
+    def _run_start_ui(self, **kwargs):
+        """Run start_ui far enough to launch the backend, then let it bail on the frontend."""
+        from cognee.api.v1.ui.ui import start_ui
+
+        with (
+            patch("cognee.api.v1.ui.ui._check_required_ports", return_value=(True, [])),
+            patch("cognee.api.v1.ui.ui.find_frontend_path", return_value=None),
+            patch("cognee.api.v1.ui.ui.prompt_user_for_download", return_value=False),
+            patch("cognee.api.v1.ui.ui.time.sleep"),
+            patch("cognee.api.v1.ui.ui._stream_process_output"),
+            patch("cognee.api.v1.ui.gateway.start_gateway") as mock_gateway,
+            patch("subprocess.Popen") as mock_popen,
+        ):
+            mock_popen.return_value.poll.return_value = None
+            start_ui(
+                pid_callback=lambda pid: None,
+                start_backend=True,
+                start_mcp=False,
+                **kwargs,
+            )
+
+            backend_command = mock_popen.call_args_list[0][0][0]
+
+        return backend_command, mock_gateway
+
+    def test_backend_learns_its_prefix_through_root_path(self):
+        backend_command, _ = self._run_start_ui(gateway_port=9000)
+
+        assert "--root-path" in backend_command
+        assert backend_command[backend_command.index("--root-path") + 1] == "/backend"
+
+    def test_custom_backend_path_is_passed_through(self):
+        backend_command, _ = self._run_start_ui(gateway_port=9000, backend_path="api/")
+
+        assert backend_command[backend_command.index("--root-path") + 1] == "/api"
+
+    def test_default_launch_is_unchanged(self):
+        backend_command, mock_gateway = self._run_start_ui()
+
+        assert "--root-path" not in backend_command
+        mock_gateway.assert_not_called()
+
+    def test_gateway_port_joins_the_port_preflight(self):
+        from cognee.api.v1.ui.ui import start_ui
+
+        with (
+            patch("cognee.api.v1.ui.ui._check_required_ports", return_value=(True, [])) as ports,
+            patch("cognee.api.v1.ui.ui.find_frontend_path", return_value=None),
+            patch("cognee.api.v1.ui.ui.prompt_user_for_download", return_value=False),
+        ):
+            start_ui(pid_callback=lambda pid: None, gateway_port=9000)
+
+        assert (9000, "Gateway") in ports.call_args[0][0]
+
+
+class TestStartUiFrontendEnvironment:
+    """In gateway mode the UI talks to the API as a same-origin path."""
+
+    def _run(self, **kwargs):
+        """Run start_ui through the frontend launch, returning its env and the gateway mock."""
+        from cognee.api.v1.ui.ui import start_ui
+
+        with (
+            patch("cognee.api.v1.ui.ui._check_required_ports", return_value=(True, [])),
+            # find_frontend_path returns a Path, not a str — a str stand-in would hide a
+            # filesystem path being mistaken for the URL prefix of the same name.
+            patch("cognee.api.v1.ui.ui.find_frontend_path", return_value=Path("/tmp/frontend")),
+            patch("cognee.api.v1.ui.ui.check_node_npm", return_value=(True, "ok")),
+            patch("cognee.api.v1.ui.ui.install_frontend_dependencies", return_value=True),
+            patch(
+                "cognee.api.v1.ui.ui.get_nvm_sh_path", return_value=MagicMock(exists=lambda: False)
+            ),
+            patch("cognee.api.v1.ui.ui._stream_process_output"),
+            patch("cognee.api.v1.ui.ui.time.sleep"),
+            patch("cognee.api.v1.ui.gateway.start_gateway") as mock_gateway,
+            patch("subprocess.Popen") as mock_popen,
+        ):
+            mock_popen.return_value.poll.return_value = None
+            start_ui(
+                pid_callback=lambda pid: None,
+                start_backend=True,
+                start_mcp=False,
+                open_browser=False,
+                **kwargs,
+            )
+
+            frontend_call = mock_popen.call_args_list[-1]
+
+        return frontend_call[1]["env"], mock_gateway
+
+    def test_api_url_is_relative_so_the_browser_stays_on_one_origin(self):
+        env, _ = self._run(gateway_port=9000)
+
+        assert env["NEXT_PUBLIC_LOCAL_API_URL"] == "/backend"
+
+    def test_api_url_is_untouched_without_a_gateway(self):
+        env, _ = self._run()
+
+        assert "NEXT_PUBLIC_LOCAL_API_URL" not in env
+
+    def test_gateway_routes_the_url_prefix_not_the_frontend_directory(self):
+        """start_ui also has a frontend *directory* local; the gateway must not get it."""
+        _, mock_gateway = self._run(gateway_port=9000)
+
+        routes = mock_gateway.call_args[0][1]
+        prefixes = [prefix for prefix, _ in routes]
+
+        assert "/" in prefixes
+        assert all(isinstance(prefix, str) for prefix, _ in routes)
+        assert not any("tmp" in prefix for prefix in prefixes)

--- a/examples/guides/start_ui_single_port_example.py
+++ b/examples/guides/start_ui_single_port_example.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Example showing how to serve cognee's UI, API backend and MCP server behind a single port.
+
+By default start_ui() gives each of the three services its own port, which means a
+deployment with only one domain available cannot expose all of them. Passing gateway_port
+puts a gateway in front: it is the only publicly bound listener, and it routes to the
+services by path prefix. No external reverse proxy is involved.
+"""
+
+import asyncio
+import time
+
+import cognee
+
+GATEWAY_PORT = 9000
+
+
+async def main():
+    print("Adding sample data to cognee...")
+    await cognee.remember(
+        "Cognee turns raw data into a knowledge graph that AI agents can query.",
+        self_improvement=False,
+    )
+
+    print("\n" + "=" * 60)
+    print(f"Starting cognee behind a single port ({GATEWAY_PORT})...")
+    print("=" * 60)
+
+    def dummy_callback(pid):
+        pass
+
+    server = cognee.start_ui(
+        pid_callback=dummy_callback,
+        start_backend=True,
+        start_mcp=True,
+        gateway_port=GATEWAY_PORT,
+        open_browser=True,
+    )
+
+    if not server:
+        print("Failed to start the UI. Check the logs above for details.")
+        return
+
+    print("Everything is reachable on one port:")
+    print(f"  UI       http://localhost:{GATEWAY_PORT}/")
+    print(f"  API      http://localhost:{GATEWAY_PORT}/backend")
+    print(f"  MCP      http://localhost:{GATEWAY_PORT}/mcp")
+    print("\nOnly this port needs to be publicly reachable — the frontend, backend and")
+    print("MCP server stay bound to localhost behind it.")
+    print("\nPress Ctrl+C to stop...")
+
+    try:
+        while server.poll() is None:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("\nStopping...")
+        server.terminate()
+        server.wait()
+        print("Stopped.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dependencies = [
     "limits>=4.4.1,<5",
     "fastapi>=0.116.2,<1.0.0",
     "starlette>=0.48",
+    # Already imported unconditionally on runtime paths (embedding engines, web scraper)
+    # and by the single-port UI gateway, so it is declared rather than left transitive.
+    "httpx>=0.27.0,<1.0.0",
     "python-multipart>=0.0.22,<1.0.0",
     "fastapi-users[sqlalchemy]>=15.0.2",
     "structlog>=25.2.0,<26",


### PR DESCRIPTION
## Description

We wanted to deploy the cognee stack locally but only have one internal domain available. Running the full stack requires three ports (frontend 3000, backend 8000 and MCP 8001), and our reverse proxy could only expose one of them.

We tried routing by path in the reverse proxy (`/frontend`, `/backend`, `/mcp`), but that didn't work. None of the services knows it is served under a prefix, so requests under `/backend` were redirected back to root.

So we solved it inside cognee instead, as a proof of concept. `start_ui()` now gets an optional `gateway_port`. Default behaviour with `None` is identical to before. When it is set, an ASGI reverse proxy binds that single port and forwards to the three services by path prefix.

For now the frontend keeps the root path, because Next.js only respects a prefix when built with a matching `basePath`, which cannot be set at runtime. The backend and MCP can be told their prefix at startup, so they get subpaths, by default `/backend` and `/mcp`.

## Acceptance Criteria

* `cognee-cli -ui --gateway-port <port>` serves everything on one port: `/` for the UI, `/backend` for the API and `/mcp` for MCP.
* Without the flag, behaviour is unchanged and the three services keep their own ports.
* The frontend opens on the gateway port and its API calls go through `/backend`.
* `/backend/health` and the other API routes answer through the gateway.
* `/backend/docs` opens the API docs, and the requests it sends are prefixed correctly.
* Paths that are not `/backend` or `/mcp` go to the frontend.
* Websocket connections work through the gateway.
* An MCP session over `/mcp` works, including `initialize` and `tools/list`.
* 33 new unit tests pass.

Known limitation: MCP on a public domain needs `MCP_ALLOWED_HOSTS` to be set, otherwise it rejects the requests coming through the gateway.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Unit tests: 4065 passed, 14 failed. The failures are not related to this PR. Most of them need an LLM API key which we do not have set, and the rest are subprocess timeouts.
<img width="2673" height="1184" alt="screenshot" src="https://github.com/user-attachments/assets/4333c452-9aee-4164-8122-3d5d66315c73" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.