### PR TITLE
fix(ci): Unbreak the nightly, its flakes, and take it off the PR gate (CLO-594)

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -90,6 +90,13 @@ jobs:
       mode: mock_llm
       label: war_and_peace_large
       runs: '3'
+      # postgres only. The file_based arm has never produced a report: ladybug's
+      # add_edges cannot land the first 2,000-edge chunk of a 100,689-node graph
+      # inside the subprocess worker's 300s per-call deadline, so cognify times
+      # out, rolls back, and three runs walk into GitHub's 6h job ceiling — red
+      # nightly plus a wasted 6h runner, every single night. Re-enable by
+      # dropping `backends` once the adapter scales (COG-6185 / CLO-594).
+      backends: postgres
       memories_key: nightly_ci_artifacts/performance_test_artifacts/war_and_peace.json
       mock_memories_key: nightly_ci_artifacts/performance_test_artifacts/mock_war_and_peace_large.json
     secrets: inherit
@@ -223,7 +230,6 @@ jobs:
             url_file_small_mock ${{ needs.perf-small-mock.outputs.file_based_html_key }}
             url_file_wap_llm ${{ needs.perf-wap-llm.outputs.file_based_html_key }}
             url_file_wap_mock ${{ needs.perf-wap-mock.outputs.file_based_html_key }}
-            url_file_wap_large_mock ${{ needs.perf-wap-large-mock.outputs.file_based_html_key }}
             url_pg_small_llm ${{ needs.perf-small-llm.outputs.postgres_html_key }}
             url_pg_small_mock ${{ needs.perf-small-mock.outputs.postgres_html_key }}
             url_pg_wap_llm ${{ needs.perf-wap-llm.outputs.postgres_html_key }}
@@ -260,7 +266,6 @@ jobs:
             📊|File Based — 50 Small Documents — Mock LLM|${{ needs.perf-small-mock.result }}|${{ needs.perf-small-mock.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_small_mock }}
             📚|File Based — War and Peace — Real LLM|${{ needs.perf-wap-llm.result }}|${{ needs.perf-wap-llm.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_wap_llm }}
             📚|File Based — War and Peace — Mock LLM|${{ needs.perf-wap-mock.result }}|${{ needs.perf-wap-mock.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_wap_mock }}
-            📚|File Based — Medium graph - Artificial 100k nodes/edges — Mock LLM|${{ needs.perf-wap-large-mock.result }}|${{ needs.perf-wap-large-mock.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_wap_large_mock }}
             📊|Full Postgres — 50 Small Documents — Real LLM|${{ needs.perf-small-llm.result }}|${{ needs.perf-small-llm.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_small_llm }}
             📊|Full Postgres — 50 Small Documents — Mock LLM|${{ needs.perf-small-mock.result }}|${{ needs.perf-small-mock.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_small_mock }}
             📚|Full Postgres — War and Peace — Real LLM|${{ needs.perf-wap-llm.result }}|${{ needs.perf-wap-llm.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_wap_llm }}

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -6,14 +6,15 @@ permissions:
 on:
   schedule:
     - cron: '0 3 * * *'
+  # Deliberately NOT on pull_request. This workflow used to run on any PR that
+  # touched the nightly/perf workflow files, to validate the edit before merge.
+  # The cost of that was the whole nightly gating the PR: ~13 jobs including
+  # Ollama, llama-cpp, four cloud/rust perf arms and a 100k-node benchmark, any
+  # one of which reddens the PR for something the PR did not cause. It also
+  # meant a nightly-only regression on dev surfaced as a failing check on an
+  # unrelated PR. Validate workflow edits with `workflow_dispatch` on the branch
+  # instead (Actions -> Nightly Tests -> Run workflow -> pick the branch).
   workflow_dispatch:
-  # Note: Run Nightly CI on change to any of the following files.
-  pull_request:
-    paths:
-      - '.github/workflows/nightly_tests.yml'
-      - '.github/workflows/performance_report.yml'
-      - '.github/workflows/performance_report_cloud.yml'
-      - '.github/workflows/performance_report_rust.yml'
 
 
 concurrency:
