### PR TITLE
feat: Add recall warm-up short-circuit (COG-6254)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -407,6 +407,16 @@ RAISE_INCREMENTAL_LOADING_ERRORS=True
 #TOOL_WRITE_CALLS_ENABLED=false
 #TEXT_TO_SQL_MAX_AFFECTED_ROWS=50
 
+########## Recall warm-up short-circuit ########################################
+# When the target datasets have never been through any pipeline, recall's
+# graph lane returns a single "memory_warming_up" marker entry (or, in
+# multi-source recalls, an empty graph contribution) instead of running the
+# search machinery. Warm verdicts are cached in-process for the TTL; cold
+# verdicts are re-probed on every recall.
+#RECALL_WARMUP_SHORTCIRCUIT=true
+#RECALL_WARMUP_THRESHOLD=1
+#RECALL_WARMUP_CACHE_TTL=60
+
 # Authentication & access control.
 #
 # ENABLE_BACKEND_ACCESS_CONTROL is the canonical posture switch:

--- a/cognee/api/v1/config/config.py
+++ b/cognee/api/v1/config/config.py
@@ -12,6 +12,7 @@ from cognee.infrastructure.llm.config import (
 from cognee.infrastructure.databases.vector.embeddings.config import get_embedding_config
 from cognee.infrastructure.databases.relational import get_relational_config, get_migration_config
 from cognee.tasks.translation.config import get_translation_config
+from cognee.modules.recall.config import get_recall_config
 from cognee.api.v1.exceptions.exceptions import InvalidConfigAttributeError
 
 
@@ -108,6 +109,26 @@ def _persist_env_var(env_var_name: str, value) -> tuple[str, bool]:
     return path, created
 
 
+def _coerce_float(value, name: str, *, min_value: float | None = None) -> float:
+    """Coerce ``value`` to ``float``, optionally enforcing a minimum. Accepts
+    ints, floats, or numeric strings. Used by setters reachable via the CLI.
+    """
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a number, got bool {value!r}")
+    if isinstance(value, (int, float)):
+        result = float(value)
+    elif isinstance(value, str):
+        try:
+            result = float(value)
+        except ValueError as exc:
+            raise ValueError(f"{name} must be a number, got {value!r}") from exc
+    else:
+        raise ValueError(f"{name} must be a number, got {type(value).__name__}")
+    if min_value is not None and result < min_value:
+        raise ValueError(f"{name} must be >= {min_value}, got {result}")
+    return result
+
+
 def _coerce_for_field(config_obj, key: str, value):
     """Coerce ``value`` to the declared type of ``config_obj.<key>`` for the
     common ``bool`` and ``int`` cases. Used by ``_update_config`` so bulk
@@ -139,6 +160,8 @@ def _coerce_for_field(config_obj, key: str, value):
         return _coerce_bool(value, key)
     if annotation is int:
         return _coerce_int(value, key)
+    if annotation is float:
+        return _coerce_float(value, key)
     return value
 
 
@@ -705,6 +728,65 @@ class config:
         """
         config._update_config(get_translation_config(), config_dict)
 
+    # Recall configuration methods
+
+    @staticmethod
+    def set_recall_warmup_shortcircuit(recall_warmup_shortcircuit):
+        """Enable/disable the recall graph-lane warm-up short-circuit.
+
+        Enabled by default: recalls against datasets whose knowledge graph
+        has never been built return an instant "memory warming up" marker
+        instead of running graph search plus an LLM call.
+
+        Parameters
+        ----------
+        recall_warmup_shortcircuit : bool | str
+            True/False, or a boolean-like string when set via the CLI.
+        """
+        recall_config = get_recall_config()
+        recall_config.recall_warmup_shortcircuit = _coerce_bool(
+            recall_warmup_shortcircuit, "recall_warmup_shortcircuit"
+        )
+
+    @staticmethod
+    def set_recall_warmup_threshold(recall_warmup_threshold):
+        """Set the minimum datapoint count considered "warm" (default 1).
+
+        Parameters
+        ----------
+        recall_warmup_threshold : int | str
+            Minimum count; values above the probe's cap are clamped.
+        """
+        recall_config = get_recall_config()
+        recall_config.recall_warmup_threshold = _coerce_int(
+            recall_warmup_threshold, "recall_warmup_threshold", min_value=1
+        )
+
+    @staticmethod
+    def set_recall_warmup_cache_ttl(recall_warmup_cache_ttl):
+        """Set how long (seconds) a warm verdict is cached in-process.
+
+        Parameters
+        ----------
+        recall_warmup_cache_ttl : float | str
+            TTL in seconds (default 60).
+        """
+        recall_config = get_recall_config()
+        recall_config.recall_warmup_cache_ttl = _coerce_float(
+            recall_warmup_cache_ttl, "recall_warmup_cache_ttl", min_value=0.0
+        )
+
+    @staticmethod
+    def set_recall_config(config_dict: dict):
+        """Update the recall config with values from a dictionary.
+
+        Parameters
+        ----------
+        config_dict : dict
+            A dictionary of recall config attributes to update.
+        """
+        config._update_config(get_recall_config(), config_dict)
+
     # Map configuration keys to their setter methods. Used by ``set()``.
     _setter_mapping = {
         "llm_provider": "set_llm_provider",
@@ -732,6 +814,9 @@ class config:
         "classification_model": "set_classification_model",
         "summarization_model": "set_summarization_model",
         "graph_model": "set_graph_model",
+        "recall_warmup_shortcircuit": "set_recall_warmup_shortcircuit",
+        "recall_warmup_threshold": "set_recall_warmup_threshold",
+        "recall_warmup_cache_ttl": "set_recall_warmup_cache_ttl",
         "system_root_directory": "system_root_directory",
         "data_root_directory": "data_root_directory",
     }
@@ -767,6 +852,9 @@ class config:
         "classification_model": (get_cognify_config, "classification_model"),
         "summarization_model": (get_cognify_config, "summarization_model"),
         "graph_model": (get_graph_config, "graph_model"),
+        "recall_warmup_shortcircuit": (get_recall_config, "recall_warmup_shortcircuit"),
+        "recall_warmup_threshold": (get_recall_config, "recall_warmup_threshold"),
+        "recall_warmup_cache_ttl": (get_recall_config, "recall_warmup_cache_ttl"),
         "system_root_directory": (get_base_config, "system_root_directory"),
         "data_root_directory": (get_base_config, "data_root_directory"),
     }

