### PR TITLE
feat: day-one seeding — auto-ingest what already exists on install [COG-6253]

### DIFF
--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1934,6 +1934,46 @@ def load_class(model_file, model_name):
     return model_class
 
 
+async def _auto_seed_if_fresh() -> None:
+    """Day-one seeding: on a fresh local install, ingest what already exists.
+
+    Memory files (MEMORY.md, SOUL.md, ...), the workspace README, recent
+    session transcripts, and the codebase are ingested automatically so the
+    first recall has something to return — the default, not an accident.
+
+    Runs only when COGNEE_AUTO_SEED is not false and the user owns zero
+    datasets, which makes it once-per-fresh-install by construction. The
+    import is guarded because cognee-mcp depends on cognee from PyPI, which
+    may predate cognee.modules.seeding.
+    """
+    if os.getenv("COGNEE_AUTO_SEED", "true").strip().lower() in {"0", "false", "no", "off"}:
+        logger.info("Day-one auto-seed disabled via COGNEE_AUTO_SEED")
+        return
+
+    try:
+        from cognee.modules.seeding import seed
+    except ImportError:
+        logger.info("Installed cognee has no seeding module; skipping day-one auto-seed.")
+        return
+
+    try:
+        existing = await cognee_client.list_datasets()
+        if existing:
+            return  # not a fresh install — never re-seed behind the user's back
+
+        with redirect_stdout(sys.stderr):
+            result = await seed()
+
+        if result.plan.is_empty:
+            logger.info(
+                "Day-one auto-seed found nothing to ingest around %s", result.plan.workspace
+            )
+        else:
+            logger.info("Day-one auto-seed:\n%s", result.summary())
+    except Exception as error:
+        logger.warning(f"Day-one auto-seed failed (non-fatal): {error}")
+
+
 async def main():
     global cognee_client
 
@@ -2087,6 +2127,13 @@ async def main():
         logger.info("Database migrations done.")
     elif not is_remote:
         logger.info("Skipping DB migrations")
+
+    # Day-one seeding (local mode only): a fresh install immediately ingests
+    # what already exists around the workspace so the first recall has
+    # something to return. Backgrounded so startup never blocks on it; opt
+    # out with COGNEE_AUTO_SEED=false.
+    if not is_remote:
+        _track_background(_auto_seed_if_fresh())
 
     try:
         match args.transport.lower():

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1960,6 +1960,10 @@ async def _auto_seed_if_fresh() -> None:
         existing = await cognee_client.list_datasets()
         if existing:
             return  # not a fresh install — never re-seed behind the user's back
+        # This check races with concurrent server instances, but the race is
+        # benign: seed() re-checks dataset existence itself, every instance
+        # seeds the same dataset name, and add()'s content-hash dedup makes
+        # concurrent seeds converge to one copy.
 
         with redirect_stdout(sys.stderr):
             result = await seed()

--- a/cognee/__init__.py
+++ b/cognee/__init__.py
@@ -59,6 +59,7 @@ from cognee.modules.visualization.cognee_network_visualization import (
 )
 from .api.v1.ui import start_ui
 from .api.v1.session import session
+from .modules.seeding import seed
 
 # Pipelines
 from .modules import pipelines

--- a/cognee/cli/_cognee.py
+++ b/cognee/cli/_cognee.py
@@ -102,6 +102,7 @@ def _discover_commands() -> List[Type[SupportsCliCommand]]:
         ("cognee.cli.commands.feedback_command", "FeedbackCommand"),
         ("cognee.cli.commands.memify_command", "MemifyCommand"),
         ("cognee.cli.commands.remember_command", "RememberCommand"),
+        ("cognee.cli.commands.seed_command", "SeedCommand"),
         ("cognee.cli.commands.recall_command", "RecallCommand"),
         ("cognee.cli.commands.improve_command", "ImproveCommand"),
         ("cognee.cli.commands.forget_command", "ForgetCommand"),

--- a/cognee/cli/commands/seed_command.py
+++ b/cognee/cli/commands/seed_command.py
@@ -64,6 +64,8 @@ content-hash dedup makes --force cheap on unchanged files.
             from cognee.modules.seeding import DEFAULT_SEED_DATASET, seed
 
             workspace = Path(args.workspace).expanduser() if args.workspace else None
+            if workspace and not workspace.is_dir():
+                raise CliCommandInnerException(f"Workspace is not a directory: {workspace}")
             dataset_name = args.dataset_name or DEFAULT_SEED_DATASET
 
             async def run_seed():

--- a/cognee/cli/commands/seed_command.py
+++ b/cognee/cli/commands/seed_command.py
@@ -1,0 +1,112 @@
+import argparse
+import asyncio
+from pathlib import Path
+
+from cognee.cli.reference import SupportsCliCommand
+from cognee.cli import DEFAULT_DOCS_URL
+import cognee.cli.echo as fmt
+from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.hints import hint_recall
+
+
+class SeedCommand(SupportsCliCommand):
+    command_string = "seed"
+    help_string = "Ingest what already exists in this workspace so the first recall returns"
+    docs_url = DEFAULT_DOCS_URL
+    description = """
+Day-one seeding: discover and ingest the knowledge that already exists around
+this workspace — agent memory files (MEMORY.md, SOUL.md, AGENTS.md,
+CLAUDE.md, ...), the README, recent coding-agent session logs, and the
+codebase itself (when the workspace is a code project).
+
+Seeding runs in stages ordered by size, memory files first, so a recall
+issued moments later already has something to return. Re-running is safe:
+it refuses to re-seed an existing seed dataset unless --force is given, and
+content-hash dedup makes --force cheap on unchanged files.
+    """
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--workspace",
+            "-w",
+            default=None,
+            help="Workspace root to seed (default: auto-detected from the current directory)",
+        )
+        parser.add_argument(
+            "--dataset-name",
+            "-d",
+            default=None,
+            help="Dataset the seed lands in (default: workspace)",
+        )
+        parser.add_argument(
+            "--no-code",
+            action="store_true",
+            help="Skip indexing the codebase",
+        )
+        parser.add_argument(
+            "--no-session-logs",
+            action="store_true",
+            help="Skip ingesting recent agent session transcripts",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Only print what would be ingested, without ingesting anything",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Re-seed even when the seed dataset already exists",
+        )
+
+    def execute(self, args: argparse.Namespace) -> None:
+        try:
+            from cognee.modules.seeding import DEFAULT_SEED_DATASET, seed
+
+            workspace = Path(args.workspace).expanduser() if args.workspace else None
+            dataset_name = args.dataset_name or DEFAULT_SEED_DATASET
+
+            async def run_seed():
+                try:
+                    return await seed(
+                        workspace,
+                        dataset_name=dataset_name,
+                        include_codebase=not args.no_code,
+                        include_session_logs=not args.no_session_logs,
+                        force=args.force,
+                        dry_run=args.dry_run,
+                    )
+                except Exception as e:
+                    raise CliCommandInnerException(f"Failed to seed: {str(e)}") from e
+
+            if not args.dry_run:
+                fmt.echo("Discovering day-one sources...")
+
+            result = asyncio.run(run_seed())
+
+            if args.dry_run:
+                fmt.echo(result.plan.describe())
+                return
+
+            if result.plan.is_empty:
+                fmt.warning(
+                    "Nothing to seed: no memory files, README, session logs, or code "
+                    f"project found around {result.plan.workspace}."
+                )
+                return
+
+            if result.skipped_existing:
+                fmt.note(result.summary())
+                return
+
+            fmt.echo(result.summary())
+            if result.ingested_anything:
+                fmt.success("Day-one seed complete.")
+                hint_recall(dataset_name)
+            else:
+                raise CliCommandInnerException("Seeding ingested nothing; see errors above.")
+
+        except Exception as e:
+            if isinstance(e, CliCommandInnerException):
+                raise CliCommandException(str(e), error_code=1) from e
+            raise CliCommandException(f"Failed to seed: {str(e)}", error_code=1) from e

