### PR TITLE
feat(ci): Add the Henkel dataset to the nightly + fix litellm_native fenced JSON (CLO-595, CLO-596)

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -81,6 +81,34 @@ jobs:
       mock_memories_key: nightly_ci_artifacts/performance_test_artifacts/mock_war_and_peace.json
     secrets: inherit
 
+  # Henkel technical datasheets: 164 real PDFs (~1.35M chars). Complements the
+  # existing corpora on document *count* -- War and Peace is one long document,
+  # the 50-doc set is short synthetic ones. This is many medium-sized real-world
+  # documents, which is the shape most user datasets actually have.
+  #
+  # No Rust arms yet: those read fixtures from topoteretes/cognee-rs
+  # (scripts/perf/fixtures/<label>/), so they land with that repo's PR.
+  perf-henkel-llm:
+    name: Performance — Henkel (real LLM)
+    uses: ./.github/workflows/performance_report.yml
+    with:
+      mode: llm
+      label: henkel
+      runs: '3'
+      memories_key: nightly_ci_artifacts/performance_test_artifacts/henkel.json
+    secrets: inherit
+
+  perf-henkel-mock:
+    name: Performance — Henkel (mock LLM)
+    uses: ./.github/workflows/performance_report.yml
+    with:
+      mode: mock_llm
+      label: henkel
+      runs: '3'
+      memories_key: nightly_ci_artifacts/performance_test_artifacts/henkel.json
+      mock_memories_key: nightly_ci_artifacts/performance_test_artifacts/mock_henkel.json
+    secrets: inherit
+
   # 27x-multiplied capture of the same book (~100k graph nodes/edges per run):
   # the production-scale stress benchmark. Mock-only — the corpus IS a replay
   # artifact; a "real LLM" variant would re-extract 27 identical copies.
@@ -121,6 +149,15 @@ jobs:
       label: war_and_peace
       runs: '3'
       memories_key: nightly_ci_artifacts/performance_test_artifacts/war_and_peace.json
+    secrets: inherit
+
+  perf-henkel-cloud:
+    name: Performance — Henkel (cloud)
+    uses: ./.github/workflows/performance_report_cloud.yml
+    with:
+      label: henkel
+      runs: '3'
+      memories_key: nightly_ci_artifacts/performance_test_artifacts/henkel.json
     secrets: inherit
 
   # ══ Performance (Rust SDK): builds latest cognee-rs and drives the SAME ═════
@@ -173,9 +210,12 @@ jobs:
       perf-small-mock,
       perf-wap-llm,
       perf-wap-mock,
+      perf-henkel-llm,
+      perf-henkel-mock,
       perf-wap-large-mock,
       perf-small-cloud,
       perf-wap-cloud,
+      perf-henkel-cloud,
       perf-rust,
       perf-rust-wap,
       perf-rust-llm,
@@ -198,9 +238,12 @@ jobs:
                 "${{ needs.perf-small-mock.result }}" == "success" &&
                 "${{ needs.perf-wap-llm.result }}" == "success" &&
                 "${{ needs.perf-wap-mock.result }}" == "success" &&
+                "${{ needs.perf-henkel-llm.result }}" == "success" &&
+                "${{ needs.perf-henkel-mock.result }}" == "success" &&
                 "${{ needs.perf-wap-large-mock.result }}" == "success" &&
                 "${{ needs.perf-small-cloud.result }}" == "success" &&
                 "${{ needs.perf-wap-cloud.result }}" == "success" &&
+                "${{ needs.perf-henkel-cloud.result }}" == "success" &&
                 "${{ needs.perf-rust.result }}" == "success" &&
                 "${{ needs.perf-rust-wap.result }}" == "success" &&
                 "${{ needs.perf-rust-llm.result }}" == "success" &&
@@ -233,9 +276,14 @@ jobs:
             url_pg_small_mock ${{ needs.perf-small-mock.outputs.postgres_html_key }}
             url_pg_wap_llm ${{ needs.perf-wap-llm.outputs.postgres_html_key }}
             url_pg_wap_mock ${{ needs.perf-wap-mock.outputs.postgres_html_key }}
