### PR TITLE
test(ci): add a full-stack docker-compose e2e suite [COG-6240]

### DIFF
--- a/.github/workflows/docker_compose.yml
+++ b/.github/workflows/docker_compose.yml
@@ -5,6 +5,9 @@ on:
 
 env:
   COGNEE_SKIP_CONNECTION_TEST: 'true'
+  # Profiles exercised by the full-stack e2e: the default `cognee` service plus
+  # postgres (persistence) and the MCP server.
+  COMPOSE_PROFILES: 'postgres,mcp'
 
 jobs:
   docker-compose-test:
@@ -16,6 +19,11 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
 
     - name: Build Docker images
       env:
@@ -40,6 +48,35 @@ jobs:
         printenv | grep -E '^(LLM_|EMBEDDING_)' > .env
         echo "EMBEDDING_DIMENSIONS=300" >> .env
         echo "COGNEE_SKIP_CONNECTION_TEST=true" >> .env
+        # Point the relational store at the postgres service so the e2e
+        # persistence test is genuinely Postgres-backed. docker compose reads
+        # the same .env for ${DB_*} interpolation in docker-compose.yml, which
+        # is how the cognee-mcp service picks up the same database.
+        cat >> .env <<'EOF'
+        DB_PROVIDER=postgres
+        DB_HOST=postgres
+        DB_PORT=5432
+        DB_NAME=cognee_db
+        DB_USERNAME=cognee
+        DB_PASSWORD=cognee
+        EOF
+
+    - name: Start Postgres and wait for it
+      # The app services have no depends_on for postgres, so bring the
+      # database up first to keep them from crash-looping on boot.
+      run: |
+        docker compose -f docker-compose.yml up -d postgres
+        echo "Waiting for postgres to become ready..."
+        for attempt in $(seq 1 30); do
+          if docker compose -f docker-compose.yml exec -T postgres pg_isready -U cognee -d cognee_db >/dev/null 2>&1; then
+            echo "postgres ready after ~$((attempt * 3))s"
+            exit 0
+          fi
+          sleep 3
+        done
+        echo "postgres never became ready"
+        docker compose -f docker-compose.yml logs postgres | tail -60
+        exit 1
 
     - name: Run Docker Compose
       env:
@@ -64,6 +101,40 @@ jobs:
         echo "server did not become healthy in time"
         docker compose -f docker-compose.yml logs cognee | tail -60
         exit 1
+
+    - name: Wait for MCP server health
+      run: |
+        for attempt in $(seq 1 60); do
+          if curl -sf http://localhost:8001/health >/dev/null; then
+            echo "cognee-mcp healthy after ~$((attempt * 3))s"
+            exit 0
+          fi
+          sleep 3
+        done
+        echo "cognee-mcp did not become healthy in time"
+        docker compose -f docker-compose.yml logs cognee-mcp | tail -60
+        exit 1
+
+    - name: Run full-stack e2e suite
+      # Runs before the real-LLM round-trip below so the suite's traceback
+      # scan only covers deterministic, LLM-free paths (startup, ingestion,
+      # MCP, persistence) and cannot flake on model-provider noise.
+      env:
+        COGNEE_E2E_MANAGE_COMPOSE: '1'
+        COGNEE_E2E_COMPOSE_PROFILES: 'postgres,mcp'
+      run: |
+        # The suite is decoupled from the `cognee` package: --confcutdir keeps
+        # pytest from loading the heavy ancestor conftests, and --no-project
+        # keeps uv from syncing the whole project on the runner.
+        uv run --no-project \
+          --with pytest \
+          --with pytest-timeout \
+          --with requests \
+          --with mcp \
+          python -m pytest cognee/tests/e2e/docker_compose \
+            -p no:cacheprovider \
+            --confcutdir=cognee/tests/e2e/docker_compose \
+            -v --timeout=900
 
     - name: Verify remember and recall round-trip
       run: |
@@ -96,13 +167,13 @@ jobs:
         echo "recall (GRAPH_COMPLETION): $ANSWER"
         echo "$ANSWER" | grep -qi "Marsk" || { echo "graph completion did not mention the remembered entity"; exit 1; }
 
-    - name: Show server logs on failure
+    - name: Show service logs on failure
       if: failure()
       # Filter key-shaped lines: GitHub masks exact secret values, but partial
       # or transformed echoes (e.g. provider auth errors) would slip through.
