### PR TITLE
feat: Add OrcaRouter as a first-class LLM provider

### DIFF
--- a/.claude/skills/cognee-integrations/SKILL.md
+++ b/.claude/skills/cognee-integrations/SKILL.md
@@ -21,6 +21,7 @@ Default is OpenAI (`LLM_API_KEY` is all you need). To switch, set
 - **Anthropic** (`cognee[anthropic]`): `LLM_PROVIDER=anthropic`, model e.g. `claude-3-5-sonnet-20241022`.
 - **Ollama, local** (`cognee[ollama]`): `LLM_PROVIDER=ollama`, `LLM_ENDPOINT=http://localhost:11434/v1`, and set the embedding block + `HUGGINGFACE_TOKENIZER` too.
 - **Custom / OpenRouter / vLLM**: `LLM_PROVIDER=custom` with the provider's OpenAI-compatible endpoint.
+- **OrcaRouter**: `LLM_PROVIDER=orcarouter` — first-class OpenAI-compatible gateway; `LLM_ENDPOINT` defaults to `https://api.orcarouter.ai/v1` (key prefix `sk-orca-`). OrcaRouter routes on provider-prefixed ids, so the model needs the prefix twice (`openai/openai/gpt-4o-mini`).
 - **AWS Bedrock** (`cognee[aws]`): `LLM_PROVIDER=bedrock` + AWS credentials/region.
 
 **The classic trap**: LLM and embeddings are configured independently

--- a/.env.template
+++ b/.env.template
@@ -791,6 +791,17 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #LLM_MODEL="openrouter/google/gemini-2.0-flash-lite-preview-02-05:free"
 #LLM_ENDPOINT="https://openrouter.ai/api/v1"
 