+            url_file_henkel_llm ${{ needs.perf-henkel-llm.outputs.file_based_html_key }}
+            url_file_henkel_mock ${{ needs.perf-henkel-mock.outputs.file_based_html_key }}
+            url_pg_henkel_llm ${{ needs.perf-henkel-llm.outputs.postgres_html_key }}
+            url_pg_henkel_mock ${{ needs.perf-henkel-mock.outputs.postgres_html_key }}
             url_pg_wap_large_mock ${{ needs.perf-wap-large-mock.outputs.postgres_html_key }}
             url_cloud_small ${{ needs.perf-small-cloud.outputs.cloud_html_key }}
             url_cloud_wap ${{ needs.perf-wap-cloud.outputs.cloud_html_key }}
+            url_cloud_henkel ${{ needs.perf-henkel-cloud.outputs.cloud_html_key }}
             url_rust ${{ needs.perf-rust.outputs.html_key }}
             url_rust_wap ${{ needs.perf-rust-wap.outputs.html_key }}
             url_rust_llm ${{ needs.perf-rust-llm.outputs.html_key }}
@@ -265,13 +313,18 @@ jobs:
             📊|File Based — 50 Small Documents — Mock LLM|${{ needs.perf-small-mock.result }}|${{ needs.perf-small-mock.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_small_mock }}
             📚|File Based — War and Peace — Real LLM|${{ needs.perf-wap-llm.result }}|${{ needs.perf-wap-llm.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_wap_llm }}
             📚|File Based — War and Peace — Mock LLM|${{ needs.perf-wap-mock.result }}|${{ needs.perf-wap-mock.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_wap_mock }}
+            🧪|File Based — Henkel — Real LLM|${{ needs.perf-henkel-llm.result }}|${{ needs.perf-henkel-llm.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_henkel_llm }}
+            🧪|File Based — Henkel — Mock LLM|${{ needs.perf-henkel-mock.result }}|${{ needs.perf-henkel-mock.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_henkel_mock }}
             📊|Full Postgres — 50 Small Documents — Real LLM|${{ needs.perf-small-llm.result }}|${{ needs.perf-small-llm.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_small_llm }}
             📊|Full Postgres — 50 Small Documents — Mock LLM|${{ needs.perf-small-mock.result }}|${{ needs.perf-small-mock.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_small_mock }}
             📚|Full Postgres — War and Peace — Real LLM|${{ needs.perf-wap-llm.result }}|${{ needs.perf-wap-llm.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_wap_llm }}
             📚|Full Postgres — War and Peace — Mock LLM|${{ needs.perf-wap-mock.result }}|${{ needs.perf-wap-mock.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_wap_mock }}
             📚|Full Postgres — Medium graph - Artificial 100k nodes/edges — Mock LLM|${{ needs.perf-wap-large-mock.result }}|${{ needs.perf-wap-large-mock.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_wap_large_mock }}
+            🧪|Full Postgres — Henkel — Real LLM|${{ needs.perf-henkel-llm.result }}|${{ needs.perf-henkel-llm.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_henkel_llm }}
+            🧪|Full Postgres — Henkel — Mock LLM|${{ needs.perf-henkel-mock.result }}|${{ needs.perf-henkel-mock.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_henkel_mock }}
             📊|Cognee Cloud — 50 Small Documents|${{ needs.perf-small-cloud.result }}|${{ needs.perf-small-cloud.outputs.cloud_metrics }}|${{ steps.presign.outputs.url_cloud_small }}
             📚|Cognee Cloud — War and Peace|${{ needs.perf-wap-cloud.result }}|${{ needs.perf-wap-cloud.outputs.cloud_metrics }}|${{ steps.presign.outputs.url_cloud_wap }}