-      run: docker compose -f docker-compose.yml logs cognee | grep -viE "api[-_]?key|authorization|bearer" | tail -100
+      run: docker compose -f docker-compose.yml logs --no-color | grep -viE "api[-_]?key|authorization|bearer" | tail -200
 
     - name: Shut down Docker Compose
       if: always()
       run: |
-        docker compose -f docker-compose.yml down
+        docker compose -f docker-compose.yml down -v

--- a/cognee/api/v1/health/health.py
+++ b/cognee/api/v1/health/health.py
@@ -159,12 +159,15 @@ class HealthChecker:
             provider = "s3" if base_config.data_root_directory.startswith("s3://") else "local"
 
             import uuid
+
             test_id = str(uuid.uuid4())
             # Test storage accessibility - for local storage, just check directory exists
             if provider == "local":
                 os.makedirs(base_config.data_root_directory, exist_ok=True)
                 # Simple write/read test
-                test_file = os.path.join(base_config.data_root_directory, f"health_check_test_{test_id}")
+                test_file = os.path.join(
+                    base_config.data_root_directory, f"health_check_test_{test_id}"
+                )
                 with open(test_file, "w") as f:
                     f.write("test")
                 os.remove(test_file)

--- a/cognee/tests/e2e/docker_compose/README.md
+++ b/cognee/tests/e2e/docker_compose/README.md
@@ -1,0 +1,43 @@
+# Docker Compose full-stack e2e
+
+A real end-to-end test for the `docker-compose.yml` deployment. It runs in
+[`.github/workflows/docker_compose.yml`](../../../../.github/workflows/docker_compose.yml)
+alongside the workflow's remember/recall round-trip smoke test, and covers the
+parts that smoke test does not: the MCP service, Postgres-backed persistence,
+and service log hygiene.
+
+## What it covers
+
+| Test | Asserts |
+| --- | --- |
+| `test_golden_flow_api` | `health → login → add → datasets → data` against the API on `:8000` (cognify + search when an LLM key is provided). |
+| `test_mcp_health_and_tool_call` | `cognee-mcp` `/health` on `:8001` **and** one real MCP tool call (`list_datasets_json`) over SSE. |
+| `test_service_logs_are_traceback_free` | No service emitted an unhandled Python traceback (runs before the Postgres recreate, which legitimately logs connection errors). |
+| `test_postgres_persistence_across_recreate` | Data added via the API survives a Postgres container **force-recreate** — proving the `postgres_data` volume is required. |
+
+The LLM-dependent leg is **off by default**, so this suite never calls a real
+model ("mock LLM by default").
+
+## Run it locally
+
+```bash
+# 1. Bring the stack up with the same profiles CI uses.
+cp .env.template .env            # set LLM_API_KEY only if you want the LLM leg
+docker compose --profile postgres --profile mcp up -d --build
+
+# 2. Run the suite (compose-driving tests need COGNEE_E2E_MANAGE_COMPOSE=1).
+COGNEE_E2E_MANAGE_COMPOSE=1 \
+  uv run --no-project --with pytest --with requests --with mcp \
+  python -m pytest cognee/tests/e2e/docker_compose -v
+```
+
+## Configuration (all via env vars)
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `COGNEE_API_URL` | `http://localhost:8000` | Main API base URL. |
+| `COGNEE_MCP_URL` | `http://localhost:8001` | MCP service base URL. |
+| `COGNEE_E2E_RUN_LLM` | `0` | Run the cognify/search leg (needs a real LLM key). |
+| `COGNEE_E2E_MANAGE_COMPOSE` | `0` | Allow the suite to drive `docker compose` (persistence + log tests). |
+| `COGNEE_E2E_COMPOSE_PROFILES` | `postgres,mcp` | Profiles passed to `docker compose`. |
+| `COGNEE_E2E_STARTUP_TIMEOUT` | `300` | Seconds to wait for a service to become healthy. |

