### PR TITLE
fix(ingestion): Open ~4 DB sessions per added file, not ~12 (CLO-590)

### DIFF
--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -223,19 +223,6 @@ async def add(
                 transformed[item] = {}
         preferred_loaders = transformed
 
-    tasks = [
-        Task(resolve_data_directories, include_subdirectories=True),
-        Task(
-            ingest_data,
-            dataset_name,
-            user,
-            node_set,
-            dataset_id,
-            preferred_loaders,
-            importance_weight,
-        ),
-    ]
-
     await setup()
 
     # The pipeline-run log writers INSERT the operation-record columns
@@ -258,6 +245,23 @@ async def add(
     user, authorized_dataset = await resolve_authorized_user_dataset(
         dataset_name=dataset_name, dataset_id=dataset_id, user=user
     )
+
+    # The dataset is resolved (created if needed) and write-checked above; hand
+    # its id to the ingestion task so it does not resolve the name again on
+    # every item (the pipeline also passes the dataset via ctx — this keeps the
+    # non-pipeline fallback on the cheap branch too).
+    tasks = [
+        Task(resolve_data_directories, include_subdirectories=True),
+        Task(
+            ingest_data,
+            dataset_name,
+            user,
+            node_set,
+            authorized_dataset.id,
+            preferred_loaders,
+            importance_weight,
+        ),
+    ]
 
     # Expand DLT resources (and auto-detected CSV/connection strings) into
     # standard DataItems before the pipeline sees them. orphan_cleanup (when

--- a/cognee/modules/ingestion/__init__.py
+++ b/cognee/modules/ingestion/__init__.py
@@ -1,5 +1,5 @@
 from .classify import classify
-from .identify import identify
+from .identify import identify, identify_data
 from .identify_many import identify_many
 from .save_data_to_file import save_data_to_file
 from .get_matched_datasets import get_matched_datasets

--- a/cognee/modules/ingestion/identify.py
+++ b/cognee/modules/ingestion/identify.py
@@ -2,12 +2,31 @@ from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.data.models.Data import Data
 from cognee.modules.users.models import User
 
 from .data_types import IngestionData
+
+
+def content_hash_predicates(content_hash: str, user: User, dataset_id: UUID) -> tuple:
+    """The dedup predicate every ingestion lookup shares.
+
+    Dedup is scoped to (dataset, owner, tenant): in a shared multi-writer
+    dataset, two users adding the same bytes stay two rows — matching the
+    old per-user identity semantics and keeping owner_id checks meaningful.
+    ``identify``, ``identify_data`` and ``identify_many`` must agree on which
+    row wins for a given hash, so they all build their filter here.
+    """
+    tenant_filter = Data.tenant_id == user.tenant_id if user.tenant_id else Data.tenant_id.is_(None)
+    return (
+        Data.dataset_id == dataset_id,
+        Data.content_hash == content_hash,
+        Data.owner_id == user.id,
+        tenant_filter,
+    )
 
 
 async def identify(data: IngestionData, user: User, dataset_id: UUID) -> Optional[UUID]:
@@ -23,21 +42,41 @@ async def identify(data: IngestionData, user: User, dataset_id: UUID) -> Optiona
     content_hash: str = data.get_identifier()
     db_engine = get_relational_engine()
 
-    # Dedup is scoped to (dataset, owner, tenant): in a shared multi-writer
-    # dataset, two users adding the same bytes stay two rows — matching the
-    # old per-user identity semantics and keeping owner_id checks meaningful.
-    tenant_filter = Data.tenant_id == user.tenant_id if user.tenant_id else Data.tenant_id.is_(None)
-
     async with db_engine.get_async_session() as session:
         return (
             await session.execute(
                 select(Data.id)
-                .filter(
-                    Data.dataset_id == dataset_id,
-                    Data.content_hash == content_hash,
-                    Data.owner_id == user.id,
-                    tenant_filter,
-                )
+                .filter(*content_hash_predicates(content_hash, user, dataset_id))
                 .limit(1)
             )
         ).scalar_one_or_none()
+
+
+async def identify_data(
+    data: IngestionData,
+    user: User,
+    dataset_id: UUID,
+    session: Optional[AsyncSession] = None,
+) -> Optional[Data]:
+    """:func:`identify`, but return the whole row instead of its id.
+
+    Callers that need the row's columns right after resolving it — the
+    incremental pipeline wrapper reads ``pipeline_status`` — used to pay a
+    second session (and, under ``NullPool``, a second TLS+SCRAM connection)
+    to fetch by the id ``identify`` had just returned. One scoped probe
+    returns the same row. Pass ``session`` to run inside a session the
+    caller already holds (e.g. the one that goes on to update the row).
+    """
+    content_hash: str = data.get_identifier()
+    predicates = content_hash_predicates(content_hash, user, dataset_id)
+
+    async def _lookup(active_session: AsyncSession) -> Optional[Data]:
+        return (
+            await active_session.execute(select(Data).filter(*predicates).limit(1))
+        ).scalar_one_or_none()
+
+    if session is not None:
+        return await _lookup(session)
+
+    async with get_relational_engine().get_async_session() as own_session:
+        return await _lookup(own_session)

--- a/cognee/modules/ingestion/identify_many.py
+++ b/cognee/modules/ingestion/identify_many.py
@@ -1,6 +1,8 @@
+from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.data.models.Data import Data
@@ -16,6 +18,7 @@ async def identify_many(
     hashes: list[str],
     user: User,
     dataset_id: UUID,
+    session: Optional[AsyncSession] = None,
 ) -> dict[str, UUID]:
     """Batch version of :func:`identify`: resolve existing ``Data`` rows for
     multiple content hashes in one dataset.
@@ -28,6 +31,11 @@ async def identify_many(
     both functions always agree on which row wins for a given hash.  Large
     inputs are chunked into batches of at most :data:`_CHUNK_SIZE` hashes to
     stay within SQLite's bind-parameter limit.
+
+    Pass ``session`` to run the lookup inside a session the caller already
+    holds instead of opening one: under ``NullPool`` (the cloud pods) every
+    session is a fresh TLS+SCRAM connection, so the add path groups its
+    read-only lookups into one.
     """
     if not hashes:
         return {}
@@ -37,13 +45,12 @@ async def identify_many(
     # old per-user identity semantics and keeping owner_id checks meaningful.
     tenant_filter = Data.tenant_id == user.tenant_id if user.tenant_id else Data.tenant_id.is_(None)
 
-    db_engine = get_relational_engine()
     result: dict[str, UUID] = {}
 
-    async with db_engine.get_async_session() as session:
+    async def _lookup(active_session: AsyncSession) -> None:
         for start in range(0, len(hashes), _CHUNK_SIZE):
             chunk = hashes[start : start + _CHUNK_SIZE]
-            rows = await session.execute(
+            rows = await active_session.execute(
                 select(Data.id, Data.content_hash).filter(
                     Data.dataset_id == dataset_id,
                     Data.content_hash.in_(chunk),
@@ -56,5 +63,12 @@ async def identify_many(
                 # semantics: if duplicate rows exist, we take whichever the DB
                 # returns first rather than silently picking the last one).
                 result.setdefault(content_hash, data_id)
+
+    if session is not None:
+        await _lookup(session)
+        return result
+
+    async with get_relational_engine().get_async_session() as own_session:
+        await _lookup(own_session)
 
     return result

--- a/cognee/modules/pipelines/operations/run_tasks_data_item.py
+++ b/cognee/modules/pipelines/operations/run_tasks_data_item.py
@@ -63,8 +63,16 @@ async def run_tasks_data_item_incremental(
     db_engine = get_relational_engine()
 
     # If incremental_loading of data is set to True don't process documents already processed by pipeline
-    # If data is being added to Cognee for the first time resolve the id of the data
+    # If data is being added to Cognee for the first time resolve the id of the data.
+    #
+    # Every session below is a fresh connection on the cloud pods (NullPool
+    # over Neon: TCP + TLS + SCRAM per session, ~14 ms of CPU before any
+    # latency), and this wrapper runs once PER ITEM — so the pre-check resolves
+    # the row and reads its pipeline_status in ONE lookup instead of
+    # identify()-then-select-by-id, and the post-run status write below
+    # re-resolves fresh content inside the session that records the status.
     classified_data = None
+    data_point = None
     if not isinstance(data_item, Data):
         # If the DataItem carries a stable data_id (e.g. from DLT), prefer it
         # over the content lookup so lookups stay consistent.
@@ -72,37 +80,43 @@ async def run_tasks_data_item_incremental(
 
         if isinstance(data_item, DataItemType) and data_item.data_id is not None:
             data_id = data_item.data_id
+            async with db_engine.get_async_session() as session:
+                data_point = (
+                    await session.execute(select(Data).filter(Data.id == data_id))
+                ).scalar_one_or_none()
         else:
             file_path = await save_data_item_to_storage(data_item)
             # Ingest data and add metadata
             async with open_data_file(file_path) as file:
                 classified_data = ingestion.classify(file)
-                # Dataset-scoped content lookup: an existing row's id, or None
-                # for content this dataset has not seen (ingestion mints the id).
-                data_id = await ingestion.identify(classified_data, user, dataset.id)
+                # Dataset-scoped content lookup: the existing row (its id and
+                # pipeline_status) or None for content this dataset has not
+                # seen (ingestion mints the id).
+                data_point = await ingestion.identify_data(classified_data, user, dataset.id)
+            data_id = data_point.id if data_point is not None else None
     else:
         # If data was already processed by Cognee get data id
         data_id = data_item.id
+        async with db_engine.get_async_session() as session:
+            data_point = (
+                await session.execute(select(Data).filter(Data.id == data_id))
+            ).scalar_one_or_none()
 
     # Check pipeline status, if Data already processed for pipeline before skip current processing
-    async with db_engine.get_async_session() as session:
-        data_point = (
-            await session.execute(select(Data).filter(Data.id == data_id))
-        ).scalar_one_or_none()
-        if data_point:
-            if (
-                data_point.pipeline_status.get(pipeline_name, {}).get(str(dataset.id))
-                == DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED
-            ):
-                yield {
-                    "run_info": PipelineRunAlreadyCompleted(
-                        pipeline_run_id=pipeline_run_id,
-                        dataset_id=dataset.id,
-                        dataset_name=dataset.name,
-                    ),
-                    "data_id": data_id,
-                }
-                return
+    if data_point:
+        if (
+            data_point.pipeline_status.get(pipeline_name, {}).get(str(dataset.id))
+            == DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED
+        ):
+            yield {
+                "run_info": PipelineRunAlreadyCompleted(
+                    pipeline_run_id=pipeline_run_id,
+                    dataset_id=dataset.id,
+                    dataset_name=dataset.name,
+                ),
+                "data_id": data_id,
+            }
+            return
 
     try:
         # Process data based on data_item and list of tasks
@@ -122,14 +136,19 @@ async def run_tasks_data_item_incremental(
 
         # Update pipeline status for Data element. Fresh content had no row at
         # the pre-check (data_id None); ingestion has created it since — resolve
-        # the id it was given.
-        if data_id is None and classified_data is not None:
-            data_id = await ingestion.identify(classified_data, user, dataset.id)
-
+        # the row it was given, in the same session that records the status.
         async with db_engine.get_async_session() as session:
-            data_point = (
-                await session.execute(select(Data).filter(Data.id == data_id))
-            ).scalar_one_or_none()
+            if data_id is not None:
+                data_point = (
+                    await session.execute(select(Data).filter(Data.id == data_id))
+                ).scalar_one_or_none()
+            elif classified_data is not None:
+                data_point = await ingestion.identify_data(
+                    classified_data, user, dataset.id, session=session
+                )
+                data_id = data_point.id if data_point is not None else None
+            else:
+                data_point = None
             if data_point is not None:
                 status_for_pipeline = data_point.pipeline_status.setdefault(pipeline_name, {})
                 status_for_pipeline[str(dataset.id)] = DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED

--- a/cognee/tasks/ingestion/ingest_data.py
+++ b/cognee/tasks/ingestion/ingest_data.py
@@ -2,7 +2,7 @@ import json
 import inspect
 import os
 from uuid import UUID, uuid4
-from typing import Union, BinaryIO, Any, List, Optional
+from typing import TYPE_CHECKING, Union, BinaryIO, Any, List, Optional
 
 import cognee.modules.ingestion as ingestion
 from sqlalchemy import select
@@ -20,7 +20,6 @@ from cognee.infrastructure.loaders.LoaderInterface import LoaderResult
 from cognee.modules.data.methods import (
     get_authorized_existing_datasets,
     resolve_data_id,
-    get_dataset_data,
     load_or_create_datasets,
 )
 
@@ -30,7 +29,34 @@ from .save_data_item_to_storage import save_data_item_to_storage
 from .data_item_to_text_file import data_item_to_text_file
 from .data_item import DataItem
 
+if TYPE_CHECKING:  # pragma: no cover - import cycle: pipelines imports this package
+    from cognee.modules.pipelines.models import PipelineContext
+
 logger = get_logger(__name__)
+
+
+def _pipeline_dataset_for(ctx, dataset_name: Optional[str], dataset_id: Optional[UUID], user: User):
+    """The run's dataset from ``ctx`` when it is the one this call targets, else None.
+
+    The pipeline sets ``ctx.dataset`` to the dataset it resolved (with write
+    permission) for the run. Reuse it only when it demonstrably matches the
+    caller's selector — by id, or by name for a dataset the caller owns — so a
+    custom pipeline that points ``ingest_data`` at another dataset still goes
+    through the full resolution + permission check.
+    """
+    pipeline_dataset = getattr(ctx, "dataset", None) if ctx is not None else None
+    if pipeline_dataset is None:
+        return None
+    if dataset_id is not None:
+        return pipeline_dataset if str(pipeline_dataset.id) == str(dataset_id) else None
+    if (
+        dataset_name is not None
+        and getattr(pipeline_dataset, "name", None) == dataset_name
+        and str(getattr(pipeline_dataset, "owner_id", None)) == str(user.id)
+        and getattr(pipeline_dataset, "tenant_id", None) == getattr(user, "tenant_id", None)
+    ):
+        return pipeline_dataset
+    return None
 
 
 async def ingest_data(
@@ -41,7 +67,16 @@ async def ingest_data(
     dataset_id: UUID = None,
     preferred_loaders: dict[str, dict[str, Any]] = None,
     importance_weight: float = 0.5,
+    ctx: "PipelineContext" = None,
 ):
+    """Store ``data`` in ``dataset`` as ``Data`` rows (files land in storage first).
+
+    ``ctx`` is injected by the pipeline machinery (any task with a ``ctx``
+    parameter gets the run's ``PipelineContext``). When it carries the dataset
+    this task writes to, that dataset was already resolved and write-checked by
+    ``run_pipeline`` — re-resolving it here would cost three more DB sessions
+    per call, and the incremental pipeline calls this task once per item.
+    """
     if not user:
         user = await get_default_user()
 
@@ -66,7 +101,12 @@ async def ingest_data(
             # Convert data to a list as we work with lists further down.
             data = [data]
 
-        if dataset_id:
+        pipeline_dataset = _pipeline_dataset_for(ctx, dataset_name, dataset_id, user)
+        if pipeline_dataset is not None:
+            # The pipeline resolved (and write-authorized) this dataset once for
+            # the whole run; reuse it instead of three lookups per item.
+            dataset = pipeline_dataset
+        elif dataset_id:
             # Retrieve existing dataset
             dataset = await get_specific_user_permission_datasets(user.id, "write", [dataset_id])
             # Convert from list to Dataset element
@@ -84,9 +124,6 @@ async def ingest_data(
             )
             if isinstance(dataset, list):
                 dataset = dataset[0]
-
-        dataset_data: list[Data] = await get_dataset_data(dataset.id)
-        dataset_data_map = {str(data.id): True for data in dataset_data}
 
         db_engine = get_relational_engine()
 
@@ -116,47 +153,62 @@ async def ingest_data(
             }
             unique_content_hashes.add(item_content_hash)
 
-        # Single batch query: find existing rows for all content hashes in this
-        # dataset+owner+tenant scope — replaces N per-file identify() calls.
-        # identify_many() shares the exact same filter as identify() and chunks
-        # large inputs to stay within SQLite's bind-parameter limit.
-        existing_by_hash: dict[str, UUID] = await identify_many(
-            list(unique_content_hashes), user, dataset.id
-        )
-
-        # Resolve pinned IDs (items with explicit data_id) — still needs DB for
-        # resolve_data_id, but only for the subset that actually has a pinned id.
-        # Unpinned items use the batch result above.
-        batch_id_by_hash: dict[str, UUID] = {}
-        data_point_ids = []
-        for data_item in data:
-            cached = precomputed_items[id(data_item)]
-            item_data_id = cached["item_data_id"]
-            item_content_hash = cached["item_content_hash"]
-
-            if item_data_id is not None:
-                # A pinned id may be one the user held before a fork/update —
-                # resolve it (exact, then legacy) instead of minting a new row
-                # under a legacy value. Unknown pins stay as-is (dlt mints
-                # stable ids through this path deliberately).
-                resolved_pin = await resolve_data_id(dataset.id, item_data_id)
-                data_id = resolved_pin if resolved_pin is not None else item_data_id
-            else:
-                # Use batch result; fall back to dedup-within-batch or mint new id
-                data_id = existing_by_hash.get(item_content_hash)
-                if data_id is None:
-                    data_id = batch_id_by_hash.get(item_content_hash) or uuid4()
-            batch_id_by_hash.setdefault(item_content_hash, data_id)
-
-            cached["data_id"] = data_id
-            data_point_ids.append(data_id)
-
+        # All read-only lookups share ONE session: on the cloud pods every
+        # session is a fresh TLS+SCRAM connection (NullPool), and this runs
+        # once per item. The session is released before the loader/storage
+        # work below so no connection is held idle across S3 round trips.
         existing_data_map: dict = {}
-        if data_point_ids:
-            async with db_engine.get_async_session() as session:
+        async with db_engine.get_async_session() as session:
+            # Single batch query: find existing rows for all content hashes in this
+            # dataset+owner+tenant scope — replaces N per-file identify() calls.
+            # identify_many() shares the exact same filter as identify() and chunks
+            # large inputs to stay within SQLite's bind-parameter limit.
+            existing_by_hash: dict[str, UUID] = await identify_many(
+                list(unique_content_hashes), user, dataset.id, session=session
+            )
+
+            # Resolve pinned IDs (items with explicit data_id) — still needs DB for
+            # resolve_data_id, but only for the subset that actually has a pinned id.
+            # Unpinned items use the batch result above.
+            batch_id_by_hash: dict[str, UUID] = {}
+            data_point_ids = []
+            for data_item in data:
+                cached = precomputed_items[id(data_item)]
+                item_data_id = cached["item_data_id"]
+                item_content_hash = cached["item_content_hash"]
+
+                if item_data_id is not None:
+                    # A pinned id may be one the user held before a fork/update —
+                    # resolve it (exact, then legacy) instead of minting a new row
+                    # under a legacy value. Unknown pins stay as-is (dlt mints
+                    # stable ids through this path deliberately).
+                    resolved_pin = await resolve_data_id(dataset.id, item_data_id)
+                    data_id = resolved_pin if resolved_pin is not None else item_data_id
+                else:
+                    # Use batch result; fall back to dedup-within-batch or mint new id
+                    data_id = existing_by_hash.get(item_content_hash)
+                    if data_id is None:
+                        data_id = batch_id_by_hash.get(item_content_hash) or uuid4()
+                batch_id_by_hash.setdefault(item_content_hash, data_id)
+
+                cached["data_id"] = data_id
+                data_point_ids.append(data_id)
+
+            if data_point_ids:
                 result = await session.execute(select(Data).filter(Data.id.in_(data_point_ids)))
                 for dp in result.scalars().all():
                     existing_data_map[str(dp.id)] = dp
+
+        # Ids already present in THIS dataset. Only rows this batch resolved
+        # to can be in here (identify_many is dataset-scoped and pins are
+        # re-resolved against the dataset), so the targeted lookup above is
+        # enough — loading every Data row of the dataset per call, as before,
+        # made a 164-file add read O(N^2) rows for a membership check.
+        dataset_data_map = {
+            str(dp.id): True
+            for dp in existing_data_map.values()
+            if str(dp.dataset_id) == str(dataset.id)
+        }
 
         for data_item in data:
             # Support for DataItem (custom label + data + optional data_id / external_metadata)

--- a/cognee/tests/unit/modules/ingestion/test_identify_data.py
+++ b/cognee/tests/unit/modules/ingestion/test_identify_data.py
@@ -1,0 +1,125 @@
+"""identify_data(): identify()'s lookup, returning the row instead of its id.
+
+Contract under test:
+  - same hash + dataset + owner + tenant → the Data row identify() points at
+  - miss (other owner / other dataset / unknown hash) → None
+  - an explicitly passed session is used as-is (no second session opened)
+  - identify_data and identify agree on the winning row
+"""
+
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter import (
+    SQLAlchemyAdapter,
+)
+from cognee.modules.data.models import Data
+from cognee.modules.ingestion.identify import identify, identify_data
+
+_ENGINE_PATCH = "cognee.modules.ingestion.identify.get_relational_engine"
+
+
+async def _make_engine(rows: list[dict]) -> tuple[SQLAlchemyAdapter, str]:
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    engine = SQLAlchemyAdapter(f"sqlite+aiosqlite:///{tmp.name}")
+    await engine.create_database()
+    async with engine.get_async_session() as session:
+        for row in rows:
+            session.add(Data(**row))
+        await session.commit()
+    return engine, tmp.name
+
+
+def _user(tenant_id=None):
+    return SimpleNamespace(id=uuid4(), tenant_id=tenant_id)
+
+
+def _row(*, dataset_id, owner_id, content_hash, tenant_id=None, pipeline_status=None):
+    return dict(
+        id=uuid4(),
+        dataset_id=dataset_id,
+        owner_id=owner_id,
+        tenant_id=tenant_id,
+        name="doc.txt",
+        content_hash=content_hash,
+        raw_data_location="file:///tmp/doc.txt",
+        pipeline_status=pipeline_status or {},
+        token_count=-1,
+    )
+
+
+def _classified(content_hash: str):
+    return SimpleNamespace(get_identifier=lambda: content_hash)
+
+
+@pytest.mark.asyncio
+async def test_hit_returns_the_row_identify_points_at():
+    user = _user()
+    dataset_id = uuid4()
+    status = {"add_pipeline": {str(dataset_id): "DATA_ITEM_PROCESSING_COMPLETED"}}
+    seeded = _row(
+        dataset_id=dataset_id, owner_id=user.id, content_hash="h1", pipeline_status=status
+    )
+    engine, db_path = await _make_engine([seeded])
+    try:
+        with patch(_ENGINE_PATCH, return_value=engine):
+            row = await identify_data(_classified("h1"), user, dataset_id)
+            same_id = await identify(_classified("h1"), user, dataset_id)
+        assert row is not None
+        assert row.id == seeded["id"] == same_id
+        # The whole point: the row carries the columns the caller needs next.
+        assert row.pipeline_status == status
+    finally:
+        await engine.engine.dispose()
+        os.unlink(db_path)
+
+
+@pytest.mark.asyncio
+async def test_miss_scopes_like_identify():
+    user = _user()
+    stranger = _user()
+    dataset_id = uuid4()
+    engine, db_path = await _make_engine(
+        [_row(dataset_id=dataset_id, owner_id=user.id, content_hash="h1")]
+    )
+    try:
+        with patch(_ENGINE_PATCH, return_value=engine):
+            assert await identify_data(_classified("h1"), stranger, dataset_id) is None
+            assert await identify_data(_classified("h1"), user, uuid4()) is None
+            assert await identify_data(_classified("unknown"), user, dataset_id) is None
+    finally:
+        await engine.engine.dispose()
+        os.unlink(db_path)
+
+
+@pytest.mark.asyncio
+async def test_explicit_session_is_used_without_opening_another():
+    """The incremental wrapper resolves fresh content inside the session that
+    then records its pipeline status — one connection, not two."""
+    user = _user()
+    dataset_id = uuid4()
+    seeded = _row(dataset_id=dataset_id, owner_id=user.id, content_hash="h1")
+    engine, db_path = await _make_engine([seeded])
+    try:
+        # Any attempt to open a session through the module's engine accessor
+        # would be a regression: the caller's session must be the only one.
+        with patch(_ENGINE_PATCH, side_effect=AssertionError("must not open a session")):
+            async with engine.get_async_session() as session:
+                row = await identify_data(_classified("h1"), user, dataset_id, session=session)
+                assert row is not None and row.id == seeded["id"]
+                # The row is attached to the caller's session, so it can be
+                # updated and committed right there.
+                row.pipeline_status = {"add_pipeline": {str(dataset_id): "done"}}
+                await session.commit()
+        async with engine.get_async_session() as session:
+            refreshed = await session.get(Data, seeded["id"])
+            assert refreshed.pipeline_status == {"add_pipeline": {str(dataset_id): "done"}}
+    finally:
+        await engine.engine.dispose()
+        os.unlink(db_path)

--- a/cognee/tests/unit/modules/pipelines/test_run_tasks_data_item_sessions.py
+++ b/cognee/tests/unit/modules/pipelines/test_run_tasks_data_item_sessions.py
@@ -1,0 +1,183 @@
+"""The incremental per-item wrapper must open at most two relational sessions
+per item: one for the pre-check (row + pipeline_status in a single lookup) and
+one for the post-run status write (which re-resolves fresh content in that same
+session).
+
+Why this matters: the cloud pods run NullPool over Neon, so every session is a
+fresh TCP + TLS + SCRAM connection (~14 ms of CPU before any latency) and this
+wrapper runs once per uploaded file. The pre-fix shape was four sessions per
+item (identify, select-by-id, identify again, update).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+import cognee.modules.pipelines.operations.run_tasks_data_item as item_module
+from cognee.modules.pipelines.models.DataItemStatus import DataItemStatus
+from cognee.modules.pipelines.models.PipelineRunInfo import (
+    PipelineRunAlreadyCompleted,
+    PipelineRunCompleted,
+)
+
+
+class _FakeSessionFactory:
+    """Counts sessions; every select returns the configured row."""
+
+    def __init__(self, row):
+        self.row = row
+        self.opened = 0
+        self.merged = []
+        self.committed = 0
+
+    def __call__(self):
+        self.opened += 1
+        session = MagicMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = self.row
+        session.execute = AsyncMock(return_value=result)
+
+        async def _merge(obj):
+            self.merged.append(obj)
+
+        async def _commit():
+            self.committed += 1
+
+        session.merge = AsyncMock(side_effect=_merge)
+        session.commit = AsyncMock(side_effect=_commit)
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+
+def _wire(monkeypatch, *, existing_row, identify_data_calls):
+    """Mock storage/classify, the engine, and ingestion.identify_data; return
+    the session factory and a runner for one content (non-pinned) item."""
+    dataset = SimpleNamespace(id=uuid4(), name="ds")
+    user = SimpleNamespace(id=uuid4(), tenant_id=None)
+    factory = _FakeSessionFactory(existing_row)
+    engine = MagicMock()
+    engine.get_async_session.side_effect = factory
+    monkeypatch.setattr(item_module, "get_relational_engine", lambda: engine)
+
+    monkeypatch.setattr(
+        item_module, "save_data_item_to_storage", AsyncMock(return_value="file:///tmp/x.txt")
+    )
+
+    class _Opened:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, *args):
+            return False
+
+    monkeypatch.setattr(item_module, "open_data_file", lambda _path: _Opened())
+    classified = SimpleNamespace(get_identifier=lambda: "hash-1")
+    monkeypatch.setattr(item_module.ingestion, "classify", lambda _f: classified)
+
+    async def _identify_data(classified_data, u, dataset_id, session=None):
+        identify_data_calls.append(session)
+        return existing_row
+
+    monkeypatch.setattr(item_module.ingestion, "identify_data", _identify_data)
+
+    async def _empty_pipeline(**kwargs):
+        return
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(item_module, "run_tasks_with_telemetry", _empty_pipeline)
+
+    async def _run():
+        events = []
+        async for event in item_module.run_tasks_data_item_incremental(
+            data_item="some text",
+            dataset=dataset,
+            tasks=[],
+            pipeline_name="add_pipeline",
+            pipeline_id=uuid4(),
+            pipeline_run_id=uuid4(),
+            ctx=None,
+            user=user,
+        ):
+            events.append(event)
+        return [e["run_info"] for e in events if isinstance(e, dict) and "run_info" in e]
+
+    return factory, _run, dataset
+
+
+@pytest.mark.asyncio
+async def test_fresh_content_uses_two_sessions_and_resolves_in_the_status_session(monkeypatch):
+    calls = []
+    # Pre-check: no row yet (identify_data returns None, own session).
+    # Post-run: the row exists now; identify_data must be handed the status session.
+    row_after = SimpleNamespace(id=uuid4(), pipeline_status={})
+    state = {"row": None}
+
+    factory, run, dataset = _wire(monkeypatch, existing_row=None, identify_data_calls=calls)
+
+    async def _identify_data(classified_data, u, dataset_id, session=None):
+        calls.append(session)
+        return state["row"]
+
+    monkeypatch.setattr(item_module.ingestion, "identify_data", _identify_data)
+
+    original_pipeline = item_module.run_tasks_with_telemetry
+
+    async def _pipeline_that_creates_the_row(**kwargs):
+        state["row"] = row_after
+        async for item in original_pipeline(**kwargs):
+            yield item
+
+    monkeypatch.setattr(item_module, "run_tasks_with_telemetry", _pipeline_that_creates_the_row)
+
+    run_infos = await run()
+
+    assert any(isinstance(i, PipelineRunCompleted) for i in run_infos)
+    # identify_data twice: pre-check (no session → its own) and post-run (the status session).
+    assert len(calls) == 2
+    assert calls[0] is None
+    assert calls[1] is not None, "post-run resolution must reuse the status-write session"
+    # Only the status-write session was opened through the engine here
+    # (the pre-check lookup lives inside identify_data, which is mocked).
+    assert factory.opened == 1
+    assert factory.committed == 1
+    assert row_after.pipeline_status["add_pipeline"][str(dataset.id)] == (
+        DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED
+    )
+
+
+@pytest.mark.asyncio
+async def test_completed_content_is_skipped_without_a_second_lookup(monkeypatch):
+    calls = []
+    dataset_id_holder = {}
+
+    def _row_for(dataset):
+        return SimpleNamespace(
+            id=uuid4(),
+            pipeline_status={
+                "add_pipeline": {str(dataset.id): DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED}
+            },
+        )
+
+    # Build the row after we know the dataset id: wire once, then patch the row.
+    factory, run, dataset = _wire(monkeypatch, existing_row=None, identify_data_calls=calls)
+    row = _row_for(dataset)
+    dataset_id_holder["row"] = row
+
+    async def _identify_data(classified_data, u, dataset_id, session=None):
+        calls.append(session)
+        return row
+
+    monkeypatch.setattr(item_module.ingestion, "identify_data", _identify_data)
+
+    run_infos = await run()
+
+    assert any(isinstance(i, PipelineRunAlreadyCompleted) for i in run_infos)
+    assert not any(isinstance(i, PipelineRunCompleted) for i in run_infos)
+    # The pre-check row already carried pipeline_status: one identify_data call,
+    # and no engine session at all (no select-by-id, no status write).
+    assert len(calls) == 1
+    assert factory.opened == 0

--- a/cognee/tests/unit/tasks/ingestion/test_ingest_data_ctx_dataset.py
+++ b/cognee/tests/unit/tasks/ingestion/test_ingest_data_ctx_dataset.py
@@ -1,0 +1,204 @@
+"""ingest_data reuses the pipeline's already-resolved dataset (``ctx.dataset``)
+instead of resolving name/id + permissions again on every call.
+
+The incremental pipeline calls ingest_data once per item; on the cloud pods
+(NullPool over Neon) each of the three resolution lookups is a fresh TLS+SCRAM
+connection, so this is ~3 connections per uploaded file. The reuse must be
+conservative: only when ``ctx.dataset`` demonstrably IS the dataset the caller
+selected (by id, or by name for a dataset the caller owns); anything else goes
+through the full resolution + permission check as before.
+"""
+
+import importlib
+import os
+import tempfile
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter import (
+    SQLAlchemyAdapter,
+)
+from cognee.modules.data.models import Data, Dataset
+
+# The package re-exports the FUNCTION under the module's name, so
+# `import ... as ingest_module` would bind the function and break patch.object.
+ingest_module = importlib.import_module("cognee.tasks.ingestion.ingest_data")
+
+USER = SimpleNamespace(id=uuid4(), tenant_id=None)
+DATASET_ID = uuid4()
+
+
+class _FakeFile:
+    name = "/tmp/doc.txt"
+
+    def read(self, *_):
+        return b""
+
+    def seek(self, *_):
+        return 0
+
+    def tell(self):
+        return 0
+
+
+class _FakeOpen:
+    def __init__(self, *_a, **_k):
+        pass
+
+    async def __aenter__(self):
+        return _FakeFile()
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _metadata():
+    return {
+        "name": "doc",
+        "file_path": "/tmp/doc.txt",
+        "mime_type": "text/plain",
+        "extension": "txt",
+        "content_hash": "hash-1",
+        "file_size": 11,
+    }
+
+
+async def _make_engine():
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    engine = SQLAlchemyAdapter(f"sqlite+aiosqlite:///{tmp.name}")
+    await engine.create_database()
+    return engine, tmp.name
+
+
+def _install_mocks(stack, engine):
+    meta = _metadata()
+    classified = SimpleNamespace(
+        get_metadata=lambda: meta, get_identifier=lambda: meta["content_hash"]
+    )
+    stack.enter_context(patch.object(ingest_module, "get_relational_engine", lambda: engine))
+    stack.enter_context(
+        patch.object(
+            ingest_module, "save_data_item_to_storage", AsyncMock(return_value="/tmp/doc.txt")
+        )
+    )
+    stack.enter_context(patch.object(ingest_module, "get_data_file_path", lambda p: p))
+    stack.enter_context(patch.object(ingest_module, "open_data_file", _FakeOpen))
+    stack.enter_context(
+        patch.object(
+            ingest_module,
+            "data_item_to_text_file",
+            AsyncMock(return_value=("/tmp/doc.txt", SimpleNamespace(loader_name="text_loader"))),
+        )
+    )
+    stack.enter_context(patch.object(ingest_module.ingestion, "classify", lambda _f: classified))
+
+    resolution = {
+        "by_id": AsyncMock(side_effect=AssertionError("resolved dataset by id")),
+        "by_name": AsyncMock(side_effect=AssertionError("resolved dataset by name")),
+        "create": AsyncMock(side_effect=AssertionError("load_or_create_datasets called")),
+    }
+    stack.enter_context(
+        patch.object(ingest_module, "get_specific_user_permission_datasets", resolution["by_id"])
+    )
+    stack.enter_context(
+        patch.object(ingest_module, "get_authorized_existing_datasets", resolution["by_name"])
+    )
+    stack.enter_context(
+        patch.object(ingest_module, "load_or_create_datasets", resolution["create"])
+    )
+    return resolution
+
+
+@pytest.mark.asyncio
+async def test_matching_ctx_dataset_skips_resolution_and_writes_the_row():
+    engine, db_path = await _make_engine()
+    dataset = Dataset(id=DATASET_ID, name="ds", owner_id=USER.id)
+    try:
+        with ExitStack() as stack:
+            _install_mocks(stack, engine)
+            rows = await ingest_module.ingest_data(
+                data="hello world",
+                dataset_name="ds",
+                user=USER,
+                dataset_id=DATASET_ID,
+                ctx=SimpleNamespace(dataset=dataset, user=USER),
+            )
+        assert len(rows) == 1
+        async with engine.get_async_session() as session:
+            stored = await session.get(Data, rows[0].id)
+            assert stored is not None
+            assert stored.dataset_id == DATASET_ID
+            assert stored.content_hash == "hash-1"
+    finally:
+        await engine.engine.dispose()
+        os.unlink(db_path)
+
+
+@pytest.mark.asyncio
+async def test_matching_ctx_dataset_by_owned_name_skips_resolution():
+    engine, db_path = await _make_engine()
+    dataset = Dataset(id=DATASET_ID, name="ds", owner_id=USER.id, tenant_id=None)
+    try:
+        with ExitStack() as stack:
+            _install_mocks(stack, engine)
+            rows = await ingest_module.ingest_data(
+                data="hello world",
+                dataset_name="ds",
+                user=USER,
+                ctx=SimpleNamespace(dataset=dataset, user=USER),
+            )
+        assert len(rows) == 1 and rows[0].dataset_id == DATASET_ID
+    finally:
+        await engine.engine.dispose()
+        os.unlink(db_path)
+
+
+@pytest.mark.asyncio
+async def test_mismatched_ctx_dataset_falls_back_to_full_resolution():
+    """A custom pipeline may point ingest_data at a different dataset than the
+    run's; that path must still resolve + permission-check as before."""
+    engine, db_path = await _make_engine()
+    other = Dataset(id=uuid4(), name="other", owner_id=USER.id)
+    target = Dataset(id=DATASET_ID, name="ds", owner_id=USER.id)
+    try:
+        with ExitStack() as stack:
+            resolution = _install_mocks(stack, engine)
+            resolution["by_id"].side_effect = None
+            resolution["by_id"].return_value = [target]
+            rows = await ingest_module.ingest_data(
+                data="hello world",
+                dataset_name="ds",
+                user=USER,
+                dataset_id=DATASET_ID,
+                ctx=SimpleNamespace(dataset=other, user=USER),
+            )
+        resolution["by_id"].assert_awaited_once()
+        assert rows[0].dataset_id == DATASET_ID
+    finally:
+        await engine.engine.dispose()
+        os.unlink(db_path)
+
+
+@pytest.mark.asyncio
+async def test_no_ctx_resolves_as_before():
+    engine, db_path = await _make_engine()
+    target = Dataset(id=DATASET_ID, name="ds", owner_id=USER.id)
+    try:
+        with ExitStack() as stack:
+            resolution = _install_mocks(stack, engine)
+            resolution["by_name"].side_effect = None
+            resolution["by_name"].return_value = []
+            resolution["create"].side_effect = None
+            resolution["create"].return_value = target
+            rows = await ingest_module.ingest_data(data="hello world", dataset_name="ds", user=USER)
+        resolution["by_name"].assert_awaited_once()
+        resolution["create"].assert_awaited_once()
+        assert rows[0].dataset_id == DATASET_ID
+    finally:
+        await engine.engine.dispose()
+        os.unlink(db_path)

--- a/cognee/tests/unit/tasks/ingestion/test_ingest_update_data_size.py
+++ b/cognee/tests/unit/tasks/ingestion/test_ingest_update_data_size.py
@@ -123,20 +123,15 @@ def _install_mocks(stack, engine):
             AsyncMock(return_value={meta["content_hash"]: DATA_ID}),
         )
     )
-    # Dataset resolution: return the seeded dataset and report DATA_ID as already
-    # belonging to it, so the existing-record UPDATE branch (not CREATE) runs.
+    # Dataset resolution: return the seeded dataset. Dataset membership is no
+    # longer a separate full-table read (get_dataset_data); ingest_data derives
+    # it from the rows the batch resolved to, and the seeded row's dataset_id
+    # is DATASET_ID, so the existing-record UPDATE branch (not CREATE) runs.
     stack.enter_context(
         patch.object(ingest_module, "get_authorized_existing_datasets", AsyncMock(return_value=[]))
     )
     stack.enter_context(
         patch.object(ingest_module, "load_or_create_datasets", AsyncMock(return_value=dataset))
-    )
-    stack.enter_context(
-        patch.object(
-            ingest_module,
-            "get_dataset_data",
-            AsyncMock(return_value=[SimpleNamespace(id=DATA_ID)]),
-        )
     )
 
 


### PR DESCRIPTION
## Description

On the cloud pods every SQLAlchemy session is a brand-new connection (`POOL_ARGS=nullpool` over Neon's pooler): TCP + TLS + SCRAM-SHA-256, which alone costs ~14 ms of event-loop CPU per connection (measured, asyncpg 0.30) before any network latency. NullPool is there deliberately — the pooled configuration leaked connections and hung a tenant — so this fix reduces the number of sessions needed, rather than pooling connections again.

PR #4571 batched `identify()` into `identify_many()`, but on the `add()` path the pipeline runs `ingest_data` once **per item** (`run_tasks` fans out one `run_tasks_data_item_incremental` per file under `Semaphore(20)` and calls the tasks with `data=[item]`), so the batch was always one hash and every "per call" lookup in `ingest_data` was really per file.

Measured with an instrumented run of 164 PDFs (real s3fs + asyncpg, NullPool): **11.1 sessions/file before → 4.1 after**; 14.6 statements/file → 6.6.

### Where the sessions went and what changes

* **`run_tasks_data_item_incremental` — 4 → 2.** The pre-check resolved the content's row id (`identify`) and then fetched the row by id to read `pipeline_status`; new `identify_data()` returns the row in one lookup. After the tasks ran it resolved fresh content again (`identify`) and then opened another session to write the status; the status session now does the resolution itself (`identify_data(session=...)`).
* **`ingest_data` — 7 → 2.**
  - The dataset was re-resolved on every call although `run_pipeline` had already resolved and write-checked it; the task now accepts the pipeline's `ctx` and reuses `ctx.dataset` when it demonstrably is the dataset the caller selected (by id, or by name for a dataset the caller owns in the caller's tenant), falling back to the full resolution + permission check otherwise. `add()` also hands the resolved dataset id to the task so the non-`ctx` fallback is the cheap branch.
  - `get_dataset_data` loaded **every** `Data` row of the dataset per call just to build a membership map — O(N²) rows over a 164-file add — while the targeted "existing rows for this batch" query already returns the only ids that can be in it; the map is now derived from that.
  - `identify_many` and the existing-rows select share one read session (`identify_many` takes an optional `session`); the commit keeps its own, so no connection is held idle across the loader/S3 work in between.

`identify()`, `identify_data()` and `identify_many()` now build their `(dataset, owner, tenant, content_hash)` filter from one shared helper so they cannot disagree on which row wins.

## Acceptance Criteria

- 3 new test files + 1 updated (`identify_data`: row, scoping, shared session; the incremental wrapper opens exactly one engine session for fresh content and none for an already-completed item; `ingest_data` reuses a matching `ctx.dataset` and still resolves/permission-checks a mismatched or absent one)
- `cognee/tests/unit` = 4296 passed, 64 skipped; the 11 pre-existing failures (retrieval/LLM-env config + `code_repo`) are identical on pristine `origin/dev`
- Measured with an instrumented local twin (real s3fs + asyncpg against Postgres with the cloud pod's `POOL_ARGS`) over 164 PDFs: DB sessions/file 11.1 → 4.1

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

N/A — measured via an instrumented local script, not a UI change.

## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [ ] I have added necessary documentation (if applicable) — N/A
- [x] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description — CLO-590
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)