@@ -184,9 +185,7 @@ jobs:
     if: ${{ !cancelled() }}
     steps:
       # This job runs repo scripts (the Slack block renderer, the MotherDuck
-      # ETL), so it needs a working tree. It previously had none: the ETL is
-      # skipped on pull_request and has never run on a schedule from this
-      # branch, so nothing exercised the gap until the renderer landed.
+      # ETL), so it needs a working tree.
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -280,9 +279,9 @@ jobs:
         run: python .github/scripts/build_nightly_slack_blocks.py
 
       - name: Post status to Slack
-        # Posts on scheduled/manual runs AND on pull_request validation runs
-        # (which fire when the nightly workflow files themselves change), so
-        # workflow changes surface their reports in the channel too.
+        # Posts on scheduled and manual (workflow_dispatch) runs. There is no
+        # longer a pull_request trigger, so a workflow edit surfaces its reports
+        # by being dispatched on the branch rather than by opening a PR.
         uses: slackapi/slack-github-action@v2.1.0
         with:
           method: chat.postMessage
@@ -298,8 +297,9 @@ jobs:
         # failure gate and marked continue-on-error: a warehouse hiccup must not
         # turn a green nightly red, and the reports from a failed suite are the
         # interesting rows, so they still need to land.
-        # Skipped on pull_request for the same reason as the Slack post — the
-        # trigger exists to validate this file, not to write to the warehouse.
+        # The pull_request trigger is gone, so this guard is now a belt-and-braces
+        # no-op. Kept deliberately: if anyone reinstates a PR trigger, a
+        # validation run must not write to the shared warehouse.
         if: ${{ github.event_name != 'pull_request' }}
         continue-on-error: true
         env:

--- a/.github/workflows/performance_report.yml
+++ b/.github/workflows/performance_report.yml
@@ -5,7 +5,8 @@ name: performance report
 # headline metrics + HTML object key as outputs for the caller (the Slack bot in
 # nightly_tests.yml).
 #
-# Both backends run on every call, as two separate jobs:
+# Both backends run on every call by default (see the `backends` input), as two
+# separate jobs:
 #   - file_based : cognee defaults (SQLite + Kuzu + LanceDB), no services.
 #   - postgres   : full Postgres (relational + PGVector + Postgres graph) via a
 #                  `services: postgres` container (mirrors e2e_tests.yml).
@@ -40,6 +41,16 @@ on:
         required: false
         type: string
         default: ''
+      backends:
+        # war_and_peace_large is file_based-exempt: ladybug's edge writer cannot
+        # land a 100k-node graph inside the subprocess worker's 300s per-call
+        # deadline, so that arm has never once produced a report (COG-6185).
+        # Until the adapter scales, that caller asks for 'postgres' only rather
+        # than burning a 6h runner every night. See CLO-594.
+        description: "Which backends to run: 'both' (default), 'file_based' or 'postgres'."
+        required: false
+        type: string
+        default: 'both'
     outputs:
       file_based_metrics:
         description: "File-based run: success + add/cognify/search (GRAPH_COMPLETION + HYBRID_COMPLETION)/total p50/p90/p99."
@@ -64,7 +75,13 @@ jobs:
   # ── File-based backend: SQLite + Kuzu + LanceDB (cognee defaults) ────────────
   file_based:
     name: file_based — ${{ inputs.label }} (${{ inputs.mode }})
+    if: ${{ inputs.backends == 'both' || inputs.backends == 'file_based' }}
     runs-on: ubuntu-22.04
+    # Without this the job inherits GitHub's 360-minute ceiling. A wedged
+    # benchmark then burns a full 6h runner and reports as `cancelled`, which
+    # reads like an infra blip rather than the failure it is. The slowest arm
+    # that has ever PASSED is war_and_peace_large/postgres at 59 min.
+    timeout-minutes: 120
     outputs:
       metrics: ${{ steps.parse.outputs.metrics }}
       html_key: ${{ steps.upload.outputs.html_key }}
