### PR TITLE
feat: Add aggregate integrations status endpoint (SDK-422)

### DIFF
--- a/cognee/api/v1/integrations/routers/get_integrations_router.py
+++ b/cognee/api/v1/integrations/routers/get_integrations_router.py
@@ -55,12 +55,21 @@ from cognee.modules.integrations.connect import complete_installation
 from cognee.modules.integrations.credentials import (
     CrossUserConflictError,
     get_active_credential_for_user,
+    list_active_credentials_for_user,
     revoke_credential_by_account,
 )
 from cognee.modules.integrations.oauth_flow import make_state, validate_state
-from cognee.modules.integrations.plugins import get_plugin
-from cognee.modules.integrations.registry import get_integration
+from cognee.modules.integrations.plugin_status import (
+    PluginStatusRow,
+    identity_plugin_statuses,
+    legacy_plugin_statuses,
+    merge_plugin_statuses,
+    registry_plugin_statuses,
+)
+from cognee.modules.integrations.plugins import KNOWN_PLUGINS, get_plugin
+from cognee.modules.integrations.registry import get_integration, supported_integrations
 from cognee.modules.observability import new_span
+from cognee.modules.session_lifecycle.visibility import visible_user_ids
 from cognee.modules.users.api_key.create_api_key import create_api_key
 from cognee.modules.users.api_key.delete_api_key import delete_api_key
 from cognee.modules.users.api_key.get_api_keys import get_api_keys
@@ -105,6 +114,29 @@ class PluginProvisionDTO(OutDTO):
     agent_id: UUID
     api_key: str
     created: bool
+
+
+class IntegrationStatusItemDTO(OutDTO):
+    provider: str
+    connected: bool
+    account_label: Optional[str] = None
+    provider_account_id: Optional[str] = None
+    connected_at: Optional[datetime] = None
+
+
+class PluginStatusItemDTO(OutDTO):
+    key: str
+    connected: bool
+    agent_id: Optional[UUID] = None
+    provisioned_at: Optional[datetime] = None
+    last_active_at: Optional[datetime] = None
+    session_count: int = 0
+    source: Optional[str] = None
+
+
+class IntegrationsStatusDTO(OutDTO):
+    integrations: list[IntegrationStatusItemDTO]
+    plugins: list[PluginStatusItemDTO]
 
 
 def _integration_or_404(provider: str) -> OAuthIntegration:
@@ -203,6 +235,97 @@ def _frontend_redirect(integration: OAuthIntegration, outcome: str) -> RedirectR
 
 def get_integrations_router():
     integrations_router = APIRouter()
+
+    # ------------------------------------------------------------------ #
+    # Aggregate status (fixed /status path — before the {provider} routes)
+    # ------------------------------------------------------------------ #
+
+    @integrations_router.get("/status")
+    async def integrations_status(
+        user: User = Depends(get_authenticated_user),
+    ) -> IntegrationsStatusDTO:
+        """Aggregate connection status: every OAuth provider + every known plugin.
+
+        One call powers the whole integrations page. Every registered
+        provider and every known plugin appears, connected or not, with
+        display fields only — never token material. Each status source
+        (credentials, identity plugins, legacy prefixes, agent registry) is
+        fetched independently and degrades to its empty default on failure:
+        a broken source logs server-side and blanks its section rather than
+        500ing the page (same posture as the sessions list).
+        """
+        with new_span("cognee.integrations.status"):
+            credentials = {}
+            try:
+                credentials = await list_active_credentials_for_user(user.id)
+            except Exception:
+                logger.exception(
+                    "integrations status: credential lookup failed for user %s", user.id
+                )
+
+            integrations = []
+            for provider in sorted(supported_integrations):
+                credential = credentials.get(provider)
+                integrations.append(
+                    IntegrationStatusItemDTO(
+                        provider=provider,
+                        connected=credential is not None,
+                        account_label=credential.account_label if credential else None,
+                        provider_account_id=credential.provider_account_id if credential else None,
+                        connected_at=credential.created_at if credential else None,
+                    )
+                )
+
+            plugin_rows: dict[str, PluginStatusRow] = {}
+            try:
+                plugin_rows = await identity_plugin_statuses(user.id)
+            except Exception:
+                logger.exception(
+                    "integrations status: identity plugin lookup failed for user %s", user.id
+                )
+
+            visible_ids = [user.id]
+            try:
+                visible_ids = await visible_user_ids(user)
+            except Exception:
+                logger.exception(
+                    "integrations status: visible-user lookup failed for user %s", user.id
+                )
+
+            try:
+                legacy_rows = await legacy_plugin_statuses(
+                    visible_ids, exclude_keys=set(plugin_rows)
+                )
+                plugin_rows = merge_plugin_statuses(plugin_rows, legacy_rows)
+            except Exception:
+                logger.exception(
+                    "integrations status: legacy session lookup failed for user %s", user.id
+                )
+
+            try:
+                registry_rows = await registry_plugin_statuses(visible_ids)
+                plugin_rows = merge_plugin_statuses(plugin_rows, registry_rows)
+            except Exception:
+                logger.exception(
+                    "integrations status: agent registry lookup failed for user %s", user.id
+                )
+
+            plugins = []
+            for plugin_key in KNOWN_PLUGINS:
+                row = plugin_rows.get(plugin_key) or PluginStatusRow(key=plugin_key)
+                plugins.append(
+                    PluginStatusItemDTO(
+                        key=plugin_key,
+                        connected=row.connected,
+                        agent_id=row.agent_id,
+                        provisioned_at=row.provisioned_at,
+                        last_active_at=row.last_active_at,
+                        session_count=row.session_count,
+                        source=row.source,
+                    )
+                )
+
+            return IntegrationsStatusDTO(integrations=integrations, plugins=plugins)
 
     # ------------------------------------------------------------------ #
     # Agent plugins (fixed /plugins prefix — before the {provider} routes)

--- a/cognee/api/v1/integrations/routers/get_integrations_router.py
+++ b/cognee/api/v1/integrations/routers/get_integrations_router.py
@@ -61,6 +61,7 @@ from cognee.modules.integrations.credentials import (
 from cognee.modules.integrations.oauth_flow import make_state, validate_state
 from cognee.modules.integrations.plugin_status import (
     PluginStatusRow,
+    as_utc,
     coerce_provisioned_at,
     identity_plugin_statuses,
     legacy_plugin_statuses,
@@ -278,7 +279,7 @@ def get_integrations_router():
                         connected=credential is not None,
                         account_label=credential.account_label if credential else None,
                         provider_account_id=credential.provider_account_id if credential else None,
-                        connected_at=credential.created_at if credential else None,
+                        connected_at=as_utc(credential.created_at) if credential else None,
                     )
                 )
 
@@ -510,7 +511,7 @@ def get_integrations_router():
             connected=True,
             account_label=credential.account_label,
             provider_account_id=credential.provider_account_id,
-            connected_at=credential.created_at,
+            connected_at=as_utc(credential.created_at),
         )
 
     @integrations_router.delete("/{provider}/connection")

