### PR TITLE
fix(graph): delete unowned edges before nodes in source-ref removal

### DIFF
--- a/cognee/infrastructure/databases/unified/provenance_delete_planner.py
+++ b/cognee/infrastructure/databases/unified/provenance_delete_planner.py
@@ -6,13 +6,22 @@ source ref remains -> hard delete) versus which merely *survive* (some ref
 remains -> detach the targeted refs only). It then performs the removal in a
 retry-safe order:
 
-  1. delete vectors for unowned artifacts (from snapshots only),
-  2. ``remove_*_source_refs`` for the targeted refs on ALL matched artifacts
-     (idempotent),
-  3. ``delete_nodes`` / ``delete_edge_triples`` for the unowned artifacts.
+  1. delete per-edge triplet vectors for unowned edges (from snapshots only),
+  2. ``remove_*_source_refs`` for the targeted refs on SURVIVING matched
+     artifacts (idempotent),
+  3. ``delete_edge_triples`` for the unowned edges (edge-first),
+  4. retention check: an unowned-candidate node that is still an endpoint of any
+     remaining relationship is NOT hard-deleted — backends implement node
+     deletion as a detaching delete, which would destroy foreign-owned incident
+     relationships. Such nodes only lose the targeted refs (idempotent) and keep
+     their vectors,
+  5. delete vectors for the remaining truly-unowned nodes, then ``delete_nodes``
+     for them (they have no incident relationships at this point, so the
+     backend's detach semantics cannot remove anything foreign-owned).
 
-Vectors are deleted first so that a failure leaves graph provenance intact and a
-retry converges. All three steps are individually idempotent.
+Unowned artifacts keep their source refs until their hard delete, so a failure
+at any step leaves them rediscoverable by source ref and a retry converges. All
+steps are individually idempotent.
 
 Vector ids mirror ``delete_from_graph_and_vector``:
   - node -> collection ``f"{node_type}_{field}"`` for each indexed field,
@@ -77,18 +86,10 @@ async def execute_source_ref_removal(
             unowned_edges.append(edge)
 
     # ------------------------------------------------------------------
-    # 2. Delete vectors for unowned artifacts (from snapshots only).
+    # 2. Delete per-edge triplet vectors for unowned edges (from snapshots
+    #    only). Node vectors are deleted later, after the surviving-endpoint
+    #    retention check decides which nodes are actually hard-deleted.
     # ------------------------------------------------------------------
-    node_vector_collections: dict[str, list[str]] = {}
-    for node_id in unowned_node_ids:
-        data = node_data[node_id]
-        for field in data.indexed_fields:
-            collection_name = f"{data.node_type}_{field}"
-            node_vector_collections.setdefault(collection_name, []).append(node_id)
-
-    for collection, ids in node_vector_collections.items():
-        await _delete_vector_points(vector_engine, collection, ids)
-
     if unowned_edges:
         # Per-edge triplet vectors are tied to a single deleted edge instance, so
         # they are safe to delete here. EdgeType vectors are keyed by *shared*
@@ -135,20 +136,71 @@ async def execute_source_ref_removal(
         await graph_engine.remove_edge_source_refs(edges, list(removed_refs))
 
     # ------------------------------------------------------------------
-    # 4. Hard-delete unowned artifacts.
+    # 4. Hard-delete unowned edges FIRST. Node deletion is a detaching delete
+    #    on graph backends, so deleting nodes before edges would also destroy
+    #    incident relationships that still carry foreign ownership — including
+    #    relationships that never matched the targeted refs at all.
     # ------------------------------------------------------------------
-    if unowned_node_ids:
-        await graph_engine.delete_nodes(unowned_node_ids)
-
     if unowned_edges:
         await graph_engine.delete_edge_triples(unowned_edges)
 
     # ------------------------------------------------------------------
-    # 5. Post-delete cleanup parity with delete_from_graph_and_vector
-    #    (best-effort, non-fatal).
+    # 5. Surviving-endpoint retention check. With the unowned edges gone, any
+    #    relationship still incident to an unowned-candidate node is by
+    #    definition foreign-owned and must survive; the node is retained as its
+    #    endpoint, loses only the targeted refs, and keeps its vectors.
+    # ------------------------------------------------------------------
+    retained_node_ids: list[str] = []
+    deletable_node_ids: list[str] = []
+    for node_id in unowned_node_ids:
+        incident_edges = await graph_engine.get_edges(node_id)
+        if incident_edges:
+            retained_node_ids.append(node_id)
+        else:
+            deletable_node_ids.append(node_id)
+
+    if retained_node_ids:
+        logger.info(
+            "Retained %d unowned node(s) still incident to surviving relationships",
+            len(retained_node_ids),
+        )
+
+    retained_by_removed_refs: dict[tuple[str, ...], list[str]] = {}
+    for node_id in retained_node_ids:
+        removed = refs_by_node.get(node_id, [])
+        if not removed:
+            continue
+        retained_by_removed_refs.setdefault(tuple(removed), []).append(node_id)
+
+    for removed_refs, node_ids in retained_by_removed_refs.items():
+        await graph_engine.remove_node_source_refs(node_ids, list(removed_refs))
+
+    # ------------------------------------------------------------------
+    # 6. Delete vectors for the truly-unowned nodes, then hard-delete them.
+    #    They have no incident relationships at this point, so the backend's
+    #    detach semantics cannot remove anything foreign-owned. Refs stay on
+    #    the nodes until this delete, keeping a failed run rediscoverable.
+    # ------------------------------------------------------------------
+    node_vector_collections: dict[str, list[str]] = {}
+    for node_id in deletable_node_ids:
+        data = node_data[node_id]
+        for field in data.indexed_fields:
+            collection_name = f"{data.node_type}_{field}"
+            node_vector_collections.setdefault(collection_name, []).append(node_id)
+
+    for collection, ids in node_vector_collections.items():
+        await _delete_vector_points(vector_engine, collection, ids)
+
+    if deletable_node_ids:
+        await graph_engine.delete_nodes(deletable_node_ids)
+
+    # ------------------------------------------------------------------
+    # 7. Post-delete cleanup parity with delete_from_graph_and_vector
+    #    (best-effort, non-fatal). NodeSet tag cleanup only considers nodes
+    #    that were actually hard-deleted; retained NodeSet nodes keep tags.
     # ------------------------------------------------------------------
     await _cleanup_orphaned_edge_types(graph_engine, vector_engine, unowned_edges, edge_data)
-    await _cleanup_orphaned_nodeset_tags(graph_engine, vector_engine, unowned_node_ids, node_data)
+    await _cleanup_orphaned_nodeset_tags(graph_engine, vector_engine, deletable_node_ids, node_data)
 
 
 async def _cleanup_orphaned_edge_types(

--- a/cognee/tests/unit/infrastructure/databases/provenance/test_unified_graph_provenance_delete.py
+++ b/cognee/tests/unit/infrastructure/databases/provenance/test_unified_graph_provenance_delete.py
@@ -195,8 +195,19 @@ class FakeProvenanceGraphEngine:
 
     async def delete_nodes(self, node_ids):
         self._guard()
-        for node_id in node_ids:
+        # Mirror real graph backends: node deletion is a DETACHING delete
+        # (Neo4j ``DETACH DELETE``, Kuzu detach semantics), so every incident
+        # relationship disappears with the node. Modeling this here is what
+        # lets the suite catch planners that hard-delete an endpoint while a
+        # foreign-owned relationship is still attached to it.
+        removed = set(node_ids)
+        for node_id in removed:
             self.nodes.pop(node_id, None)  # idempotent
+        self.edges = {
+            edge: row
+            for edge, row in self.edges.items()
+            if edge.source_id not in removed and edge.target_id not in removed
+        }
 
     async def delete_edge_triples(self, edges):
         self._guard()
@@ -300,6 +311,19 @@ class FakeProvenanceGraphEngine:
             for e, row in self.edges.items()
         ]
         return nodes, edges
+
+    async def get_edges(self, node_id):
+        # Mirror the real adapters' incident-edge lookup (undirected match on
+        # either endpoint), returning the queried node first like Neo4j does.
+        return [
+            (
+                node_id,
+                e.target_id if e.source_id == node_id else e.source_id,
+                {"relationship_name": e.relationship_name},
+            )
+            for e in self.edges
+            if e.source_id == node_id or e.target_id == node_id
+        ]
 
     async def remove_belongs_to_set_tags(self, tags):
         self._guard()
@@ -627,6 +651,250 @@ async def test_orphaned_nodeset_tags_stripped_on_delete():
     assert "ns" not in graph.nodes
     assert getattr(graph, "removed_tags", []) == [["my_nodeset"]]
     assert vector.removed_tags == [["my_nodeset"]]
+
+
+# ---------------------------------------------------------------------------
+# Surviving-endpoint retention regressions (edge-first delete + get_edges check)
+# ---------------------------------------------------------------------------
+
+
+async def test_endpoint_with_foreign_edge_outside_matched_set_is_retained():
+    """A node unowned by the deleted ref must survive while a relationship the
+    deletion never matched (owned by a different ref) is still incident to it.
+
+    This is the exact detaching-delete corruption class: hard-deleting the node
+    would destroy the foreign-owned relationship."""
+    ref_a = make_source_ref_key(uuid4(), uuid4())
+    ref_b = make_source_ref_key(uuid4(), uuid4())
+    run = uuid4()
+
+    graph = FakeProvenanceGraphEngine()
+    graph.add_node("n_candidate", "Entity", ["name"], {"name": "candidate"})
+    graph.add_node("n_other", "Entity", ["name"], {"name": "other"})
+    foreign_edge = graph.add_edge("n_candidate", "n_other", "linked_to", "linked to")
+
+    await graph.attach_node_source_refs(["n_candidate"], [ref_a], run)
+    await graph.attach_node_source_refs(["n_other"], [ref_b], run)
+    await graph.attach_edge_source_refs([foreign_edge], [ref_b], run)
+
+    vector = FakeVectorEngine()
+    engine = _build_engine(graph, vector)
+
+    await engine.delete_by_source_ref(ref_a)
+
+    # The candidate node is retained as an endpoint of the foreign edge.
+    assert "n_candidate" in graph.nodes
+    assert graph.nodes["n_candidate"].source_ref_keys == []
+    assert graph.nodes["n_candidate"].source_run_refs == []
+    # The foreign-owned relationship survives with its ownership intact.
+    assert foreign_edge in graph.edges
+    assert graph.edges[foreign_edge].source_ref_keys == [ref_b]
+    # The retained node keeps its vector (it still exists in the graph).
+    assert all(ids != ["n_candidate"] for _, ids in vector.deleted)
+
+
+async def test_endpoint_of_shared_detached_edge_is_retained():
+    """A node unowned by the deleted ref survives when a shared edge (detached
+    of the ref, still foreign-owned) remains incident to it."""
+    ref_a = make_source_ref_key(uuid4(), uuid4())
+    ref_b = make_source_ref_key(uuid4(), uuid4())
+    run = uuid4()
+
+    graph = FakeProvenanceGraphEngine()
+    graph.add_node("n_candidate", "Entity", ["name"], {"name": "candidate"})
+    graph.add_node("n_other", "Entity", ["name"], {"name": "other"})
+    shared_edge = graph.add_edge("n_candidate", "n_other", "linked_to", "linked to")
+
+    await graph.attach_node_source_refs(["n_candidate"], [ref_a], run)
+    await graph.attach_node_source_refs(["n_other"], [ref_a, ref_b], run)
+    await graph.attach_edge_source_refs([shared_edge], [ref_a, ref_b], run)
+
+    vector = FakeVectorEngine()
+    engine = _build_engine(graph, vector)
+
+    await engine.delete_by_source_ref(ref_a)
+
+    assert shared_edge in graph.edges
+    assert graph.edges[shared_edge].source_ref_keys == [ref_b]
+    assert "n_candidate" in graph.nodes
+    assert graph.nodes["n_candidate"].source_ref_keys == []
+    assert "n_other" in graph.nodes
+    assert graph.nodes["n_other"].source_ref_keys == [ref_b]
+
+
+async def test_fully_unowned_component_is_deleted_edge_first():
+    """When node and incident edges are all unowned, everything is deleted and
+    the node passes the retention check (no incident edges remain)."""
+    ref = make_source_ref_key(uuid4(), uuid4())
+    run = uuid4()
+
+    graph = FakeProvenanceGraphEngine()
+    graph.add_node("n1", "Entity", ["name"], {"name": "a"})
+    graph.add_node("n2", "Entity", ["name"], {"name": "b"})
+    edge = graph.add_edge("n1", "n2", "linked_to", "linked to")
+
+    await graph.attach_node_source_refs(["n1", "n2"], [ref], run)
+    await graph.attach_edge_source_refs([edge], [ref], run)
+
+    vector = FakeVectorEngine()
+    engine = _build_engine(graph, vector)
+
+    await engine.delete_by_source_ref(ref)
+
+    assert graph.nodes == {}
+    assert graph.edges == {}
+    assert ("Entity_name", ["n1", "n2"]) in vector.deleted or (
+        ("Entity_name", ["n1"]) in vector.deleted and ("Entity_name", ["n2"]) in vector.deleted
+    )
+
+
+async def test_repeated_delete_is_idempotent_and_retained_node_stays():
+    """A second delete of the same ref is a no-op; the retained endpoint is not
+    rediscovered (its refs are gone) and is not deleted later."""
+    ref_a = make_source_ref_key(uuid4(), uuid4())
+    ref_b = make_source_ref_key(uuid4(), uuid4())
+    run = uuid4()
+
+    graph = FakeProvenanceGraphEngine()
+    graph.add_node("n_candidate", "Entity", ["name"], {"name": "candidate"})
+    graph.add_node("n_other", "Entity", ["name"], {"name": "other"})
+    foreign_edge = graph.add_edge("n_candidate", "n_other", "linked_to", "linked to")
+
+    await graph.attach_node_source_refs(["n_candidate"], [ref_a], run)
+    await graph.attach_node_source_refs(["n_other"], [ref_b], run)
+    await graph.attach_edge_source_refs([foreign_edge], [ref_b], run)
+
+    vector = FakeVectorEngine()
+    engine = _build_engine(graph, vector)
+
+    await engine.delete_by_source_ref(ref_a)
+    assert await graph.find_nodes_by_source_ref(ref_a) == []
+
+    snapshot_nodes = {nid: list(n.source_ref_keys) for nid, n in graph.nodes.items()}
+    snapshot_edges = {e: list(r.source_ref_keys) for e, r in graph.edges.items()}
+    deleted_before = list(vector.deleted)
+
+    await engine.delete_by_source_ref(ref_a)
+
+    assert {nid: list(n.source_ref_keys) for nid, n in graph.nodes.items()} == snapshot_nodes
+    assert {e: list(r.source_ref_keys) for e, r in graph.edges.items()} == snapshot_edges
+    assert vector.deleted == deleted_before
+
+
+async def test_retention_is_order_dependent_and_both_orders_preserve_foreign_ownership():
+    """Node A owned by ref_1; edge A->B owned by ref_2. Deleting ref_1 first
+    retains A (the ref_2 edge still needs its endpoint); deleting ref_2 first
+    removes the edge, so A is isolated and deleted afterwards. Neither order may
+    ever lose foreign-owned artifacts prematurely."""
+    ref_1 = make_source_ref_key(uuid4(), uuid4())
+    ref_2 = make_source_ref_key(uuid4(), uuid4())
+    run = uuid4()
+
+    def build():
+        graph = FakeProvenanceGraphEngine()
+        graph.add_node("a", "Entity", ["name"], {"name": "a"})
+        graph.add_node("b", "Entity", ["name"], {"name": "b"})
+        return graph, graph.add_edge("a", "b", "linked_to", "linked to")
+
+    # Order 1: ref_1 then ref_2.
+    graph, edge = build()
+    await graph.attach_node_source_refs(["a"], [ref_1], run)
+    await graph.attach_node_source_refs(["b"], [ref_2], run)
+    await graph.attach_edge_source_refs([edge], [ref_2], run)
+    engine = _build_engine(graph, FakeVectorEngine())
+
+    await engine.delete_by_source_ref(ref_1)
+    assert "a" in graph.nodes  # retained: ref_2 edge still incident
+    assert edge in graph.edges
+    await engine.delete_by_source_ref(ref_2)
+    assert edge not in graph.edges
+    assert "b" not in graph.nodes
+    # "a" became provenance-empty at ref_1 time and is never matched again.
+    assert "a" in graph.nodes
+    assert graph.nodes["a"].source_ref_keys == []
+
+    # Order 2: ref_2 then ref_1.
+    graph, edge = build()
+    await graph.attach_node_source_refs(["a"], [ref_1], run)
+    await graph.attach_node_source_refs(["b"], [ref_2], run)
+    await graph.attach_edge_source_refs([edge], [ref_2], run)
+    engine = _build_engine(graph, FakeVectorEngine())
+
+    await engine.delete_by_source_ref(ref_2)
+    assert edge not in graph.edges
+    assert "b" not in graph.nodes
+    assert "a" in graph.nodes  # still owned by ref_1
+    assert graph.nodes["a"].source_ref_keys == [ref_1]
+    await engine.delete_by_source_ref(ref_1)
+    assert "a" not in graph.nodes  # isolated and unowned -> deleted
+
+
+async def test_crash_between_edge_delete_and_node_delete_converges_on_retry():
+    """A failure after the edge hard-delete leaves the unowned node with its
+    refs (rediscoverable); the retry converges to the exact final state."""
+    ref = make_source_ref_key(uuid4(), uuid4())
+    run = uuid4()
+
+    class FailOnceDeleteNodes(FakeProvenanceGraphEngine):
+        def __init__(self):
+            super().__init__()
+            self._fail_delete_nodes = True
+
+        async def delete_nodes(self, node_ids):
+            if self._fail_delete_nodes:
+                self._fail_delete_nodes = False
+                raise RuntimeError("injected delete_nodes failure")
+            await super().delete_nodes(node_ids)
+
+    graph = FailOnceDeleteNodes()
+    graph.add_node("n1", "Entity", ["name"], {"name": "a"})
+    graph.add_node("n2", "Entity", ["name"], {"name": "b"})
+    edge = graph.add_edge("n1", "n2", "linked_to", "linked to")
+
+    await graph.attach_node_source_refs(["n1", "n2"], [ref], run)
+    await graph.attach_edge_source_refs([edge], [ref], run)
+
+    vector = FakeVectorEngine()
+    engine = _build_engine(graph, vector)
+
+    with pytest.raises(RuntimeError, match="injected delete_nodes failure"):
+        await engine.delete_by_source_ref(ref)
+
+    # The unowned edge is already gone (edge-first), but both nodes still carry
+    # their refs and stay rediscoverable for the retry.
+    assert edge not in graph.edges
+    assert await graph.find_nodes_by_source_ref(ref) == ["n1", "n2"]
+
+    await engine.delete_by_source_ref(ref)
+    assert graph.nodes == {}
+    assert graph.edges == {}
+
+
+async def test_retained_nodeset_keeps_its_tag():
+    """A NodeSet retained as a surviving endpoint must not have its tag
+    stripped from other artifacts — tag cleanup applies to deleted nodes only."""
+    ref_a = make_source_ref_key(uuid4(), uuid4())
+    ref_b = make_source_ref_key(uuid4(), uuid4())
+    run = uuid4()
+
+    graph = FakeProvenanceGraphEngine()
+    graph.add_node("ns", "NodeSet", ["name"], {"name": "my_nodeset"})
+    graph.add_node("member", "Entity", ["name"], {"name": "member"})
+    membership = graph.add_edge("member", "ns", "belongs_to", "belongs to")
+
+    await graph.attach_node_source_refs(["ns"], [ref_a], run)
+    await graph.attach_node_source_refs(["member"], [ref_b], run)
+    await graph.attach_edge_source_refs([membership], [ref_b], run)
+
+    vector = FakeVectorEngine()
+    engine = _build_engine(graph, vector)
+
+    await engine.delete_by_source_ref(ref_a)
+
+    assert "ns" in graph.nodes  # retained endpoint of the foreign membership edge
+    assert membership in graph.edges
+    assert getattr(graph, "removed_tags", []) == []
+    assert vector.removed_tags == []
 
 
 # Sanity: the parseable-ref helpers used by the fakes agree with the contract.


### PR DESCRIPTION
## Description

`execute_source_ref_removal` in `provenance_delete_planner.py` hard-deletes unowned nodes before it deletes unowned edges. Backends implement `delete_nodes` as a detaching delete: Neo4j issues `DETACH DELETE`, Kuzu/Ladybug detaches as well. Deleting an unowned endpoint therefore also destroys relationships that other source refs still own, including relationships the removed refs never matched.

I hit this on a dataset built from a Markdown repository where the same entities are referenced from many files. Content-hash identity makes every edited file a delete plus a re-add, so `delete_by_source_ref` is a hot path rather than a rare operation. On a fixture exported from that graph (7,615 nodes, 16,818 logical relationships), removing 10 source refs through the current planner drops 167 protected nodes and 354 protected edge rows. Reversing the iteration order changes the node count to 212 and leaves the same 354 edge rows missing, so the exact damage depends on traversal order but the class does not.

The planner now deletes the unowned edges first. It then asks `GraphDBInterface.get_edges(node_id)` for each node that looked unowned. A node with any remaining incident relationship is retained: it loses the targeted refs and keeps its vectors and its foreign relationships. Only isolated nodes are hard-deleted, so detach semantics cannot reach anything foreign-owned. Because the check runs after the unowned edges are already gone, an edge that is still incident is by definition a surviving one, and the check does not need to compare edge direction.

Unowned artifacts keep their source refs until their own hard delete. That preserves the Part 0 retry invariant: a failure at any step leaves them discoverable by source ref, and a retry converges.

No new adapter method was needed. The retention check goes through the existing public `get_edges` and costs one indexed lookup per candidate node rather than a scan.

The ordering dates back to #3299, which introduced the planner. The file is identical on `v1.5.0` and on current `dev`.

## Acceptance Criteria

The planner unit suite passes with the fix and fails without it:

```
uv sync --group dev
uv run pytest cognee/tests/unit/infrastructure/databases/provenance/test_unified_graph_provenance_delete.py -q
```

With the fix: `19 passed`.
With the planner reverted to its previous ordering: `5 failed, 14 passed`.

The suite could not catch this class before, because its fake graph engine deleted nodes without detaching. The fake now models detaching `delete_nodes` like the real backends and implements `get_edges`. The new regressions cover an endpoint carrying a foreign edge outside the matched set, a shared detached edge, dataset-scoped multi-ref retention, an idempotent repeat, order dependence, a crash between the edge delete and the node delete, and a retained NodeSet keeping its tag.

Wider suites on the same tree, Python 3.13.12, macOS arm64:

```
uv run pytest cognee/tests/unit/infrastructure/databases -q
uv run pytest cognee/tests/integration/infrastructure/graph -q
```

```
563 passed, 16 skipped
87 passed, 39 skipped, 4 xfailed, 2 xpassed
```

The two xpassed cases are long-standing `KuzuAdapter.get_graph_metrics` quirks and are unrelated to this change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

```
$ uv run pytest cognee/tests/unit/infrastructure/databases/provenance/test_unified_graph_provenance_delete.py -q
19 passed, 10 warnings in 0.05s
```

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