--- a/cognee/cli/config.py
+++ b/cognee/cli/config.py
@@ -19,6 +19,7 @@ COMMAND_DESCRIPTIONS = {
     "feedback": "Add or remove feedback on session Q&A entries",
     "memify": "Run the memory enrichment pipeline on a dataset",
     "remember": "Ingest data and build the knowledge graph in a single call",
+    "seed": "Ingest what already exists in this workspace so the first recall returns",
     "recall": "Search the knowledge graph for relevant information",
     "improve": "Enrich an existing knowledge graph with additional context and rules",
     "forget": "Remove data from the knowledge graph",

--- a/cognee/cli/hints.py
+++ b/cognee/cli/hints.py
@@ -21,10 +21,11 @@ def hint_recall(dataset_name: str) -> None:
 
 
 def hint_recall_empty(dataset_name: str) -> None:
-    """After a ``recall`` that found nothing, point back at ``remember`` to seed the dataset."""
+    """After a ``recall`` that found nothing, point at seeding or ``remember``."""
     _next(
-        f'no matches in "{dataset_name}". Try "cognee-cli remember <path-or-text> '
-        f'-d {dataset_name}" to seed it, then rerun this recall.'
+        f'no matches in "{dataset_name}". Try "cognee-cli seed" to ingest what this '
+        f'workspace already knows (memory files, README, code), or "cognee-cli remember '
+        f'<path-or-text> -d {dataset_name}", then rerun this recall.'
     )
 
 

--- a/cognee/modules/seeding/__init__.py
+++ b/cognee/modules/seeding/__init__.py
@@ -1,0 +1,12 @@
+from .discovery import SeedPlan, discover_seed_plan, find_workspace_root
+from .seed import DEFAULT_SEED_DATASET, SeedResult, StageResult, seed
+
+__all__ = [
+    "DEFAULT_SEED_DATASET",
+    "SeedPlan",
+    "SeedResult",
+    "StageResult",
+    "discover_seed_plan",
+    "find_workspace_root",
+    "seed",
+]

--- a/cognee/modules/seeding/discovery.py
+++ b/cognee/modules/seeding/discovery.py
@@ -1,0 +1,223 @@
+"""Discovery of day-one seed sources.
+
+Pure discovery: walk the workspace and known coding-agent homes and return a
+:class:`SeedPlan` describing what a seed run *would* ingest — agent memory
+files (``MEMORY.md``, ``SOUL.md``, …), the workspace README, recent session
+transcripts, and the workspace codebase. Nothing here reads file contents or
+touches cognee storage; the runner in :mod:`cognee.modules.seeding.seed`
+decides what to do with the plan.
+
+Safety posture: only explicitly allowlisted dot-paths are ever picked up
+(``.claude/CLAUDE.md`` and the Claude Code project home for *this* workspace),
+so secrets in ``.env`` or other hidden files can never enter the plan. Session
+transcripts are bounded by count and size.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+# Agent memory conventions at the workspace root. Covers the Claude Code /
+# OpenClaw-style file set; missing files are simply not discovered.
+MEMORY_FILE_NAMES = (
+    "MEMORY.md",
+    "SOUL.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "USER.md",
+    "IDENTITY.md",
+    "TOOLS.md",
+)
+
+# Dot-paths that are allowed despite the hidden-file rule.
+ALLOWED_DOT_RELATIVE_PATHS = (Path(".claude") / "CLAUDE.md",)
+
+DEFAULT_MAX_SESSION_LOGS = 3
+DEFAULT_MAX_SESSION_LOG_BYTES = 5 * 1024 * 1024
+DEFAULT_MAX_FILE_BYTES = 10 * 1024 * 1024
+
+
+def _env_bool(name: str, default: bool = True) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+@dataclass
+class SeedPlan:
+    """Everything a seed run would ingest, grouped by provenance."""
+
+    workspace: Path
+    memory_files: List[Path] = field(default_factory=list)
+    readmes: List[Path] = field(default_factory=list)
+    session_logs: List[Path] = field(default_factory=list)
+    codebase: Optional[Path] = None
+    skipped: List[str] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.memory_files or self.readmes or self.session_logs or self.codebase)
+
+    def describe(self) -> str:
+        """Human-readable plan, used by ``cognee-cli seed --dry-run`` and logs."""
+        lines = [f"Seed plan for workspace: {self.workspace}"]
+
+        def section(title: str, paths: List[Path]) -> None:
+            lines.append(f"  {title}: {len(paths)}")
+            for path in paths:
+                lines.append(f"    - {path}")
+
+        section("Agent memory files", self.memory_files)
+        section("Workspace docs", self.readmes)
+        section("Session logs", self.session_logs)
+        if self.codebase:
+            lines.append(f"  Codebase: {self.codebase} (resolved as a code project)")
+        else:
+            lines.append("  Codebase: none")
+        for reason in self.skipped:
+            lines.append(f"  (skipped) {reason}")
+        return "\n".join(lines)
+
+
+def find_workspace_root(start: Optional[Path] = None) -> Path:
+    """Best-effort workspace root: the nearest ancestor that is a code project.
+
+    Falls back to ``start`` itself when no ancestor carries a project marker,
+    so seeding still works in a plain notes directory.
+    """
+    from cognee.tasks.code_graph.code_repo import detect_code_project
+
+    start = (start or Path.cwd()).resolve()
+    for candidate in (start, *start.parents):
+        if detect_code_project(candidate):
+            return candidate
+    return start
+
+
+def claude_code_project_dir(workspace: Path, claude_home: Optional[Path] = None) -> Path:
+    """The Claude Code per-project directory for this workspace.
+
+    Claude Code slugs the absolute workspace path by replacing every
+    non-alphanumeric character with ``-`` (e.g. ``/Users/me/proj_x`` becomes
+    ``-Users-me-proj-x``).
+    """
+    claude_home = claude_home or (Path.home() / ".claude")
+    slug = re.sub(r"[^A-Za-z0-9-]", "-", str(workspace.resolve()))
+    return claude_home / "projects" / slug
+
+
+def _file_within_cap(path: Path, cap: int, skipped: List[str], label: str) -> bool:
+    try:
+        size = path.stat().st_size
+    except OSError:
+        skipped.append(f"{label} {path}: unreadable")
+        return False
+    if size == 0:
+        skipped.append(f"{label} {path}: empty")
+        return False
+    if size > cap:
+        skipped.append(f"{label} {path}: {size} bytes exceeds cap of {cap}")
+        return False
+    return True
+
+
+def discover_seed_plan(
+    workspace: Optional[Path] = None,
+    *,
+    include_codebase: bool = True,
+    include_session_logs: bool = True,
+    claude_home: Optional[Path] = None,
+    max_session_logs: Optional[int] = None,
+    max_session_log_bytes: Optional[int] = None,
+    max_file_bytes: Optional[int] = None,
+) -> SeedPlan:
+    """Discover what a day-one seed of ``workspace`` would ingest."""
+    from cognee.tasks.code_graph.code_repo import detect_code_project
+
+    workspace = (workspace or find_workspace_root()).resolve()
+    include_codebase = include_codebase and _env_bool("COGNEE_SEED_CODEBASE", True)
+    include_session_logs = include_session_logs and _env_bool("COGNEE_SEED_SESSION_LOGS", True)
+    max_session_logs = max_session_logs or _env_int(
+        "COGNEE_SEED_MAX_SESSION_LOGS", DEFAULT_MAX_SESSION_LOGS
+    )
+    max_session_log_bytes = max_session_log_bytes or _env_int(
+        "COGNEE_SEED_MAX_SESSION_LOG_BYTES", DEFAULT_MAX_SESSION_LOG_BYTES
+    )
+    max_file_bytes = max_file_bytes or _env_int(
+        "COGNEE_SEED_MAX_FILE_BYTES", DEFAULT_MAX_FILE_BYTES
+    )
+
+    plan = SeedPlan(workspace=workspace)
+
+    # --- Agent memory files -------------------------------------------------
+    memory_candidates: List[Path] = [workspace / name for name in MEMORY_FILE_NAMES]
+    memory_candidates += [workspace / rel for rel in ALLOWED_DOT_RELATIVE_PATHS]
+    memory_dir = workspace / "memory"
+    if memory_dir.is_dir():
+        memory_candidates += sorted(memory_dir.glob("*.md"))
+
+    project_dir = claude_code_project_dir(workspace, claude_home)
+    auto_memory_dir = project_dir / "memory"
+    if auto_memory_dir.is_dir():
+        memory_candidates += sorted(auto_memory_dir.glob("*.md"))
+
+    for candidate in memory_candidates:
+        if candidate.is_file() and _file_within_cap(
+            candidate, max_file_bytes, plan.skipped, "memory file"
+        ):
+            plan.memory_files.append(candidate)
+
+    # --- Workspace docs -----------------------------------------------------
+    for candidate in sorted(workspace.glob("README*")):
+        if candidate.is_file() and _file_within_cap(
+            candidate, max_file_bytes, plan.skipped, "readme"
+        ):
+            plan.readmes.append(candidate)
+
+    # --- Session logs -------------------------------------------------------
+    if include_session_logs:
+        transcripts = [path for path in project_dir.glob("*.jsonl") if path.is_file()]
+        transcripts.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+        if len(transcripts) > max_session_logs:
+            plan.skipped.append(
+                f"session logs: keeping newest {max_session_logs} of {len(transcripts)}"
+            )
+        for transcript in transcripts[:max_session_logs]:
+            if _file_within_cap(transcript, max_session_log_bytes, plan.skipped, "session log"):
+                plan.session_logs.append(transcript)
+
+        extra_glob = os.getenv("COGNEE_SEED_SESSION_LOG_GLOB")
+        if extra_glob:
+            for path in sorted(Path("/").glob(extra_glob.lstrip("/"))):
+                if path.is_file() and _file_within_cap(
+                    path, max_session_log_bytes, plan.skipped, "session log"
+                ):
+                    plan.session_logs.append(path)
+    else:
+        plan.skipped.append("session logs: disabled")
+
+    # --- Codebase -----------------------------------------------------------
+    if include_codebase:
+        if detect_code_project(workspace):
+            plan.codebase = workspace
+        else:
+            plan.skipped.append("codebase: workspace is not a recognized code project")
+    else:
+        plan.skipped.append("codebase: disabled")
+
+    return plan

--- a/cognee/modules/seeding/discovery.py
+++ b/cognee/modules/seeding/discovery.py
@@ -3,9 +3,11 @@
 Pure discovery: walk the workspace and known coding-agent homes and return a
 :class:`SeedPlan` describing what a seed run *would* ingest — agent memory
 files (``MEMORY.md``, ``SOUL.md``, …), the workspace README, recent session
-transcripts, and the workspace codebase. Nothing here reads file contents or
-touches cognee storage; the runner in :mod:`cognee.modules.seeding.seed`
-decides what to do with the plan.
+transcripts (Claude Code, Codex, Gemini CLI, pi, Aider), and the workspace
+codebase. Nothing here ingests or touches cognee storage — the only content
+read is each Codex rollout's first metadata line, needed to match sessions to
+this workspace; the runner in :mod:`cognee.modules.seeding.seed` decides what
+to do with the plan.
 
 Safety posture: only explicitly allowlisted dot-paths are ever picked up
 (``.claude/CLAUDE.md`` and the Claude Code project home for *this* workspace),
@@ -121,6 +123,120 @@ def claude_code_project_dir(workspace: Path, claude_home: Optional[Path] = None)
     return claude_home / "projects" / slug
 
 
+def _newest_first(paths: List[Path]) -> List[Path]:
+    def mtime(path: Path) -> float:
+        try:
+            return path.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    return sorted(paths, key=mtime, reverse=True)
+
+
+def _claude_code_transcripts(
+    workspace: Path, limit: int, claude_home: Optional[Path] = None
+) -> List[Path]:
+    """Claude Code: ``~/.claude/projects/<slug>/*.jsonl`` (slug = the
+    workspace path with every non-alphanumeric character replaced by ``-``)."""
+    project_dir = claude_code_project_dir(workspace, claude_home)
+    transcripts = [path for path in project_dir.glob("*.jsonl") if path.is_file()]
+    return _newest_first(transcripts)[:limit]
+
+
+# Rollout meta lines are small; a sane first line fits well under this.
+_CODEX_META_READ_BYTES = 64 * 1024
+# Rollouts for every workspace share one tree, so bound how many meta lines
+# one discovery pass will read.
+_CODEX_MAX_SCANNED = 500
+
+
+def _codex_transcripts(
+    workspace: Path, limit: int, codex_home: Optional[Path] = None
+) -> List[Path]:
+    """Codex CLI: ``~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl``.
+
+    Rollouts for every workspace live in one date-partitioned tree; the first
+    line of each file is a session-meta record whose ``payload.cwd`` (``cwd``
+    at the top level in older layouts) names the working directory, so each
+    candidate's meta line is read to keep only this workspace's sessions.
+    """
+    import json
+
+    codex_home = codex_home or (Path.home() / ".codex")
+    sessions_dir = codex_home / "sessions"
+    if not sessions_dir.is_dir():
+        return []
+
+    # The YYYY/MM/DD partitioning plus the timestamped filename make the
+    # lexicographic path order chronological — reversed() is newest-first
+    # without a stat() per file.
+    candidates = sorted(sessions_dir.glob("*/*/*/rollout-*.jsonl"), reverse=True)
+    workspace_str = str(workspace.resolve())
+
+    matches: List[Path] = []
+    for rollout in candidates[:_CODEX_MAX_SCANNED]:
+        try:
+            with rollout.open("r", encoding="utf-8", errors="replace") as stream:
+                meta = json.loads(stream.readline(_CODEX_META_READ_BYTES))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(meta, dict):
+            continue
+        payload = meta.get("payload")
+        if not isinstance(payload, dict):
+            payload = meta
+        if payload.get("cwd") == workspace_str:
+            matches.append(rollout)
+            if len(matches) >= limit:
+                break
+    return matches
+
+
+def _gemini_session_files(
+    workspace: Path, limit: int, gemini_home: Optional[Path] = None
+) -> List[Path]:
+    """Gemini CLI: ``~/.gemini/tmp/<sha256(project_root)>/`` holds ``logs.json``
+    and saved chats under ``chats/``."""
+    import hashlib
+
+    gemini_home = gemini_home or (Path.home() / ".gemini")
+    project_hash = hashlib.sha256(str(workspace.resolve()).encode("utf-8")).hexdigest()
+    project_dir = gemini_home / "tmp" / project_hash
+    if not project_dir.is_dir():
+        return []
+
+    files: List[Path] = []
+    logs = project_dir / "logs.json"
+    if logs.is_file():
+        files.append(logs)
+    chats_dir = project_dir / "chats"
+    if chats_dir.is_dir():
+        files.extend(_newest_first([p for p in chats_dir.glob("*.json") if p.is_file()])[:limit])
+    return files
+
+
+def _pi_transcripts(workspace: Path, limit: int, pi_home: Optional[Path] = None) -> List[Path]:
+    """pi: ``~/.pi/agent/sessions/--<cwd with / -> ->--/*.jsonl``.
+
+    Directory naming observed in the wild (not officially documented): the
+    workspace path with ``/`` replaced by ``-``, wrapped in ``--``. When the
+    derived directory does not exist, nothing is discovered — harmless.
+    """
+    pi_home = pi_home or (Path.home() / ".pi")
+    slug = "--" + str(workspace.resolve()).strip("/").replace("/", "-") + "--"
+    session_dir = pi_home / "agent" / "sessions" / slug
+    if not session_dir.is_dir():
+        return []
+    return _newest_first([p for p in session_dir.glob("*.jsonl") if p.is_file()])[:limit]
+
+
+def _aider_history(workspace: Path) -> List[Path]:
+    """Aider: ``.aider.chat.history.md`` at the workspace root (an explicitly
+    allowlisted dotfile — markdown chat history, no secrets by design)."""
+    history = workspace / ".aider.chat.history.md"
+    return [history] if history.is_file() else []
+
+
 def _file_within_cap(path: Path, cap: int, skipped: List[str], label: str) -> bool:
     try:
         size = path.stat().st_size
@@ -142,6 +258,9 @@ def discover_seed_plan(
     include_codebase: bool = True,
     include_session_logs: bool = True,
     claude_home: Optional[Path] = None,
+    codex_home: Optional[Path] = None,
+    gemini_home: Optional[Path] = None,
+    pi_home: Optional[Path] = None,
     max_session_logs: Optional[int] = None,
     max_session_log_bytes: Optional[int] = None,
     max_file_bytes: Optional[int] = None,
@@ -190,20 +309,27 @@ def discover_seed_plan(
             plan.readmes.append(candidate)
 
     # --- Session logs -------------------------------------------------------
+    # One adapter per coding agent, each scoped to this workspace and capped
+    # to the newest max_session_logs entries. Adapters over free-form globs on
+    # purpose: cognee loads .env from the working directory, so an env-driven
+    # glob would let a hostile repo point the seeder at arbitrary files.
     if include_session_logs:
-        transcripts = [path for path in project_dir.glob("*.jsonl") if path.is_file()]
-        transcripts.sort(key=lambda path: path.stat().st_mtime, reverse=True)
-        if len(transcripts) > max_session_logs:
-            plan.skipped.append(
-                f"session logs: keeping newest {max_session_logs} of {len(transcripts)}"
-            )
-        for transcript in transcripts[:max_session_logs]:
-            if _file_within_cap(transcript, max_session_log_bytes, plan.skipped, "session log"):
-                plan.session_logs.append(transcript)
-        # No free-form glob override on purpose: cognee loads .env from the
-        # working directory, so an env-driven glob would let a hostile repo
-        # point the seeder at arbitrary files. Additional agents get explicit
-        # discovery adapters instead.
+        adapters = (
+            ("Claude Code", _claude_code_transcripts(workspace, max_session_logs, claude_home)),
+            ("Codex", _codex_transcripts(workspace, max_session_logs, codex_home)),
+            ("Gemini CLI", _gemini_session_files(workspace, max_session_logs, gemini_home)),
+            ("pi", _pi_transcripts(workspace, max_session_logs, pi_home)),
+            ("Aider", _aider_history(workspace)),
+        )
+        for agent_name, session_files in adapters:
+            for session_file in session_files:
+                if _file_within_cap(
+                    session_file,
+                    max_session_log_bytes,
+                    plan.skipped,
+                    f"{agent_name} session log",
+                ):
+                    plan.session_logs.append(session_file)
     else:
         plan.skipped.append("session logs: disabled")
 

--- a/cognee/modules/seeding/discovery.py
+++ b/cognee/modules/seeding/discovery.py
@@ -200,14 +200,10 @@ def discover_seed_plan(
         for transcript in transcripts[:max_session_logs]:
             if _file_within_cap(transcript, max_session_log_bytes, plan.skipped, "session log"):
                 plan.session_logs.append(transcript)
-
-        extra_glob = os.getenv("COGNEE_SEED_SESSION_LOG_GLOB")
-        if extra_glob:
-            for path in sorted(Path("/").glob(extra_glob.lstrip("/"))):
-                if path.is_file() and _file_within_cap(
-                    path, max_session_log_bytes, plan.skipped, "session log"
-                ):
-                    plan.session_logs.append(path)
+        # No free-form glob override on purpose: cognee loads .env from the
+        # working directory, so an env-driven glob would let a hostile repo
+        # point the seeder at arbitrary files. Additional agents get explicit
+        # discovery adapters instead.
     else:
         plan.skipped.append("session logs: disabled")
 

--- a/cognee/modules/seeding/discovery.py
+++ b/cognee/modules/seeding/discovery.py
@@ -215,6 +215,16 @@ def _gemini_session_files(
     return files
 
 
+def _pi_session_dir(workspace: Path, pi_home: Optional[Path] = None) -> Path:
+    """pi's per-workspace session directory: ``--<slug>--`` under
+    ``~/.pi/agent/sessions``, slug = the path with separators replaced by
+    ``-`` (drive colons dropped so the name stays valid on Windows)."""
+    pi_home = pi_home or (Path.home() / ".pi")
+    normalized = str(workspace.resolve()).replace("\\", "/").replace(":", "")
+    slug = "--" + normalized.strip("/").replace("/", "-") + "--"
+    return pi_home / "agent" / "sessions" / slug
+
+
 def _pi_transcripts(workspace: Path, limit: int, pi_home: Optional[Path] = None) -> List[Path]:
     """pi: ``~/.pi/agent/sessions/--<cwd with / -> ->--/*.jsonl``.
 
@@ -222,9 +232,7 @@ def _pi_transcripts(workspace: Path, limit: int, pi_home: Optional[Path] = None)
     workspace path with ``/`` replaced by ``-``, wrapped in ``--``. When the
     derived directory does not exist, nothing is discovered — harmless.
     """
-    pi_home = pi_home or (Path.home() / ".pi")
-    slug = "--" + str(workspace.resolve()).strip("/").replace("/", "-") + "--"
-    session_dir = pi_home / "agent" / "sessions" / slug
+    session_dir = _pi_session_dir(workspace, pi_home)
     if not session_dir.is_dir():
         return []
     return _newest_first([p for p in session_dir.glob("*.jsonl") if p.is_file()])[:limit]

--- a/cognee/modules/seeding/seed.py
+++ b/cognee/modules/seeding/seed.py
@@ -20,6 +20,7 @@ disk. Identical content hashes to the same record, so staging does not defeat
 
 from __future__ import annotations
 
+import filecmp
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -113,7 +114,7 @@ def _prepare_paths(paths: List[Path], category: str, skipped: List[str]) -> List
             staging_root.mkdir(parents=True, exist_ok=True)
         target = staging_root / path.name
         counter = 1
-        while target.exists() and target.read_bytes() != path.read_bytes():
+        while target.exists() and not filecmp.cmp(path, target, shallow=False):
             target = staging_root / f"{path.stem}-{counter}{path.suffix}"
             counter += 1
         try:

--- a/cognee/modules/seeding/seed.py
+++ b/cognee/modules/seeding/seed.py
@@ -1,0 +1,237 @@
+"""Day-one seeding: ingest what already exists so the first recall returns.
+
+``seed()`` takes the :class:`~cognee.modules.seeding.discovery.SeedPlan` for a
+workspace and ingests it in stages ordered by size — agent memory files and
+the README first (seconds), then recent session logs, then the codebase — so
+a recall issued shortly after install already has stage-1 knowledge to hit.
+
+Each stage runs ``add()`` (LLM-free) and then ``cognify()``, isolated per
+stage: a missing or broken LLM key leaves the data ingested with cognify
+deferred and reported, instead of failing the whole seed.
+
+Sources that live outside cognee's allowed local-file roots (session
+transcripts and Claude Code auto-memory under ``~/.claude``) are staged —
+copied into ``{data_root}/seed_staging/<category>/`` — before being added.
+The copy is deliberate: it keeps the path allowlist intact for every other
+caller while making the seeder's reads explicit, size-capped, and visible on
+disk. Identical content hashes to the same record, so staging does not defeat
+``add()``'s dedup.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+from cognee.shared.logging_utils import get_logger
+
+from .discovery import SeedPlan, discover_seed_plan
+
+logger = get_logger("seeding")
+
+DEFAULT_SEED_DATASET = "workspace"
+
+# Stage order is the fast-first-value order; the node_set tags provenance.
+STAGE_MEMORY = "agent_memory"
+STAGE_DOCS = "workspace_docs"
+STAGE_SESSIONS = "session_logs"
+STAGE_CODEBASE = "codebase"
+
+
+@dataclass
+class StageResult:
+    name: str
+    files: List[str]
+    added: bool = False
+    cognified: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class SeedResult:
+    plan: SeedPlan
+    dataset_name: str
+    stages: List[StageResult] = field(default_factory=list)
+    skipped_existing: bool = False
+    dry_run: bool = False
+
+    @property
+    def ingested_anything(self) -> bool:
+        return any(stage.added for stage in self.stages)
+
+    def summary(self) -> str:
+        if self.dry_run:
+            return self.plan.describe()
+        if self.skipped_existing:
+            return (
+                f"Seed skipped: dataset '{self.dataset_name}' already exists "
+                "(use force to re-seed)."
+            )
+        lines = [f"Seeded dataset '{self.dataset_name}':"]
+        for stage in self.stages:
+            status = (
+                "ok"
+                if stage.cognified
+                else ("added, cognify deferred" if stage.added else "failed")
+            )
+            lines.append(f"  {stage.name}: {len(stage.files)} item(s) — {status}")
+            if stage.error:
+                lines.append(f"    error: {stage.error}")
+        for reason in self.plan.skipped:
+            lines.append(f"  (skipped) {reason}")
+        return "\n".join(lines)
+
+
+def _staging_dir() -> Path:
+    from cognee.base_config import get_base_config
+
+    return Path(get_base_config().data_root_directory) / "seed_staging"
+
+
+def _prepare_paths(paths: List[Path], category: str, skipped: List[str]) -> List[str]:
+    """Return add()-able paths, staging any source outside the allowed roots."""
+    from cognee.infrastructure.files.utils.local_path_safety import resolve_local_path
+
+    prepared: List[str] = []
+    staging_root: Optional[Path] = None
+
+    for path in paths:
+        try:
+            resolve_local_path(path, must_exist=True)
+            prepared.append(str(path))
+            continue
+        except FileNotFoundError:
+            skipped.append(f"{category} {path}: vanished before ingestion")
+            continue
+        except ValueError:
+            pass  # outside allowed roots -> stage a copy below
+
+        if staging_root is None:
+            staging_root = _staging_dir() / category
+            staging_root.mkdir(parents=True, exist_ok=True)
+        target = staging_root / path.name
+        counter = 1
+        while target.exists() and target.read_bytes() != path.read_bytes():
+            target = staging_root / f"{path.stem}-{counter}{path.suffix}"
+            counter += 1
+        try:
+            shutil.copyfile(path, target)
+        except OSError as error:
+            skipped.append(f"{category} {path}: staging failed ({error})")
+            continue
+        prepared.append(str(target))
+
+    return prepared
+
+
+async def _dataset_exists(dataset_name: str, user) -> bool:
+    from cognee.api.v1.datasets.datasets import datasets as datasets_api
+
+    existing = await datasets_api.list_datasets(user)
+    return any(getattr(dataset, "name", None) == dataset_name for dataset in existing)
+
+
+async def seed(
+    workspace: Optional[Path] = None,
+    *,
+    dataset_name: str = DEFAULT_SEED_DATASET,
+    include_codebase: bool = True,
+    include_session_logs: bool = True,
+    user=None,
+    force: bool = False,
+    dry_run: bool = False,
+) -> SeedResult:
+    """Discover and ingest day-one sources for ``workspace``.
+
+    Args:
+        workspace: Workspace root; auto-detected from the current directory
+            when omitted.
+        dataset_name: Dataset the seed lands in. Default ``"workspace"`` —
+            a default ``recall()`` (which searches every dataset the user
+            owns) finds it without any dataset argument.
+        include_codebase: Ingest the workspace as a code project when it is
+            one (also gated by ``COGNEE_SEED_CODEBASE``).
+        include_session_logs: Ingest recent agent session transcripts (also
+            gated by ``COGNEE_SEED_SESSION_LOGS``).
+        user: Owner of the seeded data; the default user when omitted.
+        force: Re-seed even when the seed dataset already exists. Cheap on
+            unchanged files thanks to content-hash dedup in ``add()``.
+        dry_run: Only discover; return the plan without ingesting.
+    """
+    plan = discover_seed_plan(
+        workspace,
+        include_codebase=include_codebase,
+        include_session_logs=include_session_logs,
+    )
+    result = SeedResult(plan=plan, dataset_name=dataset_name, dry_run=dry_run)
+
+    if dry_run or plan.is_empty:
+        return result
+
+    if not force and await _dataset_exists(dataset_name, user):
+        result.skipped_existing = True
+        return result
+
+    from cognee.api.v1.add import add
+    from cognee.api.v1.cognify import cognify
+    from cognee.infrastructure.files.utils.local_path_safety import resolve_local_path
+
+    stages: List[StageResult] = []
+
+    def stage_paths(name: str, paths: List[Path]) -> None:
+        if not paths:
+            return
+        prepared = _prepare_paths(paths, name, plan.skipped)
+        if prepared:
+            stages.append(StageResult(name=name, files=prepared))
+
+    stage_paths(STAGE_MEMORY, plan.memory_files)
+    stage_paths(STAGE_DOCS, plan.readmes)
+    stage_paths(STAGE_SESSIONS, plan.session_logs)
+
+    if plan.codebase is not None:
+        # The codebase cannot be staged; it must resolve within the allowed
+        # roots (it does when seeding runs from the workspace, the normal
+        # CLI/MCP case).
+        try:
+            resolve_local_path(plan.codebase, must_exist=True)
+            stages.append(StageResult(name=STAGE_CODEBASE, files=[str(plan.codebase)]))
+        except (ValueError, FileNotFoundError):
+            plan.skipped.append(
+                f"codebase {plan.codebase}: outside allowed local-file roots — run the "
+                "seed from the workspace or extend COGNEE_ALLOWED_LOCAL_FILE_ROOTS"
+            )
+
+    cognify_available = True
+    for stage in stages:
+        try:
+            await add(stage.files, dataset_name=dataset_name, user=user, node_set=[stage.name])
+            stage.added = True
+        except Exception as error:
+            stage.error = f"add failed: {error}"
+            logger.warning("Seed stage %s failed to add: %s", stage.name, error)
+            continue
+
+        if not cognify_available:
+            continue
+        try:
+            await cognify(datasets=[dataset_name], user=user)
+            stage.cognified = True
+        except Exception as error:
+            # Typically a missing/broken LLM key. Data stays ingested; a later
+            # cognify picks it up. Don't retry per-stage: it would fail the
+            # same way and stall the seed.
+            stage.error = f"cognify deferred: {error}"
+            cognify_available = False
+            logger.warning(
+                "Seed stage %s ingested, cognify deferred (%s). Later cognify "
+                "runs will process it.",
+                stage.name,
+                error,
+            )
+
+    result.stages = stages
+    logger.info("Day-one seed finished:\n%s", result.summary())
+    return result

--- a/cognee/tests/unit/modules/seeding/test_discovery.py
+++ b/cognee/tests/unit/modules/seeding/test_discovery.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 from pathlib import Path
 
@@ -143,10 +144,11 @@ def test_claude_code_project_dir_slug(tmp_path):
     workspace.mkdir()
     project_dir = claude_code_project_dir(workspace, tmp_path / "home")
 
-    # Every non-alphanumeric character in the absolute path becomes '-'.
-    assert project_dir.name == str(workspace.resolve()).replace("/", "-").replace("_", "-").replace(
-        ".", "-"
-    )
+    # Every non-alphanumeric character in the absolute path becomes '-'
+    # (path separators included, so the rule holds on Windows too).
+    assert project_dir.parent == tmp_path / "home" / "projects"
+    assert re.fullmatch(r"[A-Za-z0-9-]+", project_dir.name)
+    assert project_dir.name.endswith("my-proj-x")
 
 
 def test_find_workspace_root_walks_up_to_project_marker(tmp_path):

--- a/cognee/tests/unit/modules/seeding/test_discovery.py
+++ b/cognee/tests/unit/modules/seeding/test_discovery.py
@@ -1,0 +1,164 @@
+import os
+import time
+from pathlib import Path
+
+from cognee.modules.seeding.discovery import (
+    claude_code_project_dir,
+    discover_seed_plan,
+    find_workspace_root,
+)
+
+
+def make_workspace(tmp_path: Path, *, code_project: bool = True) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    if code_project:
+        (workspace / "pyproject.toml").write_text("[project]\nname = 'demo'\n")
+    (workspace / "MEMORY.md").write_text("# Memory\nProject uses uv.\n")
+    (workspace / "SOUL.md").write_text("# Soul\nBe helpful.\n")
+    (workspace / "README.md").write_text("# Demo\nA demo project.\n")
+    memory_dir = workspace / "memory"
+    memory_dir.mkdir()
+    (memory_dir / "notes.md").write_text("- a fact\n")
+    claude_dir = workspace / ".claude"
+    claude_dir.mkdir()
+    (claude_dir / "CLAUDE.md").write_text("Project instructions.\n")
+    (claude_dir / "settings.json").write_text("{}")  # must never be discovered
+    (workspace / ".env").write_text("SECRET=1\n")  # must never be discovered
+    return workspace
+
+
+def make_claude_home(tmp_path: Path, workspace: Path, transcripts: int = 5) -> Path:
+    claude_home = tmp_path / "claude-home"
+    project_dir = claude_code_project_dir(workspace, claude_home)
+    project_dir.mkdir(parents=True)
+    for index in range(transcripts):
+        transcript = project_dir / f"session-{index}.jsonl"
+        transcript.write_text('{"role": "user"}\n')
+        stamp = time.time() - (transcripts - index) * 60
+        os.utime(transcript, (stamp, stamp))
+    auto_memory = project_dir / "memory"
+    auto_memory.mkdir()
+    (auto_memory / "MEMORY.md").write_text("# Auto memory\n")
+    return claude_home
+
+
+def test_discovers_memory_docs_sessions_and_codebase(tmp_path):
+    workspace = make_workspace(tmp_path)
+    claude_home = make_claude_home(tmp_path, workspace)
+
+    plan = discover_seed_plan(workspace, claude_home=claude_home)
+
+    memory_names = {path.name for path in plan.memory_files}
+    assert "MEMORY.md" in memory_names
+    assert "SOUL.md" in memory_names
+    assert "CLAUDE.md" in memory_names  # .claude/CLAUDE.md allowlisted
+    assert "notes.md" in memory_names
+    # Two MEMORY.md entries: workspace root + Claude auto-memory.
+    assert sum(1 for path in plan.memory_files if path.name == "MEMORY.md") == 2
+
+    assert [path.name for path in plan.readmes] == ["README.md"]
+    assert plan.codebase == workspace
+    assert not plan.is_empty
+
+    # Never pick up secrets or non-allowlisted dotfiles.
+    discovered = {str(path) for path in plan.memory_files + plan.readmes + plan.session_logs}
+    assert not any(item.endswith(".env") for item in discovered)
+    assert not any(item.endswith("settings.json") for item in discovered)
+
+
+def test_session_logs_keep_newest_n(tmp_path):
+    workspace = make_workspace(tmp_path)
+    claude_home = make_claude_home(tmp_path, workspace, transcripts=5)
+
+    plan = discover_seed_plan(workspace, claude_home=claude_home, max_session_logs=3)
+
+    assert len(plan.session_logs) == 3
+    # Newest first: index 4 has the most recent mtime.
+    assert [path.name for path in plan.session_logs] == [
+        "session-4.jsonl",
+        "session-3.jsonl",
+        "session-2.jsonl",
+    ]
+
+
+def test_size_caps_and_empty_files_are_skipped(tmp_path):
+    workspace = make_workspace(tmp_path)
+    claude_home = make_claude_home(tmp_path, workspace, transcripts=1)
+    (workspace / "MEMORY.md").write_text("")  # empty -> skipped
+
+    plan = discover_seed_plan(
+        workspace,
+        claude_home=claude_home,
+        max_session_log_bytes=4,  # transcript is larger than this
+    )
+
+    assert not plan.session_logs
+    assert sum(1 for path in plan.memory_files if path.name == "MEMORY.md") == 1  # auto-memory only
+    assert any("exceeds cap" in reason for reason in plan.skipped)
+    assert any("empty" in reason for reason in plan.skipped)
+
+
+def test_toggles_disable_categories(tmp_path):
+    workspace = make_workspace(tmp_path)
+    claude_home = make_claude_home(tmp_path, workspace)
+
+    plan = discover_seed_plan(
+        workspace,
+        claude_home=claude_home,
+        include_codebase=False,
+        include_session_logs=False,
+    )
+
+    assert plan.codebase is None
+    assert not plan.session_logs
+    assert any("codebase: disabled" in reason for reason in plan.skipped)
+    assert any("session logs: disabled" in reason for reason in plan.skipped)
+
+
+def test_non_code_workspace_has_no_codebase(tmp_path):
+    workspace = make_workspace(tmp_path, code_project=False)
+
+    plan = discover_seed_plan(workspace, claude_home=tmp_path / "claude-home")
+
+    assert plan.codebase is None
+    assert any("not a recognized code project" in reason for reason in plan.skipped)
+    assert plan.memory_files  # memory files still seed a plain notes directory
+
+
+def test_env_toggles(tmp_path, monkeypatch):
+    workspace = make_workspace(tmp_path)
+    claude_home = make_claude_home(tmp_path, workspace)
+    monkeypatch.setenv("COGNEE_SEED_CODEBASE", "false")
+    monkeypatch.setenv("COGNEE_SEED_SESSION_LOGS", "0")
+
+    plan = discover_seed_plan(workspace, claude_home=claude_home)
+
+    assert plan.codebase is None
+    assert not plan.session_logs
+
+
+def test_claude_code_project_dir_slug(tmp_path):
+    workspace = tmp_path / "my_proj.x"
+    workspace.mkdir()
+    project_dir = claude_code_project_dir(workspace, tmp_path / "home")
+
+    # Every non-alphanumeric character in the absolute path becomes '-'.
+    assert project_dir.name == str(workspace.resolve()).replace("/", "-").replace("_", "-").replace(
+        ".", "-"
+    )
+
+
+def test_find_workspace_root_walks_up_to_project_marker(tmp_path):
+    workspace = make_workspace(tmp_path)
+    nested = workspace / "src" / "pkg"
+    nested.mkdir(parents=True)
+
+    assert find_workspace_root(nested) == workspace
+
+
+def test_find_workspace_root_falls_back_to_start(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+
+    assert find_workspace_root(plain) == plain

--- a/cognee/tests/unit/modules/seeding/test_discovery.py
+++ b/cognee/tests/unit/modules/seeding/test_discovery.py
@@ -234,12 +234,15 @@ def test_gemini_adapter_uses_project_hash(tmp_path):
 
 
 def test_pi_and_aider_adapters(tmp_path):
-    from cognee.modules.seeding.discovery import _aider_history, _pi_transcripts
+    from cognee.modules.seeding.discovery import (
+        _aider_history,
+        _pi_session_dir,
+        _pi_transcripts,
+    )
 
     workspace = make_workspace(tmp_path)
-    slug = "--" + str(workspace.resolve()).strip("/").replace("/", "-") + "--"
     pi_home = tmp_path / "pi-home"
-    session_dir = pi_home / "agent" / "sessions" / slug
+    session_dir = _pi_session_dir(workspace, pi_home)
     session_dir.mkdir(parents=True)
     (session_dir / "0001_abc.jsonl").write_text("{}\n")
     (workspace / ".aider.chat.history.md").write_text("# aider chat\n")

--- a/cognee/tests/unit/modules/seeding/test_discovery.py
+++ b/cognee/tests/unit/modules/seeding/test_discovery.py
@@ -164,3 +164,118 @@ def test_find_workspace_root_falls_back_to_start(tmp_path):
     plain.mkdir()
 
     assert find_workspace_root(plain) == plain
+
+
+def make_codex_home(tmp_path: Path, workspace: Path) -> Path:
+    """Fake ~/.codex with rollouts for this workspace, another one, and junk."""
+    import json
+
+    codex_home = tmp_path / "codex-home"
+
+    def rollout(day: str, name: str, first_line: str) -> None:
+        day_dir = codex_home / "sessions" / "2026" / "08" / day
+        day_dir.mkdir(parents=True, exist_ok=True)
+        (day_dir / f"rollout-2026-08-{day}T10-00-00-{name}.jsonl").write_text(first_line + "\n")
+
+    meta = {"timestamp": "t", "type": "session_meta", "payload": {"cwd": str(workspace)}}
+    other = {"timestamp": "t", "type": "session_meta", "payload": {"cwd": "/elsewhere"}}
+    legacy = {"timestamp": "t", "cwd": str(workspace)}  # cwd at top level (older layout)
+    rollout("18", "old-match", json.dumps(meta))
+    rollout("19", "other-ws", json.dumps(other))
+    rollout("19", "legacy-match", json.dumps(legacy))
+    rollout("20", "malformed", "{not json")
+    rollout("20", "new-match", json.dumps(meta))
+    return codex_home
+
+
+def test_codex_adapter_filters_by_cwd_newest_first(tmp_path):
+    from cognee.modules.seeding.discovery import _codex_transcripts
+
+    workspace = make_workspace(tmp_path)
+    codex_home = make_codex_home(tmp_path, workspace)
+
+    matches = _codex_transcripts(workspace, 10, codex_home)
+
+    names = [path.name for path in matches]
+    assert [name.split("-")[-1].replace(".jsonl", "") for name in names] == [
+        "match",
+        "match",
+        "match",
+    ]
+    # Newest day first; the other-workspace and malformed rollouts are excluded.
+    assert "new-match" in names[0]
+    assert "legacy-match" in names[1]
+    assert "old-match" in names[2]
+
+    assert [path.name for path in _codex_transcripts(workspace, 1, codex_home)] == names[:1]
+
+
+def test_gemini_adapter_uses_project_hash(tmp_path):
+    import hashlib
+
+    from cognee.modules.seeding.discovery import _gemini_session_files
+
+    workspace = make_workspace(tmp_path)
+    gemini_home = tmp_path / "gemini-home"
+    project_hash = hashlib.sha256(str(workspace.resolve()).encode()).hexdigest()
+    project_dir = gemini_home / "tmp" / project_hash
+    (project_dir / "chats").mkdir(parents=True)
+    (project_dir / "logs.json").write_text("[]")
+    (project_dir / "chats" / "session.json").write_text("{}")
+    # A different project's directory must not be picked up.
+    other_dir = gemini_home / "tmp" / ("0" * 64)
+    other_dir.mkdir(parents=True)
+    (other_dir / "logs.json").write_text("[]")
+
+    files = _gemini_session_files(workspace, 5, gemini_home)
+
+    assert {path.name for path in files} == {"logs.json", "session.json"}
+    assert all(project_hash in str(path) for path in files)
+
+
+def test_pi_and_aider_adapters(tmp_path):
+    from cognee.modules.seeding.discovery import _aider_history, _pi_transcripts
+
+    workspace = make_workspace(tmp_path)
+    slug = "--" + str(workspace.resolve()).strip("/").replace("/", "-") + "--"
+    pi_home = tmp_path / "pi-home"
+    session_dir = pi_home / "agent" / "sessions" / slug
+    session_dir.mkdir(parents=True)
+    (session_dir / "0001_abc.jsonl").write_text("{}\n")
+    (workspace / ".aider.chat.history.md").write_text("# aider chat\n")
+
+    assert [path.name for path in _pi_transcripts(workspace, 3, pi_home)] == ["0001_abc.jsonl"]
+    assert [path.name for path in _aider_history(workspace)] == [".aider.chat.history.md"]
+    assert _pi_transcripts(workspace, 3, tmp_path / "missing") == []
+
+
+def test_discover_plan_collects_all_agent_sessions(tmp_path):
+    import hashlib
+
+    workspace = make_workspace(tmp_path)
+    claude_home = make_claude_home(tmp_path, workspace, transcripts=1)
+    codex_home = make_codex_home(tmp_path, workspace)
+    gemini_home = tmp_path / "gemini-home"
+    project_dir = (
+        gemini_home / "tmp" / hashlib.sha256(str(workspace.resolve()).encode()).hexdigest()
+    )
+    project_dir.mkdir(parents=True)
+    (project_dir / "logs.json").write_text("[]")
+    (workspace / ".aider.chat.history.md").write_text("# aider chat\n")
+
+    plan = discover_seed_plan(
+        workspace,
+        claude_home=claude_home,
+        codex_home=codex_home,
+        gemini_home=gemini_home,
+        pi_home=tmp_path / "pi-home",
+        max_session_logs=2,
+    )
+
+    names = {path.name for path in plan.session_logs}
+    assert "session-0.jsonl" in names  # Claude Code
+    assert any("rollout-" in name for name in names)  # Codex
+    assert "logs.json" in names  # Gemini CLI
+    assert ".aider.chat.history.md" in names  # Aider
+    # Codex respects the per-agent newest-N cap.
+    assert sum(1 for name in names if "rollout-" in name) == 2

--- a/cognee/tests/unit/modules/seeding/test_seed.py
+++ b/cognee/tests/unit/modules/seeding/test_seed.py
@@ -1,0 +1,170 @@
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+import importlib
+
+from cognee.modules.seeding.discovery import claude_code_project_dir
+
+# The package __init__ re-exports the seed *function*, which shadows the
+# submodule attribute — resolve the module through importlib instead.
+seed_module = importlib.import_module("cognee.modules.seeding.seed")
+seed = seed_module.seed
+
+
+def make_workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "pyproject.toml").write_text("[project]\nname = 'demo'\n")
+    (workspace / "MEMORY.md").write_text("# Memory\n")
+    (workspace / "README.md").write_text("# Demo\n")
+    return workspace
+
+
+def make_claude_home(tmp_path: Path, workspace: Path) -> Path:
+    claude_home = tmp_path / "claude-home"
+    project_dir = claude_code_project_dir(workspace, claude_home)
+    project_dir.mkdir(parents=True)
+    transcript = project_dir / "session-1.jsonl"
+    transcript.write_text('{"role": "user"}\n')
+    stamp = time.time() - 60
+    os.utime(transcript, (stamp, stamp))
+    return claude_home
+
+
+@pytest.fixture
+def harness(monkeypatch, tmp_path):
+    """Stub the ingestion surface and record every call."""
+    calls = {"add": [], "cognify": []}
+
+    async def fake_add(data, dataset_name=None, user=None, node_set=None, **kwargs):
+        calls["add"].append((list(data), dataset_name, tuple(node_set or ())))
+
+    async def fake_cognify(datasets=None, user=None, **kwargs):
+        calls["cognify"].append(tuple(datasets or ()))
+
+    async def no_existing_dataset(dataset_name, user):
+        return False
+
+    monkeypatch.setattr("cognee.api.v1.add.add", fake_add)
+    monkeypatch.setattr("cognee.api.v1.cognify.cognify", fake_cognify)
+    monkeypatch.setattr(seed_module, "_dataset_exists", no_existing_dataset)
+    monkeypatch.setattr(seed_module, "_staging_dir", lambda: tmp_path / "staging")
+
+    workspace = make_workspace(tmp_path)
+    claude_home = make_claude_home(tmp_path, workspace)
+    monkeypatch.setattr(
+        "cognee.modules.seeding.discovery.claude_code_project_dir",
+        lambda ws, home=None: claude_code_project_dir(ws, claude_home),
+    )
+    return calls, workspace, tmp_path
+
+
+@pytest.mark.asyncio
+async def test_seed_stages_in_fast_first_value_order(harness):
+    calls, workspace, _ = harness
+
+    result = await seed(workspace, dataset_name="workspace")
+
+    stage_names = [stage.name for stage in result.stages]
+    assert stage_names == ["agent_memory", "workspace_docs", "session_logs", "codebase"]
+    assert all(stage.added for stage in result.stages)
+    assert all(stage.cognified for stage in result.stages)
+
+    # Every add is tagged with its stage's node_set and lands in one dataset.
+    assert [call[2] for call in calls["add"]] == [
+        ("agent_memory",),
+        ("workspace_docs",),
+        ("session_logs",),
+        ("codebase",),
+    ]
+    assert {call[1] for call in calls["add"]} == {"workspace"}
+    assert calls["cognify"] == [("workspace",)] * 4
+
+    # The codebase stage passes the workspace directory itself (the repo
+    # resolver turns it into a manifest + documents downstream).
+    assert calls["add"][-1][0] == [str(workspace)]
+    assert result.ingested_anything
+
+
+@pytest.mark.asyncio
+async def test_seed_stages_out_of_root_sources(harness, monkeypatch):
+    calls, workspace, tmp_path = harness
+    # Only the workspace is an allowed root: the transcript under the fake
+    # agent home must be staged into cognee's own storage before being added.
+    monkeypatch.setenv("COGNEE_ALLOWED_LOCAL_FILE_ROOTS", str(workspace))
+
+    result = await seed(workspace)
+
+    session_stage = next(stage for stage in result.stages if stage.name == "session_logs")
+    staged_path = Path(session_stage.files[0])
+    assert staged_path.is_relative_to(tmp_path / "staging")
+    assert staged_path.name == "session-1.jsonl"
+    assert staged_path.read_text() == '{"role": "user"}\n'
+
+
+@pytest.mark.asyncio
+async def test_cognify_failure_defers_but_keeps_ingesting(harness, monkeypatch):
+    calls, workspace, _ = harness
+
+    async def broken_cognify(datasets=None, user=None, **kwargs):
+        calls["cognify"].append(tuple(datasets or ()))
+        raise RuntimeError("no LLM key")
+
+    monkeypatch.setattr("cognee.api.v1.cognify.cognify", broken_cognify)
+
+    result = await seed(workspace)
+
+    assert all(stage.added for stage in result.stages)
+    assert not any(stage.cognified for stage in result.stages)
+    # One failed attempt, then cognify is not retried per stage.
+    assert len(calls["cognify"]) == 1
+    assert "cognify deferred" in (result.stages[0].error or "")
+    # Everything was still added — the data is there for a later cognify.
+    assert len(calls["add"]) == len(result.stages)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_discovers_without_ingesting(harness):
+    calls, workspace, _ = harness
+
+    result = await seed(workspace, dry_run=True)
+
+    assert result.dry_run
+    assert not result.stages
+    assert not calls["add"] and not calls["cognify"]
+    assert not result.plan.is_empty
+    assert "Seed plan" in result.summary()
+
+
+@pytest.mark.asyncio
+async def test_existing_dataset_skips_unless_forced(harness, monkeypatch):
+    calls, workspace, _ = harness
+
+    async def dataset_exists(dataset_name, user):
+        return True
+
+    monkeypatch.setattr(seed_module, "_dataset_exists", dataset_exists)
+
+    result = await seed(workspace)
+    assert result.skipped_existing
+    assert not calls["add"]
+
+    forced = await seed(workspace, force=True)
+    assert not forced.skipped_existing
+    assert calls["add"]
+
+
+@pytest.mark.asyncio
+async def test_empty_plan_short_circuits(harness, tmp_path):
+    calls, _, _ = harness
+    barren = tmp_path / "barren"
+    barren.mkdir()
+
+    result = await seed(barren, include_session_logs=False)
+
+    assert result.plan.is_empty
+    assert not result.stages
+    assert not calls["add"]

--- a/docs/day-one-seeding.md
+++ b/docs/day-one-seeding.md
@@ -8,7 +8,7 @@ return** instead of an empty result:
 | --- | --- | --- |
 | Agent memory | `agent_memory` | `MEMORY.md`, `SOUL.md`, `AGENTS.md`, `CLAUDE.md`, `USER.md`, `IDENTITY.md`, `TOOLS.md` at the workspace root; `memory/*.md`; `.claude/CLAUDE.md`; Claude Code auto-memory for this workspace |
 | Workspace docs | `workspace_docs` | `README.*` at the workspace root |
-| Session logs | `session_logs` | The newest Claude Code transcripts for this workspace (default 3, ≤5 MB each) |
+| Session logs | `session_logs` | Recent sessions for this workspace from known coding agents (newest 3 per agent by default, ≤5 MB each) — see the adapter table below |
 | Codebase | `codebase` | The workspace itself, when it is a code project — resolved through the repo-manifest ingestion path |
 
 Everything lands in one dataset (default `workspace`), and a default
@@ -64,6 +64,24 @@ There is intentionally no free-form path/glob override: cognee loads `.env`
 from the working directory, so an env-driven glob would let a hostile repo
 point the seeder at arbitrary files. Support for more agents' transcript
 locations lands as explicit discovery adapters.
+
+## Session-log adapters
+
+Each adapter is scoped to *this* workspace and capped to the newest
+`COGNEE_SEED_MAX_SESSION_LOGS` entries:
+
+| Agent | Location | Workspace mapping |
+| --- | --- | --- |
+| Claude Code | `~/.claude/projects/<slug>/*.jsonl` | slug = absolute path, non-alphanumerics → `-` |
+| Codex CLI | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` | first-line session meta `payload.cwd` (top-level `cwd` in older layouts); newest 500 rollouts scanned |
+| Gemini CLI | `~/.gemini/tmp/<hash>/logs.json` + `chats/*.json` | hash = SHA-256 hex of the absolute project root |
+| pi | `~/.pi/agent/sessions/--<slug>--/*.jsonl` | slug = path with `/` → `-`, wrapped in `--` (observed, not officially documented) |
+| Aider | `.aider.chat.history.md` | lives at the workspace root (explicitly allowlisted dotfile) |
+
+Not yet supported (session stores are binary/SQLite rather than files):
+Cursor CLI (`~/.cursor/chats/**/store.db`), opencode ≥1.2
+(`~/.local/share/opencode/opencode.db`), Amp (server-synced
+`~/.local/share/amp/threads/*.json`, mapping undocumented).
 
 ## Safety
 

--- a/docs/day-one-seeding.md
+++ b/docs/day-one-seeding.md
@@ -59,7 +59,11 @@ print(result.summary())
 | `COGNEE_SEED_MAX_SESSION_LOGS` | `3` | Newest N transcripts to ingest |
 | `COGNEE_SEED_MAX_SESSION_LOG_BYTES` | `5242880` | Per-transcript size cap |
 | `COGNEE_SEED_MAX_FILE_BYTES` | `10485760` | Per-file size cap for memory/docs |
-| `COGNEE_SEED_SESSION_LOG_GLOB` | unset | Extra transcript glob for other agents |
+
+There is intentionally no free-form path/glob override: cognee loads `.env`
+from the working directory, so an env-driven glob would let a hostile repo
+point the seeder at arbitrary files. Support for more agents' transcript
+locations lands as explicit discovery adapters.
 
 ## Safety
 

--- a/docs/day-one-seeding.md
+++ b/docs/day-one-seeding.md
@@ -1,0 +1,76 @@
+# Day-one seeding
+
+On a fresh install, cognee can immediately ingest the knowledge that already
+exists around your workspace — so the **first `recall` has something to
+return** instead of an empty result:
+
+| Category | node_set | What is picked up |
+| --- | --- | --- |
+| Agent memory | `agent_memory` | `MEMORY.md`, `SOUL.md`, `AGENTS.md`, `CLAUDE.md`, `USER.md`, `IDENTITY.md`, `TOOLS.md` at the workspace root; `memory/*.md`; `.claude/CLAUDE.md`; Claude Code auto-memory for this workspace |
+| Workspace docs | `workspace_docs` | `README.*` at the workspace root |
+| Session logs | `session_logs` | The newest Claude Code transcripts for this workspace (default 3, ≤5 MB each) |
+| Codebase | `codebase` | The workspace itself, when it is a code project — resolved through the repo-manifest ingestion path |
+
+Everything lands in one dataset (default `workspace`), and a default
+`recall()` searches every dataset you own, so no dataset argument is needed.
+
+Seeding runs in stages ordered by size — memory files and the README first —
+so a recall issued moments after install already hits stage-1 knowledge.
+`add()` is LLM-free; if no LLM key is configured yet, the data is still
+ingested and `cognify` is deferred to the next run with a key.
+
+## Automatic (MCP server)
+
+The cognee MCP server seeds automatically on startup when all of these hold:
+
+- local mode (no `--api-url` / cloud connection),
+- the user owns **zero datasets** (a genuinely fresh install — it never
+  re-seeds behind your back),
+- `COGNEE_AUTO_SEED` is not set to `false`.
+
+Seeding runs in the background; server startup never blocks on it.
+
+## Manual (CLI)
+
+```bash
+cognee-cli seed --dry-run     # print what would be ingested, ingest nothing
+cognee-cli seed               # seed the current workspace
+cognee-cli seed --no-code --no-session-logs
+cognee-cli seed --force       # re-seed an existing seed dataset
+cognee-cli seed -w /path/to/workspace -d my_dataset
+```
+
+## SDK
+
+```python
+import cognee
+
+result = await cognee.seed()          # auto-detects the workspace root
+print(result.summary())
+```
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `COGNEE_AUTO_SEED` | `true` | MCP-server auto-seed on fresh installs |
+| `COGNEE_SEED_CODEBASE` | `true` | Include the codebase stage |
+| `COGNEE_SEED_SESSION_LOGS` | `true` | Include session transcripts |
+| `COGNEE_SEED_MAX_SESSION_LOGS` | `3` | Newest N transcripts to ingest |
+| `COGNEE_SEED_MAX_SESSION_LOG_BYTES` | `5242880` | Per-transcript size cap |
+| `COGNEE_SEED_MAX_FILE_BYTES` | `10485760` | Per-file size cap for memory/docs |
+| `COGNEE_SEED_SESSION_LOG_GLOB` | unset | Extra transcript glob for other agents |
+
+## Safety
+
+- Hidden files are never picked up, with one explicit allowlist entry
+  (`.claude/CLAUDE.md`) — `.env` and friends can never enter the seed.
+- Sources outside cognee's allowed local-file roots (session transcripts,
+  Claude Code auto-memory) are staged into
+  `{data_root}/seed_staging/<category>/` before ingestion, keeping the path
+  allowlist intact for every other caller.
+- Session transcripts can contain secrets echoed by tools; cap sizes are
+  enforced and the category is off-switchable.
+- Re-running is safe: seeding refuses to touch an existing seed dataset
+  without `--force`, and content-hash dedup makes `--force` cheap on
+  unchanged files.


### PR DESCRIPTION
## Goal

On a fresh install the first `recall` returns nothing. Retention analysis showed the retained accounts all had automatic ingestion wired **before** value was judged — this makes that the default instead of an accident. On install, cognee immediately ingests what already exists: agent memory files (`MEMORY.md`, `SOUL.md`, `AGENTS.md`, `CLAUDE.md`, …), the workspace README, recent coding-agent session logs, and the codebase itself. **First recall then has something to return.**

Plan + design rationale: `docs/day-one-seeding.md`.

## What's in the box

### `cognee/modules/seeding/` (exported as `cognee.seed()`)

- **`discovery.py`** — pure discovery returning a `SeedPlan`:
  - agent memory files at the workspace root + `memory/*.md` + allowlisted `.claude/CLAUDE.md` + Claude Code auto-memory for this workspace (`~/.claude/projects/<slug>/memory/*.md`),
  - `README.*`,
  - the newest N (default 3, ≤5 MB each) Claude Code transcripts for this workspace (slug derivation verified against real `~/.claude/projects` layout),
  - the workspace as a **code project** — reuses the existing repo-manifest resolution (`resolve_code_repository`), so "index any codebase automatically" costs one directory path.
  - Hidden files are never picked up beyond the explicit allowlist → `.env` can never enter the plan. Everything is size-capped; every skip is recorded with a reason.
- **`seed.py`** — staged runner, **fast-first-value order**: memory files + README (seconds) → session logs → codebase. Each stage runs `add()` (LLM-free) then `cognify()`, isolated: no LLM key ⇒ data ingested, cognify deferred and reported — never a failed seed. Sources outside the local-file allowlist are **staged** into `{data_root}/seed_staging/` instead of punching holes in `resolve_local_path`. Lands in one dataset (default `workspace`), which a default `recall()` finds with no arguments.

### Getting-started wiring

- **`cognee-cli seed`** — `--dry-run` prints the full plan without ingesting; `--force`, `--no-code`, `--no-session-logs`, `-w`, `-d`. Refuses to re-seed an existing seed dataset without `--force`; content-hash dedup makes `--force` cheap.
- **Empty recall now hints at `cognee-cli seed`** instead of only `remember`.
- **MCP server auto-seed**: on startup in local mode, when the user owns **zero datasets** (genuinely fresh — never re-seeds behind your back), seed in the background. Startup never blocks. Opt out with `COGNEE_AUTO_SEED=false`. Import is guarded so cognee-mcp keeps booting against PyPI cognee releases that predate the module.

## Verification

- 15 unit tests (`cognee/tests/unit/modules/seeding/`): allowlists & secret-exclusion, size caps, newest-N transcript selection, env/flag toggles, workspace-root walking, slug derivation, stage ordering, out-of-root staging, cognify deferral, idempotency, dry-run, empty-plan short-circuit.
- `cognee-cli seed --dry-run` run against a real workspace correctly discovered its `AGENTS.md`/`CLAUDE.md`, both READMEs, the live session transcript under `~/.claude/projects/<slug>/`, and resolved the repo as a code project.

## Follow-ups (deferred)

`/api/v1/seed` endpoint; cognee-memory plugin install hook calling `cognee-cli seed`; re-seed on change detection (per-source hashes); more agent adapters (Codex, Cursor) beyond the `COGNEE_SEED_SESSION_LOG_GLOB` escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
