### PR TITLE
fix: Unbreak 3.10 and Windows unit tests after COG-6241

### DIFF
--- a/cognee/infrastructure/files/storage/LocalFileStorage.py
+++ b/cognee/infrastructure/files/storage/LocalFileStorage.py
@@ -145,7 +145,21 @@ class LocalFileStorage(Storage):
                                 file.write(chunk)
                         else:
                             file.write(data)
-                os.replace(temp_file_path, full_file_path)
+                try:
+                    os.replace(temp_file_path, full_file_path)
+                except PermissionError:
+                    # Windows: replacing a file another handle holds open needs
+                    # DELETE sharing on that handle, which ordinary open()s do
+                    # not grant. Fall back to the pre-atomic in-place write —
+                    # non-atomic for that reader, but a succeeding store beats
+                    # failing it (and matches the old behavior there). POSIX
+                    # never takes this path.
+                    with (
+                        open(temp_file_path, mode="rb") as written,
+                        open(full_file_path, mode="wb") as target,
+                    ):
+                        while chunk := written.read(WRITE_CHUNK_SIZE):
+                            target.write(chunk)
             finally:
                 try:
                     os.unlink(temp_file_path)

--- a/cognee/tests/unit/infrastructure/files/test_local_file_storage_atomic_store.py
+++ b/cognee/tests/unit/infrastructure/files/test_local_file_storage_atomic_store.py
@@ -7,6 +7,8 @@ must never observe a truncated/half-written object, and no temp files may
 survive, success or failure.
 """
 
+import os
+
 import pytest
 
 from cognee.infrastructure.files.storage.LocalFileStorage import LocalFileStorage
@@ -28,15 +30,21 @@ async def test_overwrite_leaves_only_the_final_file(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_reader_with_old_handle_sees_a_complete_version(tmp_path):
-    # os.replace keeps an already-open handle on the OLD inode intact: the
-    # reader finishes with a complete old version, never a truncated file.
+async def test_store_succeeds_while_a_reader_holds_the_file(tmp_path):
+    # An overwrite must never FAIL because someone is reading the target. On
+    # POSIX os.replace swaps under the reader; on Windows the rename is blocked
+    # by the open handle and store falls back to an in-place write.
     storage = LocalFileStorage(str(tmp_path))
     await storage.store("doc.txt", "old-complete-content", overwrite=True)
 
     with open(tmp_path / "doc.txt", encoding="utf-8") as reader:
         await storage.store("doc.txt", "new", overwrite=True)
-        assert reader.read() == "old-complete-content"
+        if os.name != "nt":
+            # POSIX only: the reader's handle stays on the old inode, so it
+            # sees a complete old version, never a truncated file. On Windows
+            # the fallback writes in place, so the old handle observes the new
+            # bytes — the pre-atomic behavior there.
+            assert reader.read() == "old-complete-content"
 
     assert (tmp_path / "doc.txt").read_text() == "new"
 

--- a/cognee/tests/unit/modules/ingestion/test_identify_data.py
+++ b/cognee/tests/unit/modules/ingestion/test_identify_data.py
@@ -7,6 +7,7 @@ Contract under test:
   - identify_data and identify agree on the winning row
 """
 
+import importlib
 import os
 import tempfile
 from types import SimpleNamespace
@@ -21,7 +22,17 @@ from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter imp
 from cognee.modules.data.models import Data
 from cognee.modules.ingestion.identify import identify, identify_data
 
-_ENGINE_PATCH = "cognee.modules.ingestion.identify.get_relational_engine"
+# ``cognee.modules.ingestion.__init__`` rebinds the name ``identify`` from the
+# submodule to the function it exports. Python 3.10's ``mock.patch`` resolves a
+# dotted string target with ``getattr``, so it lands on the function and raises
+# AttributeError; 3.11+ resolves it with ``pkgutil.resolve_name`` and finds the
+# module. Import the module explicitly and patch the object, so the target is
+# the module on every supported version. (Same recipe as test_identify_many.)
+_identify_module = importlib.import_module("cognee.modules.ingestion.identify")
+
+
+def _patch_engine(engine):
+    return patch.object(_identify_module, "get_relational_engine", return_value=engine)
 
 
 async def _make_engine(rows: list[dict]) -> tuple[SQLAlchemyAdapter, str]:
@@ -71,7 +82,7 @@ async def test_hit_returns_the_row_identify_points_at():
     )
     engine, db_path = await _make_engine([seeded])
     try:
-        with patch(_ENGINE_PATCH, return_value=engine):
+        with _patch_engine(engine):
             row = await identify_data(_classified("h1"), user, dataset_id)
             same_id = await identify(_classified("h1"), user, dataset_id)
         assert row is not None
@@ -92,7 +103,7 @@ async def test_miss_scopes_like_identify():
         [_row(dataset_id=dataset_id, owner_id=user.id, content_hash="h1")]
     )
     try:
-        with patch(_ENGINE_PATCH, return_value=engine):
+        with _patch_engine(engine):
             assert await identify_data(_classified("h1"), stranger, dataset_id) is None
             assert await identify_data(_classified("h1"), user, uuid4()) is None
             assert await identify_data(_classified("unknown"), user, dataset_id) is None
@@ -112,7 +123,11 @@ async def test_explicit_session_is_used_without_opening_another():
     try:
         # Any attempt to open a session through the module's engine accessor
         # would be a regression: the caller's session must be the only one.
-        with patch(_ENGINE_PATCH, side_effect=AssertionError("must not open a session")):
+        with patch.object(
+            _identify_module,
+            "get_relational_engine",
+            side_effect=AssertionError("must not open a session"),
+        ):
             async with engine.get_async_session() as session:
                 row = await identify_data(_classified("h1"), user, dataset_id, session=session)
                 assert row is not None and row.id == seeded["id"]


### PR DESCRIPTION
Follow-up to #4581, which merged while its OS/Python matrix still had two red jobs. Both are fixed here, cherry-picked from the original branch (`8416c6c75`).

## Python 3.10 — `test_identify_data` AttributeError

`mock.patch` resolves a dotted string target with `getattr` on 3.10, so `cognee.modules.ingestion.identify.get_relational_engine` lands on the `identify` **function** (the package `__init__` rebinds the name over the submodule) and raises; 3.11+ resolves via `pkgutil.resolve_name` and finds the module. The test now imports the module explicitly and uses `patch.object` — the same recipe #4587 (CLO-591) applied to `test_identify_many`.

## Windows — `LocalFileStorage` overwrite-while-read regression

#4581 made local stores atomic (write temp + `os.replace`). On Windows, replacing a file another handle holds open fails with `PermissionError` (the rename needs DELETE sharing, which ordinary `open()`s don't grant) — so a previously succeeding overwrite-while-read became a failure, caught by the new atomic-store test on the `windows-latest` job. `store()` now falls back to the pre-atomic in-place write on `PermissionError` (Windows-only path; POSIX keeps the atomic swap), and the test asserts the POSIX snapshot guarantee only where it holds.

## Testing

- `test_identify_data` + `infrastructure/files` suites: 30 passed
- `uv run ty check .` exit 0
- Failure evidence: [3.10 job](https://github.com/topoteretes/cognee/actions/runs/32379071885/job/96457714238), [Windows job](https://github.com/topoteretes/cognee/actions/runs/32379071885/job/96457714517)

🤖 Generated with [Claude Code](https://claude.com/claude-code)