--- a/cognee/tests/e2e/docker_compose/compose_utils.py
+++ b/cognee/tests/e2e/docker_compose/compose_utils.py
@@ -1,0 +1,91 @@
+"""Thin wrappers around the ``docker compose`` CLI and HTTP health polling.
+
+These helpers let the e2e test orchestrate the parts of the stack it needs:
+waiting on healthchecks (replacing the old ``sleep 30``), recreating a service
+for the persistence check, and reading service logs for the traceback scan.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from typing import List, Optional
+
+import requests
+
+from config import CONFIG
+
+
+class ServiceNotHealthy(AssertionError):
+    """Raised when a service fails to become healthy within the timeout."""
+
+
+def _compose_base_cmd() -> List[str]:
+    cmd = ["docker", "compose", "-f", CONFIG.compose_file]
+    for profile in CONFIG.compose_profiles:
+        cmd += ["--profile", profile]
+    return cmd
+
+
+def compose(*args: str, check: bool = True, capture: bool = False) -> subprocess.CompletedProcess:
+    """Run a ``docker compose`` subcommand against the configured stack."""
+    cmd = _compose_base_cmd() + list(args)
+    return subprocess.run(
+        cmd,
+        check=check,
+        text=True,
+        capture_output=capture,
+    )
+
+
+def service_logs(service: Optional[str] = None) -> str:
+    """Return logs for a single service (or the whole stack when omitted)."""
+    args = ["logs", "--no-color"]
+    if service:
+        args.append(service)
+    result = compose(*args, check=False, capture=True)
+    # `docker compose logs` interleaves stdout/stderr; concatenate both.
+    return (result.stdout or "") + (result.stderr or "")
+
+
+def recreate_service(service: str) -> None:
+    """Force-recreate a single service container.
+
+    Unlike ``restart`` (which reuses the same container and so keeps its
+    writable layer), ``up --force-recreate`` throws the container away and
+    builds a fresh one. Named volumes survive; anything written only to the
+    container layer does not. This is what makes the Postgres persistence
+    check meaningful — without the named volume the data would be gone.
+    """
+    compose("up", "-d", "--force-recreate", "--no-deps", service)
+
+
+def wait_for_http_ok(
+    url: str,
+    *,
+    timeout: Optional[float] = None,
+    poll_interval: Optional[float] = None,
+    name: Optional[str] = None,
+    expect_status: tuple = (200,),
+) -> requests.Response:
+    """Poll ``url`` until it returns an expected status or the timeout elapses."""
+    timeout = CONFIG.startup_timeout if timeout is None else timeout
+    poll_interval = CONFIG.poll_interval if poll_interval is None else poll_interval
+    label = name or url
+
+    deadline = time.monotonic() + timeout
+    last_error: Optional[str] = None
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(url, timeout=10)
+            if response.status_code in expect_status:
+                return response
+            last_error = f"HTTP {response.status_code}"
+        except requests.RequestException as exc:
+            last_error = repr(exc)
+        time.sleep(poll_interval)
+
+    raise ServiceNotHealthy(
+        f"Service '{label}' did not become healthy within {timeout:.0f}s "
+        f"(last error: {last_error})."
+    )

--- a/cognee/tests/e2e/docker_compose/config.py
+++ b/cognee/tests/e2e/docker_compose/config.py
@@ -1,0 +1,88 @@
+"""Configuration for the docker-compose full-stack end-to-end test.
+
+Everything is driven by environment variables so the same test runs unchanged
+in CI (where the workflow brings the stack up) and on a developer machine
+(where you bring the stack up yourself with ``docker compose up``).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import List
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class E2EConfig:
+    """Resolved settings for the full-stack e2e run."""
+
+    # Public API of the main `cognee` service (compose port 8000).
+    api_url: str = field(
+        default_factory=lambda: os.getenv("COGNEE_API_URL", "http://localhost:8000")
+    )
+    # Public endpoint of the `cognee-mcp` service (compose port 8001 -> 8000).
+    mcp_url: str = field(
+        default_factory=lambda: os.getenv("COGNEE_MCP_URL", "http://localhost:8001")
+    )
+
+    # Seeded default account created on first boot.
+    username: str = field(
+        default_factory=lambda: os.getenv("COGNEE_DEFAULT_USER", "default_user@example.com")
+    )
+    password: str = field(
+        default_factory=lambda: os.getenv("COGNEE_DEFAULT_PASSWORD", "default_password")
+    )
+
+    # How long to wait for a freshly-started service to report healthy.
+    startup_timeout: float = field(
+        default_factory=lambda: float(os.getenv("COGNEE_E2E_STARTUP_TIMEOUT", "300"))
+    )
+    poll_interval: float = field(
+        default_factory=lambda: float(os.getenv("COGNEE_E2E_POLL_INTERVAL", "3"))
+    )
+
+    # Run the LLM-dependent leg of the golden flow (cognify + search).
+    # Off by default -> the PR-blocking run never touches a real LLM ("mock LLM
+    # by default"). Turn on locally with COGNEE_E2E_RUN_LLM=1 and a real key.
+    run_llm: bool = field(default_factory=lambda: _env_bool("COGNEE_E2E_RUN_LLM", False))
+
+    # Whether this process is allowed to drive `docker compose` (restart a
+    # service for the persistence check, read logs for the traceback check).
+    # The CI workflow sets this to 1; a developer hitting an already-running
+    # stack can leave it off to skip the compose-driving tests.
+    manage_compose: bool = field(
+        default_factory=lambda: _env_bool("COGNEE_E2E_MANAGE_COMPOSE", False)
+    )
+
+    compose_file: str = field(
+        default_factory=lambda: os.getenv("COGNEE_E2E_COMPOSE_FILE", "docker-compose.yml")
+    )
+    compose_profiles: List[str] = field(
+        default_factory=lambda: [
+            p.strip()
+            for p in os.getenv("COGNEE_E2E_COMPOSE_PROFILES", "postgres,mcp").split(",")
+            if p.strip()
+        ]
+    )
+
+    @property
+    def health_url(self) -> str:
+        return f"{self.api_url.rstrip('/')}/health"
+
+    @property
+    def mcp_health_url(self) -> str:
+        return f"{self.mcp_url.rstrip('/')}/health"
+
+    @property
+    def mcp_sse_url(self) -> str:
+        return f"{self.mcp_url.rstrip('/')}/sse"
+
+
+CONFIG = E2EConfig()