+########## OrcaRouter (OpenAI-compatible gateway) ##############################
+# First-class provider. LLM_ENDPOINT is optional and defaults to
+# https://api.orcarouter.ai/v1. OrcaRouter routes on provider-prefixed model ids
+# and litellm strips one prefix, so use a double-prefixed id
+# (openai/openai/gpt-4o-mini) or the orcarouter/<catalog-id> shorthand
+# (orcarouter/openai/gpt-4o-mini).
+#LLM_API_KEY="sk-orca-..."
+#LLM_PROVIDER="orcarouter"
+#LLM_MODEL="openai/openai/gpt-4o-mini"
+#LLM_ENDPOINT="https://api.orcarouter.ai/v1"
+
 ########## DeepInfra ##########################################################
 #LLM_API_KEY="<<>>"
 #LLM_PROVIDER="custom"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,6 +464,19 @@ LLM_ENDPOINT="https://openrouter.ai/api/v1"
 LLM_API_KEY="your_api_key"
 ```
 
+#### OrcaRouter
+[OrcaRouter](https://www.orcarouter.ai) is a first-class provider (OpenAI-compatible
+gateway). `LLM_ENDPOINT` is optional — it defaults to `https://api.orcarouter.ai/v1`.
+OrcaRouter routes on provider-prefixed model ids and litellm strips one prefix for its
+own routing, so the id needs the prefix twice (`openai/openai/gpt-4o-mini`), or use the
+`orcarouter/<catalog-id>` shorthand (`orcarouter/openai/gpt-4o-mini`):
+```bash
+LLM_PROVIDER="orcarouter"
+LLM_MODEL="openai/openai/gpt-4o-mini"  # or orcarouter/openai/gpt-4o-mini
+LLM_API_KEY="sk-orca-..."
+# LLM_ENDPOINT="https://api.orcarouter.ai/v1"  # optional, this is the default
+```
+
 #### AWS Bedrock (requires aws extra)
 ```bash
 LLM_PROVIDER="bedrock"

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -29,8 +29,13 @@ KNOWN_LLM_PROVIDERS = frozenset(
         "bedrock",
         "llama_cpp",
         "mcp-sampling",
+        "orcarouter",
     }
 )
+
+# Default base URL for the OrcaRouter gateway (an OpenAI-compatible endpoint).
+# ``LLM_ENDPOINT`` overrides it when set explicitly.
+ORCAROUTER_ENDPOINT = "https://api.orcarouter.ai/v1"
 
 # Local inference servers process requests (near-)serially, unlike cloud
 # providers. One definition of the distinction, for everything that needs it:

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
@@ -5,7 +5,7 @@ from enum import Enum
 from functools import lru_cache
 from typing import Any, Hashable, TypeGuard
 
-from cognee.infrastructure.llm.config import get_llm_context_config
+from cognee.infrastructure.llm.config import ORCAROUTER_ENDPOINT, get_llm_context_config
 from cognee.infrastructure.llm.exceptions import (
     LLMAPIKeyNotSetError,
     UnsupportedLLMProviderError,
@@ -80,6 +80,7 @@ class LLMProvider(Enum):
     - GEMINI: Represents the Gemini provider.
     - MISTRAL: Represents the Mistral AI provider.
     - BEDROCK: Represents the AWS Bedrock provider.
+    - ORCAROUTER: Represents the OrcaRouter gateway (OpenAI-compatible, https://api.orcarouter.ai/v1).
     """
 
     OPENAI = "openai"
@@ -93,6 +94,7 @@ class LLMProvider(Enum):
     LLAMA_CPP = "llama_cpp"
     # Delegates completions to the host harness via MCP sampling (no API key).
     MCP_SAMPLING = "mcp-sampling"
+    ORCAROUTER = "orcarouter"
 
 
 _API_KEY_REQUIRED_PROVIDERS = {
@@ -102,6 +104,7 @@ _API_KEY_REQUIRED_PROVIDERS = {
     LLMProvider.GEMINI,
     LLMProvider.MISTRAL,
     LLMProvider.ANTHROPIC,
+    LLMProvider.ORCAROUTER,
 }
 
 
@@ -289,6 +292,32 @@ def _get_llm_client_cached(cache_key: _LLMClientCacheKey) -> LLMInterface:
             max_completion_tokens=max_completion_tokens,
             name="Custom",
             endpoint=cache_key.endpoint,
+            instructor_mode=cache_key.instructor_mode,
+            fallback_api_key=llm_config.fallback_api_key,
+            fallback_endpoint=cache_key.fallback_endpoint,
+            fallback_model=cache_key.fallback_model,
+            llm_args=llm_args,
+        )
+
+    elif provider == LLMProvider.ORCAROUTER:
+        from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api.adapter import (
+            GenericAPIAdapter,
+        )
+
+        # OrcaRouter routes on provider-prefixed model ids (e.g.
+        # ``openai/gpt-4o-mini``) but litellm strips exactly one prefix for its
+        # own routing, so the id must reach litellm with the prefix twice
+        # (``openai/openai/gpt-4o-mini``). The ``orcarouter/<catalog-id>``
+        # shorthand is expanded here to keep the model config readable.
+        model = cache_key.model
+        if model.startswith("orcarouter/"):
+            model = "openai/" + model.removeprefix("orcarouter/")
+        return GenericAPIAdapter(
+            api_key=llm_api_key,
+            model=model,
+            max_completion_tokens=max_completion_tokens,
+            name="OrcaRouter",
+            endpoint=cache_key.endpoint or ORCAROUTER_ENDPOINT,
             instructor_mode=cache_key.instructor_mode,
             fallback_api_key=llm_config.fallback_api_key,
             fallback_endpoint=cache_key.fallback_endpoint,

--- a/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
+++ b/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import BaseModel
 
 from cognee.context_global_variables import llm_config as llm_config_ctx
-from cognee.infrastructure.llm.config import LLMConfig
+from cognee.infrastructure.llm.config import ORCAROUTER_ENDPOINT, LLMConfig
 from cognee.infrastructure.llm.exceptions import LLMAPIKeyNotSetError
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api import (
     adapter as generic_adapter,
@@ -131,6 +131,8 @@ def test_api_key_validation_still_happens_before_cache_lookup():
         raise_api_key_error=True,
         use_managed_identity=True,
     )
+    with pytest.raises(LLMAPIKeyNotSetError):
+        _raise_for_missing_api_key(LLMProvider.ORCAROUTER, None, raise_api_key_error=True)
 
 
 def test_inferred_ollama_provider_uses_bare_model_name(monkeypatch):
@@ -155,6 +157,81 @@ def test_inferred_ollama_provider_uses_bare_model_name(monkeypatch):
     assert config.llm_provider == LLMProvider.OLLAMA.value
     assert isinstance(client, OllamaAPIAdapter)
     assert client.model == "llama3.1:8b"
+
+
+def test_orcarouter_provider_builds_generic_adapter_with_default_endpoint(monkeypatch):
+    for environment_variable in ("LLM_PROVIDER", "LLM_MODEL", "LLM_ENDPOINT", "LLM_API_KEY"):
+        monkeypatch.delenv(environment_variable, raising=False)
+
+    config = LLMConfig(
+        llm_provider="orcarouter",
+        llm_model="openai/openai/gpt-5-mini",
+        llm_api_key="sk-orca-test",
+        _env_file=None,
+    )
+    token = llm_config_ctx.set(config)
+    _get_llm_client_cached.cache_clear()
+
+    try:
+        client = get_llm_client()
+    finally:
+        llm_config_ctx.reset(token)
+        _get_llm_client_cached.cache_clear()
+
+    assert isinstance(client, generic_adapter.GenericAPIAdapter)
+    assert client.name == "OrcaRouter"
+    assert client.model == "openai/openai/gpt-5-mini"
+    assert client.endpoint == ORCAROUTER_ENDPOINT
+
+
+def test_orcarouter_provider_expands_orcarouter_model_prefix(monkeypatch):
+    for environment_variable in ("LLM_PROVIDER", "LLM_MODEL", "LLM_ENDPOINT", "LLM_API_KEY"):
+        monkeypatch.delenv(environment_variable, raising=False)
+
+    config = LLMConfig(
+        llm_provider="orcarouter",
+        llm_model="orcarouter/openai/gpt-5-mini",
+        llm_api_key="sk-orca-test",
+        _env_file=None,
+    )
+    token = llm_config_ctx.set(config)
+    _get_llm_client_cached.cache_clear()
+
+    try:
+        client = get_llm_client()
+    finally:
+        llm_config_ctx.reset(token)
+        _get_llm_client_cached.cache_clear()
+
+    assert isinstance(client, generic_adapter.GenericAPIAdapter)
+    assert client.name == "OrcaRouter"
+    # ``orcarouter/<catalog-id>`` expands to a litellm-routable double-prefixed id.
+    assert client.model == "openai/openai/gpt-5-mini"
+    assert client.endpoint == ORCAROUTER_ENDPOINT
+
+
+def test_orcarouter_provider_honors_explicit_endpoint(monkeypatch):
+    for environment_variable in ("LLM_PROVIDER", "LLM_MODEL", "LLM_ENDPOINT", "LLM_API_KEY"):
+        monkeypatch.delenv(environment_variable, raising=False)
+
+    config = LLMConfig(
+        llm_provider="orcarouter",
+        llm_model="openai/openai/gpt-5-mini",
+        llm_api_key="sk-orca-test",
+        llm_endpoint="https://gateway.example.test/v1",
+        _env_file=None,
+    )
+    token = llm_config_ctx.set(config)
+    _get_llm_client_cached.cache_clear()
+
+    try:
+        client = get_llm_client()
+    finally:
+        llm_config_ctx.reset(token)
+        _get_llm_client_cached.cache_clear()
+
+    assert isinstance(client, generic_adapter.GenericAPIAdapter)
+    assert client.endpoint == "https://gateway.example.test/v1"
 
 
 def test_openai_adapter_preserves_default_instructor_mode_for_non_gpt5_models(monkeypatch):

--- a/cognee/tests/unit/infrastructure/llm/test_llm_config.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_config.py
@@ -72,6 +72,17 @@ def test_infer_provider_from_model(monkeypatch):
     assert config.llm_provider == "anthropic"
 
 
+def test_infer_orcarouter_provider_from_model(monkeypatch):
+    """
+    An ``orcarouter/<model>`` prefix infers the first-class OrcaRouter provider.
+    """
+    for var in ("LLM_PROVIDER", "LLM_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+
+    config = LLMConfig(llm_model="orcarouter/openai/gpt-5-mini", _env_file=None)
+    assert config.llm_provider == "orcarouter"
+
+
 def test_explicit_provider_takes_precedence(monkeypatch):
     """
     An explicitly set llm_provider is never overridden by inference.


### PR DESCRIPTION
## Description

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a first-class LLM provider in cognee.

OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Until now, OrcaRouter worked only through the generic `LLM_PROVIDER=custom` path with a hand-set `LLM_ENDPOINT`. This PR registers it as a named provider (mirroring the existing `custom` wiring), so `LLM_PROVIDER=orcarouter` works out of the box:

- **`LLMProvider.ORCAROUTER`** enum member, dispatched to the same `GenericAPIAdapter` the `custom` provider uses, with `name="OrcaRouter"` and a default endpoint of `https://api.orcarouter.ai/v1` (overridable via `LLM_ENDPOINT`).
- **`orcarouter` in `KNOWN_LLM_PROVIDERS`** — `LLM_MODEL=orcarouter/...` infers the provider automatically.
- **Model id handling** — OrcaRouter routes on provider-prefixed model ids and litellm strips one prefix, so the `orcarouter/<catalog-id>` shorthand (e.g. `orcarouter/openai/gpt-4o-mini`) expands to a double-prefixed litellm id (`openai/openai/gpt-4o-mini`).
- **Docs** — `CLAUDE.md`, `.env.template`, and the `cognee-integrations` skill now document the provider block.
- **Tests** — provider inference, dispatch, prefix expansion, endpoint default/override, and API-key validation.

I'm an engineer on the OrcaRouter team.

## Acceptance Criteria

- [x] `LLM_PROVIDER=orcarouter` routes through the OrcaRouter gateway without a manually set `LLM_ENDPOINT` (default `https://api.orcarouter.ai/v1`).
- [x] `orcarouter` is a first-class entry in the `LLMProvider` enum and `KNOWN_LLM_PROVIDERS`.
- [x] Unit tests cover inference, dispatch, and prefix expansion.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Local test run (Windows, Python 3.12):

```
$ pytest cognee/tests/unit/infrastructure/llm/test_get_llm_client.py cognee/tests/unit/infrastructure/llm/test_llm_config.py
30 passed, 10 warnings in 1.19s
```

L3 live test against https://api.orcarouter.ai/v1 with a real key:

```
[client] GenericAPIAdapter name=OrcaRouter model=openai/openai/gpt-4o-mini endpoint=https://api.orcarouter.ai/v1
[result:orcarouter/openai/gpt-4o-mini] Connected
```

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
