### PR TITLE
fix(embeddings): recover from Vertex AI batch-size rejections in embed_text

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -38,7 +38,10 @@ logger = get_logger("LiteLLMEmbeddingEngine")
 # BadRequestError (e.g. OpenAI 400 "maximum input length is 8192 tokens"). Match
 # those by message so the split/pool recovery below can handle them too. Kept
 # narrow to length/token-limit phrasings so genuinely-bad requests still fail fast.
-_EMBED_LENGTH_ERROR_RE = re.compile(r"maximum\s+input\s+length", re.IGNORECASE)
+_EMBED_LENGTH_ERROR_RE = re.compile(
+    r"maximum\s+input\s+length|instance\(s\)\s+is\s+allowed\s+per\s+prediction",
+    re.IGNORECASE,
+)
 
 
 class LiteLLMEmbeddingEngine(EmbeddingEngine):
@@ -203,7 +206,8 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
             # ContextWindowExceededError subclasses BadRequestError. litellm raises
             # it for chat context-length errors, but the embeddings API returns a
             # plain BadRequestError for over-length input (OpenAI 400: "maximum input
-            # length is 8192 tokens"). Recover (split + pool) for both; re-raise any
+            # length is 8192 tokens"; Vertex AI 400: "2048 instance(s) is allowed per
+            # prediction"). Recover (split + pool) for both; re-raise any
             # other BadRequest unchanged so genuinely bad requests still fail fast.
             if not (
                 isinstance(error, litellm.exceptions.ContextWindowExceededError)

--- a/cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py
+++ b/cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py
@@ -189,3 +189,36 @@ async def test_openai_compatible_embedding_does_not_retry_unsplittable_context_w
         await engine.embed_text(["ab"])
 
     assert create_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedding_splits_batch_on_vertex_instance_limit_error():
+    import litellm
+
+    with patch(
+        "cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine."
+        "LiteLLMEmbeddingEngine.get_tokenizer",
+        return_value=Mock(),
+    ):
+        from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine import (
+            LiteLLMEmbeddingEngine,
+        )
+
+        engine = LiteLLMEmbeddingEngine(model="test-model", dimensions=2)
+
+    instance_limit_error = litellm.exceptions.BadRequestError(
+        message="2 instance(s) is allowed per prediction. Actual: 4",
+        model="test-model",
+        llm_provider="vertex_ai",
+    )
+
+    async def fake_aembedding(**kwargs):
+        if len(kwargs["input"]) > 2:
+            raise instance_limit_error
+        return Mock(data=[{"embedding": [1.0, 1.0]} for _ in kwargs["input"]])
+
+    with patch("litellm.aembedding", AsyncMock(side_effect=fake_aembedding)) as embed_mock:
+        result = await engine.embed_text(["a", "b", "c", "d"])
+
+    assert result == [[1.0, 1.0]] * 4
+    assert embed_mock.await_count > 1


### PR DESCRIPTION
## Description

Support vertex style batch-size rejections.
embed_text already has recursive split-and-retry for oversized batches. The guard currently only matches OpenAI's "maximum input length" wording. Vertex AI words it differently, so it falls through and is re-raised.

## Acceptance Criteria

- Vertex AI batch-size rejections are recovered by the existing split-and-pool path instead of being re-raised.
- Genuinely bad requests still fail fast (unchanged).
- New unit test fails without the fix and passes with it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

**Unit tests** (`test_embedding_context_window_fallbacks.py`, includes the new Vertex case):

![unit tests passing](https://raw.githubusercontent.com/lallenlowe/cognee/pr-assets/1-unit-tests.png)

**Integration test** (`cognee/tests/test_library.py`, run against Vertex via a LiteLLM-compatible gateway, exit 0):

![integration test passing](https://raw.githubusercontent.com/lallenlowe/cognee/pr-assets/2-integration-test.png)

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.