--- a/cognee/api/v1/integrations/routers/get_integrations_router.py
+++ b/cognee/api/v1/integrations/routers/get_integrations_router.py
@@ -61,6 +61,7 @@ from cognee.modules.integrations.credentials import (
 from cognee.modules.integrations.oauth_flow import make_state, validate_state
 from cognee.modules.integrations.plugin_status import (
     PluginStatusRow,
+    coerce_provisioned_at,
     identity_plugin_statuses,
     legacy_plugin_statuses,
     merge_plugin_statuses,
@@ -177,7 +178,9 @@ async def _record_plugin_on_agent(agent_user_id: UUID, plugin_key: str) -> None:
     Stored under the same ``AGENT_CONFIG_NAME`` blob the agent-connection
     registry persists to, so no ``User`` schema change is needed. The first
     ``provisioned_at`` sticks across re-provisions (key rotation isn't a new
-    install).
+    install) — but only if it still parses as a datetime: the blob is
+    agent-writable, so a tampered value is repaired here rather than
+    preserved.
     """
     all_configs = await get_principal_all_configuration(agent_user_id)
     existing_config = {}
@@ -186,8 +189,11 @@ async def _record_plugin_on_agent(agent_user_id: UUID, plugin_key: str) -> None:
             existing_config = config.get("configuration", {})
             break
 
-    plugin_entry = existing_config.get("plugin", {})
-    provisioned_at = plugin_entry.get("provisioned_at") or datetime.now(timezone.utc).isoformat()
+    plugin_entry = existing_config.get("plugin")
+    if not isinstance(plugin_entry, dict):
+        plugin_entry = {}
+    existing_provisioned_at = coerce_provisioned_at(plugin_entry.get("provisioned_at"))
+    provisioned_at = (existing_provisioned_at or datetime.now(timezone.utc)).isoformat()
 
     await store_principal_configuration(
         principal_id=agent_user_id,

--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -22,12 +22,12 @@ from cognee.modules.session_lifecycle.metrics import (
     list_session_rows,
 )
 from cognee.modules.session_lifecycle.models import SessionModelUsage, SessionRecord
-from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.session_lifecycle.visibility import (
+    permitted_dataset_ids_for,
+    visible_user_ids,
+)
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.modules.users.models import User
-from cognee.modules.users.permissions.methods.get_specific_user_permission_datasets import (
-    get_specific_user_permission_datasets,
-)
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("sessions_api")
@@ -45,36 +45,6 @@ def _range_since(range_key: _RangeLiteral) -> Optional[datetime]:
     if range_key == "30d":
         return now - timedelta(days=30)
     return None  # "all"
-
-
-async def _permitted_dataset_ids_for(user: User) -> list[UUIDType]:
-    """Return the UUIDs of datasets this user can read (empty on none)."""
-    try:
-        datasets = await get_specific_user_permission_datasets(user.id, "read", None)
-        return [ds.id for ds in datasets] if datasets else []
-    except PermissionDeniedError:
-        return []
-    except Exception:
-        return []
-
-
-async def _child_agent_user_ids(user_id: UUIDType) -> list[UUIDType]:
-    """Return user IDs of agents whose parent_user_id matches this user."""
-    engine = get_relational_engine()
-    async with engine.get_async_session() as session:
-        from cognee.modules.users.models import User as UserModel
-
-        rows = (
-            await session.execute(select(UserModel.id).where(UserModel.parent_user_id == user_id))
-        ).all()
-        return [row.id for row in rows]
-
-
-async def _visible_user_ids(user: User) -> list[UUIDType]:
-    """User's own ID plus any child agent IDs."""
-    ids = [user.id]
-    ids.extend(await _child_agent_user_ids(user.id))
-    return ids
 
 
 def get_sessions_router() -> APIRouter:
@@ -139,8 +109,8 @@ def get_sessions_router() -> APIRouter:
         """
         since = _range_since(range)
         try:
-            permitted = await _permitted_dataset_ids_for(user)
-            visible_ids = await _visible_user_ids(user)
+            permitted = await permitted_dataset_ids_for(user)
+            visible_ids = await visible_user_ids(user)
             page = await list_session_rows(
                 user_ids=visible_ids,
                 permitted_dataset_ids=permitted,
@@ -193,8 +163,8 @@ def get_sessions_router() -> APIRouter:
         """
         since = _range_since(range)
         eff = get_effective_status_sql()
-        permitted = await _permitted_dataset_ids_for(user)
-        visible_ids = await _visible_user_ids(user)
+        permitted = await permitted_dataset_ids_for(user)
+        visible_ids = await visible_user_ids(user)
 
         engine = get_relational_engine()
         async with engine.get_async_session() as session:
@@ -294,8 +264,8 @@ def get_sessions_router() -> APIRouter:
         - **range** (Literal): Time window: 24h, 7d, 30d, or all (default: 30d).
         """
         since = _range_since(range)
-        permitted = await _permitted_dataset_ids_for(user)
-        visible_ids = await _visible_user_ids(user)
+        permitted = await permitted_dataset_ids_for(user)
+        visible_ids = await visible_user_ids(user)
         engine = get_relational_engine()
         async with engine.get_async_session() as session:
             visibility_terms = [SessionRecord.user_id.in_(visible_ids)]
@@ -350,8 +320,8 @@ def get_sessions_router() -> APIRouter:
         ),
         user: User = Depends(get_authenticated_user),
     ):
-        permitted = await _permitted_dataset_ids_for(user)
-        visible_ids = await _visible_user_ids(user)
+        permitted = await permitted_dataset_ids_for(user)
+        visible_ids = await visible_user_ids(user)
         row = await get_session_row(
             session_id=session_id,
             user_id=user.id,

--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -7,7 +7,6 @@ abandonment-by-idle rule so no sweeper is needed.
 
 from datetime import datetime, timedelta, timezone
 from typing import Literal, Optional
-from uuid import UUID as UUIDType
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi.encoders import jsonable_encoder

--- a/cognee/modules/integrations/credentials.py
+++ b/cognee/modules/integrations/credentials.py
@@ -160,6 +160,32 @@ async def get_active_credential_for_user(
         return result.scalars().first()
 
 
+async def list_active_credentials_for_user(user_id: UUID) -> dict[str, IntegrationCredential]:
+    """The user's active connections across all providers, one query.
+
+    Returns a dict of ``provider -> credential`` holding at most one
+    credential per provider, chosen newest-first — the same tiebreak as
+    :func:`get_active_credential_for_user`, so the aggregate status endpoint
+    and the per-provider connection endpoint always agree on which
+    connection represents a provider. For display use: token material stays
+    encrypted on the rows and must not be surfaced by callers.
+    """
+    engine = get_relational_engine()
+    async with engine.get_async_session() as db:
+        result = await db.execute(
+            select(IntegrationCredential)
+            .where(
+                IntegrationCredential.user_id == user_id,
+                IntegrationCredential.status == STATUS_ACTIVE,
+            )
+            .order_by(IntegrationCredential.created_at.desc())
+        )
+        credentials: dict[str, IntegrationCredential] = {}
+        for credential in result.scalars().all():
+            credentials.setdefault(credential.provider, credential)
+        return credentials
+
+
 async def get_active_credential_for_workspace(
     workspace_id: UUID, provider: str
 ) -> Optional[IntegrationCredential]:

--- a/cognee/modules/integrations/plugin_status.py
+++ b/cognee/modules/integrations/plugin_status.py
@@ -70,8 +70,12 @@ class PluginStatusRow:
     source: Optional[str] = None
 
 
-def _as_utc(value: Optional[datetime]) -> Optional[datetime]:
-    """Normalize to aware-UTC; SQLite hands back tz-naive datetimes."""
+def as_utc(value: Optional[datetime]) -> Optional[datetime]:
+    """Normalize to aware-UTC; SQLite hands back tz-naive datetimes.
+
+    Public: the integrations router runs credential timestamps through this
+    too, so every datetime in the status payload serializes with an offset.
+    """
     if value is None:
         return None
     if value.tzinfo is None:
@@ -80,7 +84,7 @@ def _as_utc(value: Optional[datetime]) -> Optional[datetime]:
 
 
 def _max_datetime(*values: Optional[datetime]) -> Optional[datetime]:
-    present = [_as_utc(value) for value in values if value is not None]
+    present = [as_utc(value) for value in values if value is not None]
     return max(present) if present else None
 
 
@@ -94,10 +98,10 @@ def coerce_provisioned_at(value) -> Optional[datetime]:
     whole status page.
     """
     if isinstance(value, datetime):
-        return _as_utc(value)
+        return as_utc(value)
     if isinstance(value, str):
         try:
-            return _as_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
+            return as_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
         except ValueError:
             return None
     return None
@@ -249,7 +253,7 @@ async def legacy_plugin_statuses(
         row.plugin_key: PluginStatusRow(
             key=row.plugin_key,
             connected=True,
-            last_active_at=_as_utc(row.last_activity_at),
+            last_active_at=as_utc(row.last_activity_at),
             session_count=int(row.session_count),
             source=SOURCE_SESSIONS_LEGACY,
         )

--- a/cognee/modules/integrations/plugin_status.py
+++ b/cognee/modules/integrations/plugin_status.py
@@ -1,0 +1,272 @@
+"""Per-plugin connection status, aggregated from three sources.
+
+The status endpoint answers "which plugins are connected?" from, in order
+of authority:
+
+* **identity** — the caller's agent sub-users that carry a ``plugin_key``
+  in their principal configuration (written by the provision endpoint).
+  Connected means an API key currently exists for that agent (revocation
+  deletes the row, so existence == active); activity joins the key's
+  throttled ``last_used_at`` with the agent's session records.
+* **sessions-legacy** — pre-migration installs that still authenticate
+  with the shared tenant key. Inferred from the legacy session-id prefixes
+  in :data:`KNOWN_PLUGINS`, only for plugins with no provisioned identity.
+* **registry** — the agent-connection registry
+  (:func:`list_persisted_agent_connections`), bucketed onto plugin keys by
+  connection type, so e.g. MCP clients registered before first traffic
+  show up.
+
+Same key from several sources merges: ``connected`` is the OR,
+``last_active_at`` the max, and the more authoritative row keeps
+``agent_id``/``provisioned_at``/``source``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import case, func, or_, select
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.agents.registry import AGENT_CONFIG_NAME, list_persisted_agent_connections
+from cognee.modules.integrations.plugins import KNOWN_PLUGINS
+from cognee.modules.session_lifecycle.models import SessionRecord
+from cognee.modules.session_lifecycle.visibility import child_agent_user_ids
+from cognee.modules.users.methods.get_principal_configuration import (
+    get_principal_all_configuration,
+)
+from cognee.modules.users.models.UserApiKey import UserApiKey
+
+SOURCE_IDENTITY = "identity"
+SOURCE_SESSIONS_LEGACY = "sessions-legacy"
+SOURCE_REGISTRY = "registry"
+
+# AgentConnectionType -> KNOWN_PLUGINS key (reverse of the provision
+# endpoint's plugin -> connection-type map, plus the generic "sdk" bucket,
+# which lands on the "api" card alongside direct API usage).
+_CONNECTION_TYPE_PLUGIN_KEYS: dict[str, str] = {
+    "claude_code": "claude-code",
+    "opencode": "opencode",
+    "mcp": "mcp",
+    "api": "api",
+    "sdk": "api",
+}
+
+
+@dataclass
+class PluginStatusRow:
+    """One plugin's aggregated connection state (display fields only)."""
+
+    key: str
+    connected: bool = False
+    agent_id: Optional[UUID] = None
+    provisioned_at: Optional[str] = None
+    last_active_at: Optional[datetime] = None
+    session_count: int = 0
+    source: Optional[str] = None
+
+
+def _as_utc(value: Optional[datetime]) -> Optional[datetime]:
+    """Normalize to aware-UTC; SQLite hands back tz-naive datetimes."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _max_datetime(*values: Optional[datetime]) -> Optional[datetime]:
+    present = [_as_utc(value) for value in values if value is not None]
+    return max(present) if present else None
+
+
+def _escape_like_prefix(prefix: str) -> str:
+    r"""Build a LIKE pattern matching ids that start with ``prefix`` literally.
+
+    ``_`` and ``%`` are LIKE wildcards, so an unescaped ``cc_%`` pattern
+    would also match ``ccx...`` ids. Escaped with ``\`` — pass
+    ``escape="\\"`` alongside.
+    """
+    escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"{escaped}%"
+
+
+async def identity_plugin_statuses(user_id: UUID) -> dict[str, PluginStatusRow]:
+    """Statuses of plugins provisioned with their own agent identity.
+
+    A child agent counts as a plugin identity iff its principal
+    configuration carries the ``plugin`` entry the provision endpoint
+    writes. ``connected`` means the agent currently holds an API key
+    (disconnect deletes keys, so existence == active); ``last_active_at``
+    is the max of the key's throttled ``last_used_at`` and the agent's
+    latest session activity, so pure-recall plugins that never open
+    sessions still report "last seen".
+    """
+    plugin_agents: dict[UUID, tuple[str, Optional[str]]] = {}
+    for agent_id in await child_agent_user_ids(user_id):
+        for config in await get_principal_all_configuration(agent_id):
+            if config.get("name") != AGENT_CONFIG_NAME:
+                continue
+            plugin_entry = (config.get("configuration") or {}).get("plugin") or {}
+            plugin_key = plugin_entry.get("key")
+            if plugin_key in KNOWN_PLUGINS:
+                plugin_agents[agent_id] = (plugin_key, plugin_entry.get("provisioned_at"))
+            break
+
+    if not plugin_agents:
+        return {}
+
+    agent_ids = list(plugin_agents)
+    engine = get_relational_engine()
+    async with engine.get_async_session() as session:
+        key_rows = (
+            await session.execute(
+                select(
+                    UserApiKey.user_id,
+                    func.count().label("key_count"),
+                    func.max(UserApiKey.last_used_at).label("last_used_at"),
+                )
+                .where(UserApiKey.user_id.in_(agent_ids))
+                .group_by(UserApiKey.user_id)
+            )
+        ).all()
+        session_rows = (
+            await session.execute(
+                select(
+                    SessionRecord.user_id,
+                    func.count().label("session_count"),
+                    func.max(SessionRecord.last_activity_at).label("last_activity_at"),
+                )
+                .where(SessionRecord.user_id.in_(agent_ids))
+                .group_by(SessionRecord.user_id)
+            )
+        ).all()
+
+    keys_by_agent = {row.user_id: row for row in key_rows}
+    sessions_by_agent = {row.user_id: row for row in session_rows}
+
+    statuses: dict[str, PluginStatusRow] = {}
+    for agent_id, (plugin_key, provisioned_at) in plugin_agents.items():
+        key_row = keys_by_agent.get(agent_id)
+        session_row = sessions_by_agent.get(agent_id)
+        statuses[plugin_key] = PluginStatusRow(
+            key=plugin_key,
+            connected=bool(key_row and key_row.key_count),
+            agent_id=agent_id,
+            provisioned_at=provisioned_at,
+            last_active_at=_max_datetime(
+                key_row.last_used_at if key_row else None,
+                session_row.last_activity_at if session_row else None,
+            ),
+            session_count=int(session_row.session_count) if session_row else 0,
+            source=SOURCE_IDENTITY,
+        )
+    return statuses
+
+
+async def legacy_plugin_statuses(
+    visible_user_ids: list[UUID], exclude_keys: Optional[set[str]] = None
+) -> dict[str, PluginStatusRow]:
+    """Prefix-inferred statuses for pre-migration shared-key installs.
+
+    One grouped query over the caller's visible user ids, matching each
+    plugin's legacy ``session_prefix`` with the LIKE wildcards escaped —
+    a ``ccx_...`` session id must never count toward the ``cc_`` prefix.
+    Plugins in ``exclude_keys`` (those with a provisioned identity) are
+    skipped: once a plugin has its own agent, prefix inference for it is
+    stale noise, not signal.
+    """
+    exclude = exclude_keys or set()
+    prefixes = {
+        key: spec["session_prefix"]
+        for key, spec in KNOWN_PLUGINS.items()
+        if spec.get("session_prefix") and key not in exclude
+    }
+    if not prefixes or not visible_user_ids:
+        return {}
+
+    like_terms = {
+        key: SessionRecord.session_id.like(_escape_like_prefix(prefix), escape="\\")
+        for key, prefix in prefixes.items()
+    }
+    plugin_key_case = case(*[(term, key) for key, term in like_terms.items()], else_=None)
+
+    engine = get_relational_engine()
+    async with engine.get_async_session() as session:
+        rows = (
+            await session.execute(
+                select(
+                    plugin_key_case.label("plugin_key"),
+                    func.count().label("session_count"),
+                    func.max(SessionRecord.last_activity_at).label("last_activity_at"),
+                )
+                .where(
+                    SessionRecord.user_id.in_(visible_user_ids),
+                    or_(*like_terms.values()),
+                )
+                .group_by("plugin_key")
+            )
+        ).all()
+
+    return {
+        row.plugin_key: PluginStatusRow(
+            key=row.plugin_key,
+            connected=True,
+            last_active_at=_as_utc(row.last_activity_at),
+            session_count=int(row.session_count),
+            source=SOURCE_SESSIONS_LEGACY,
+        )
+        for row in rows
+        if row.plugin_key is not None
+    }
+
+
+async def registry_plugin_statuses(user_ids: list[UUID]) -> dict[str, PluginStatusRow]:
+    """Statuses from the agent-connection registry.
+
+    Connections registered by the provision endpoint carry the plugin key
+    in their metadata; everything else buckets by connection type. Only
+    active connections are consulted, so a row here means connected.
+    """
+    statuses: dict[str, PluginStatusRow] = {}
+    for connection in await list_persisted_agent_connections(user_ids, active_only=True):
+        plugin_key = (connection.metadata or {}).get("plugin_key") or (
+            _CONNECTION_TYPE_PLUGIN_KEYS.get(connection.type)
+        )
+        if plugin_key not in KNOWN_PLUGINS:
+            continue
+        row = statuses.setdefault(
+            plugin_key, PluginStatusRow(key=plugin_key, connected=True, source=SOURCE_REGISTRY)
+        )
+        row.last_active_at = _max_datetime(row.last_active_at, connection.last_active_at)
+    return statuses
+
+
+def merge_plugin_statuses(
+    base: dict[str, PluginStatusRow], extra: dict[str, PluginStatusRow]
+) -> dict[str, PluginStatusRow]:
+    """Merge ``extra`` into ``base``; base rows are the more authoritative.
+
+    Same key: ``connected`` is the OR, ``last_active_at`` the max,
+    ``session_count`` the max (identity and legacy counts never coexist for
+    a key, so max never double-counts), and the base row keeps its
+    ``agent_id``/``provisioned_at``/``source`` — identity rows win those
+    fields over registry echoes of the same plugin.
+    """
+    merged = dict(base)
+    for key, row in extra.items():
+        existing = merged.get(key)
+        if existing is None:
+            merged[key] = row
+            continue
+        existing.connected = existing.connected or row.connected
+        existing.last_active_at = _max_datetime(existing.last_active_at, row.last_active_at)
+        existing.session_count = max(existing.session_count, row.session_count)
+        if existing.agent_id is None:
+            existing.agent_id = row.agent_id
+        if existing.provisioned_at is None:
+            existing.provisioned_at = row.provisioned_at
+    return merged

--- a/cognee/modules/integrations/plugin_status.py
+++ b/cognee/modules/integrations/plugin_status.py
@@ -16,7 +16,8 @@ of authority:
   connection type, so e.g. MCP clients registered before first traffic
   show up.
 
-Same key from several sources merges: ``connected`` is the OR,
+Same key from several sources merges: ``connected`` is the OR — unless the
+base row is identity-sourced, whose key-existence check is authoritative —
 ``last_active_at`` the max, and the more authoritative row keeps
 ``agent_id``/``provisioned_at``/``source``.
 """
@@ -34,7 +35,7 @@ from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.agents.registry import AGENT_CONFIG_NAME, list_persisted_agent_connections
 from cognee.modules.integrations.plugins import KNOWN_PLUGINS
 from cognee.modules.session_lifecycle.models import SessionRecord
-from cognee.modules.session_lifecycle.visibility import child_agent_user_ids
+from cognee.modules.session_lifecycle.visibility import child_agent_emails
 from cognee.modules.users.methods.get_principal_configuration import (
     get_principal_all_configuration,
 )
@@ -63,7 +64,7 @@ class PluginStatusRow:
     key: str
     connected: bool = False
     agent_id: Optional[UUID] = None
-    provisioned_at: Optional[str] = None
+    provisioned_at: Optional[datetime] = None
     last_active_at: Optional[datetime] = None
     session_count: int = 0
     source: Optional[str] = None
@@ -83,6 +84,25 @@ def _max_datetime(*values: Optional[datetime]) -> Optional[datetime]:
     return max(present) if present else None
 
 
+def coerce_provisioned_at(value) -> Optional[datetime]:
+    """Coerce the stored ``provisioned_at`` into an aware datetime.
+
+    The value lives in the agent's principal-configuration blob, which the
+    agent itself can rewrite through the public configuration endpoint — so
+    it is untrusted input. Anything unparseable degrades to ``None`` (the
+    row still surfaces) instead of blowing up DTO validation and 500ing the
+    whole status page.
+    """
+    if isinstance(value, datetime):
+        return _as_utc(value)
+    if isinstance(value, str):
+        try:
+            return _as_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
+        except ValueError:
+            return None
+    return None
+
+
 def _escape_like_prefix(prefix: str) -> str:
     r"""Build a LIKE pattern matching ids that start with ``prefix`` literally.
 
@@ -99,21 +119,35 @@ async def identity_plugin_statuses(user_id: UUID) -> dict[str, PluginStatusRow]:
 
     A child agent counts as a plugin identity iff its principal
     configuration carries the ``plugin`` entry the provision endpoint
-    writes. ``connected`` means the agent currently holds an API key
+    writes. The plugin *key*, however, is derived from the agent's
+    server-assigned deterministic email
+    (``<plugin_key>+<parent_id>@cognee.agent`` — the same identity the
+    provision endpoint resolves by), never from that configuration blob: a
+    child agent can rewrite its own blob through the public configuration
+    endpoint, so a config-claimed key could impersonate another plugin.
+    ``connected`` means the agent currently holds an API key
     (disconnect deletes keys, so existence == active); ``last_active_at``
     is the max of the key's throttled ``last_used_at`` and the agent's
     latest session activity, so pure-recall plugins that never open
     sessions still report "last seen".
     """
-    plugin_agents: dict[UUID, tuple[str, Optional[str]]] = {}
-    for agent_id in await child_agent_user_ids(user_id):
+    email_suffix = f"+{user_id}@cognee.agent"
+    plugin_agents: dict[UUID, tuple[str, Optional[datetime]]] = {}
+    for agent_id, email in (await child_agent_emails(user_id)).items():
+        if not (email or "").endswith(email_suffix):
+            continue
+        plugin_key = email[: -len(email_suffix)]
+        if plugin_key not in KNOWN_PLUGINS:
+            continue
         for config in await get_principal_all_configuration(agent_id):
             if config.get("name") != AGENT_CONFIG_NAME:
                 continue
-            plugin_entry = (config.get("configuration") or {}).get("plugin") or {}
-            plugin_key = plugin_entry.get("key")
-            if plugin_key in KNOWN_PLUGINS:
-                plugin_agents[agent_id] = (plugin_key, plugin_entry.get("provisioned_at"))
+            plugin_entry = (config.get("configuration") or {}).get("plugin")
+            if isinstance(plugin_entry, dict) and plugin_entry:
+                plugin_agents[agent_id] = (
+                    plugin_key,
+                    coerce_provisioned_at(plugin_entry.get("provisioned_at")),
+                )
             break
 
     if not plugin_agents:
@@ -250,9 +284,13 @@ def merge_plugin_statuses(
 ) -> dict[str, PluginStatusRow]:
     """Merge ``extra`` into ``base``; base rows are the more authoritative.
 
-    Same key: ``connected`` is the OR, ``last_active_at`` the max,
-    ``session_count`` the max (identity and legacy counts never coexist for
-    a key, so max never double-counts), and the base row keeps its
+    Same key: ``connected`` is the OR — except when the base row is
+    identity-sourced, whose key-existence check is authoritative: after
+    disconnect revokes every API key, a stale registry connection (e.g.
+    legacy traffic auto-typed onto the same plugin) must not flip the row
+    back to connected. ``last_active_at`` is the max, ``session_count``
+    the max (identity and legacy counts never coexist for a key, so max
+    never double-counts), and the base row keeps its
     ``agent_id``/``provisioned_at``/``source`` — identity rows win those
     fields over registry echoes of the same plugin.
     """
@@ -262,7 +300,8 @@ def merge_plugin_statuses(
         if existing is None:
             merged[key] = row
             continue
-        existing.connected = existing.connected or row.connected
+        if existing.source != SOURCE_IDENTITY:
+            existing.connected = existing.connected or row.connected
         existing.last_active_at = _max_datetime(existing.last_active_at, row.last_active_at)
         existing.session_count = max(existing.session_count, row.session_count)
         if existing.agent_id is None:

--- a/cognee/modules/session_lifecycle/visibility.py
+++ b/cognee/modules/session_lifecycle/visibility.py
@@ -1,0 +1,45 @@
+"""Caller-visibility helpers shared across HTTP surfaces.
+
+Who a caller "is" for read purposes: their own user id plus any child
+agent sub-users (plugins provisioned with their own identity), and the
+datasets they hold read permission on. Lifted out of the sessions router
+so other surfaces (e.g. the integrations status endpoint) can reuse the
+same rule without importing router privates.
+"""
+
+from uuid import UUID
+
+from sqlalchemy import select
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.models import User
+from cognee.modules.users.permissions.methods.get_specific_user_permission_datasets import (
+    get_specific_user_permission_datasets,
+)
+
+
+async def permitted_dataset_ids_for(user: User) -> list[UUID]:
+    """Return the UUIDs of datasets this user can read (empty on none)."""
+    try:
+        datasets = await get_specific_user_permission_datasets(user.id, "read", None)
+        return [ds.id for ds in datasets] if datasets else []
+    except PermissionDeniedError:
+        return []
+    except Exception:
+        return []
+
+
+async def child_agent_user_ids(user_id: UUID) -> list[UUID]:
+    """Return user IDs of agents whose parent_user_id matches this user."""
+    engine = get_relational_engine()
+    async with engine.get_async_session() as session:
+        rows = (await session.execute(select(User.id).where(User.parent_user_id == user_id))).all()
+        return [row.id for row in rows]
+
+
+async def visible_user_ids(user: User) -> list[UUID]:
+    """User's own ID plus any child agent IDs."""
+    ids = [user.id]
+    ids.extend(await child_agent_user_ids(user.id))
+    return ids

--- a/cognee/modules/session_lifecycle/visibility.py
+++ b/cognee/modules/session_lifecycle/visibility.py
@@ -32,10 +32,23 @@ async def permitted_dataset_ids_for(user: User) -> list[UUID]:
 
 async def child_agent_user_ids(user_id: UUID) -> list[UUID]:
     """Return user IDs of agents whose parent_user_id matches this user."""
+    return list(await child_agent_emails(user_id))
+
+
+async def child_agent_emails(user_id: UUID) -> dict[UUID, str]:
+    """Return ``{agent user id: internal email}`` of this user's child agents.
+
+    The email is the deterministic identity ``create_agent`` derives
+    (``<name>+<parent_id>@cognee.agent``) — server-assigned, unlike the
+    agent-writable principal-configuration blob, so callers can trust it
+    for attribution.
+    """
     engine = get_relational_engine()
     async with engine.get_async_session() as session:
-        rows = (await session.execute(select(User.id).where(User.parent_user_id == user_id))).all()
-        return [row.id for row in rows]
+        rows = (
+            await session.execute(select(User.id, User.email).where(User.parent_user_id == user_id))
+        ).all()
+        return {row.id: row.email for row in rows}
 
 
 async def visible_user_ids(user: User) -> list[UUID]:

--- a/cognee/tests/unit/modules/integrations/test_integrations_status.py
+++ b/cognee/tests/unit/modules/integrations/test_integrations_status.py
@@ -162,7 +162,9 @@ def test_connected_provider_exposes_display_fields_and_no_token_material(client)
     assert row["connected"] is True
     assert row["accountLabel"] == "Acme Workspace"
     assert row["providerAccountId"] == "ACC1"
-    assert row["connectedAt"].startswith("2026-08-01T12:00:00")
+    # Offset required: SQLite hands back tz-naive datetimes, and an
+    # offset-less ISO string gets parsed as local time by JS Date.
+    assert row["connectedAt"] in ("2026-08-01T12:00:00Z", "2026-08-01T12:00:00+00:00")
     # Whitelist, not blacklist: the serialized row is exactly the display
     # fields — nothing token-shaped can leak through renames.
     assert set(row) == {"provider", "connected", "accountLabel", "providerAccountId", "connectedAt"}

--- a/cognee/tests/unit/modules/integrations/test_integrations_status.py
+++ b/cognee/tests/unit/modules/integrations/test_integrations_status.py
@@ -1,0 +1,520 @@
+"""Unit tests for GET /integrations/status and its plugin_status sources.
+
+Two layers, matching how the endpoint is built:
+
+* Router tests exercise the aggregation/degradation logic with every
+  status source mocked at module level (the same pattern as
+  test_get_integrations_router.py), including the guarantee that no token
+  material ever reaches the serialized JSON.
+* plugin_status tests run the real SQL against an in-memory SQLite engine
+  seeded with UserApiKey / SessionRecord rows, so the grouped queries —
+  and in particular the LIKE-escape regression for the legacy prefixes —
+  are tested against a real dialect, not mocks.
+"""
+
+import importlib
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from cognee.api.v1.integrations.routers.get_integrations_router import get_integrations_router
+from cognee.infrastructure.databases.relational import Base
+from cognee.modules.agents.models import AgentConnection
+from cognee.modules.agents.registry import AGENT_CONFIG_NAME
+from cognee.modules.integrations.base import OAuthInstallation, OAuthIntegration
+from cognee.modules.integrations.plugin_status import (
+    SOURCE_IDENTITY,
+    SOURCE_REGISTRY,
+    PluginStatusRow,
+    identity_plugin_statuses,
+    legacy_plugin_statuses,
+    merge_plugin_statuses,
+    registry_plugin_statuses,
+)
+from cognee.modules.integrations.plugins import KNOWN_PLUGINS
+from cognee.modules.integrations.registry import supported_integrations, use_integration
+from cognee.modules.session_lifecycle.models import SessionRecord
+from cognee.modules.users.methods import get_authenticated_user
+from cognee.modules.users.models.UserApiKey import UserApiKey
+
+USER_ID = uuid4()
+
+# Import the submodules explicitly: the packages' __init__.py rebind these
+# names to functions, shadowing the submodules (see the fuller explanation in
+# test_get_integrations_router.py).
+_router_module = importlib.import_module(
+    "cognee.api.v1.integrations.routers.get_integrations_router"
+)
+_status_module = importlib.import_module("cognee.modules.integrations.plugin_status")
+
+
+class _FakeUser:
+    id = USER_ID
+    tenant_id = None
+
+
+class _FakeIntegration(OAuthIntegration):
+    provider = "fake"
+    settings_cls = None
+
+    def authorize_url(self, state):
+        return f"https://fake.example/authorize?state={state}"
+
+    async def exchange_code(self, code):
+        return {"code": code}
+
+    def parse_installation(self, token_response):
+        return OAuthInstallation(provider_account_id="ACC1", token_payload={})
+
+    def state_signing_secret(self):
+        return "fake-secret"
+
+    def frontend_base_url(self):
+        return "https://app.example.com"
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(get_integrations_router(), prefix="/api/v1/integrations")
+    app.dependency_overrides[get_authenticated_user] = lambda: _FakeUser()
+
+    before = dict(supported_integrations)
+    supported_integrations.clear()
+    use_integration(_FakeIntegration())
+
+    yield TestClient(app)
+
+    supported_integrations.clear()
+    supported_integrations.update(before)
+
+
+@contextmanager
+def _quiet_plugin_sources():
+    """Blank every plugin-status source so router tests isolate one at a time."""
+    with (
+        patch.object(_router_module, "identity_plugin_statuses", new=AsyncMock(return_value={})),
+        patch.object(_router_module, "legacy_plugin_statuses", new=AsyncMock(return_value={})),
+        patch.object(_router_module, "registry_plugin_statuses", new=AsyncMock(return_value={})),
+        patch.object(_router_module, "visible_user_ids", new=AsyncMock(return_value=[USER_ID])),
+    ):
+        yield
+
+
+# --------------------------------------------------------------------------- #
+# Router: integrations half
+# --------------------------------------------------------------------------- #
+
+
+def test_registered_provider_without_credential_reports_disconnected(client):
+    with (
+        patch.object(
+            _router_module, "list_active_credentials_for_user", new=AsyncMock(return_value={})
+        ),
+        _quiet_plugin_sources(),
+    ):
+        response = client.get("/api/v1/integrations/status")
+
+    assert response.status_code == 200
+    integrations = response.json()["integrations"]
+    assert integrations == [
+        {
+            "provider": "fake",
+            "connected": False,
+            "accountLabel": None,
+            "providerAccountId": None,
+            "connectedAt": None,
+        }
+    ]
+
+
+def test_connected_provider_exposes_display_fields_and_no_token_material(client):
+    # A realistic credential row: display fields AND encrypted token
+    # material. Only the former may ever reach the wire.
+    credential = SimpleNamespace(
+        provider="fake",
+        account_label="Acme Workspace",
+        provider_account_id="ACC1",
+        created_at=datetime(2026, 8, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ciphertext=b"secret-ciphertext",
+        nonce=b"secret-nonce",
+        encryption_version=1,
+        key_id="k1",
+    )
+    with (
+        patch.object(
+            _router_module,
+            "list_active_credentials_for_user",
+            new=AsyncMock(return_value={"fake": credential}),
+        ),
+        _quiet_plugin_sources(),
+    ):
+        response = client.get("/api/v1/integrations/status")
+
+    (row,) = response.json()["integrations"]
+    assert row["connected"] is True
+    assert row["accountLabel"] == "Acme Workspace"
+    assert row["providerAccountId"] == "ACC1"
+    assert row["connectedAt"].startswith("2026-08-01T12:00:00")
+    # Whitelist, not blacklist: the serialized row is exactly the display
+    # fields — nothing token-shaped can leak through renames.
+    assert set(row) == {"provider", "connected", "accountLabel", "providerAccountId", "connectedAt"}
+    body_text = response.text.lower()
+    for forbidden in ("ciphertext", "nonce", "token", "apikey", "api_key"):
+        assert forbidden not in body_text
+
+
+# --------------------------------------------------------------------------- #
+# Router: plugins half (sources mocked)
+# --------------------------------------------------------------------------- #
+
+
+def test_every_known_plugin_appears_disconnected_by_default(client):
+    with (
+        patch.object(
+            _router_module, "list_active_credentials_for_user", new=AsyncMock(return_value={})
+        ),
+        _quiet_plugin_sources(),
+    ):
+        response = client.get("/api/v1/integrations/status")
+
+    plugins = response.json()["plugins"]
+    assert [p["key"] for p in plugins] == list(KNOWN_PLUGINS)
+    for plugin in plugins:
+        assert plugin["connected"] is False
+        assert plugin["agentId"] is None
+        assert plugin["sessionCount"] == 0
+        assert plugin["source"] is None
+
+
+def test_identity_row_surfaces_through_the_dto(client):
+    agent_id = uuid4()
+    identity_row = PluginStatusRow(
+        key="claude-code",
+        connected=True,
+        agent_id=agent_id,
+        provisioned_at="2026-08-10T08:00:00+00:00",
+        last_active_at=datetime(2026, 8, 18, 9, 30, tzinfo=timezone.utc),
+        session_count=14,
+        source=SOURCE_IDENTITY,
+    )
+    with (
+        patch.object(
+            _router_module, "list_active_credentials_for_user", new=AsyncMock(return_value={})
+        ),
+        patch.object(
+            _router_module,
+            "identity_plugin_statuses",
+            new=AsyncMock(return_value={"claude-code": identity_row}),
+        ),
+        patch.object(_router_module, "legacy_plugin_statuses", new=AsyncMock(return_value={})),
+        patch.object(_router_module, "registry_plugin_statuses", new=AsyncMock(return_value={})),
+        patch.object(_router_module, "visible_user_ids", new=AsyncMock(return_value=[USER_ID])),
+    ):
+        response = client.get("/api/v1/integrations/status")
+
+    by_key = {p["key"]: p for p in response.json()["plugins"]}
+    claude = by_key["claude-code"]
+    assert claude["connected"] is True
+    assert claude["agentId"] == str(agent_id)
+    assert claude["provisionedAt"].startswith("2026-08-10T08:00:00")
+    assert claude["lastActiveAt"].startswith("2026-08-18T09:30:00")
+    assert claude["sessionCount"] == 14
+    assert claude["source"] == "identity"
+
+
+def test_legacy_lookup_excludes_identity_provisioned_keys(client):
+    identity_row = PluginStatusRow(key="claude-code", connected=True, source=SOURCE_IDENTITY)
+    legacy_lookup = AsyncMock(return_value={})
+    with (
+        patch.object(
+            _router_module, "list_active_credentials_for_user", new=AsyncMock(return_value={})
+        ),
+        patch.object(
+            _router_module,
+            "identity_plugin_statuses",
+            new=AsyncMock(return_value={"claude-code": identity_row}),
+        ),
+        patch.object(_router_module, "legacy_plugin_statuses", new=legacy_lookup),
+        patch.object(_router_module, "registry_plugin_statuses", new=AsyncMock(return_value={})),
+        patch.object(_router_module, "visible_user_ids", new=AsyncMock(return_value=[USER_ID])),
+    ):
+        client.get("/api/v1/integrations/status")
+
+    legacy_lookup.assert_awaited_once_with([USER_ID], exclude_keys={"claude-code"})
+
+
+def test_each_failing_source_degrades_its_section_never_500s(client):
+    boom = AsyncMock(side_effect=RuntimeError("db went away"))
+    with (
+        patch.object(_router_module, "list_active_credentials_for_user", new=boom),
+        patch.object(_router_module, "identity_plugin_statuses", new=boom),
+        patch.object(_router_module, "legacy_plugin_statuses", new=boom),
+        patch.object(_router_module, "registry_plugin_statuses", new=boom),
+        patch.object(_router_module, "visible_user_ids", new=boom),
+    ):
+        response = client.get("/api/v1/integrations/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    # Every section is present at its degraded default, not missing.
+    assert [i["provider"] for i in body["integrations"]] == ["fake"]
+    assert body["integrations"][0]["connected"] is False
+    assert [p["key"] for p in body["plugins"]] == list(KNOWN_PLUGINS)
+    assert all(p["connected"] is False for p in body["plugins"])
+
+
+# --------------------------------------------------------------------------- #
+# plugin_status sources against a real in-memory SQLite engine
+# --------------------------------------------------------------------------- #
+
+
+async def _sqlite_engine(*models):
+    engine = create_async_engine("sqlite+aiosqlite://")
+    tables = [model.__table__ for model in models]
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda sync_conn: Base.metadata.create_all(sync_conn, tables=tables))
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    return SimpleNamespace(get_async_session=maker), engine
+
+
+def _session_record(session_id, user_id, last_activity_at):
+    return SessionRecord(
+        session_id=session_id,
+        user_id=user_id,
+        status="running",
+        started_at=last_activity_at - timedelta(minutes=5),
+        last_activity_at=last_activity_at,
+        tokens_in=0,
+        tokens_out=0,
+        cost_usd=0.0,
+        error_count=0,
+    )
+
+
+def _identity_config(plugin_key, provisioned_at="2026-08-10T08:00:00+00:00"):
+    return [
+        {
+            "name": AGENT_CONFIG_NAME,
+            "configuration": {"plugin": {"key": plugin_key, "provisioned_at": provisioned_at}},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_identity_status_joins_keys_and_sessions():
+    agent_id = uuid4()
+    key_last_used = datetime(2026, 8, 17, 8, 0, tzinfo=timezone.utc)
+    latest_session = datetime(2026, 8, 18, 9, 30, tzinfo=timezone.utc)
+
+    fake_engine, engine = await _sqlite_engine(UserApiKey, SessionRecord)
+    try:
+        async with fake_engine.get_async_session() as session:
+            session.add(
+                UserApiKey(
+                    id=uuid4(),
+                    user_id=agent_id,
+                    api_key="hashed",
+                    label="cc-key",
+                    last_used_at=key_last_used,
+                )
+            )
+            session.add(_session_record("cc_first", agent_id, latest_session))
+            session.add(_session_record("cc_second", agent_id, latest_session - timedelta(days=1)))
+            await session.commit()
+
+        with (
+            patch.object(
+                _status_module, "child_agent_user_ids", new=AsyncMock(return_value=[agent_id])
+            ),
+            patch.object(
+                _status_module,
+                "get_principal_all_configuration",
+                new=AsyncMock(return_value=_identity_config("claude-code")),
+            ),
+            patch.object(_status_module, "get_relational_engine", return_value=fake_engine),
+        ):
+            statuses = await identity_plugin_statuses(uuid4())
+    finally:
+        await engine.dispose()
+
+    row = statuses["claude-code"]
+    assert row.connected is True
+    assert row.agent_id == agent_id
+    assert row.provisioned_at == "2026-08-10T08:00:00+00:00"
+    assert row.session_count == 2
+    # Sessions are more recent than the key's last auth here — max wins.
+    assert row.last_active_at == latest_session
+    assert row.source == SOURCE_IDENTITY
+
+
+@pytest.mark.asyncio
+async def test_identity_status_revoked_key_reports_disconnected():
+    """Disconnect deletes the agent's keys: no UserApiKey row → connected
+    False, while the identity row itself (agent, provisioned_at) survives."""
+    agent_id = uuid4()
+    fake_engine, engine = await _sqlite_engine(UserApiKey, SessionRecord)
+    try:
+        with (
+            patch.object(
+                _status_module, "child_agent_user_ids", new=AsyncMock(return_value=[agent_id])
+            ),
+            patch.object(
+                _status_module,
+                "get_principal_all_configuration",
+                new=AsyncMock(return_value=_identity_config("codex")),
+            ),
+            patch.object(_status_module, "get_relational_engine", return_value=fake_engine),
+        ):
+            statuses = await identity_plugin_statuses(uuid4())
+    finally:
+        await engine.dispose()
+
+    row = statuses["codex"]
+    assert row.connected is False
+    assert row.agent_id == agent_id
+    assert row.session_count == 0
+    assert row.last_active_at is None
+
+
+@pytest.mark.asyncio
+async def test_legacy_status_escapes_like_and_scopes_to_visible_users():
+    """The LIKE-escape regression: ``ccx_...`` ids must not count toward the
+    ``cc_`` prefix, and other users' sessions must not count at all."""
+    me = uuid4()
+    someone_else = uuid4()
+    now = datetime(2026, 8, 18, 9, 0, tzinfo=timezone.utc)
+
+    fake_engine, engine = await _sqlite_engine(SessionRecord)
+    try:
+        async with fake_engine.get_async_session() as session:
+            session.add(_session_record("cc_mine", me, now))
+            session.add(_session_record("ccx_not_claude", me, now))  # must NOT count as cc_
+            session.add(_session_record("codex_mine", me, now - timedelta(hours=1)))
+            session.add(_session_record("cc_theirs", someone_else, now))  # not visible to me
+            session.add(_session_record("unprefixed", me, now))
+            await session.commit()
+
+        with patch.object(_status_module, "get_relational_engine", return_value=fake_engine):
+            statuses = await legacy_plugin_statuses([me])
+    finally:
+        await engine.dispose()
+
+    assert set(statuses) == {"claude-code", "codex"}
+    claude = statuses["claude-code"]
+    assert claude.connected is True
+    assert claude.session_count == 1  # cc_mine only: ccx_ and cc_theirs excluded
+    assert claude.last_active_at == now
+    assert claude.source == "sessions-legacy"
+    assert statuses["codex"].session_count == 1
+
+
+@pytest.mark.asyncio
+async def test_legacy_status_skips_identity_provisioned_plugins():
+    me = uuid4()
+    now = datetime(2026, 8, 18, 9, 0, tzinfo=timezone.utc)
+    fake_engine, engine = await _sqlite_engine(SessionRecord)
+    try:
+        async with fake_engine.get_async_session() as session:
+            session.add(_session_record("cc_old_install", me, now))
+            session.add(_session_record("codex_old_install", me, now))
+            await session.commit()
+
+        with patch.object(_status_module, "get_relational_engine", return_value=fake_engine):
+            statuses = await legacy_plugin_statuses([me], exclude_keys={"claude-code"})
+    finally:
+        await engine.dispose()
+
+    # claude-code has its own identity now — prefix inference for it is off.
+    assert set(statuses) == {"codex"}
+
+
+@pytest.mark.asyncio
+async def test_registry_status_buckets_by_metadata_and_connection_type():
+    seen_at = datetime(2026, 8, 16, 10, 0, tzinfo=timezone.utc)
+    connections = [
+        # Provisioned connection: metadata plugin_key wins over type.
+        AgentConnection(
+            id="a",
+            agent_session_name="plugin:claude-code",
+            type="claude_code",
+            status="active",
+            last_active_at=seen_at,
+            metadata={"plugin_key": "claude-code"},
+        ),
+        # Bare MCP client, no metadata: bucketed by connection type.
+        AgentConnection(
+            id="b",
+            agent_session_name="my-mcp",
+            type="mcp",
+            status="active",
+            last_active_at=seen_at + timedelta(hours=1),
+        ),
+        # Generic sdk connection lands on the "api" card.
+        AgentConnection(
+            id="c",
+            agent_session_name="script",
+            type="sdk",
+            status="active",
+            last_active_at=seen_at,
+        ),
+    ]
+    with patch.object(
+        _status_module,
+        "list_persisted_agent_connections",
+        new=AsyncMock(return_value=connections),
+    ):
+        statuses = await registry_plugin_statuses([uuid4()])
+
+    assert set(statuses) == {"claude-code", "mcp", "api"}
+    assert all(row.connected for row in statuses.values())
+    assert statuses["mcp"].last_active_at == seen_at + timedelta(hours=1)
+    assert all(row.source == SOURCE_REGISTRY for row in statuses.values())
+
+
+# --------------------------------------------------------------------------- #
+# Merge
+# --------------------------------------------------------------------------- #
+
+
+def test_merge_identity_and_registry_rows_for_same_key():
+    agent_id = uuid4()
+    identity = {
+        "claude-code": PluginStatusRow(
+            key="claude-code",
+            connected=False,  # key revoked...
+            agent_id=agent_id,
+            provisioned_at="2026-08-10T08:00:00+00:00",
+            last_active_at=datetime(2026, 8, 12, tzinfo=timezone.utc),
+            session_count=3,
+            source=SOURCE_IDENTITY,
+        )
+    }
+    registry = {
+        "claude-code": PluginStatusRow(
+            key="claude-code",
+            connected=True,  # ...but the registry still holds an active connection
+            last_active_at=datetime(2026, 8, 15, tzinfo=timezone.utc),
+            source=SOURCE_REGISTRY,
+        ),
+        "mcp": PluginStatusRow(key="mcp", connected=True, source=SOURCE_REGISTRY),
+    }
+
+    merged = merge_plugin_statuses(identity, registry)
+
+    assert set(merged) == {"claude-code", "mcp"}  # same key → one row
+    row = merged["claude-code"]
+    assert row.connected is True  # either source connected
+    assert row.last_active_at == datetime(2026, 8, 15, tzinfo=timezone.utc)  # max
+    assert row.agent_id == agent_id  # identity wins agentId...
+    assert row.provisioned_at == "2026-08-10T08:00:00+00:00"  # ...and provisionedAt
+    assert row.source == SOURCE_IDENTITY
+    assert row.session_count == 3
+    assert merged["mcp"].source == SOURCE_REGISTRY

--- a/cognee/tests/unit/modules/integrations/test_integrations_status.py
+++ b/cognee/tests/unit/modules/integrations/test_integrations_status.py
@@ -200,7 +200,7 @@ def test_identity_row_surfaces_through_the_dto(client):
         key="claude-code",
         connected=True,
         agent_id=agent_id,
-        provisioned_at="2026-08-10T08:00:00+00:00",
+        provisioned_at=datetime(2026, 8, 10, 8, 0, tzinfo=timezone.utc),
         last_active_at=datetime(2026, 8, 18, 9, 30, tzinfo=timezone.utc),
         session_count=14,
         source=SOURCE_IDENTITY,
@@ -271,6 +271,76 @@ def test_each_failing_source_degrades_its_section_never_500s(client):
     assert all(p["connected"] is False for p in body["plugins"])
 
 
+def test_failing_credentials_source_leaves_plugin_section_intact(client):
+    """Partial failure: only the integrations half degrades; a healthy
+    identity source still surfaces its connected plugin row."""
+    identity_row = PluginStatusRow(key="claude-code", connected=True, source=SOURCE_IDENTITY)
+    with (
+        patch.object(
+            _router_module,
+            "list_active_credentials_for_user",
+            new=AsyncMock(side_effect=RuntimeError("credentials db went away")),
+        ),
+        patch.object(
+            _router_module,
+            "identity_plugin_statuses",
+            new=AsyncMock(return_value={"claude-code": identity_row}),
+        ),
+        patch.object(_router_module, "legacy_plugin_statuses", new=AsyncMock(return_value={})),
+        patch.object(_router_module, "registry_plugin_statuses", new=AsyncMock(return_value={})),
+        patch.object(_router_module, "visible_user_ids", new=AsyncMock(return_value=[USER_ID])),
+    ):
+        response = client.get("/api/v1/integrations/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["integrations"][0]["connected"] is False  # degraded half
+    by_key = {p["key"]: p for p in body["plugins"]}
+    assert by_key["claude-code"]["connected"] is True  # healthy half untouched
+    assert by_key["claude-code"]["source"] == "identity"
+
+
+def test_failing_identity_source_leaves_integrations_section_intact(client):
+    """Partial failure, other direction: identity blows up, but a healthy
+    credential still reports its provider connected."""
+    credential = SimpleNamespace(
+        provider="fake",
+        account_label="Acme Workspace",
+        provider_account_id="ACC1",
+        created_at=datetime(2026, 8, 1, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    with (
+        patch.object(
+            _router_module,
+            "list_active_credentials_for_user",
+            new=AsyncMock(return_value={"fake": credential}),
+        ),
+        patch.object(
+            _router_module,
+            "identity_plugin_statuses",
+            new=AsyncMock(side_effect=RuntimeError("identity lookup went away")),
+        ),
+        patch.object(_router_module, "legacy_plugin_statuses", new=AsyncMock(return_value={})),
+        patch.object(_router_module, "registry_plugin_statuses", new=AsyncMock(return_value={})),
+        patch.object(_router_module, "visible_user_ids", new=AsyncMock(return_value=[USER_ID])),
+    ):
+        response = client.get("/api/v1/integrations/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["integrations"][0]["connected"] is True  # healthy half untouched
+    assert all(p["connected"] is False for p in body["plugins"])  # degraded half
+
+
+def test_status_rejects_unauthenticated_callers():
+    # No dependency override: the real auth stack must gate the aggregate
+    # status route just like the provisioning routes.
+    app = FastAPI()
+    app.include_router(get_integrations_router(), prefix="/api/v1/integrations")
+    response = TestClient(app).get("/api/v1/integrations/status")
+    assert response.status_code == 401
+
+
 # --------------------------------------------------------------------------- #
 # plugin_status sources against a real in-memory SQLite engine
 # --------------------------------------------------------------------------- #
@@ -308,8 +378,14 @@ def _identity_config(plugin_key, provisioned_at="2026-08-10T08:00:00+00:00"):
     ]
 
 
+def _agent_email(plugin_key, parent_id):
+    """The deterministic internal email ``create_agent`` derives."""
+    return f"{plugin_key}+{parent_id}@cognee.agent"
+
+
 @pytest.mark.asyncio
 async def test_identity_status_joins_keys_and_sessions():
+    parent_id = uuid4()
     agent_id = uuid4()
     key_last_used = datetime(2026, 8, 17, 8, 0, tzinfo=timezone.utc)
     latest_session = datetime(2026, 8, 18, 9, 30, tzinfo=timezone.utc)
@@ -332,7 +408,9 @@ async def test_identity_status_joins_keys_and_sessions():
 
         with (
             patch.object(
-                _status_module, "child_agent_user_ids", new=AsyncMock(return_value=[agent_id])
+                _status_module,
+                "child_agent_emails",
+                new=AsyncMock(return_value={agent_id: _agent_email("claude-code", parent_id)}),
             ),
             patch.object(
                 _status_module,
@@ -341,14 +419,14 @@ async def test_identity_status_joins_keys_and_sessions():
             ),
             patch.object(_status_module, "get_relational_engine", return_value=fake_engine),
         ):
-            statuses = await identity_plugin_statuses(uuid4())
+            statuses = await identity_plugin_statuses(parent_id)
     finally:
         await engine.dispose()
 
     row = statuses["claude-code"]
     assert row.connected is True
     assert row.agent_id == agent_id
-    assert row.provisioned_at == "2026-08-10T08:00:00+00:00"
+    assert row.provisioned_at == datetime(2026, 8, 10, 8, 0, tzinfo=timezone.utc)
     assert row.session_count == 2
     # Sessions are more recent than the key's last auth here — max wins.
     assert row.last_active_at == latest_session
@@ -359,12 +437,15 @@ async def test_identity_status_joins_keys_and_sessions():
 async def test_identity_status_revoked_key_reports_disconnected():
     """Disconnect deletes the agent's keys: no UserApiKey row → connected
     False, while the identity row itself (agent, provisioned_at) survives."""
+    parent_id = uuid4()
     agent_id = uuid4()
     fake_engine, engine = await _sqlite_engine(UserApiKey, SessionRecord)
     try:
         with (
             patch.object(
-                _status_module, "child_agent_user_ids", new=AsyncMock(return_value=[agent_id])
+                _status_module,
+                "child_agent_emails",
+                new=AsyncMock(return_value={agent_id: _agent_email("codex", parent_id)}),
             ),
             patch.object(
                 _status_module,
@@ -373,7 +454,7 @@ async def test_identity_status_revoked_key_reports_disconnected():
             ),
             patch.object(_status_module, "get_relational_engine", return_value=fake_engine),
         ):
-            statuses = await identity_plugin_statuses(uuid4())
+            statuses = await identity_plugin_statuses(parent_id)
     finally:
         await engine.dispose()
 
@@ -382,6 +463,72 @@ async def test_identity_status_revoked_key_reports_disconnected():
     assert row.agent_id == agent_id
     assert row.session_count == 0
     assert row.last_active_at is None
+
+
+@pytest.mark.asyncio
+async def test_identity_status_derives_key_from_email_not_config_blob():
+    """A child agent can rewrite its own configuration blob through the
+    public store_user_configuration endpoint. The email is server-assigned,
+    so a blob claiming another plugin's key must not let the agent
+    impersonate (or clobber) that plugin's status row."""
+    parent_id = uuid4()
+    agent_id = uuid4()
+    fake_engine, engine = await _sqlite_engine(UserApiKey, SessionRecord)
+    try:
+        with (
+            patch.object(
+                _status_module,
+                "child_agent_emails",
+                new=AsyncMock(return_value={agent_id: _agent_email("claude-code", parent_id)}),
+            ),
+            patch.object(
+                _status_module,
+                "get_principal_all_configuration",
+                # Tampered blob claims to be the codex plugin.
+                new=AsyncMock(return_value=_identity_config("codex")),
+            ),
+            patch.object(_status_module, "get_relational_engine", return_value=fake_engine),
+        ):
+            statuses = await identity_plugin_statuses(parent_id)
+    finally:
+        await engine.dispose()
+
+    # The row lands on the email-derived key; the claimed key is ignored.
+    assert set(statuses) == {"claude-code"}
+    assert statuses["claude-code"].agent_id == agent_id
+
+
+@pytest.mark.asyncio
+async def test_identity_status_drops_unparseable_provisioned_at():
+    """provisioned_at comes from the agent-writable blob: a non-datetime
+    value degrades to None instead of 500ing the status page later at DTO
+    validation."""
+    parent_id = uuid4()
+    agent_id = uuid4()
+    fake_engine, engine = await _sqlite_engine(UserApiKey, SessionRecord)
+    try:
+        with (
+            patch.object(
+                _status_module,
+                "child_agent_emails",
+                new=AsyncMock(return_value={agent_id: _agent_email("claude-code", parent_id)}),
+            ),
+            patch.object(
+                _status_module,
+                "get_principal_all_configuration",
+                new=AsyncMock(
+                    return_value=_identity_config("claude-code", provisioned_at="not-a-date")
+                ),
+            ),
+            patch.object(_status_module, "get_relational_engine", return_value=fake_engine),
+        ):
+            statuses = await identity_plugin_statuses(parent_id)
+    finally:
+        await engine.dispose()
+
+    row = statuses["claude-code"]
+    assert row.provisioned_at is None  # dropped, row itself survives
+    assert row.agent_id == agent_id
 
 
 @pytest.mark.asyncio
@@ -465,6 +612,23 @@ async def test_registry_status_buckets_by_metadata_and_connection_type():
             status="active",
             last_active_at=seen_at,
         ),
+        # Unmapped connection type, no metadata: no plugin bucket → skipped.
+        AgentConnection(
+            id="d",
+            agent_session_name="pipeline",
+            type="workflow",
+            status="active",
+            last_active_at=seen_at,
+        ),
+        # Bogus user-supplied metadata plugin_key: not a known plugin → skipped.
+        AgentConnection(
+            id="e",
+            agent_session_name="impostor",
+            type="unknown",
+            status="active",
+            last_active_at=seen_at,
+            metadata={"plugin_key": "not-a-plugin"},
+        ),
     ]
     with patch.object(
         _status_module,
@@ -473,6 +637,7 @@ async def test_registry_status_buckets_by_metadata_and_connection_type():
     ):
         statuses = await registry_plugin_statuses([uuid4()])
 
+    # The workflow and bogus-metadata connections produce no rows at all.
     assert set(statuses) == {"claude-code", "mcp", "api"}
     assert all(row.connected for row in statuses.values())
     assert statuses["mcp"].last_active_at == seen_at + timedelta(hours=1)
@@ -486,12 +651,13 @@ async def test_registry_status_buckets_by_metadata_and_connection_type():
 
 def test_merge_identity_and_registry_rows_for_same_key():
     agent_id = uuid4()
+    provisioned_at = datetime(2026, 8, 10, 8, 0, tzinfo=timezone.utc)
     identity = {
         "claude-code": PluginStatusRow(
             key="claude-code",
-            connected=False,  # key revoked...
+            connected=False,  # every key revoked...
             agent_id=agent_id,
-            provisioned_at="2026-08-10T08:00:00+00:00",
+            provisioned_at=provisioned_at,
             last_active_at=datetime(2026, 8, 12, tzinfo=timezone.utc),
             session_count=3,
             source=SOURCE_IDENTITY,
@@ -500,7 +666,7 @@ def test_merge_identity_and_registry_rows_for_same_key():
     registry = {
         "claude-code": PluginStatusRow(
             key="claude-code",
-            connected=True,  # ...but the registry still holds an active connection
+            connected=True,  # ...but a stale registry connection lingers
             last_active_at=datetime(2026, 8, 15, tzinfo=timezone.utc),
             source=SOURCE_REGISTRY,
         ),
@@ -511,10 +677,23 @@ def test_merge_identity_and_registry_rows_for_same_key():
 
     assert set(merged) == {"claude-code", "mcp"}  # same key → one row
     row = merged["claude-code"]
-    assert row.connected is True  # either source connected
+    # Identity's key-existence check is authoritative: revoking every API
+    # key means disconnected, no matter what the registry still claims.
+    assert row.connected is False
     assert row.last_active_at == datetime(2026, 8, 15, tzinfo=timezone.utc)  # max
     assert row.agent_id == agent_id  # identity wins agentId...
-    assert row.provisioned_at == "2026-08-10T08:00:00+00:00"  # ...and provisionedAt
+    assert row.provisioned_at == provisioned_at  # ...and provisionedAt
     assert row.source == SOURCE_IDENTITY
     assert row.session_count == 3
     assert merged["mcp"].source == SOURCE_REGISTRY
+
+
+def test_merge_ors_connected_for_non_identity_rows():
+    """The identity-authoritative rule is scoped: a legacy (or default) base
+    row still ORs connected in from the registry."""
+    base = {"mcp": PluginStatusRow(key="mcp", connected=False)}
+    extra = {"mcp": PluginStatusRow(key="mcp", connected=True, source=SOURCE_REGISTRY)}
+
+    merged = merge_plugin_statuses(base, extra)
+
+    assert merged["mcp"].connected is True


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/integrations/status`: one server-side answer to "what is connected?" for both OAuth integrations and agent plugins, replacing the client-side session-prefix + localStorage inference.

- **Integrations half**: every registered OAuth provider appears (connected or not) with display fields from a single active-credentials query (`list_active_credentials_for_user`, newest-first per provider, same tiebreak as the per-provider endpoint). Token material never leaves the server.
- **Plugins half**, merged from three sources (identity rows win; same key merges):
  - *identity* — provisioned per-plugin agents from SDK-421, keyed off the server-assigned deterministic agent email (not agent-writable config); `connected` = active API key exists, `lastActiveAt` = max(key `last_used_at`, latest session activity), plus session counts
  - *sessions-legacy* — session-id prefix aggregation for pre-migration shared-key installs, with LIKE underscore escaping so `ccx_…` ids don't count toward `cc_`
  - *agent-connection registry* — mcp/api/sdk channels; a revoked identity stays `connected: false` even if a stale registry row is active
- Each source degrades independently: on failure that section is logged and blanked instead of 500ing the whole page.
- The sessions router's visibility helpers move to shared `cognee/modules/session_lifecycle/visibility.py` so the status endpoint reuses the parent+child-agent rule without importing router privates.

Backend only — no frontend changes.

**Stacked PR**: this is part 2 of 2, stacked on #4563 (SDK-421) and must merge after it. When #4563 merges, retarget this PR's base to `dev`.

Design doc: INTEGRATION_STATUS_ENDPOINT_PLAN.md (local, "Per-plugin identity + aggregate status endpoint" — Phase 2).

Closes SDK-422

## Test plan

- `.venv/bin/python -m pytest cognee/tests/unit/modules/integrations/ -q` — 194 passed on this branch
- New `cognee/tests/unit/modules/integrations/test_integrations_status.py`: identity path (provisioned agent + seeded sessions → connected row with counts/lastActive; revoked key → `connected: false`); legacy path (LIKE-escape regression — `ccx_` doesn't count as `cc_`; other users' sessions excluded); integrations half (provider without credential → `connected: false`; with credential → display fields only, no token keys in serialized JSON); merge (identity + registry → single row, identity authoritative); partial source failure in both directions; unauthenticated → 401; registry skip branch for unmapped types/bogus metadata
- Hardening commit addresses adversarial-review findings around trusting agent-writable state (email-derived plugin key, coerced `provisioned_at`, identity-authoritative merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)