+            🧪|Cognee Cloud — Henkel|${{ needs.perf-henkel-cloud.result }}|${{ needs.perf-henkel-cloud.outputs.cloud_metrics }}|${{ steps.presign.outputs.url_cloud_henkel }}
             📊|Rust SDK (file_based) — 50 Small Documents — Real LLM|${{ needs.perf-rust-llm.result }}|${{ needs.perf-rust-llm.outputs.metrics }}|${{ steps.presign.outputs.url_rust_llm }}
             📊|Rust SDK (file_based) — 50 Small Documents — Mock LLM|${{ needs.perf-rust.result }}|${{ needs.perf-rust.outputs.metrics }}|${{ steps.presign.outputs.url_rust }}
             📚|Rust SDK (file_based) — War and Peace — Real LLM|${{ needs.perf-rust-wap-llm.result }}|${{ needs.perf-rust-wap-llm.outputs.metrics }}|${{ steps.presign.outputs.url_rust_wap_llm }}

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_native/native_adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_native/native_adapter.py
@@ -21,6 +21,7 @@ to the configured fallback model. This file never imports ``instructor``.
 import asyncio
 import json
 import logging
+import re
 from typing import Any, cast
 
 import litellm
@@ -45,6 +46,22 @@ from cognee.shared.rate_limiting import llm_rate_limiter_context_manager
 
 logger = get_logger()
 observe = get_observe()
+
+# Models on the prompted-JSON path routinely wrap their answer in a markdown
+# fence (```json ... ```). That is not a malformed answer -- the JSON inside is
+# valid -- but model_validate_json() sees a backtick at column 1 and rejects it,
+# and the self-correction retry does not help because a model that fences once
+# fences again. Strip a fence that wraps the entire payload before parsing.
+# Deliberately anchored to the whole string: JSON that merely *contains*
+# backticks in a value is left alone.
+_JSON_FENCE_RE = re.compile(r"\A\s*```(?:json)?\s*\n?(.*?)\n?\s*```\s*\Z", re.DOTALL)
+
+
+def _strip_json_fence(text: str) -> str:
+    """Return ``text`` with a wrapping markdown code fence removed, if present."""
+    match = _JSON_FENCE_RE.match(text)
+    return match.group(1) if match else text
+
 
 # Max self-correction attempts when a json-object provider returns JSON that
 # fails validation. Separate from the tenacity retry (transient HTTP errors).
@@ -249,7 +266,7 @@ class NativeLiteLLMAdapter:
                     **merged_kwargs,
                 )
 