--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -30,6 +30,7 @@ from cognee.modules.recall.types.RecallResponse import (
     RecallResponse,
     ResponseAgentTraceEntry,
     ResponseGraphEntry,
+    ResponseMarkerEntry,
     ResponseQAEntry,
     ResponseSessionContextEntry,
     ResponseToolEntry,
@@ -634,6 +635,86 @@ async def recall(
                     ]
                     if not search_dataset_ids:
                         raise DatasetNotFoundError(message="No datasets found.")
+
+                from cognee.modules.recall.config import get_recall_config
+
+                # Warm-up short-circuit. Config errors fail open (skip the
+                # guard) so a malformed RECALL_WARMUP_* value can never take
+                # recall down; only_context callers skip it too because they
+                # expect context, not a marker.
+                recall_config = None
+                try:
+                    recall_config = get_recall_config()
+                except Exception as error:
+                    logger.warning(
+                        "Recall warm-up config failed to load; skipping guard: %s", error
+                    )
+                guard_active = (
+                    recall_config is not None
+                    and recall_config.recall_warmup_shortcircuit
+                    and not only_context
+                )
+                probe_dataset_ids = search_dataset_ids
+                if guard_active and dataset_ids:
+                    from cognee.modules.users.exceptions import PermissionDeniedError
+                    from cognee.modules.users.permissions.methods import (
+                        get_specific_user_permission_datasets,
+                    )
+
+                    # Authorize caller-supplied dataset ids *before* probing —
+                    # the same check authorized_search performs — so the guard
+                    # can neither leak other tenants' processing state nor
+                    # mask the PermissionDeniedError authorized_search would
+                    # raise for unpermitted or nonexistent ids. Infrastructure
+                    # errors fail open (skip the guard): authorized_search
+                    # then performs the authoritative check as before.
+                    try:
+                        probe_dataset_ids = [
+                            dataset.id
+                            for dataset in await get_specific_user_permission_datasets(
+                                user.id, "read", dataset_ids
+                            )
+                        ]
+                    except PermissionDeniedError:
+                        raise
+                    except Exception as error:
+                        logger.warning(
+                            "Recall warm-up pre-probe authorization failed; skipping guard: %s",
+                            error,
+                        )
+                        guard_active = False
+
+                if guard_active:
+                    from cognee.modules.recall.methods.graph_warmup import is_memory_warm
+
+                    warm, datapoint_count = await is_memory_warm(user, probe_dataset_ids)
+                    if not warm:
+                        logger.info(
+                            "Recall warm-up short-circuit: graph has %d datapoints "
+                            "(threshold %d); skipping search.",
+                            datapoint_count,
+                            recall_config.recall_warmup_threshold,
+                        )
+                        span.set_attribute("cognee.recall.warmup_shortcircuit", True)
+                        if sources != ["graph"]:
+                            # Multi-source recall: a cold graph contributes
+                            # nothing, so other lanes — and the tools
+                            # "on_empty" fallback, which fires only when the
+                            # merged result is empty — behave exactly as if
+                            # the graph lane returned no results.
+                            return []
+                        return [
+                            ResponseMarkerEntry(
+                                source="system",
+                                status="memory_warming_up",
+                                text=(
+                                    "Memory is still warming up: no knowledge graph data "
+                                    "exists yet for the requested datasets."
+                                ),
+                                datapoint_count=datapoint_count,
+                                threshold=recall_config.recall_warmup_threshold,
+                            )
+                        ]
 
                 graph_results = await authorized_search(
                     query_text=query_text,

--- a/cognee/modules/recall/config.py
+++ b/cognee/modules/recall/config.py
@@ -1,0 +1,42 @@
+"""Configuration for recall behavior flags.
+
+Currently holds the warm-up short-circuit: when a recall targets datasets
+whose knowledge graph has never been built, the graph lane returns a cheap
+"memory warming up" marker instead of spinning up search machinery.
+"""
+
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class RecallConfig(BaseSettings):
+    # Kill switch for the graph-lane warm-up short-circuit. When off,
+    # recall's graph lane behaves exactly as before.
+    recall_warmup_shortcircuit: bool = True
+
+    # Minimum graph datapoint count considered "warm". Default 1: only
+    # truly-empty graphs short-circuit. The probe is binary and reports a
+    # large fixed count for any populated graph, so values above that cap
+    # are clamped — they can never read a populated graph as cold.
+    recall_warmup_threshold: int = 1
+
+    # Seconds an in-process *warm* verdict is cached, so repeated recalls
+    # against a warm graph skip even the relational probe. Cold verdicts
+    # are never cached: a graph populated moments after a cold probe must
+    # be searchable on the very next recall.
+    recall_warmup_cache_ttl: float = 60.0
+
+    model_config = SettingsConfigDict(env_file=".env", extra="allow")
+
+    def to_dict(self) -> dict:
+        return {
+            "recall_warmup_shortcircuit": self.recall_warmup_shortcircuit,
+            "recall_warmup_threshold": self.recall_warmup_threshold,
+            "recall_warmup_cache_ttl": self.recall_warmup_cache_ttl,
+        }
+
+
+@lru_cache
+def get_recall_config() -> RecallConfig:
+    return RecallConfig()

--- a/cognee/modules/recall/methods/graph_warmup.py
+++ b/cognee/modules/recall/methods/graph_warmup.py
@@ -1,0 +1,130 @@
+"""Cheap warm-graph probe for recall's graph-lane short-circuit.
+
+The probe never touches a graph or vector engine: it asks the relational
+``pipeline_runs`` table whether *any* pipeline has ever run for the permitted
+datasets. Ingestion through the public surface (add/cognify/memify/improve/
+code-graph via ``run_tasks``) logs a PipelineRun row with a dataset_id at
+start, so a dataset that has been through any pipeline reads warm. add-only
+datasets (staged, not yet cognified) also read warm on purpose: the deferred
+custom-pipeline surface (``run_pipeline`` → ``run_tasks_base``) builds graphs
+without logging runs, so the only fail-safe signal is "some pipeline touched
+this dataset". Over-reporting warm merely falls through to a normal search —
+the pre-feature behavior — while under-reporting cold would hide a populated
+graph. The only datasets that can read cold despite holding graph data are
+ones created entirely outside add() and populated via ``run_tasks_base``;
+disable the guard (RECALL_WARMUP_SHORTCIRCUIT=false) in that setup.
+
+Explicitly passed ``dataset_ids`` are intersected with the datasets the user
+can read before the probe runs, so this module can never act as a
+cross-tenant oracle for other tenants' processing state.
+"""
+
+import time
+from uuid import UUID
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("recall.graph_warmup")
+
+# The probe is binary (run-exists), not a real datapoint count. Report a
+# count that satisfies any threshold when a pipeline run exists; thresholds
+# above this value are clamped in is_memory_warm so a raised
+# RECALL_WARMUP_THRESHOLD can never falsely read a populated graph as cold.
+_WARM_COUNT = 2**31
+
+# Bound on cached verdicts; on overflow expired entries are evicted and, if
+# still full, the cache is dropped wholesale (it is only an optimization).
+_CACHE_MAX_ENTRIES = 1024
+
+# key -> (is_warm, datapoint_count, expires_at); expires_at from time.monotonic().
+_warmup_cache: dict[tuple, tuple[bool, int, float]] = {}
+
+
+def clear_warmup_cache() -> None:
+    _warmup_cache.clear()
+
+
+def _evict_expired() -> None:
+    now = time.monotonic()
+    for key in [key for key, value in _warmup_cache.items() if value[2] <= now]:
+        _warmup_cache.pop(key, None)
+    if len(_warmup_cache) >= _CACHE_MAX_ENTRIES:
+        _warmup_cache.clear()
+
+
+async def get_graph_datapoint_count(user, dataset_ids: list[UUID] | None) -> int:
+    """Return a datapoint-count proxy for the user's target knowledge graphs.
+
+    ``dataset_ids=None`` means all datasets the user can read; an explicit
+    list is filtered down to the datasets the user can read, so unpermitted
+    or nonexistent ids contribute nothing (they can never leak state).
+    Returns 0 only when no pipeline run exists for those datasets; otherwise
+    a large positive number (the relational DB has no cheap exact count).
+    """
+    from sqlalchemy import exists, select
+
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.modules.pipelines.models import PipelineRun
+    from cognee.modules.users.permissions.methods import get_permitted_dataset_ids
+
+    permitted_ids = await get_permitted_dataset_ids(user.id)
+    if dataset_ids is None:
+        ids = permitted_ids
+    else:
+        permitted = set(permitted_ids)
+        ids = [dataset_id for dataset_id in dataset_ids if dataset_id in permitted]
+    if not ids:
+        return 0
+
+    async with get_relational_engine().get_async_session() as session:
+        warm = (
+            await session.execute(select(exists().where(PipelineRun.dataset_id.in_(ids))))
+        ).scalar()
+
+    return _WARM_COUNT if warm else 0
+
+
+async def is_memory_warm(user, dataset_ids: list[UUID] | None) -> tuple[bool, int]:
+    """Return (is_warm, datapoint_count).
+
+    Only *warm* verdicts are cached (for RECALL_WARMUP_CACHE_TTL): warm is
+    effectively monotone — a later forget() merely falls through to a normal
+    search on an empty graph — while a cached cold verdict would keep
+    short-circuiting recalls after cognify() populates the graph. Cold
+    verdicts therefore always re-run the (single indexed EXISTS) probe.
+
+    Fails open: any probe or config error reports warm, so a broken probe
+    can never block a real search.
+    """
+    from cognee.modules.recall.config import get_recall_config
+
+    try:
+        config = get_recall_config()
+        key = (
+            str(user.id),
+            "__all__"
+            if dataset_ids is None
+            else tuple(sorted(str(dataset_id) for dataset_id in dataset_ids)),
+        )
+
+        cached = _warmup_cache.get(key)
+        if cached is not None and cached[2] > time.monotonic():
+            return cached[0], cached[1]
+
+        count = await get_graph_datapoint_count(user, dataset_ids)
+        # Clamp: the probe reports at most _WARM_COUNT, so a threshold above
+        # it must not read every populated graph as cold.
+        warm = count >= min(config.recall_warmup_threshold, _WARM_COUNT)
+
+        if warm:
+            if len(_warmup_cache) >= _CACHE_MAX_ENTRIES:
+                _evict_expired()
+            _warmup_cache[key] = (
+                warm,
+                count,
+                time.monotonic() + config.recall_warmup_cache_ttl,
+            )
+        return warm, count
+    except Exception as error:
+        logger.warning("Graph warm-up probe failed; treating memory as warm: %s", error)
+        return True, _WARM_COUNT

--- a/cognee/modules/recall/types/RecallResponse.py
+++ b/cognee/modules/recall/types/RecallResponse.py
@@ -42,11 +42,26 @@ class ResponseToolEntry(BaseModel):
     structured: Optional[dict] = None
 
 
+class ResponseMarkerEntry(BaseModel):
+    """System-generated marker (not data), e.g. "memory still warming up".
+
+    ``text`` carries a human-readable message so generic consumers that fall
+    back to text rendering display something sensible.
+    """
+
+    source: Literal["system"]
+    status: str
+    text: str
+    datapoint_count: int
+    threshold: int
+
+
 RecallResponse = Annotated[
     ResponseQAEntry
     | ResponseAgentTraceEntry
     | ResponseSessionContextEntry
     | ResponseGraphEntry
-    | ResponseToolEntry,
+    | ResponseToolEntry
+    | ResponseMarkerEntry,
     Field(discriminator="source"),
 ]

--- a/cognee/tests/unit/api/conftest.py
+++ b/cognee/tests/unit/api/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def warm_graph_probe(monkeypatch):
+    """Neutralize recall's warm-up short-circuit for API unit tests.
+
+    The guard's relational probe would otherwise hit whatever local DB the
+    developer has and short-circuit graph-lane tests that expect
+    authorized_search to run. Warm-up tests override this stub per test.
+    """
+    from cognee.modules.recall.methods import graph_warmup
+
+    async def always_warm(user, dataset_ids):
+        return graph_warmup._WARM_COUNT
+
+    monkeypatch.setattr(graph_warmup, "get_graph_datapoint_count", always_warm)
+    graph_warmup.clear_warmup_cache()
+    yield
+    graph_warmup.clear_warmup_cache()

--- a/cognee/tests/unit/api/v1/recall/test_recall_warmup.py
+++ b/cognee/tests/unit/api/v1/recall/test_recall_warmup.py
@@ -469,3 +469,63 @@ async def test_probe_failure_verdict_is_not_cached(
     assert warm is True
     assert count >= 1
     assert len(probe_calls) == 1
+
+
+class TestGlobalConfigWiring:
+    """cognee.config exposes the warm-up settings as runtime setters that
+    mutate the same cached RecallConfig instance the guard reads."""
+
+    def test_set_recall_config_updates_cached_instance(self):
+        from cognee.api.v1.config.config import config as global_config
+        from cognee.modules.recall.config import get_recall_config
+
+        cfg = get_recall_config()
+        original = cfg.to_dict()
+        try:
+            # String payloads (the CLI contract) must coerce to real types.
+            global_config.set_recall_config(
+                {
+                    "recall_warmup_shortcircuit": "false",
+                    "recall_warmup_threshold": "5",
+                    "recall_warmup_cache_ttl": "1.5",
+                }
+            )
+            assert cfg.recall_warmup_shortcircuit is False
+            assert cfg.recall_warmup_threshold == 5
+            assert cfg.recall_warmup_cache_ttl == 1.5
+            # The guard reads the same lru_cached instance the setter mutated.
+            assert get_recall_config() is cfg
+        finally:
+            global_config.set_recall_config(original)
+
+    def test_generic_set_and_get_cover_warmup_keys(self):
+        from cognee.api.v1.config.config import config as global_config
+        from cognee.modules.recall.config import get_recall_config
+
+        original = get_recall_config().to_dict()
+        try:
+            global_config.set("recall_warmup_shortcircuit", "true")
+            global_config.set("recall_warmup_threshold", 3)
+            global_config.set("recall_warmup_cache_ttl", "30")
+            assert global_config.get("recall_warmup_shortcircuit") is True
+            assert global_config.get("recall_warmup_threshold") == 3
+            assert global_config.get("recall_warmup_cache_ttl") == 30.0
+            assert global_config.get_all()["recall_warmup_shortcircuit"] is True
+        finally:
+            global_config.set_recall_config(original)
+
+    def test_invalid_values_are_rejected(self):
+        from cognee.api.v1.config.config import config as global_config
+        from cognee.modules.recall.config import get_recall_config
+
+        original = get_recall_config().to_dict()
+        try:
+            with pytest.raises(ValueError):
+                global_config.set_recall_warmup_shortcircuit("not-a-bool")
+            with pytest.raises(ValueError):
+                global_config.set_recall_warmup_threshold(0)
+            with pytest.raises(ValueError):
+                global_config.set_recall_warmup_cache_ttl(-1)
+            assert get_recall_config().to_dict() == original
+        finally:
+            global_config.set_recall_config(original)

--- a/cognee/tests/unit/api/v1/recall/test_recall_warmup.py
+++ b/cognee/tests/unit/api/v1/recall/test_recall_warmup.py
@@ -101,6 +101,15 @@ def _stub_count(monkeypatch, graph_warmup_mod, value):
     return calls
 
 
+def test_shortcircuit_is_enabled_by_default():
+    # The guard must be on for fresh installs with no env vars set; every
+    # other test injects an explicit config, so only this pins the default.
+    config = RecallConfig(_env_file=None)
+    assert config.recall_warmup_shortcircuit is True
+    assert config.recall_warmup_threshold == 1
+    assert config.recall_warmup_cache_ttl == 60.0
+
+
 class TestResponseUnion:
     def test_marker_entry_round_trips_through_union(self):
         adapter = TypeAdapter(list[RecallResponse])

--- a/cognee/tests/unit/api/v1/recall/test_recall_warmup.py
+++ b/cognee/tests/unit/api/v1/recall/test_recall_warmup.py
@@ -1,0 +1,462 @@
+"""Tests for recall's graph-lane warm-up short-circuit."""
+
+import importlib
+import types
+from uuid import uuid4
+
+import pytest
+from pydantic import TypeAdapter
+
+from cognee.modules.recall.config import RecallConfig
+from cognee.modules.recall.types.RecallResponse import RecallResponse, ResponseMarkerEntry
+from cognee.modules.search.types import SearchType
+
+
+def _make_user(user_id=None, tenant_id=None):
+    return types.SimpleNamespace(id=user_id or uuid4(), tenant_id=tenant_id)
+
+
+@pytest.fixture
+def api_recall_mod():
+    return importlib.import_module("cognee.api.v1.recall.recall")
+
+
+@pytest.fixture
+def graph_warmup_mod():
+    return importlib.import_module("cognee.modules.recall.methods.graph_warmup")
+
+
+@pytest.fixture
+def recall_config_mod():
+    return importlib.import_module("cognee.modules.recall.config")
+
+
+@pytest.fixture
+def no_remote_client(monkeypatch):
+    serve_state = importlib.import_module("cognee.api.v1.serve.state")
+    monkeypatch.setattr(serve_state, "get_remote_client", lambda: None)
+
+
+@pytest.fixture
+def stub_dataset_auth(monkeypatch):
+    """Stub the pre-probe dataset authorization; returns the spy call list."""
+    permission_methods = importlib.import_module("cognee.modules.users.permissions.methods")
+    calls = []
+
+    async def fake_get_specific_user_permission_datasets(user_id, permission_type, dataset_ids):
+        calls.append((user_id, permission_type, dataset_ids))
+        return [types.SimpleNamespace(id=dataset_id) for dataset_id in dataset_ids]
+
+    monkeypatch.setattr(
+        permission_methods,
+        "get_specific_user_permission_datasets",
+        fake_get_specific_user_permission_datasets,
+    )
+    return calls
+
+
+@pytest.fixture
+def stubbed_graph_lane(monkeypatch, api_recall_mod):
+    """Stub everything downstream of the guard; returns the spy call list."""
+    search_methods = importlib.import_module("cognee.modules.search.methods.search")
+    search_operations = importlib.import_module("cognee.modules.search.operations")
+
+    calls = []
+
+    async def spy_authorized_search(**kwargs):
+        calls.append(kwargs)
+        return []
+
+    async def dummy_log_search_history(*args, **kwargs):
+        return None
+
+    async def dummy_set_session_user_context_variable(_user):
+        return None
+
+    monkeypatch.setattr(search_methods, "authorized_search", spy_authorized_search)
+    monkeypatch.setattr(search_operations, "log_search_history", dummy_log_search_history)
+    monkeypatch.setattr(
+        api_recall_mod,
+        "set_session_user_context_variable",
+        dummy_set_session_user_context_variable,
+    )
+    return calls
+
+
+def _use_config(monkeypatch, recall_config_mod, **overrides):
+    config = RecallConfig(_env_file=None, **overrides)
+    monkeypatch.setattr(recall_config_mod, "get_recall_config", lambda: config)
+
+
+def _stub_count(monkeypatch, graph_warmup_mod, value):
+    calls = []
+
+    async def counting_stub(user, dataset_ids):
+        calls.append((user, dataset_ids))
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    monkeypatch.setattr(graph_warmup_mod, "get_graph_datapoint_count", counting_stub)
+    return calls
+
+
+class TestResponseUnion:
+    def test_marker_entry_round_trips_through_union(self):
+        adapter = TypeAdapter(list[RecallResponse])
+        entries = adapter.validate_python(
+            [
+                {
+                    "source": "system",
+                    "status": "memory_warming_up",
+                    "text": "memory still warming up, no graph data yet",
+                    "datapoint_count": 0,
+                    "threshold": 1,
+                }
+            ]
+        )
+        assert isinstance(entries[0], ResponseMarkerEntry)
+        assert entries[0].status == "memory_warming_up"
+        assert entries[0].datapoint_count == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_graph_returns_marker_and_skips_search(
+    monkeypatch,
+    api_recall_mod,
+    graph_warmup_mod,
+    recall_config_mod,
+    no_remote_client,
+    stub_dataset_auth,
+):
+    _use_config(monkeypatch, recall_config_mod)
+    _stub_count(monkeypatch, graph_warmup_mod, 0)
+    search_methods = importlib.import_module("cognee.modules.search.methods.search")
+    search_operations = importlib.import_module("cognee.modules.search.operations")
+
+    authorized_calls = []
+    history_calls = []
+
+    async def spy_authorized_search(**kwargs):
+        authorized_calls.append(kwargs)
+        return []
+
+    async def spy_log_search_history(*args, **kwargs):
+        history_calls.append(args)
+
+    async def dummy_set_session_user_context_variable(_user):
+        return None
+
+    monkeypatch.setattr(search_methods, "authorized_search", spy_authorized_search)
+    monkeypatch.setattr(search_operations, "log_search_history", spy_log_search_history)
+    monkeypatch.setattr(
+        api_recall_mod,
+        "set_session_user_context_variable",
+        dummy_set_session_user_context_variable,
+    )
+
+    out = await api_recall_mod.recall(
+        query_text="q",
+        query_type=SearchType.GRAPH_COMPLETION,
+        dataset_ids=[uuid4()],
+        auto_route=False,
+        user=_make_user(),
+    )
+
+    assert len(out) == 1
+    marker = out[0]
+    assert isinstance(marker, ResponseMarkerEntry)
+    assert marker.source == "system"
+    assert marker.status == "memory_warming_up"
+    assert marker.datapoint_count == 0
+    assert marker.threshold == 1
+    assert authorized_calls == []
+    assert history_calls == []
+    # The guard authorized the caller-supplied ids before probing.
+    assert len(stub_dataset_auth) == 1
+
+
+@pytest.mark.asyncio
+async def test_warm_graph_runs_normal_search(
+    monkeypatch,
+    api_recall_mod,
+    graph_warmup_mod,
+    recall_config_mod,
+    no_remote_client,
+    stubbed_graph_lane,
+    stub_dataset_auth,
+):
+    _use_config(monkeypatch, recall_config_mod)
+    _stub_count(monkeypatch, graph_warmup_mod, 5)
+
+    out = await api_recall_mod.recall(
+        query_text="q",
+        query_type=SearchType.GRAPH_COMPLETION,
+        dataset_ids=[uuid4()],
+        auto_route=False,
+        user=_make_user(),
+    )
+
+    assert out == []
+    assert len(stubbed_graph_lane) == 1
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_fails_open(
+    monkeypatch,
+    api_recall_mod,
+    graph_warmup_mod,
+    recall_config_mod,
+    no_remote_client,
+    stubbed_graph_lane,
+    stub_dataset_auth,
+):
+    _use_config(monkeypatch, recall_config_mod)
+    _stub_count(monkeypatch, graph_warmup_mod, RuntimeError("probe broke"))
+
+    out = await api_recall_mod.recall(
+        query_text="q",
+        query_type=SearchType.GRAPH_COMPLETION,
+        dataset_ids=[uuid4()],
+        auto_route=False,
+        user=_make_user(),
+    )
+
+    assert out == []
+    assert len(stubbed_graph_lane) == 1
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_off_runs_search_even_when_cold(
+    monkeypatch,
+    api_recall_mod,
+    graph_warmup_mod,
+    recall_config_mod,
+    no_remote_client,
+    stubbed_graph_lane,
+):
+    _use_config(monkeypatch, recall_config_mod, recall_warmup_shortcircuit=False)
+    probe_calls = _stub_count(monkeypatch, graph_warmup_mod, 0)
+
+    out = await api_recall_mod.recall(
+        query_text="q",
+        query_type=SearchType.GRAPH_COMPLETION,
+        dataset_ids=[uuid4()],
+        auto_route=False,
+        user=_make_user(),
+    )
+
+    assert out == []
+    assert len(stubbed_graph_lane) == 1
+    assert probe_calls == []
+
+
+@pytest.mark.asyncio
+async def test_cold_verdicts_are_never_cached(monkeypatch, graph_warmup_mod, recall_config_mod):
+    # A cold verdict must not stick: a graph populated right after a cold
+    # probe has to be searchable on the very next recall.
+    _use_config(monkeypatch, recall_config_mod)
+    counts = iter([0, 5])
+    probe_calls = []
+
+    async def counting_stub(user, dataset_ids):
+        probe_calls.append((user, dataset_ids))
+        return next(counts)
+
+    monkeypatch.setattr(graph_warmup_mod, "get_graph_datapoint_count", counting_stub)
+    graph_warmup_mod.clear_warmup_cache()
+    user = _make_user()
+    dataset_ids = [uuid4()]
+
+    assert await graph_warmup_mod.is_memory_warm(user, dataset_ids) == (False, 0)
+    # Second call re-probes (no cached cold verdict) and sees the new data.
+    assert await graph_warmup_mod.is_memory_warm(user, dataset_ids) == (True, 5)
+    assert len(probe_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_ttl_cache_caches_warm_verdicts_too(monkeypatch, graph_warmup_mod, recall_config_mod):
+    _use_config(monkeypatch, recall_config_mod)
+    probe_calls = _stub_count(monkeypatch, graph_warmup_mod, 7)
+    graph_warmup_mod.clear_warmup_cache()
+    user = _make_user()
+
+    assert await graph_warmup_mod.is_memory_warm(user, None) == (True, 7)
+    assert await graph_warmup_mod.is_memory_warm(user, None) == (True, 7)
+    assert len(probe_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_expired_ttl_re_queries(monkeypatch, graph_warmup_mod, recall_config_mod):
+    # TTL of 0 makes every cached (warm) verdict already expired.
+    _use_config(monkeypatch, recall_config_mod, recall_warmup_cache_ttl=0.0)
+    probe_calls = _stub_count(monkeypatch, graph_warmup_mod, 7)
+    graph_warmup_mod.clear_warmup_cache()
+    user = _make_user()
+
+    await graph_warmup_mod.is_memory_warm(user, None)
+    await graph_warmup_mod.is_memory_warm(user, None)
+    assert len(probe_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_empty_dataset_list_does_not_share_all_datasets_cache_key(
+    monkeypatch, graph_warmup_mod, recall_config_mod
+):
+    # dataset_ids=[] and dataset_ids=None must map to distinct cache keys.
+    _use_config(monkeypatch, recall_config_mod)
+    probe_calls = _stub_count(monkeypatch, graph_warmup_mod, 7)
+    graph_warmup_mod.clear_warmup_cache()
+    user = _make_user()
+
+    assert await graph_warmup_mod.is_memory_warm(user, None) == (True, 7)
+    # [] must not hit the cached "__all__" verdict.
+    assert await graph_warmup_mod.is_memory_warm(user, []) == (True, 7)
+    assert len(probe_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_threshold_above_probe_cap_is_clamped(
+    monkeypatch, graph_warmup_mod, recall_config_mod
+):
+    # The probe is binary and reports at most _WARM_COUNT; a larger
+    # threshold must not read every populated graph as cold.
+    _use_config(monkeypatch, recall_config_mod, recall_warmup_threshold=2**40)
+    _stub_count(monkeypatch, graph_warmup_mod, graph_warmup_mod._WARM_COUNT)
+    graph_warmup_mod.clear_warmup_cache()
+
+    warm, count = await graph_warmup_mod.is_memory_warm(_make_user(), None)
+    assert warm is True
+    assert count == graph_warmup_mod._WARM_COUNT
+
+
+@pytest.mark.asyncio
+async def test_config_failure_fails_open_and_skips_guard(
+    monkeypatch,
+    api_recall_mod,
+    graph_warmup_mod,
+    recall_config_mod,
+    no_remote_client,
+    stubbed_graph_lane,
+):
+    def broken_config():
+        raise ValueError("malformed RECALL_WARMUP_* env value")
+
+    monkeypatch.setattr(recall_config_mod, "get_recall_config", broken_config)
+    probe_calls = _stub_count(monkeypatch, graph_warmup_mod, 0)
+
+    out = await api_recall_mod.recall(
+        query_text="q",
+        query_type=SearchType.GRAPH_COMPLETION,
+        dataset_ids=[uuid4()],
+        auto_route=False,
+        user=_make_user(),
+    )
+
+    assert out == []
+    assert len(stubbed_graph_lane) == 1
+    assert probe_calls == []
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_dataset_ids_raise_before_probe(
+    monkeypatch,
+    api_recall_mod,
+    graph_warmup_mod,
+    recall_config_mod,
+    no_remote_client,
+    stubbed_graph_lane,
+):
+    from cognee.modules.users.exceptions import PermissionDeniedError
+
+    _use_config(monkeypatch, recall_config_mod)
+    probe_calls = _stub_count(monkeypatch, graph_warmup_mod, 0)
+    permission_methods = importlib.import_module("cognee.modules.users.permissions.methods")
+
+    async def deny(user_id, permission_type, dataset_ids):
+        raise PermissionDeniedError("no read permission")
+
+    monkeypatch.setattr(permission_methods, "get_specific_user_permission_datasets", deny)
+
+    with pytest.raises(PermissionDeniedError):
+        await api_recall_mod.recall(
+            query_text="q",
+            query_type=SearchType.GRAPH_COMPLETION,
+            dataset_ids=[uuid4()],
+            auto_route=False,
+            user=_make_user(),
+        )
+
+    assert probe_calls == []
+    assert stubbed_graph_lane == []
+
+
+@pytest.mark.asyncio
+async def test_only_context_skips_guard(
+    monkeypatch,
+    api_recall_mod,
+    graph_warmup_mod,
+    recall_config_mod,
+    no_remote_client,
+    stubbed_graph_lane,
+    stub_dataset_auth,
+):
+    _use_config(monkeypatch, recall_config_mod)
+    probe_calls = _stub_count(monkeypatch, graph_warmup_mod, 0)
+
+    out = await api_recall_mod.recall(
+        query_text="q",
+        query_type=SearchType.GRAPH_COMPLETION,
+        dataset_ids=[uuid4()],
+        auto_route=False,
+        only_context=True,
+        user=_make_user(),
+    )
+
+    assert out == []
+    assert len(stubbed_graph_lane) == 1
+    assert probe_calls == []
+
+
+@pytest.mark.asyncio
+async def test_multi_source_cold_graph_returns_empty_not_marker(
+    monkeypatch,
+    api_recall_mod,
+    graph_warmup_mod,
+    recall_config_mod,
+    no_remote_client,
+    stubbed_graph_lane,
+    stub_dataset_auth,
+):
+    _use_config(monkeypatch, recall_config_mod)
+    _stub_count(monkeypatch, graph_warmup_mod, 0)
+
+    out = await api_recall_mod.recall(
+        query_text="q",
+        query_type=SearchType.GRAPH_COMPLETION,
+        dataset_ids=[uuid4()],
+        auto_route=False,
+        scope=["session", "graph"],
+        user=_make_user(),
+    )
+
+    # A cold graph in a multi-source recall contributes nothing instead of
+    # injecting a marker next to other sources' results (and instead of
+    # suppressing the tools "on_empty" fallback).
+    assert out == []
+    assert stubbed_graph_lane == []
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_verdict_is_not_cached(
+    monkeypatch, graph_warmup_mod, recall_config_mod
+):
+    _use_config(monkeypatch, recall_config_mod)
+    probe_calls = _stub_count(monkeypatch, graph_warmup_mod, RuntimeError("boom"))
+    graph_warmup_mod.clear_warmup_cache()
+    user = _make_user()
+
+    warm, count = await graph_warmup_mod.is_memory_warm(user, [uuid4()])
+    assert warm is True
+    assert count >= 1
+    assert len(probe_calls) == 1


### PR DESCRIPTION
## Description

Auto-recall against an empty or never-cognified graph runs the full GRAPH_COMPLETION machinery — a graph search plus an LLM call — and returns nothing useful. These are pure-cost turns: the heartbeat prompt alone accounts for **511k wasted searches from 7,426 accounts**.

This PR adds a warm-up guard to `recall()`'s graph lane. Before `authorized_search` runs, a cheap relational probe (one indexed `EXISTS` on `pipeline_runs` — no graph/vector engine spin-up) checks whether the target datasets have ever been through a pipeline. If not, recall returns instantly with a `ResponseMarkerEntry` (`source="system"`, `status="memory_warming_up"`, new member of the `RecallResponse` discriminated union) instead of running the search + LLM call.

## Design / safety properties

- **Fail-open**: any probe or config error falls through to a normal search; the guard can never block a real answer. A malformed `RECALL_WARMUP_*` env value skips the guard rather than failing recall.
- **Behavior-safe defaults**: `RECALL_WARMUP_THRESHOLD=1` — only truly-empty graphs short-circuit; any populated graph behaves exactly as before. Kill switch: `RECALL_WARMUP_SHORTCIRCUIT=false`.
- **Cached in the right direction**: warm verdicts are cached in-process for `RECALL_WARMUP_CACHE_TTL` (default 60s, `time.monotonic()`, bounded at 1024 entries); cold verdicts are **never** cached, so the first recall after cognify sees the populated graph immediately.
- **Authorization preserved**: caller-supplied `dataset_ids` are authorized before the probe with the same check `authorized_search` performs (`get_specific_user_permission_datasets`), so the guard cannot leak foreign datasets' processing state (cross-tenant oracle) or mask `PermissionDeniedError` for unpermitted/nonexistent ids.
- **Multi-source safe**: when recall merges multiple sources (session/trace/tools), a cold graph contributes `[]` rather than a marker — so the tools `on_empty` fallback still fires and markers never sit next to real session hits. `only_context=True` skips the guard entirely.
- **Probe is deliberately conservative**: any `PipelineRun` row reads warm (including add-only datasets and the custom-pipeline surface), because over-reporting warm merely falls through to pre-feature behavior while under-reporting cold would hide a populated graph. The threshold is effectively binary (the relational DB has no cheap exact datapoint count); values above the probe's cap are clamped so a populated graph can never read cold.

## Config

```
RECALL_WARMUP_SHORTCIRCUIT=true   # kill switch
RECALL_WARMUP_THRESHOLD=1         # min datapoint-count proxy considered warm
RECALL_WARMUP_CACHE_TTL=60        # in-process warm-verdict cache TTL (seconds)
```

## Testing

- New `cognee/tests/unit/api/v1/recall/test_recall_warmup.py` (15 tests): marker + full skip on cold graph (`authorized_search` and `log_search_history` spied, not called), warm → normal path, probe/config failure → fail open, kill switch, pre-probe auth raises before the probe runs, `only_context` skip, multi-source returns `[]` not marker, TTL cache hit/expiry/clear, `[]`/`None` cache-key separation, threshold clamp, union round-trip via `TypeAdapter`.
- New `cognee/tests/unit/api/conftest.py` stubs the probe warm for the pre-existing recall/session unit tests (they'd otherwise hit the developer's real sqlite through the new guard).
- Full run: 122 recall/search unit tests green; `ruff check` / `ruff format` clean; probe SQL live-verified against a local sqlite (random dataset id → cold, cognified dataset → warm).

Fixes COG-6254

🤖 Generated with [Claude Code](https://claude.com/claude-code)