### PR TITLE
Mention the remember(content_type="code") one-liner in the code graph example

### DIFF
--- a/examples/guides/code_graph_example.py
+++ b/examples/guides/code_graph_example.py
@@ -12,6 +12,11 @@ Requirements:
 
 SearchType.CODE does not require an LLM API key or embedding model.
 
+Prefer a one-liner? cognee.remember(repo_path_or_git_url, content_type="code")
+runs this same pipeline in a single call (it also accepts a list of
+repositories, and index_vectors=True to enable embeddings). This example
+assembles the pipeline explicitly so each step stays visible.
+
 For cross-repository paths, generate one Enola append/multi-repository snapshot
 and ingest it into one dataset. Repositories indexed in separate datasets are
 searched independently and cannot have graph paths between them.


### PR DESCRIPTION
The `examples/guides/code_graph_example.py` docstring now points readers at `cognee.remember(repo_path_or_git_url, content_type="code")` as the single-call way to run the same code graph pipeline (including its list-of-repositories and `index_vectors=True` options), while noting the example assembles the pipeline explicitly so each step stays visible.

Came out of the docs review of topoteretes/cognee-docs#1327: the synced guide page had no pointer to the simpler entry point, and the right place for it is the upstream example (the docs code block must stay verbatim with this script). The example docs sync will pick up the new blob SHA after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)