### PR TITLE
fix(embeddings): enforce the documented EMBEDDING_RATE_LIMIT_TOKENS budget

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/FastembedEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/FastembedEmbeddingEngine.py
@@ -29,7 +29,10 @@ from cognee.infrastructure.databases.exceptions import (
     EmbeddingException,
 )
 from cognee.infrastructure.llm.tokenizer.resolver import resolve_embedding_tokenizer
-from cognee.shared.rate_limiting import embedding_rate_limiter_context_manager
+from cognee.shared.rate_limiting import (
+    consume_embedding_token_budget,
+    embedding_rate_limiter_context_manager,
+)
 from cognee.infrastructure.databases.vector.embeddings.utils import (
     sanitize_embedding_text_inputs,
     handle_embedding_response,
@@ -123,6 +126,7 @@ class FastembedEmbeddingEngine(EmbeddingEngine):
                 embeddings = [[0.0] * self.dimensions for _ in sanitized_text]
             else:
                 async with embedding_rate_limiter_context_manager():
+                    await consume_embedding_token_budget(self.tokenizer, sanitized_text)
                     embeddings = self.embedding_model.embed(
                         sanitized_text,
                         batch_size=len(sanitized_text),

--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -24,7 +24,10 @@ from cognee.infrastructure.databases.exceptions import (
 )
 
 from cognee.infrastructure.llm.tokenizer.resolver import resolve_embedding_tokenizer
-from cognee.shared.rate_limiting import embedding_rate_limiter_context_manager
+from cognee.shared.rate_limiting import (
+    consume_embedding_token_budget,
+    embedding_rate_limiter_context_manager,
+)
 from cognee.infrastructure.databases.vector.embeddings.utils import (
     sanitize_embedding_text_inputs,
     handle_embedding_response,
@@ -156,6 +159,7 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
                 return [data["embedding"] for data in response["data"]]
             else:
                 async with embedding_rate_limiter_context_manager():
+                    await consume_embedding_token_budget(self.tokenizer, sanitized_text_input)
                     embedding_kwargs = {
                         "model": self.model,
                         "input": sanitized_text_input,

--- a/cognee/infrastructure/databases/vector/embeddings/OllamaEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/OllamaEmbeddingEngine.py
@@ -19,7 +19,10 @@ from tenacity import (
 from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import EmbeddingEngine
 from cognee.infrastructure.databases.exceptions import EmbeddingException
 from cognee.infrastructure.llm.tokenizer.resolver import resolve_embedding_tokenizer
-from cognee.shared.rate_limiting import embedding_rate_limiter_context_manager
+from cognee.shared.rate_limiting import (
+    consume_embedding_token_budget,
+    embedding_rate_limiter_context_manager,
+)
 from cognee.shared.utils import create_secure_ssl_context
 from cognee.infrastructure.databases.vector.embeddings.utils import (
     sanitize_embedding_text_inputs,
@@ -180,6 +183,7 @@ class OllamaEmbeddingEngine(EmbeddingEngine):
         connector = aiohttp.TCPConnector(ssl=ssl_context)
         async with aiohttp.ClientSession(connector=connector) as session:
             async with embedding_rate_limiter_context_manager():
+                await consume_embedding_token_budget(self.tokenizer, prompt)
                 async with session.post(
                     self.endpoint, json=payload, headers=headers, timeout=60.0
                 ) as response:

--- a/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
@@ -41,7 +41,10 @@ from cognee.infrastructure.databases.exceptions import (
     EmbeddingContextWindowTooSmallError,
     EmbeddingException,
 )
-from cognee.shared.rate_limiting import embedding_rate_limiter_context_manager
+from cognee.shared.rate_limiting import (
+    consume_embedding_token_budget,
+    embedding_rate_limiter_context_manager,
+)
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("OpenAICompatibleEmbeddingEngine")
@@ -140,6 +143,7 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
 
         try:
             async with embedding_rate_limiter_context_manager():
+                await consume_embedding_token_budget(self.tokenizer, sanitized_text)
                 response = await asyncio.wait_for(
                     self._client.embeddings.create(
                         model=self.model,

--- a/cognee/infrastructure/databases/vector/embeddings/config.py
+++ b/cognee/infrastructure/databases/vector/embeddings/config.py
@@ -138,6 +138,7 @@ class EmbeddingConfig(BaseSettings):
             "embedding_rate_limit_enabled": self.embedding_rate_limit_enabled,
             "embedding_rate_limit_requests": self.embedding_rate_limit_requests,
             "embedding_rate_limit_interval": self.embedding_rate_limit_interval,
+            "embedding_rate_limit_tokens": self.embedding_rate_limit_tokens,
         }
 
 

--- a/cognee/shared/rate_limiting.py
+++ b/cognee/shared/rate_limiting.py
@@ -7,15 +7,20 @@ policy live in ``cognee.infrastructure.llm.overload_policy``; configuration
 is read at use-time, never snapshotted at import.
 """
 
+import logging
 from contextlib import asynccontextmanager, nullcontext
+from typing import Any, Iterable, Union
 
 from aiolimiter import AsyncLimiter
+
+logger = logging.getLogger(__name__)
 
 # Limiters are built lazily on first use so their budgets bind the resolved
 # configuration (LLMConfig gives local inference servers a smaller default
 # LLM_RATE_LIMIT_REQUESTS) and so importing this module stays dependency-light.
 _llm_rate_limiter: "AsyncLimiter | None" = None
 _embedding_rate_limiter: "AsyncLimiter | None" = None
+_embedding_token_rate_limiter: "AsyncLimiter | None" = None
 
 
 def _get_llm_rate_limiter() -> AsyncLimiter:
@@ -81,3 +86,75 @@ def embedding_rate_limiter_context_manager():
             embedding_config.embedding_rate_limit_interval,
         )
     return _embedding_rate_limiter
+
+
+def count_embedding_tokens(tokenizer: Any, texts: Union[str, Iterable[str]]) -> int:
+    """Size one embedding dispatch in tokens, for EMBEDDING_RATE_LIMIT_TOKENS.
+
+    Returns 0 — "no token budget applies to this dispatch" — whenever the budget
+    is not in force. The configuration is read before the tokenizer runs, so the
+    default path (no budget configured) never pays for tokenization. A tokenizer
+    that cannot size the input also yields 0: a pacing knob must never be able to
+    fail a dispatch.
+    """
+    # NOTE: Import inside function to avoid a circular import at module load
+    # (embedding engines, which EmbeddingConfig is reached through, import
+    # this module).
+    from cognee.infrastructure.databases.vector.embeddings.config import (
+        get_embedding_config,
+    )
+
+    embedding_config = get_embedding_config()
+    if not (
+        embedding_config.embedding_rate_limit_enabled
+        and embedding_config.embedding_rate_limit_tokens > 0
+    ):
+        return 0
+
+    if tokenizer is None:
+        return 0
+
+    if isinstance(texts, str):
+        texts = [texts]
+
+    try:
+        return sum(tokenizer.count_tokens(text) for text in texts)
+    except Exception as error:
+        logger.warning(
+            "Could not count embedding tokens for rate limiting (%s: %s). "
+            "Pacing this dispatch by request count only.",
+            type(error).__name__,
+            error,
+        )
+        return 0
+
+
+async def consume_embedding_token_budget(tokenizer: Any, texts: Union[str, Iterable[str]]) -> None:
+    """Pace one embedding dispatch against EMBEDDING_RATE_LIMIT_TOKENS.
+
+    Called from inside ``embedding_rate_limiter_context_manager()``, which paces
+    requests per interval; this adds the tokens-per-interval budget on the same
+    interval. It is a no-op unless the operator sets a token budget, so the
+    shipped default (0 = disabled) is unchanged.
+    """
+    global _embedding_token_rate_limiter
+    # NOTE: Import inside function to avoid a circular import at module load.
+    from cognee.infrastructure.databases.vector.embeddings.config import (
+        get_embedding_config,
+    )
+
+    token_count = count_embedding_tokens(tokenizer, texts)
+    if token_count <= 0:
+        return
+
+    embedding_config = get_embedding_config()
+    token_budget = embedding_config.embedding_rate_limit_tokens
+    if _embedding_token_rate_limiter is None:
+        _embedding_token_rate_limiter = AsyncLimiter(
+            token_budget, embedding_config.embedding_rate_limit_interval
+        )
+
+    # A single dispatch larger than the whole budget can never be admitted, so
+    # spend one full interval's worth on it rather than raising ValueError out
+    # of the limiter.
+    await _embedding_token_rate_limiter.acquire(min(token_count, token_budget))

--- a/cognee/tests/unit/infrastructure/test_embedding_token_rate_limit.py
+++ b/cognee/tests/unit/infrastructure/test_embedding_token_rate_limit.py
@@ -1,0 +1,138 @@
+import asyncio
+import os
+import time
+
+import pytest
+
+import cognee.shared.rate_limiting as rate_limiting
+from cognee.infrastructure.databases.vector.embeddings.config import (
+    get_embedding_config,
+)
+
+
+class _FixedTokenizer:
+    """Tokenizer stub: every text costs a fixed number of tokens."""
+
+    def __init__(self, tokens_per_text: int):
+        self.tokens_per_text = tokens_per_text
+        self.calls = 0
+
+    def count_tokens(self, text: str) -> int:
+        self.calls += 1
+        return self.tokens_per_text
+
+
+class _BrokenTokenizer:
+    def count_tokens(self, text: str) -> int:
+        raise RuntimeError("tokenizer unavailable")
+
+
+def _configure(enabled: str, requests: str, interval: str, tokens: str) -> None:
+    os.environ["EMBEDDING_RATE_LIMIT_ENABLED"] = enabled
+    os.environ["EMBEDDING_RATE_LIMIT_REQUESTS"] = requests
+    os.environ["EMBEDDING_RATE_LIMIT_INTERVAL"] = interval
+    os.environ["EMBEDDING_RATE_LIMIT_TOKENS"] = tokens
+    get_embedding_config.cache_clear()
+    rate_limiting._embedding_rate_limiter = None
+    rate_limiting._embedding_token_rate_limiter = None
+
+
+@pytest.fixture(autouse=True)
+def _restore_environment():
+    saved = {
+        key: os.environ.get(key)
+        for key in (
+            "EMBEDDING_RATE_LIMIT_ENABLED",
+            "EMBEDDING_RATE_LIMIT_REQUESTS",
+            "EMBEDDING_RATE_LIMIT_INTERVAL",
+            "EMBEDDING_RATE_LIMIT_TOKENS",
+        )
+    }
+    yield
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    get_embedding_config.cache_clear()
+    rate_limiting._embedding_rate_limiter = None
+    rate_limiting._embedding_token_rate_limiter = None
+
+
+def test_count_embedding_tokens_is_zero_when_no_budget_is_configured():
+    """The shipped default (EMBEDDING_RATE_LIMIT_TOKENS=0) must not even tokenize."""
+    _configure(enabled="true", requests="1000", interval="1", tokens="0")
+    tokenizer = _FixedTokenizer(tokens_per_text=10)
+
+    assert rate_limiting.count_embedding_tokens(tokenizer, ["a", "b"]) == 0
+    assert tokenizer.calls == 0
+
+
+def test_count_embedding_tokens_sums_the_batch_when_a_budget_is_set():
+    _configure(enabled="true", requests="1000", interval="1", tokens="100")
+    tokenizer = _FixedTokenizer(tokens_per_text=10)
+
+    assert rate_limiting.count_embedding_tokens(tokenizer, ["a", "b", "c"]) == 30
+    # A bare string is one text, not one text per character.
+    assert rate_limiting.count_embedding_tokens(tokenizer, "a") == 10
+
+
+def test_count_embedding_tokens_survives_a_failing_tokenizer():
+    _configure(enabled="true", requests="1000", interval="1", tokens="100")
+
+    assert rate_limiting.count_embedding_tokens(_BrokenTokenizer(), ["a"]) == 0
+    assert rate_limiting.count_embedding_tokens(None, ["a"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_token_budget_paces_dispatches_that_exceed_it():
+    """Four 30-token dispatches against a 60-token/1s budget must span intervals.
+
+    The request budget is set high enough that it cannot be what paces them.
+    """
+    _configure(enabled="true", requests="1000", interval="1", tokens="60")
+    tokenizer = _FixedTokenizer(tokens_per_text=30)
+
+    async def dispatch():
+        async with rate_limiting.embedding_rate_limiter_context_manager():
+            await rate_limiting.consume_embedding_token_budget(tokenizer, ["one text"])
+
+    started = time.monotonic()
+    await asyncio.gather(*(dispatch() for _ in range(4)))
+    elapsed = time.monotonic() - started
+
+    # 120 tokens against 60 tokens/second cannot clear in under a second.
+    assert elapsed >= 0.9, f"token budget did not pace the dispatches ({elapsed:.2f}s)"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_larger_than_the_whole_budget_is_admitted():
+    """A single oversized dispatch is clamped, not rejected with ValueError."""
+    _configure(enabled="true", requests="1000", interval="1", tokens="10")
+    tokenizer = _FixedTokenizer(tokens_per_text=10_000)
+
+    async with rate_limiting.embedding_rate_limiter_context_manager():
+        await rate_limiting.consume_embedding_token_budget(tokenizer, ["huge"])
+
+
+@pytest.mark.asyncio
+async def test_no_token_budget_leaves_dispatch_unpaced():
+    """With the default token budget, only the request limiter applies."""
+    _configure(enabled="true", requests="1000", interval="1", tokens="0")
+    tokenizer = _FixedTokenizer(tokens_per_text=10_000)
+
+    async def dispatch():
+        async with rate_limiting.embedding_rate_limiter_context_manager():
+            await rate_limiting.consume_embedding_token_budget(tokenizer, ["one text"])
+
+    started = time.monotonic()
+    await asyncio.gather(*(dispatch() for _ in range(8)))
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5, f"unbudgeted dispatches were paced ({elapsed:.2f}s)"
+
+
+def test_token_budget_is_serialized_with_its_siblings():
+    _configure(enabled="true", requests="60", interval="60", tokens="4242")
+
+    assert get_embedding_config().to_dict()["embedding_rate_limit_tokens"] == 4242


### PR DESCRIPTION
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin

## Description

`EMBEDDING_RATE_LIMIT_TOKENS` is a documented knob that does nothing.

It is declared on `EmbeddingConfig` with defined semantics, and documented in `.env.template`:

```python
embedding_rate_limit_tokens: int = 0  # max tokens per interval (0 = disabled)
```

```
#EMBEDDING_RATE_LIMIT_ENABLED=false
#EMBEDDING_RATE_LIMIT_REQUESTS=60
#EMBEDDING_RATE_LIMIT_INTERVAL=60
#EMBEDDING_RATE_LIMIT_TOKENS=0
```

Its three siblings are all consumed: `embedding_rate_limit_enabled` gates the limiter, `..._requests` and `..._interval` size it in `cognee/shared/rate_limiting.py`, and all three are serialized by `EmbeddingConfig.to_dict()`. `embedding_rate_limit_tokens` is the only one of the four read **nowhere in the repository** — not by the limiter, not by `to_dict()`. An operator who sets it gets no error and no pacing.

That gap matters because a requests-per-interval budget does not bound spend or provider-side TPM. 60 requests/minute is wildly different traffic depending on whether each request carries 50 tokens or 8,000, and embedding batches vary by exactly that much — TPM is the limit most embedding providers actually enforce.

### Measured

`EMBEDDING_RATE_LIMIT_ENABLED=true`, `REQUESTS=1000` (deliberately high, so it cannot be what paces anything), `INTERVAL=1`, `TOKENS=60`. Four dispatches of 30 tokens each — 120 tokens against a 60 tokens/second budget:

```
before:  4 dispatches x 30 tokens = 120 tokens vs a 60 tokens/second budget -> 0.00s
after:   4 dispatches x 30 tokens = 120 tokens vs a 60 tokens/second budget -> 1.00s
```

## The change

- `cognee/shared/rate_limiting.py` gains `consume_embedding_token_budget(tokenizer, texts)` and a second `AsyncLimiter` for tokens, built lazily on the same interval as the request limiter.
- The four embedding engines (`LiteLLM`, `OpenAICompatible`, `Fastembed`, `Ollama`) — the only callers of the embedding seam — spend their dispatch against it as the first statement inside the existing `async with embedding_rate_limiter_context_manager():` block. All four already hold a `self.tokenizer` from `resolve_embedding_tokenizer`, and `count_tokens(text) -> int` is on the abstract tokenizer interface, so every adapter implements it.
- `EmbeddingConfig.to_dict()` now serializes the setting next to its siblings.

`embedding_rate_limiter_context_manager()` keeps its existing signature — the token budget is spent by an explicit `await` inside the block rather than through a new parameter, so nothing that already calls the seam has to change.

Three deliberate choices, all so this cannot hurt anyone who has not opted in:

- **The default path costs nothing.** The config is read *before* the tokenizer is touched, and the helper returns immediately unless a budget is in force. With the shipped default (`0 = disabled`) nothing is tokenized and the second limiter is never constructed.
- **A tokenizer that raises degrades to request-only pacing.** A rate-limit knob must not be able to fail a dispatch, so a tokenizer error is logged at warning level and treated as "unsized".
- **An oversized dispatch is clamped, not rejected.** `aiolimiter` raises `ValueError` when `amount > max_rate`, so a batch larger than the whole budget could never be admitted; it spends one full interval's worth instead. Without this, setting a small token budget would turn large batches into hard failures.

I picked wiring the knob over deleting it because its semantics are already published in `.env.template` and in the field comment, and deleting a documented setting is the more disruptive of the two. Happy to switch to removal instead if you would rather not carry the feature.

## Tests

`cognee/tests/unit/infrastructure/test_embedding_token_rate_limit.py`, 7 tests: the default does not tokenize at all (asserted on the stub's call count), a configured budget sums the batch and treats a bare `str` as one text rather than one per character, a failing/absent tokenizer degrades to `0`, a configured budget paces dispatches, an oversized dispatch is admitted, an unbudgeted dispatch is *not* paced, and the setting round-trips through `to_dict()`. **7 failed before the change, 7 passed after.**

No regressions. `pytest cognee/tests/unit/infrastructure/test_embedding_rate_limiting_realistic.py cognee/tests/unit/infrastructure/test_rate_limiting_realistic.py cognee/tests/unit/infrastructure/test_rate_limiting_retry.py cognee/tests/unit/infrastructure/databases/test_rate_limiter.py cognee/tests/unit/infrastructure/llm/test_llm_config_rate_limit_defaults.py` gives **7 failed / 24 passed both with and without this change**. Those 7 are pre-existing and unrelated: `test_llm_config_rate_limit_defaults.py` passes 13/13 when run alone and fails only because earlier modules in that command leave `LLM_RATE_LIMIT_*` set in `os.environ`. My new test file restores the four `EMBEDDING_RATE_LIMIT_*` variables it touches, so it does not add to that leakage.

`ruff check` and `ruff format --check` clean on all 7 files at the pinned `v0.15.11` from `.pre-commit-config.yaml`.

## Note on the branch base

My fork cannot be synced with upstream `dev`: `POST /merge-upstream` is refused (`refusing to allow an OAuth App to create or update workflow .github/workflows/dev_canary_release.yml without workflow scope`), and a ref write to a newer `dev` commit is refused the same way, because my token has no `workflow` scope. The branch therefore sits on an older `dev` commit.

Three of these files moved on `dev` earlier today in 0591107e ("support NVIDIA NIM input_type and dimensions"). Rather than write current-`dev` content onto an old base — which would have shown that commit's changes as mine — each file was edited **in its base-commit form**, and the edits were shaped as pure insertions so they compose with that commit instead of colliding with it. I verified the outcome by merging this branch into `dev` locally: it auto-merges with no conflicts, and the merged `OpenAICompatibleEmbeddingEngine.py` keeps 0591107e's `create_kwargs`/`input_type` restructure with the budget call correctly placed inside the limiter block. `compare/dev...` shows 1 commit ahead and only this change. The verification above was run against that merged state, not just against the base. Say the word if you would still prefer a rebase and I will find a way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