-            raw_content = response.choices[0].message.content or "{}"
+            raw_content = _strip_json_fence(response.choices[0].message.content or "{}")
             try:
                 return _attach_raw_response(
                     response_model.model_validate_json(raw_content), response

--- a/cognee/tests/performance/statistics_percentile/README.md
+++ b/cognee/tests/performance/statistics_percentile/README.md
@@ -1,0 +1,88 @@
+# Nightly performance corpora
+
+The nightly percentile benchmark (`.github/workflows/nightly_tests.yml`) runs each
+corpus through `statistics_percentile_report.py` on four backends. A corpus is two
+S3 objects under
+`s3://github-runner-cognee-tests/nightly_ci_artifacts/performance_test_artifacts/`:
+
+| Object | What it is |
+|---|---|
+| `<label>.json` | the corpus — a JSON array of `{"title", "content"}` |
+| `mock_<label>.json` | the replay cassette, keyed by the exact chunk text the LLM saw |
+
+The Rust arms read their own copies from `topoteretes/cognee-rs` at
+`scripts/perf/fixtures/<label>/{memories.json,cassette.json}` — a separate repo,
+so adding a corpus there is a separate PR.
+
+## Current corpora
+
+| Label | Shape | Size |
+|---|---|---|
+| `50_small_documents` | short synthetic documents | 21 KB |
+| `war_and_peace` | one very long document | 3.2 MB |
+| `war_and_peace_large` | the War and Peace corpus replayed against a 27×-inflated graph (~100k nodes) | 39 MB cassette |
+| `henkel` | 164 medium-sized real product datasheets | 1.4 MB |
+
+`henkel` exists because neither of the first two covers the common case: many
+medium documents rather than one long one or a handful of short ones.
+
+## Rebuilding a corpus
+
+Both steps are reproducible; neither was, before `build_corpus.py` landed. Note
+that `mock_ingestion.py` still refers to a `generate_large_mock.py` that was never
+committed — `war_and_peace_large` cannot currently be rebuilt from source.
+
+### 1. Corpus, from a directory of documents
+
+```bash
+python build_corpus.py --from-dir ~/path/to/Henkel --output henkel.json
+```
+
+Handles `.pdf` (via pypdf), `.txt`, `.md`. It also **enforces title uniqueness**,
+which is a correctness requirement rather than cosmetics: the replay in
+`mock_ingestion.install_mocks` matches a chunk to its recorded response with
+`title in chunk_text`, so a title contained in another title silently replays the
+wrong knowledge graph and the benchmark measures the wrong thing.
+
+### 2. Cassette, from one real LLM run
+
+```bash
+# Smoke-test on two documents before spending tokens on the whole corpus
+python capture_mock.py --memories henkel.json --num-memories 2 --output /tmp/probe.json
+
+python capture_mock.py --memories henkel.json --output mock_henkel.json
+```
+
+`capture_mock.py` **prunes the configured cognee instance** before ingesting. Point
+it at a throwaway one first, or it will delete your local data:
+
+```bash
+export DATA_ROOT_DIRECTORY=/tmp/capture/.data_storage
+export SYSTEM_ROOT_DIRECTORY=/tmp/capture/.cognee_system
+```
+
+Check the summary it prints: `Substring-match collisions` must be `0`, and
+`Incomplete chunks skipped` should be `0`. A non-zero collision count means two
+chunks would replay each other's graph.
+
+### 3. Upload
+
+```bash
+BUCKET=github-runner-cognee-tests
+PREFIX=nightly_ci_artifacts/performance_test_artifacts
+aws s3 cp henkel.json      "s3://$BUCKET/$PREFIX/henkel.json"
+aws s3 cp mock_henkel.json "s3://$BUCKET/$PREFIX/mock_henkel.json"
+```
+
+Needs `s3:PutObject` on that bucket, which lives in AWS account `463722570299`.
+
+## Adding a corpus to the nightly
+
+Five caller jobs in `nightly_tests.yml` — `perf-<label>-llm`, `perf-<label>-mock`,
+`perf-<label>-cloud`, `perf-rust-<label>-llm`, `perf-rust-<label>` — plus, in the
+`notify` job, seven `REPORT_KEYS` entries, seven `ARMS` lines, the `needs` list and
+the status gate. Copy the `war_and_peace` block; it is the closest template.
+
+Nothing is needed for MotherDuck: `motherduck_nightly_etl.py` discovers labels by
+globbing the S3 report keys, so a new label appears in `ci_analytics.nightly` by
+itself.

--- a/cognee/tests/performance/statistics_percentile/build_corpus.py
+++ b/cognee/tests/performance/statistics_percentile/build_corpus.py
@@ -1,0 +1,186 @@
+"""
+Build a benchmark corpus (memories.json) from a directory of documents.
+
+The percentile benchmark eats a JSON array of ``{"title", "content"}`` objects
+(see ``cognee/tests/utils/mock_ingestion``). Existing corpora — the 50 small
+documents, War and Peace — were produced ad hoc; this script makes the step
+reproducible for document sets that arrive as files on disk.
+
+Usage:
+
+    # Henkel technical datasheets (164 PDFs) -> corpus
+    python build_corpus.py --from-dir ~/Downloads/Henkel --output henkel.json
+
+    # Text/markdown corpora work the same way
+    python build_corpus.py --from-dir ./notes --output notes.json
+
+Supported inputs: ``.pdf`` (via pypdf), ``.txt``, ``.md``, ``.markdown``.
+
+Title uniqueness is a correctness requirement, not cosmetics. The mock replay
+in ``mock_ingestion.install_mocks`` matches a chunk to its recorded response by
+testing ``title in chunk_text``. If one title is a substring of another, the
+wrong knowledge graph is replayed and the benchmark silently measures the wrong
+thing. This script therefore verifies pairwise non-containment and, when a
+clash exists, disambiguates with a terminal ``[doc-NNNN]`` marker — unique to
+one document, so no disambiguated title can be contained in any other.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+TEXT_SUFFIXES = {".txt", ".md", ".markdown"}
+PDF_SUFFIXES = {".pdf"}
+SUPPORTED = TEXT_SUFFIXES | PDF_SUFFIXES
+
+# Collapse runs of whitespace introduced by PDF layout extraction. Keeping
+# paragraph breaks matters: the chunker splits on them, so flattening every
+# newline would change chunk boundaries and inflate per-chunk size.
+_WS_RUN = re.compile(r"[ \t]+")
+_BLANK_RUN = re.compile(r"\n{3,}")
+
+
+def extract_pdf_text(path: Path) -> str:
+    """Extract text from a PDF, page by page, with pypdf."""
+    try:
+        from pypdf import PdfReader
+    except ImportError:  # pragma: no cover - environment guard
+        sys.exit("pypdf is required for PDF input: pip install pypdf")
+
+    reader = PdfReader(str(path))
+    pages = []
+    for page in reader.pages:
+        try:
+            pages.append(page.extract_text() or "")
+        except Exception as exc:  # a single broken page must not kill the corpus
+            print(f"  warn: {path.name}: page extraction failed ({type(exc).__name__})")
+            pages.append("")
+    return "\n\n".join(pages)
+
+
+def normalise(text: str) -> str:
+    """Tidy extracted text without disturbing paragraph structure."""
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = _WS_RUN.sub(" ", text)
+    text = _BLANK_RUN.sub("\n\n", text)
+    return text.strip()
+
+
+def title_from_path(path: Path) -> str:
+    """Filename stem -> a human-readable title."""
+    stem = path.stem.replace("_", " ").replace("-", " ")
+    return _WS_RUN.sub(" ", stem).strip()
+
+
+def find_containment_clashes(titles: list[str]) -> list[tuple[int, int]]:
+    """Return (i, j) pairs where titles[i] is contained in titles[j].
+
+    O(n^2), which is fine for the file-backed corpora this script builds
+    (hundreds of documents). The arXiv builder, which works at 100k+ scale,
+    sidesteps the problem entirely by minting guaranteed-unique titles.
+    """
+    clashes = []
+    for i, a in enumerate(titles):
+        for j, b in enumerate(titles):
+            if i != j and a in b:
+                clashes.append((i, j))
+    return clashes
+
+
+def build(paths: list[Path], min_chars: int) -> list[dict]:
+    memories: list[dict] = []
+    skipped_empty: list[str] = []
+
+    for path in paths:
+        if path.suffix.lower() in PDF_SUFFIXES:
+            raw = extract_pdf_text(path)
+        else:
+            raw = path.read_text(encoding="utf-8", errors="replace")
+
+        content = normalise(raw)
+        if len(content) < min_chars:
+            # Scanned/image-only PDFs extract to ~nothing. Including them would
+            # add documents that produce no chunks and quietly shrink the corpus.
+            skipped_empty.append(f"{path.name} ({len(content)} chars)")
+            continue
+
+        memories.append({"title": title_from_path(path), "content": content})
+
+    if skipped_empty:
+        print(f"\nskipped {len(skipped_empty)} document(s) below --min-chars:")
+        for name in skipped_empty[:20]:
+            print(f"  - {name}")
+        if len(skipped_empty) > 20:
+            print(f"  ... and {len(skipped_empty) - 20} more")
+
+    # Disambiguate only where a real containment clash exists, so titles stay
+    # readable in the report for the common case.
+    titles = [m["title"] for m in memories]
+    clashes = find_containment_clashes(titles)
+    if clashes:
+        involved = sorted({i for pair in clashes for i in pair})
+        print(
+            f"\n{len(clashes)} title-containment clash(es); disambiguating {len(involved)} title(s)"
+        )
+        for idx in involved:
+            memories[idx]["title"] = f"{memories[idx]['title']} [doc-{idx:04d}]"
+
+        remaining = find_containment_clashes([m["title"] for m in memories])
+        if remaining:
+            sys.exit(f"error: {len(remaining)} clash(es) survived disambiguation")
+
+    return memories
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--from-dir", type=Path, required=True, help="Directory of source documents"
+    )
+    parser.add_argument(
+        "--output", "-o", type=Path, required=True, help="Destination memories.json"
+    )
+    parser.add_argument(
+        "--min-chars",
+        type=int,
+        default=200,
+        help="Skip documents whose extracted text is shorter than this (default: 200)",
+    )
+    parser.add_argument("--recursive", action="store_true", help="Recurse into subdirectories")
+    args = parser.parse_args()
+
+    if not args.from_dir.is_dir():
+        sys.exit(f"error: {args.from_dir} is not a directory")
+
+    globber = args.from_dir.rglob if args.recursive else args.from_dir.glob
+    paths = sorted(p for p in globber("*") if p.is_file() and p.suffix.lower() in SUPPORTED)
+    if not paths:
+        sys.exit(
+            f"error: no supported documents ({', '.join(sorted(SUPPORTED))}) in {args.from_dir}"
+        )
+
+    print(f"reading {len(paths)} document(s) from {args.from_dir}")
+    memories = build(paths, args.min_chars)
+    if not memories:
+        sys.exit("error: no documents survived extraction")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(memories, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    total_chars = sum(len(m["content"]) for m in memories)
+    print(
+        f"\nwrote {args.output} — {len(memories)} memories, "
+        f"{total_chars:,} chars (~{total_chars / 4 / 1e6:.1f}M tokens), "
+        f"{args.output.stat().st_size / 1e6:.1f} MB on disk"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cognee/tests/unit/infrastructure/llm/test_litellm_native.py
+++ b/cognee/tests/unit/infrastructure/llm/test_litellm_native.py
@@ -526,3 +526,47 @@ class TestQualifyModel:
 
         qualified = self._qualify("phi4", "ollama")
         assert litellm.get_llm_provider(model=qualified)[1] == "ollama"
+
+
+# ── markdown-fenced JSON on the fallback path (CLO-596) ──────────────────────
+# The prompted-JSON path hands the model's reply straight to
+# model_validate_json. Models on that path routinely wrap the answer in a
+# ```json fence: the JSON inside is valid, but pydantic sees a backtick at
+# column 1 and rejects it, and the self-correction retry cannot help because a
+# model that fences once fences again. Hit while capturing the Henkel cassette.
+
+
+class TestStripJsonFence:
+    @staticmethod
+    def _strip(text):
+        from cognee.infrastructure.llm.structured_output_framework.litellm_native.native_adapter import (
+            _strip_json_fence,
+        )
+
+        return _strip_json_fence(text)
+
+    def test_fenced_with_language_tag(self):
+        """The exact shape that broke the Henkel capture."""
+        assert self._strip('```json\n{"summary": "s"}\n```') == '{"summary": "s"}'
+
+    def test_fenced_without_language_tag(self):
+        assert self._strip('```\n{"summary": "s"}\n```') == '{"summary": "s"}'
+
+    def test_surrounding_whitespace(self):
+        assert self._strip('  ```json\n{"summary": "s"}\n```  \n') == '{"summary": "s"}'
+
+    def test_plain_json_untouched(self):
+        payload = '{"summary": "s"}'
+        assert self._strip(payload) == payload
+
+    def test_backticks_inside_a_value_untouched(self):
+        """Anchored to the whole payload, so a value containing ``` survives."""
+        payload = '{"summary": "use ```json to fence"}'
+        assert self._strip(payload) == payload
+
+    def test_fenced_payload_parses_after_stripping(self):
+        """End of the chain: the rescued payload must validate."""
+        from cognee.shared.data_models import SummarizedContent
+
+        raw = '```json\n{"summary": "a summary", "description": ""}\n```'
+        assert SummarizedContent.model_validate_json(self._strip(raw)).summary == "a summary"


### PR DESCRIPTION
## Description

Adds the  technical-datasheet corpus to the nightly performance suite, and fixes a `litellm_native` bug found while building it.

164 real product PDFs → **1,348,078 chars**, 164/164 unique titles, 0 containment clashes. It covers a shape neither existing corpus does: `war_and_peace` is one very long document, `50_small_documents` is short synthetic ones. is **many medium-sized real-world documents** (median 7,167 chars) — the shape most user datasets actually have.

### Nightly wiring

Three caller jobs, mirroring the `war_and_peace` template:

| Job | Backends |
|---|---|
| `perf--llm` | python file_based + postgres, real LLM |
| `perf--mock` | python file_based + postgres, replayed |
| `perf--cloud` | Cognee Cloud tenant |

plus 5 Slack arms, 5 presign keys, the `notify` `needs` list and the status gate.

**No Rust arms.** Those read fixtures from `topoteretes/cognee-rs` (`scripts/perf/fixtures/<label>/`), so they land with that repo's PR rather than sitting red here.

**MotherDuck needs no change** — `motherduck_nightly_etl.py` discovers labels by globbing the S3 report keys, so `` appears in `ci_analytics.nightly` on its own.

### `litellm_native`: markdown-fenced JSON breaks the fallback path

The prompted-JSON fallback hands the model's reply straight to `model_validate_json`. Models on that path routinely wrap the answer in a fence — the JSON inside is valid, but pydantic sees a backtick at column 1:

```
ValidationError: 1 validation error for SummarizedContent
  Invalid JSON: expected value at line 1 column 1
  [input_value='```json\n{\n  "summary":...\n}\n```', input_type=str]
```

The self-correction retry can't rescue it — a model that fences once fences again — so it burns every attempt and the run dies. This killed the cassette capture ~30 minutes into a 164-document run against Azure `gpt-4.1-mini`.

This is the **second** bug in this same function; the first was the unqualified model name in ee7f784a1 (#4600). Both only affect the fallback path, which is where every non-OpenAI and local model lands, and `litellm_native` only recently became the default framework — so neither had much exercise. Worth a broader look at that path.

The regex is anchored to the whole payload, so JSON merely *containing* backticks in a value is untouched.

### Also here

`build_corpus.py` — a reproducible corpus builder. Neither existing corpus had a committed way to rebuild it, and `mock_ingestion.py:16` still points at a `generate_large_mock.py` that was **never committed**, so `war_and_peace_large` cannot be reproduced from source at all.

It enforces **title uniqueness**, which is correctness rather than cosmetics: replay matches a chunk with `title in chunk_text`, so one title contained in another silently replays the wrong knowledge graph. Across datasheets named `LOCTITE-AA-3345` etc. that is a live risk.

Plus a README covering what a corpus is, the two commands that build one, and the two traps — `capture_mock.py` prunes the configured cognee instance, and title collisions fail silently.

## Acceptance Criteria

- `` reports on file_based, postgres and cloud in the nightly, and appears in `ci_analytics.nightly` with no ETL change.
- Five arms render in Slack, including the no-metrics shape when a job fails.
- A fenced `` ```json `` reply parses on the `litellm_native` fallback; JSON containing backticks in a value is unchanged.
- `build_corpus.py` rebuilds the corpus and fails loudly on a title collision.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

```
$ python build_corpus.py --from-dir .../--output.json
wrote.json — 164 memories, 1,348,078 chars (~0.3M tokens), 1.4 MB on disk

# wiring validated by parsing the workflow, not by eye
jobs=16  needs=16
  needs w/o job    : none ✓      bad needs refs  : none ✓
  jobs not in needs: none ✓      ungated jobs    : none ✓
  presign keys=20 consumed=20    orphans         : none ✓


$ pytest cognee/tests/unit/infrastructure/llm/test_litellm_native.py
25 passed
```

## Notes / open questions

**Draft — the S3 artifacts still have to land.** The jobs read
`nightly_ci_artifacts/performance_test_artifacts/.json` and `.json`.
The corpus is built; the cassette is capturing now (it needed the fence fix in this PR
to get past ~30 minutes). Upload needs `s3:PutObject` on `github-runner-cognee-tests`
in account `463722570299` — every credential set I have been given so far was either
read-only or had already expired. Commands are in the README.

Rebased onto `dev` after #4600 merged; the `nightly_tests.yml` conflict is resolved and
the PR-gate removal from that PR is preserved.

## Pre-submission Checklist

- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages
