### PR TITLE
fix: decode each token id in decode_token_list

### DIFF
--- a/cognee/infrastructure/llm/tokenizer/TikToken/adapter.py
+++ b/cognee/infrastructure/llm/tokenizer/TikToken/adapter.py
@@ -59,7 +59,9 @@ class TikTokenTokenizer(TokenizerInterface):
         """
         if not isinstance(tokens, list):
             tokens = [tokens]
-        return [self.tokenizer.decode(i) for i in tokens]
+        # tiktoken's decode expects a sequence of ids, so wrap each id: passing a
+        # bare int raises "'int' object is not an instance of 'Sequence'".
+        return [self.tokenizer.decode([i]) for i in tokens]
 
     def decode_single_token(self, token: int) -> str:
         """

--- a/cognee/tests/unit/infrastructure/llm/test_tiktoken_adapter.py
+++ b/cognee/tests/unit/infrastructure/llm/test_tiktoken_adapter.py
@@ -1,0 +1,16 @@
+from cognee.infrastructure.llm.tokenizer.TikToken.adapter import TikTokenTokenizer
+
+
+def test_decode_token_list_returns_text_for_each_token():
+    """decode_token_list must decode each id, not pass a bare int to tiktoken.
+
+    tiktoken's decode expects a sequence of ids, so decoding a list previously
+    raised "'int' object is not an instance of 'Sequence'".
+    """
+    tokenizer = TikTokenTokenizer(model=None)
+
+    tokens = tokenizer.extract_tokens("hello world foo")
+    decoded = tokenizer.decode_token_list(tokens)
+
+    assert all(isinstance(piece, str) for piece in decoded)
+    assert "".join(decoded) == "hello world foo"


### PR DESCRIPTION
Fixes #4594.

`decode_token_list` passes each id to `Encoding.decode` as a bare int. tiktoken expects a sequence there, so the call raises `'int' object is not an instance of 'Sequence'` and the method cannot return for any non-empty input.

```python
return [self.tokenizer.decode(i) for i in tokens]
```

Wrapping the id makes it decode per token, which is what the list comprehension was already trying to do.

Added `cognee/tests/unit/infrastructure/llm/test_tiktoken_adapter.py`, which round trips `extract_tokens` into `decode_token_list` and checks the pieces rejoin into the original string.

### Validation

```
.venv/bin/python -m pytest -q cognee/tests/unit/infrastructure/llm/test_tiktoken_adapter.py -p no:randomly
1 passed
```

With `adapter.py` reverted to `dev` the same test fails on the `Sequence` error, so it pins the behavior.

One note carried over from the issue. This method is not on `TokenizerInterface` and I could not find a caller for it in the repo, so if you would rather delete it than fix it, say so and I will swap this for the removal.