### PR TITLE
fix(tests): Unbreak reingest data_size test on dev (COG-6239)

### DIFF
--- a/cognee/api/v1/health/health.py
+++ b/cognee/api/v1/health/health.py
@@ -159,12 +159,15 @@ class HealthChecker:
             provider = "s3" if base_config.data_root_directory.startswith("s3://") else "local"
 
             import uuid
+
             test_id = str(uuid.uuid4())
             # Test storage accessibility - for local storage, just check directory exists
             if provider == "local":
                 os.makedirs(base_config.data_root_directory, exist_ok=True)
                 # Simple write/read test
-                test_file = os.path.join(base_config.data_root_directory, f"health_check_test_{test_id}")
+                test_file = os.path.join(
+                    base_config.data_root_directory, f"health_check_test_{test_id}"
+                )
                 with open(test_file, "w") as f:
                     f.write("test")
                 os.remove(test_file)

--- a/cognee/tests/unit/api/test_health_checker.py
+++ b/cognee/tests/unit/api/test_health_checker.py
@@ -5,31 +5,34 @@ from unittest.mock import patch
 from cognee.api.v1.health.health import HealthChecker, HealthStatus
 from cognee.base_config import get_base_config
 
+
 @pytest.mark.asyncio
 async def test_health_check_does_not_delete_existing_file():
     """Test that check_file_storage does not overwrite or delete an existing health_check_test file."""
     config = get_base_config()
     test_dir = config.data_root_directory
     os.makedirs(test_dir, exist_ok=True)
-    
+
     # Create a dummy file that simulates existing user data that happens to be named "health_check_test"
     existing_file = os.path.join(test_dir, "health_check_test")
     with open(existing_file, "w") as f:
         f.write("important_user_data")
-        
+
     checker = HealthChecker()
-    
+
     # Run the check
     result = await checker.check_file_storage()
-    
+
     # The check should be healthy
     assert result.status == HealthStatus.HEALTHY
-    
+
     # The existing file should still exist and its content should be untouched
     assert os.path.exists(existing_file), "The existing file was deleted by the health check!"
     with open(existing_file, "r") as f:
         content = f.read()
-    assert content == "important_user_data", "The existing file was overwritten by the health check!"
-    
+    assert content == "important_user_data", (
+        "The existing file was overwritten by the health check!"
+    )
+
     # Clean up
     os.remove(existing_file)

--- a/cognee/tests/unit/tasks/ingestion/test_ingest_update_data_size.py
+++ b/cognee/tests/unit/tasks/ingestion/test_ingest_update_data_size.py
@@ -72,6 +72,9 @@ async def _make_engine():
                 name="doc.txt",
                 content_hash="old-hash",
                 data_size=OLD_SIZE,
+                # Rows are dataset-scoped: the update branch refuses to mutate a
+                # row owned by a different dataset (foreign-pin guard).
+                dataset_id=DATASET_ID,
             )
         )
         await session.commit()
@@ -84,7 +87,12 @@ def _install_mocks(stack, engine):
     storage, loaders, or dataset/permission machinery — only the relational
     engine is real."""
     meta = _metadata()
-    classified = SimpleNamespace(get_metadata=lambda: meta)
+    # get_identifier feeds the pre-loop's batch dedup (batch_id_by_hash); the
+    # mocked `identify` already returns DATA_ID, so the value only has to exist.
+    classified = SimpleNamespace(
+        get_metadata=lambda: meta,
+        get_identifier=lambda: meta["content_hash"],
+    )
     # A real (transient) mapped Dataset: store_data_to_dataset does `dataset in
     # session` / session.add / session.merge, which require a mapped instance.
     dataset = Dataset(id=DATASET_ID, name="ds", owner_id=USER.id)


### PR DESCRIPTION
## Description

`test_reingest_updates_persisted_data_size` fails on **every unit-test CI job on `dev`** (e.g. [Test Suites run 32236761861](https://github.com/topoteretes/cognee/actions/runs/32236761861)) with:

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'get_identifier'
```

so every PR into `dev` currently shows red unit matrices.

Linear: COG-6239

### Root cause

PR #3161 (`fix(ingestion): persist data_size on re-ingest update`, commit `710755406`) wrote this test against an older `ingest_data.py` and crossed with two changes that landed alongside it:

1. The batch-dedup pre-loop in `ingest_data.py` now calls `classified_data.get_identifier()` before reaching the update branch — the test's `ingestion.classify` mock (`SimpleNamespace(get_metadata=...)`) doesn't provide it.
2. The foreign-pin guard refuses to update a `Data` row whose `dataset_id` differs from the target dataset — the test seeded its row without `dataset_id`, so after fixing (1) the update branch raised `IngestionError: Data id ... is not available in dataset ...`.

### Fix (test-only, no production code touched)

- Give the `classify` mock a `get_identifier` returning the metadata's `content_hash`.
- Seed the existing `Data` row with `dataset_id=DATASET_ID` so the update branch is reachable.

The test still exercises exactly what it was written for: the re-ingest UPDATE branch persisting the new `data_size` against a real SQLite relational engine.

## Test plan

- `cognee/tests/unit/tasks/ingestion/` — 47 passed, 4 skipped locally (including the previously failing test).
- `pre-commit` (ruff check + format) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)