--- a/cognee/tests/e2e/docker_compose/conftest.py
+++ b/cognee/tests/e2e/docker_compose/conftest.py
@@ -1,0 +1,51 @@
+"""Fixtures for the docker-compose full-stack e2e suite.
+
+The suite assumes the stack is already up (the CI workflow brings it up before
+invoking pytest; locally you run ``docker compose --profile postgres --profile
+mcp up -d``). The session-scoped fixtures below block until each service is
+healthy, so no test races the stack's startup.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# This suite is intentionally NOT part of the importable `cognee` package: it
+# only talks to the running stack over HTTP, so it must collect on a minimal
+# runner that has not installed cognee. Put this directory on sys.path so the
+# sibling helper modules import as top-level (`from config import ...`) without
+# dragging in `cognee/__init__.py` and its heavy dependency tree.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pytest  # noqa: E402
+
+from compose_utils import wait_for_http_ok  # noqa: E402
+from config import CONFIG  # noqa: E402
+
+
+@pytest.fixture(scope="session")
+def config():
+    return CONFIG
+
+
+@pytest.fixture(scope="session")
+def api_ready(config):
+    """Block until the main cognee API reports healthy on :8000."""
+    wait_for_http_ok(config.health_url, name="cognee API (:8000)")
+    return config.api_url
+
+
+@pytest.fixture(scope="session")
+def mcp_ready(config):
+    """Block until the MCP service reports healthy on :8001."""
+    wait_for_http_ok(config.mcp_health_url, name="cognee-mcp (:8001)")
+    return config.mcp_url
+
+
+@pytest.fixture(scope="session")
+def requires_compose(config):
+    """Skip compose-driving tests when this process can't run docker compose."""
+    if not config.manage_compose:
+        pytest.skip("compose-driving test skipped (set COGNEE_E2E_MANAGE_COMPOSE=1 to enable)")
+    return config

--- a/cognee/tests/e2e/docker_compose/golden_flow.py
+++ b/cognee/tests/e2e/docker_compose/golden_flow.py
@@ -1,0 +1,175 @@
+"""The golden flow exercised against the running cognee API on :8000.
+
+``golden_flow()`` walks the core public contract a real client depends on:
+
+    health  ->  login  ->  add  ->  list datasets  ->  list data  ->  status
+
+and, only when explicitly asked (a real LLM key is configured), the heavier
+``cognify -> search`` leg. The ingestion leg needs no LLM, so the default
+PR-blocking run stays fully mocked.
+
+The function returns a :class:`GoldenFlowResult` so callers (the persistence
+test) can re-check that the same dataset is still there after a restart.
+"""
+
+from __future__ import annotations
+
+import io
+import time
+import uuid
+from dataclasses import dataclass
+from typing import List, Optional
+
+import requests
+
+from config import CONFIG
+
+
+@dataclass
+class GoldenFlowResult:
+    token: str
+    dataset_name: str
+    dataset_id: str
+    data_count: int
+    searched: bool = False
+
+
+def _auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def login(api_url: str, username: str, password: str) -> str:
+    """Authenticate against the seeded default account and return a bearer token."""
+    response = requests.post(
+        f"{api_url}/api/v1/auth/login",
+        data={"username": username, "password": password},
+        timeout=30,
+    )
+    response.raise_for_status()
+    token = response.json().get("access_token")
+    assert token, f"login returned no access_token: {response.text}"
+    return token
+
+
+def check_liveness(api_url: str) -> None:
+    """Root + health endpoints behave as the public contract promises."""
+    root = requests.get(f"{api_url}/", timeout=15)
+    assert root.status_code == 200, f"GET / -> {root.status_code}"
+    assert root.json().get("message") == "Hello, World, I am alive!", root.text
+
+    health = requests.get(f"{api_url}/health", timeout=15)
+    assert health.status_code == 200, f"GET /health -> {health.status_code}"
+
+
+def add_text(api_url: str, token: str, dataset_name: str, text: str) -> dict:
+    """Upload an in-memory text document to a dataset (synchronous ingestion)."""
+    files = {"data": (f"{dataset_name}.txt", io.BytesIO(text.encode("utf-8")), "text/plain")}
+    response = requests.post(
+        f"{api_url}/api/v1/add",
+        headers=_auth_header(token),
+        data={"datasetName": dataset_name, "run_in_background": "false"},
+        files=files,
+        timeout=120,
+    )
+    assert response.status_code in (200, 201), f"add -> {response.status_code}: {response.text}"
+    return response.json()
+
+
+def find_dataset(api_url: str, token: str, dataset_name: str) -> Optional[dict]:
+    response = requests.get(f"{api_url}/api/v1/datasets", headers=_auth_header(token), timeout=30)
+    response.raise_for_status()
+    for dataset in response.json():
+        if dataset.get("name") == dataset_name:
+            return dataset
+    return None
+
+
+def wait_for_dataset(
+    api_url: str, token: str, dataset_name: str, *, timeout: float = 120.0
+) -> dict:
+    """Poll the datasets listing until our dataset shows up after an add."""
+    deadline = time.monotonic() + timeout
+    last: Optional[dict] = None
+    while time.monotonic() < deadline:
+        last = find_dataset(api_url, token, dataset_name)
+        if last is not None:
+            return last
+        time.sleep(2)
+    raise AssertionError(f"dataset '{dataset_name}' never appeared after add")
+
+
+def list_dataset_data(api_url: str, token: str, dataset_id: str) -> List[dict]:
+    response = requests.get(
+        f"{api_url}/api/v1/datasets/{dataset_id}/data",
+        headers=_auth_header(token),
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def cognify_and_search(api_url: str, token: str, dataset_name: str) -> None:
+    """LLM-dependent leg: build the graph and run one search against it."""
+    cognify = requests.post(
+        f"{api_url}/api/v1/cognify",
+        headers=_auth_header(token),
+        json={"datasets": [dataset_name], "run_in_background": False},
+        timeout=900,
+    )
+    assert cognify.status_code in (200, 201), f"cognify -> {cognify.status_code}: {cognify.text}"
+
+    search = requests.post(
+        f"{api_url}/api/v1/search",
+        headers=_auth_header(token),
+        json={
+            "query": "What is this document about?",
+            "search_type": "GRAPH_COMPLETION",
+            "datasets": [dataset_name],
+        },
+        timeout=300,
+    )
+    assert search.status_code == 200, f"search -> {search.status_code}: {search.text}"
+    assert search.json(), "search returned an empty result"
+
+
+def golden_flow(
+    api_url: Optional[str] = None,
+    *,
+    token: Optional[str] = None,
+    dataset_name: Optional[str] = None,
+    run_llm: Optional[bool] = None,
+) -> GoldenFlowResult:
+    """Run the end-to-end golden flow against the API and return what was created."""
+    api_url = (api_url or CONFIG.api_url).rstrip("/")
+    run_llm = CONFIG.run_llm if run_llm is None else run_llm
+    dataset_name = dataset_name or f"e2e_{uuid.uuid4().hex[:8]}"
+
+    check_liveness(api_url)
+    token = token or login(api_url, CONFIG.username, CONFIG.password)
+
+    add_text(
+        api_url,
+        token,
+        dataset_name,
+        "Cognee turns documents into a queryable knowledge graph. "
+        "This text is ingested by the docker-compose end-to-end test.",
+    )
+
+    dataset = wait_for_dataset(api_url, token, dataset_name)
+    dataset_id = str(dataset["id"])
+
+    data = list_dataset_data(api_url, token, dataset_id)
+    assert data, f"dataset '{dataset_name}' has no data items after add"
+
+    searched = False
+    if run_llm:
+        cognify_and_search(api_url, token, dataset_name)
+        searched = True
+
+    return GoldenFlowResult(
+        token=token,
+        dataset_name=dataset_name,
+        dataset_id=dataset_id,
+        data_count=len(data),
+        searched=searched,
+    )

--- a/cognee/tests/e2e/docker_compose/mcp_client.py
+++ b/cognee/tests/e2e/docker_compose/mcp_client.py
@@ -1,0 +1,57 @@
+"""Minimal MCP-over-SSE client used to make one real tool call against :8001.
+
+The ``cognee-mcp`` service runs with ``TRANSPORT_MODE=sse``, so it speaks the
+standard MCP SSE protocol at ``/sse``. We use the official ``mcp`` client to
+initialize a session, confirm the tool surface, and call one LLM-free tool
+(``list_datasets_json``) end to end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, List
+
+from config import CONFIG
+
+
+@dataclass
+class McpToolCall:
+    tools: List[str]
+    result_text: str
+    structured: Any
+
+
+async def _call_list_datasets(sse_url: str) -> McpToolCall:
+    # Imported lazily so the rest of the suite still collects if `mcp` (the
+    # client library) is not installed in the runner's environment.
+    from mcp import ClientSession
+    from mcp.client.sse import sse_client
+
+    async with sse_client(sse_url, timeout=30) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools_result = await session.list_tools()
+            tool_names = [tool.name for tool in tools_result.tools]
+            # The server gates tools/list behind a tool-search transform
+            # (COGNEE_MCP_TOOL_MODE), so only assert on the memory API surface
+            # that every mode advertises. Hidden tools stay directly callable
+            # by name — that is the contract the workspace UI relies on.
+            missing = {"remember", "recall", "forget"} - set(tool_names)
+            assert not missing, (
+                f"MCP server is missing memory tools {sorted(missing)}; "
+                f"exposes: {sorted(tool_names)}"
+            )
+
+            call = await session.call_tool("list_datasets_json", arguments={})
+            assert not getattr(call, "isError", False), f"tool call errored: {call}"
+
+            text = "\n".join(getattr(item, "text", str(item)) for item in (call.content or []))
+            structured = getattr(call, "structuredContent", None)
+            return McpToolCall(tools=tool_names, result_text=text, structured=structured)
+
+
+def call_mcp_tool(sse_url: str | None = None) -> McpToolCall:
+    """Synchronously drive one real MCP tool call over SSE."""
+    return asyncio.run(_call_list_datasets(sse_url or CONFIG.mcp_sse_url))

--- a/cognee/tests/e2e/docker_compose/test_full_stack_e2e.py
+++ b/cognee/tests/e2e/docker_compose/test_full_stack_e2e.py
@@ -1,0 +1,110 @@
+"""Full-stack end-to-end test for the docker-compose deployment.
+
+Complements the workflow-level remember/recall smoke test in
+``.github/workflows/docker_compose.yml`` with a real assertion suite:
+
+* the golden flow against the cognee API on :8000,
+* a real MCP tool call against the cognee-mcp service on :8001,
+* a traceback scan over every service's logs, and
+* Postgres-backed persistence across a container recreate.
+
+By default the LLM-dependent leg (cognify/search) is skipped, so this suite
+never calls a real model ("mock LLM by default"). Set ``COGNEE_E2E_RUN_LLM=1``
+with a real key to exercise it.
+
+Ordering matters: the traceback scan runs *before* the persistence test,
+because force-recreating Postgres legitimately drops the API's live database
+connections and the resulting (recovered-from) errors may be logged with
+tracebacks.
+"""
+
+from __future__ import annotations
+
+import time
+
+import requests
+
+from compose_utils import recreate_service, service_logs, wait_for_http_ok
+from config import CONFIG
+from golden_flow import find_dataset, golden_flow, login
+from mcp_client import call_mcp_tool
+
+# Services whose logs must be free of Python tracebacks.
+LOG_SERVICES = ("cognee", "cognee-mcp", "postgres")
+
+
+def test_golden_flow_api(api_ready):
+    """health -> login -> add -> datasets -> data (+ optional cognify/search)."""
+    result = golden_flow(api_ready)
+
+    assert result.dataset_id
+    assert result.data_count >= 1
+    if CONFIG.run_llm:
+        assert result.searched, "LLM run requested but search leg did not execute"
+
+
+def test_mcp_health_and_tool_call(mcp_ready):
+    """MCP service is healthy and a real tool call returns structured content."""
+    health = wait_for_http_ok(CONFIG.mcp_health_url, name="cognee-mcp /health")
+    assert health.json().get("status") == "ok", health.text
+
+    call = call_mcp_tool()
+    # `list_datasets_json` returns {"datasets": [...]} in structuredContent.
+    assert call.structured is not None, "MCP tool returned no structured content"
+    assert "datasets" in call.structured, call.structured
+    assert isinstance(call.structured["datasets"], list)
+
+
+def test_service_logs_are_traceback_free(requires_compose):
+    """No service should have emitted an unhandled Python traceback.
+
+    Must run before the persistence test: recreating Postgres drops the API's
+    live connections, and those transient (handled) failures can be logged
+    with tracebacks.
+    """
+    offenders = {}
+    for service in LOG_SERVICES:
+        logs = service_logs(service)
+        if "Traceback (most recent call last)" in logs:
+            tail = "\n".join(logs.splitlines()[-40:])
+            offenders[service] = tail
+
+    assert not offenders, "Tracebacks found in service logs:\n" + "\n\n".join(
+        f"--- {svc} ---\n{tail}" for svc, tail in offenders.items()
+    )
+
+
+def test_postgres_persistence_across_recreate(requires_compose, api_ready):
+    """Data added through the API survives a Postgres container recreate.
+
+    A force-recreate discards the container's writable layer, so the dataset
+    only survives if Postgres data lives on the named volume. This makes the
+    volume requirement explicit: comment the volume out and this test fails.
+    """
+    result = golden_flow(api_ready)
+
+    recreate_service("postgres")
+
+    # Postgres comes back on a fresh container; wait for it (and the API) again.
+    wait_for_http_ok(CONFIG.health_url, name="cognee API after postgres recreate")
+
+    # The app re-establishes its connection pool after the DB bounced, so the
+    # first requests may fail transiently — keep retrying until the deadline.
+    deadline = time.monotonic() + 90
+    dataset = None
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            token = login(api_ready, CONFIG.username, CONFIG.password)
+            dataset = find_dataset(api_ready, token, result.dataset_name)
+            if dataset is not None:
+                break
+        except (requests.RequestException, AssertionError) as exc:
+            last_error = exc
+        time.sleep(3)
+
+    assert dataset is not None, (
+        f"dataset '{result.dataset_name}' did not survive the Postgres recreate — "
+        "the postgres_data volume is likely missing from docker-compose.yml "
+        f"(last error: {last_error!r})"
+    )

--- a/cognee/tests/unit/api/test_health_checker.py
+++ b/cognee/tests/unit/api/test_health_checker.py
@@ -5,31 +5,34 @@ from unittest.mock import patch
 from cognee.api.v1.health.health import HealthChecker, HealthStatus
 from cognee.base_config import get_base_config
 
+
 @pytest.mark.asyncio
 async def test_health_check_does_not_delete_existing_file():
     """Test that check_file_storage does not overwrite or delete an existing health_check_test file."""
     config = get_base_config()
     test_dir = config.data_root_directory
     os.makedirs(test_dir, exist_ok=True)
-    
+
     # Create a dummy file that simulates existing user data that happens to be named "health_check_test"
     existing_file = os.path.join(test_dir, "health_check_test")
     with open(existing_file, "w") as f:
         f.write("important_user_data")
-        
+
     checker = HealthChecker()
-    
+
     # Run the check
     result = await checker.check_file_storage()
-    
+
     # The check should be healthy
     assert result.status == HealthStatus.HEALTHY
-    
+
     # The existing file should still exist and its content should be untouched
     assert os.path.exists(existing_file), "The existing file was deleted by the health check!"
     with open(existing_file, "r") as f:
         content = f.read()
-    assert content == "important_user_data", "The existing file was overwritten by the health check!"
-    
+    assert content == "important_user_data", (
+        "The existing file was overwritten by the health check!"
+    )
+
     # Clean up
     os.remove(existing_file)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,13 @@ services:
       # (the MCP server still listens on 8000 inside the container).
       - "8001:8000" # MCP port
       - "5679:5678" # MCP debugger port
+    healthcheck:
+      # The MCP runtime image is python-slim (no curl), so probe with urllib.
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health', timeout=5).status==200 else 1)"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     deploy:
       resources:
         limits:
@@ -126,11 +133,21 @@ services:
       POSTGRES_USER: cognee
       POSTGRES_PASSWORD: cognee
       POSTGRES_DB: cognee_db
-      # - postgres_data:/var/lib/postgresql/data
+    # Persist data on a named volume so it survives container recreate. The
+    # docker-compose e2e (test_postgres_persistence_across_recreate) depends on
+    # this — without it, a recreated postgres container starts empty.
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
     ports:
       - 5432:5432
     networks:
       - cognee-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cognee -d cognee_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
## Goal

The docker-compose CI job's remember/recall round-trip covers the main API, but nothing exercised the **cognee-mcp service**, **Postgres-backed persistence**, or **service log hygiene**. This adds a real full-stack e2e suite to the same job.

Supersedes #3721 (rebased onto current `dev` and fixed up). Closes #3360.

## What the new suite does

New pytest package: `cognee/tests/e2e/docker_compose/` — it only talks to the running stack over HTTP, so it's decoupled from the `cognee` package (top-level imports + `--confcutdir`) and runs in an ephemeral `uv run --no-project --with pytest --with requests --with mcp` env.

| Test | Asserts |
| --- | --- |
| `test_golden_flow_api` | `health → login → add → datasets → data` against the API on `:8000`. Optional `cognify → search` leg gated behind `COGNEE_E2E_RUN_LLM` (off by default — the suite itself calls no model). |
| `test_mcp_health_and_tool_call` | `cognee-mcp` `/health` on `:8001` **and** one real MCP tool call (`list_datasets_json`) over SSE using the official `mcp` client, asserting on `structuredContent`. |
| `test_service_logs_are_traceback_free` | No Python traceback in `cognee` / `cognee-mcp` / `postgres` logs. Ordered **before** the Postgres recreate, which legitimately logs transient reconnect errors. |
| `test_postgres_persistence_across_recreate` | Data added via the API survives `docker compose up --force-recreate postgres`. Makes the volume requirement **explicit**: without the `postgres_data` volume the recreated container starts empty and the test fails. Tolerates transient connection errors while the app's pool re-establishes. |

## Workflow changes (`.github/workflows/docker_compose.yml`)

- Bring the stack up with `COMPOSE_PROFILES=postgres,mcp`; start postgres first and gate on `pg_isready` (no `depends_on` in compose).
- Point the relational store at the postgres service (via the same `.env` compose uses for `${DB_*}` interpolation), so the whole job — including the existing remember/recall round-trip — runs genuinely Postgres-backed.
- Health-gate `:8001` alongside `:8000`.
- Run the e2e suite **before** the real-LLM remember/recall round-trip, so the traceback scan only covers deterministic, LLM-free paths and can't flake on model-provider noise.
- Dump **all** service logs (secret-filtered, same grep as before) on failure; tear down with `down -v`.

The existing remember/recall round-trip smoke test is kept unchanged as the final step.

## Compose changes (`docker-compose.yml`)

- Mount the `postgres_data` named volume — it was commented out **and mis-nested under `environment:`** — and add a `pg_isready` healthcheck.
- Add a `urllib`-based healthcheck to `cognee-mcp` (its slim image has no `curl`).

## Fix-ups relative to #3721

- Rebased onto current `dev`: the workflow there had since gained the secrets-based `.env` and the remember/recall round-trip; this PR merges the two rather than replacing one with the other (job id and check name unchanged).
- Reordered the log scan before the persistence test and made the persistence re-check tolerate transient 5xx/connection errors right after the DB bounce (previously a single `raise_for_status` inside the retry loop could fail the test spuriously).
- Verified against current `dev`: `/api/v1/add` form contract, datasets endpoints, MCP `/health` route, `list_datasets_json` structured shape, FastMCP host-guard (`localhost:*` covers the `:8001` host port), and that both images ship Postgres drivers.
- The MCP test now asserts on the always-advertised memory surface (`remember`/`recall`/`forget`) instead of requiring `list_datasets_json` in `tools/list` — the server gates listing behind FastMCP's tool-search transform (`COGNEE_MCP_TOOL_MODE`), while hidden tools stay directly callable by name (the workspace-UI contract). The test still makes the real `list_datasets_json` call.
- Ruff (0.15.11, repo config) + pre-commit clean; suite collects standalone via `--confcutdir` without installing cognee.
- Includes a mechanical pre-commit fix for `cognee/api/v1/health/health.py` + `cognee/tests/unit/api/test_health_checker.py` from #4528 — `dev` is currently red on the pre-commit gate for every PR.

## Running locally

```bash
cp .env.template .env
docker compose --profile postgres --profile mcp up -d --build
COGNEE_E2E_MANAGE_COMPOSE=1 \
  uv run --no-project --with pytest --with requests --with mcp \
  python -m pytest cognee/tests/e2e/docker_compose -v \
  --confcutdir=cognee/tests/e2e/docker_compose
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