@@ -176,7 +193,10 @@ jobs:
   # ── Postgres backend: Postgres relational + PGVector + Postgres graph ────────
   postgres:
     name: postgres — ${{ inputs.label }} (${{ inputs.mode }})
+    if: ${{ inputs.backends == 'both' || inputs.backends == 'postgres' }}
     runs-on: ubuntu-22.04
+    # See the file_based job: bounded so a wedged run fails in 2h, not 6.
+    timeout-minutes: 120
     defaults:
       run:
         shell: bash

--- a/.github/workflows/performance_report_cloud.yml
+++ b/.github/workflows/performance_report_cloud.yml
@@ -57,6 +57,10 @@ jobs:
   cloud:
     name: cloud — ${{ inputs.label }}
     runs-on: ubuntu-22.04
+    # Bounded like the local perf jobs: tenant provisioning against the live
+    # tenant can hang (observed: 266s to a "Connection reset by peer"), and
+    # without this the job would sit on GitHub's 6h default.
+    timeout-minutes: 90
     outputs:
       metrics: ${{ steps.parse.outputs.metrics }}
       html_key: ${{ steps.upload.outputs.html_key }}

--- a/.github/workflows/test_different_operating_systems.yml
+++ b/.github/workflows/test_different_operating_systems.yml
@@ -66,10 +66,29 @@ jobs:
           python-version: ${{ matrix.python-version }}
           extra-dependencies: ${{ inputs.extra-dependencies }}
 
+      - name: Drop Git for Windows usr\bin from PATH
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: |
+          # Same guard the delete-test jobs already carry. Without it this job
+          # hangs: the step runs under Git for Windows' bash, so its usr\bin
+          # OpenSSL DLLs shadow the ones native extensions load, and the import
+          # deadlocks. pytest then never emits a single line -- --timeout only
+          # covers test execution, so it never engages -- and the job sits until
+          # the 60-minute ceiling cancels it. Observed on 3 of 12 recent runs.
+          $kept = $env:PATH -split ';' | Where-Object { $_ -notmatch 'Git\\usr\\bin' }
+          $dropped = ($env:PATH -split ';').Count - $kept.Count
+          "PATH=$($kept -join ';')" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "Dropped $dropped PATH entry/entries matching Git\usr\bin"
+
       - name: Run unit tests
         shell: bash
         run: uv run pytest cognee/tests/unit/ --timeout=300 --timeout-method=thread
         env:
+          # Unbuffered + faulthandler so a wedged interpreter leaves evidence
+          # instead of a 60-minute silent cancel.
+          PYTHONUNBUFFERED: 1
+          PYTHONFAULTHANDLER: 1
           PYTHONUTF8: 1
           LLM_PROVIDER: openai
           LLM_MODEL: ${{ secrets.LLM_MODEL }}
@@ -103,9 +122,26 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Drop Git for Windows usr\bin from PATH
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: |
+          # Same guard the delete-test jobs already carry. Without it this job
+          # hangs: the step runs under Git for Windows' bash, so its usr\bin
+          # OpenSSL DLLs shadow the ones native extensions load, and the import
+          # deadlocks. pytest then never emits a single line -- --timeout only
+          # covers test execution, so it never engages -- and the job sits until
+          # the 60-minute ceiling cancels it. Observed on 3 of 12 recent runs.
+          $kept = $env:PATH -split ';' | Where-Object { $_ -notmatch 'Git\\usr\\bin' }
+          $dropped = ($env:PATH -split ';').Count - $kept.Count
+          "PATH=$($kept -join ';')" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "Dropped $dropped PATH entry/entries matching Git\usr\bin"
+
       - name: Run default basic pipeline
         shell: bash
         env:
+          PYTHONUNBUFFERED: 1
+          PYTHONFAULTHANDLER: 1
           PYTHONUTF8: 1
           LLM_PROVIDER: openai
           LLM_MODEL: ${{ secrets.LLM_MODEL }}

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_native/get_native_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_native/get_native_client.py
@@ -7,6 +7,8 @@ adapter serves every provider — and construction is pure attribute assignment
 active (possibly per-request) config and builds a fresh adapter.
 """
 
+from functools import lru_cache
+
 from cognee.infrastructure.llm.config import get_llm_context_config
 from cognee.infrastructure.llm.exceptions import LLMAPIKeyNotSetError
 from cognee.infrastructure.llm.structured_output_framework.litellm_native.native_adapter import (
@@ -16,6 +18,47 @@ from cognee.infrastructure.llm.structured_output_framework.litellm_native.native
 # Providers that do not require ``llm_api_key`` (mirrors get_llm_client): Bedrock
 # authenticates with AWS credentials and llama.cpp runs locally.
 _NO_API_KEY_PROVIDERS = {"bedrock", "llama_cpp"}
+
+# cognee keeps provider and model as separate settings, and the instructor path
+# did its own per-provider dispatch. litellm instead routes on a
+# provider-qualified model name, so a config that is perfectly valid for
+# instructor -- LLM_PROVIDER=ollama with LLM_MODEL=phi4 -- reaches litellm as a
+# bare "phi4" and dies with:
+#
+#     litellm.BadRequestError: LLM Provider NOT provided. You passed model=phi4
+#
+# Only providers whose litellm prefix is unambiguous are listed. openai and azure
+# are deliberately absent: litellm already resolves bare OpenAI model names, and
+# azure needs a deployment-specific form we must not guess at.
+_LITELLM_PROVIDER_PREFIX = {
+    "ollama": "ollama",
+    "anthropic": "anthropic",
+    "gemini": "gemini",
+    "mistral": "mistral",
+    "bedrock": "bedrock",
+}
+
+
+@lru_cache(maxsize=256)
+def _qualify_model(model: str, provider: str) -> str:
+    """Prefix ``model`` with its litellm provider only when litellm needs it.
+
+    Deliberately conservative: an already-qualified name ("ollama/phi4") and any
+    bare name litellm can already resolve on its own are returned untouched, so
+    this cannot re-route a configuration that works today. It only rescues the
+    case that currently raises BadRequestError before a request is even sent.
+    """
+    if not model or "/" in model:
+        return model
+
+    import litellm
+
+    try:
+        litellm.get_llm_provider(model=model)
+        return model
+    except Exception:
+        prefix = _LITELLM_PROVIDER_PREFIX.get((provider or "").lower())
+        return f"{prefix}/{model}" if prefix else model
 
 
 def get_native_client(raise_api_key_error: bool = True) -> NativeLiteLLMAdapter:
@@ -48,7 +91,7 @@ def get_native_client(raise_api_key_error: bool = True) -> NativeLiteLLMAdapter:
 
     return NativeLiteLLMAdapter(
         api_key=api_key or "",
-        model=llm_config.llm_model,
+        model=_qualify_model(llm_config.llm_model, provider),
         max_completion_tokens=max_completion_tokens,
         endpoint=llm_config.llm_endpoint or None,
         api_version=llm_config.llm_api_version,

--- a/cognee/shared/data_models.py
+++ b/cognee/shared/data_models.py
@@ -3,7 +3,7 @@
 from enum import Enum, auto
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from cognee.infrastructure.llm.config import (
     get_llm_config,
@@ -278,6 +278,35 @@ class SummarizedContent(BaseModel):
         ),
     )
     description: str = Field("", description="Unused; kept for backwards compatibility.")
+
+    @field_validator("description", mode="before")
+    @classmethod
+    def _coerce_description(cls, value: Any) -> Any:
+        """Accept whatever a model puts in this field.
+
+        ``description`` is unused and kept only for backwards compatibility,
+        but it is still part of the schema handed to the LLM, so a model is
+        free to fill it. Smaller local models routinely answer with a list of
+        bullets instead of a string, and strict validation then fails the whole
+        structured-output call -- instructor retries, exhausts, and an entire
+        cognify run dies on a field nothing reads. Observed nightly on the
+        llama-cpp suite:
+
+            ValidationError: 1 validation error for SummarizedContent
+            description
+              Input should be a valid string [type=string_type,
+              input_value=['Natural Language Proces...'], input_type=list]
+
+        Coerce instead of rejecting. ``summary`` -- the field that is actually
+        consumed -- keeps strict validation.
+        """
+        if value is None:
+            return ""
+        if isinstance(value, (list, tuple)):
+            return "\n".join(str(item) for item in value)
+        if not isinstance(value, str):
+            return str(value)
+        return value
 
 
 class SummarizedFunction(BaseModel):

--- a/cognee/tests/performance/statistics_percentile/bench_cognee.py
+++ b/cognee/tests/performance/statistics_percentile/bench_cognee.py
@@ -402,6 +402,10 @@ def _err(e: Exception) -> str:
     return str(e) or repr(e)
 
 
+# Transient-reset retries for tenant creation (see _create_cloud_tenant).
+_TENANT_CREATE_ATTEMPTS = 3
+
+
 async def _create_cloud_tenant(
     management_url: str, api_key: str, tenant_name: str, ready_timeout_s: float = 600.0
 ) -> tuple[str, str, float]:
@@ -416,19 +420,54 @@ async def _create_cloud_tenant(
 
     t0 = time.time()
     async with aiohttp.ClientSession(headers={"X-Api-Key": api_key}) as session:
-        async with session.post(
-            f"{management_url}/api/v1/tenants", params={"tenant_name": tenant_name}
-        ) as resp:
-            if resp.status >= 400:
-                body = await resp.text()
-                raise RuntimeError(f"Tenant creation failed ({resp.status}): {body}")
-            tenant_id = (await resp.json())["tenant_id"]
+        # The controller drops the connection under load: a bare POST failed the
+        # whole nightly cloud arm on 3 of the last 4 runs with
+        # "[Errno 104] Connection reset by peer", 266s in. A reset is not a
+        # rejection -- nothing was created -- so retry it. An HTTP >=400 IS a
+        # real rejection and still fails immediately, so a genuinely broken
+        # controller is not retried into a slow green.
+        last_exc = None
+        tenant_id = None
+        for attempt in range(_TENANT_CREATE_ATTEMPTS):
+            try:
+                async with session.post(
+                    f"{management_url}/api/v1/tenants", params={"tenant_name": tenant_name}
+                ) as resp:
+                    if resp.status >= 400:
+                        body = await resp.text()
+                        raise RuntimeError(f"Tenant creation failed ({resp.status}): {body}")
+                    tenant_id = (await resp.json())["tenant_id"]
+                break
+            except (aiohttp.ClientError, OSError, asyncio.TimeoutError) as exc:
+                last_exc = exc
+                if attempt == _TENANT_CREATE_ATTEMPTS - 1:
+                    raise
+                backoff = 2**attempt
+                print(
+                    f"  Tenant creation attempt {attempt + 1}/{_TENANT_CREATE_ATTEMPTS} failed "
+                    f"({_err(exc)}); retrying in {backoff}s",
+                    flush=True,
+                )
+                await asyncio.sleep(backoff)
+        if tenant_id is None:  # pragma: no cover - defensive
+            raise RuntimeError(f"Tenant creation failed: {_err(last_exc)}")
 
         deadline = time.time() + ready_timeout_s
         while True:
-            async with session.get(f"{management_url}/api/v1/tenants/{tenant_id}/status") as resp:
-                if resp.status < 400 and (await resp.json()).get("status") == "healthy":
-                    break
+            # A transient reset while polling is not "unhealthy" -- keep polling
+            # until the deadline rather than failing the run on one bad packet.
+            try:
+                async with session.get(
+                    f"{management_url}/api/v1/tenants/{tenant_id}/status"
+                ) as resp:
+                    if resp.status < 400 and (await resp.json()).get("status") == "healthy":
+                        break
+            except (aiohttp.ClientError, OSError, asyncio.TimeoutError) as exc:
+                if time.time() > deadline:
+                    raise TimeoutError(
+                        f"Tenant {tenant_id} not healthy after {ready_timeout_s:.0f}s "
+                        f"(last error: {_err(exc)})"
+                    ) from exc
             if time.time() > deadline:
                 raise TimeoutError(f"Tenant {tenant_id} not healthy after {ready_timeout_s:.0f}s")
             await asyncio.sleep(2)

--- a/cognee/tests/unit/infrastructure/llm/test_litellm_native.py
+++ b/cognee/tests/unit/infrastructure/llm/test_litellm_native.py
@@ -477,3 +477,52 @@ async def test_cancellation_is_not_retried():
             )
 
     assert mock_acompletion.call_count == 1
+
+
+# ── provider-qualified model names (CLO-594) ─────────────────────────────────
+# cognee stores provider and model separately; litellm routes on a qualified
+# model name. The instructor path dispatched per provider, so LLM_PROVIDER=ollama
+# with LLM_MODEL=phi4 worked there and 400s on litellm_native with
+# "LLM Provider NOT provided". This broke the Ollama nightly the first time it
+# ran on dev after litellm_native became the default framework.
+
+
+class TestQualifyModel:
+    """_qualify_model must rescue unroutable names and touch nothing else."""
+
+    @staticmethod
+    def _qualify(model, provider):
+        from cognee.infrastructure.llm.structured_output_framework.litellm_native.get_native_client import (
+            _qualify_model,
+        )
+
+        return _qualify_model(model, provider)
+
+    def test_bare_ollama_model_gets_prefixed(self):
+        """The exact CI failure: LLM_PROVIDER=ollama, LLM_MODEL=phi4."""
+        assert self._qualify("phi4", "ollama") == "ollama/phi4"
+
+    def test_tagged_ollama_model_gets_prefixed(self):
+        assert self._qualify("qwen3:latest", "ollama") == "ollama/qwen3:latest"
+
+    def test_already_qualified_is_untouched(self):
+        assert self._qualify("ollama/phi4", "ollama") == "ollama/phi4"
+        assert self._qualify("openai/gpt-5-mini", "openai") == "openai/gpt-5-mini"
+
+    def test_name_litellm_already_resolves_is_untouched(self):
+        """Must not re-route a configuration that works today."""
+        assert self._qualify("gpt-4o", "openai") == "gpt-4o"
+
+    def test_unknown_provider_is_untouched(self):
+        """generic/llama_cpp have no unambiguous litellm prefix — leave them be."""
+        assert self._qualify("some-custom-model", "generic") == "some-custom-model"
+
+    def test_empty_model_is_untouched(self):
+        assert self._qualify("", "ollama") == ""
+
+    def test_qualified_name_is_routable_by_litellm(self):
+        """End of the chain: the rescued name must actually resolve."""
+        import litellm
+
+        qualified = self._qualify("phi4", "ollama")
+        assert litellm.get_llm_provider(model=qualified)[1] == "ollama"


### PR DESCRIPTION
## Description

The nightly has been red every night and PR runs fail ~45% of the time. Four distinct causes, each root-caused from run logs rather than re-run until green. One is deterministic and three are genuine flakes; each is a separate commit so any can be dropped.

### 1. The nightly failure is not flaky — `war_and_peace_large / file_based` is killed at the 6h ceiling

It reports as `cancelled`, which reads like an infra blip, so it has been mistaken for flakiness. It has **never once produced a report** — the MotherDuck warehouse has 11 `postgres` rows for this label and zero `file_based`, ever. From run [32327624324](https://github.com/topoteretes/cognee/actions/runs/32327624324):

```
03:19:51  Merged nodes 100689/100689
03:57:04  Query execution failed: Subprocess call exceeded 300.0s deadline
          Failed to add edges in batch: ...
```

Nodes merge in ~40s. Edges never land a **single chunk** — there is not one `Merged edges N/M` line in 203k log lines. `add_edges` chunks at `_WRITE_CHUNK_SIZE=2000`, and the *first* chunk alone blows the 300s per-call deadline in `cognee_db_workers/harness.py:65` on a 100,689-node graph. cognify times out, rolls back (~57 min), and `--runs 3` walks into GitHub's 6h wall. The `postgres` arm of the identical benchmark passes in **59 min**.

Two changes, neither of which papers over the adapter bug:
- A `backends` input on `performance_report.yml`; the large-graph caller asks for `postgres` only. Re-enable by dropping the input once ladybug's edge writer scales.
- `timeout-minutes` on the perf jobs (120 local, 90 cloud). They had **none**, so they inherited the 360-minute default — which is why a wedged run burned a full 6h runner. The slowest arm that has ever passed is 59 min.

**The underlying ladybug edge-write scaling limit is a product bug and needs its own ticket** — any user with a ~100k-node graph on the file-based backend hits it. This PR stops it costing a 6h runner nightly; it does not fix it.

### 2. Windows unit/library tests hang to the 60-minute ceiling

This is the sole reason failing PR runs take **60 min instead of ~22**. The pytest step emits **zero** lines before the cancel:

```
##[group]Run uv run pytest cognee/tests/unit/ --timeout=300 --timeout-method=thread
##[error]The operation was canceled.
```

The step runs under `C:\Program Files\Git\bin\bash.EXE`, so Git for Windows' `usr\bin` OpenSSL DLLs shadow the ones native extensions load and the import deadlocks. `--timeout-method=thread` only covers test *execution*, so it never engages.

The PATH guard that fixes exactly this **already existed — but only on the two delete-test jobs**. Applied the identical guard to `run-unit-tests` and `run-library-test`, plus `PYTHONUNBUFFERED`/`PYTHONFAULTHANDLER` so a future wedge leaves evidence instead of a silent 60-minute cancel.

### 3. llama-cpp nightly dies on a field nothing reads

`SummarizedContent.description` is documented *"Unused; kept for backwards compatibility"* — but it is still in the schema handed to the LLM, and smaller local models answer with a list of bullets:

```
ValidationError: 1 validation error for SummarizedContent
description
  Input should be a valid string [type=string_type,
  input_value=['Natural Language Proces...'], input_type=list]
```

instructor retries, exhausts, and the whole cognify run dies. Coerce the field instead of rejecting it. `summary` — the field actually consumed — keeps strict validation.

### 4. Cloud perf tenant creation is not retried

Failed 3 of the last 4 nightlies with `[Errno 104] Connection reset by peer`, 266s in, on 1 of 3 runs. A reset is not a rejection — nothing was created — so retry with backoff, and keep polling through a transient reset rather than failing on one bad packet. HTTP `>=400` **is** a real rejection and still fails immediately, so a genuinely broken controller is not retried into a slow green.


### 5. The nightly no longer gates PRs

`nightly_tests.yml` ran on any PR touching the nightly/perf workflow files, to validate the edit before merge. The cost was the **whole nightly gating the PR** — ~13 jobs including Ollama, llama-cpp, four cloud/rust perf arms and a 100k-node benchmark — any of which reddens the PR for something the PR did not cause.

This PR is the demonstration: it edits three perf workflow files, so it pulled in a full nightly, and `Ollama Tests` failed on it for a reason entirely unrelated to the change under review (see #6). Dropped the `pull_request` trigger; validate workflow edits with `workflow_dispatch` on the branch, which is what it is already there for. `nightly_tests.yml` is the **only** workflow in the repo carrying both a `schedule` and a `pull_request` trigger, so this is the whole of that surface.

The `github.event_name != 'pull_request'` guard on the MotherDuck ETL is kept on purpose — a no-op now, but it must stay if anyone reinstates a PR trigger.

### 6. Ollama is broken on dev: litellm gets an unqualified model name

Surfaced by this PR, not caused by it:

```
litellm.BadRequestError: LLM Provider NOT provided. You passed model=phi4
  native_adapter.py:372 acreate_structured_output -> :313 _acreate_structured
  -> :239 _acreate_json_fallback -> litellm.acompletion(...)
```

cognee stores provider and model separately, and the instructor framework dispatched per provider — so `LLM_PROVIDER=ollama` + `LLM_MODEL=phi4` is valid, and is what `test_ollama.yml` has always used. litellm routes on a **provider-qualified** name. `get_native_client` reads `llm_provider` for its API-key check but never passes it to the adapter; its docstring says *"there is no provider dispatch"*, which is exactly the gap.

Nothing caught it because the defaults diverged: `STRUCTURED_OUTPUT_FRAMEWORK` is `"instructor"` on **main** and `"litellm_native"` on **dev**. Scheduled nightlies run on main and pass 5/5; the last dev-based nightly predates the switch. The first thing to exercise it was a PR that happened to touch a nightly workflow file.

Fixed conservatively in `get_native_client`: an already-qualified name, and any bare name litellm resolves on its own, are returned untouched — a working configuration cannot be re-routed. Only the case that raises *before sending* is rescued. `openai` and `azure` are deliberately not in the prefix map. **This is not ollama-only** — bare anthropic/gemini/mistral names are unroutable on this path too and are fixed by the same change.

## Acceptance Criteria

- Nightly stops burning a 6h runner on `war_and_peace_large`; the label still reports via its postgres arm.
- A wedged perf job fails in ≤2h with a clear timeout instead of a 6h `cancelled`.
- Windows unit/library jobs no longer hang to 60 min; failing PR runs return to ~22 min wall clock.
- `SummarizedContent` accepts a list/None/int in `description`; `summary` still strictly required.
- Transient connection resets during tenant create/poll are retried; HTTP 4xx/5xx still fail fast.
- No `Nightly Tests / *` check appears on a PR any more (verified: 0 matches on this PR after the change).
- `LLM_PROVIDER=ollama` + `LLM_MODEL=phi4` routes as `ollama/phi4`; `gpt-4o` and `openai/gpt-5-mini` are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

```
$ pre-commit run --files <all six changed files>
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed

$ pytest cognee/tests/unit/ -k "summar or data_model"
86 passed, 5 skipped

$ pytest cognee/tests/unit/modules/ingestion cognee/tests/unit/processing
321 passed

# tenant-retry path, injected resets (2 on create, 1 on poll)
  Tenant creation attempt 1/3 failed ([Errno 104] Connection reset by peer); retrying in 1s
  Tenant creation attempt 2/3 failed ([Errno 104] Connection reset by peer); retrying in 2s
PASS — transient resets retried on both create and poll
```

## Notes / open questions

- **Draft on purpose.** #2 is still the one I am least sure of: the DLL-shadowing mechanism fits the evidence exactly (zero output, Git bash shell, guard already exists for the same symptom elsewhere), but I could not reproduce a Windows runner locally, so it is inference from logs rather than a confirmed repro. If it does not clear the hang, the faulthandler/unbuffered additions should at least make the next occurrence diagnosable.
- Not covered here, but measured while investigating — PR CI costs **883 machine-minutes across 181 jobs per green run**, and cost is concentrated: End-to-End 29%, Search Test 16%, OS/Python Ubuntu 14%. The single clearest win is the Search matrix, which runs 4 DB combos × **4 Python versions** (144 min/run) for behaviour that does not vary by Python minor. Cutting to one version saves ~108 min/run. Happy to do that as a follow-up — kept out of this PR since it is a scope decision, not a fix.

## Pre-submission Checklist

- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages
