### PR TITLE
feat: Add Docker Sandboxes cognee-memory kit example [COG-6264]

### DIFF
--- a/examples/integrations/docker-sandbox-kit/README.md
+++ b/examples/integrations/docker-sandbox-kit/README.md
@@ -1,0 +1,152 @@
+# Cognee memory kit for Docker Sandboxes
+
+A [Docker Sandboxes kit](https://docs.docker.com/ai/sandboxes/customize/kits/)
+that gives any sandboxed coding agent persistent, self-improving memory backed
+by [cognee](https://github.com/topoteretes/cognee) memory layer. Everything runs embedded inside the sandbox
+
+Verified end-to-end with sbx v0.39.0 under a `deny-all` network policy.
+
+## What the kit does
+
+`cognee-memory/spec.yaml` is a stackable **mixin kit** that:
+
+- installs the `cognee-cli` with `uv tool install cognee` at sandbox creation;
+- pins all memory state to `/home/agent/.cognee`, so it survives sandbox
+restarts;
+- allowlists only what cognee actually needs under `deny-all` —
+`api.openai.com`, PyPI (install), `extension.ladybugdb.com` (the embedded
+graph DB fetches its extensions at first use), and
+`raw.githubusercontent.com` (litellm's model-cost map). The list was derived
+by running under `deny-all` and reading `sbx policy log`;
+- declares a proxy-managed credential (`cognee-openai` — deliberately not
+`openai`, which the built-in agent kits already declare; two kits defining
+the same service fail composition). The agent only ever sees a placeholder
+value; the sandbox proxy injects the real key in transit;
+- pins `ENABLE_BACKEND_ACCESS_CONTROL=true` (cognee's default): multi-tenant
+ACLs and per-user+dataset database isolation;
+- appends usage instructions to the agent's memory file
+(`kits-memory/cognee-memory.md`): `recall` at task start → work →
+`remember` durable learnings, plus the multi-agent handover pattern.
+
+## Setup (one-time)
+
+```console
+$ brew trust docker/tap && brew install docker/tap/sbx
+$ sbx daemon start          # own terminal, or: nohup sbx daemon start &
+$ sbx login                 # browser OAuth
+$ sbx policy init deny-all  # strictest baseline; the kit's allowlist is the only egress
+$ sbx secret set-custom --host api.openai.com --env LLM_API_KEY --value "$LLM_API_KEY"
+```
+
+`set-custom` prints a placeholder (`sbx-cs-…`, retrievable via `sbx secret ls`).
+Sandboxes only ever see the placeholder; the proxy substitutes the real key on
+requests to `api.openai.com`.
+
+## Single-agent usage
+
+```console
+$ sbx run claude --kit ./cognee-memory          # agent with persistent memory
+$ sbx run shell  --kit ./cognee-memory          # or a plain shell sandbox
+```
+
+Inside, the agent has `cognee-cli remember / recall / improve / forget`. For
+headless `sbx exec` use, set the key to the placeholder explicitly (the kit's
+`proxy-managed` env value is for the interactive credential-binding path):
+
+```console
+$ sbx exec <sandbox> -- sh -lc 'export LLM_API_KEY=<placeholder> LOG_LEVEL=ERROR; \
+    cognee-cli remember "fact worth keeping"'
+```
+
+## Multi-agent demo: supervisor → worker memory handover
+
+`./demo/handover.sh` runs a **round-trip handover between two real
+sandboxes**. Both are created from this kit and share the `demo/` directory as
+their workspace. The cognee state runs on each VM's **local disk** during a
+phase (embedded LanceDB cannot operate on the shared virtiofs workspace
+mount — discovered the hard way) and is handed between sandboxes as a
+snapshot with `sbx cp`, making the memory handover literal. The host keeps
+the canonical snapshot in `demo/cognee-state/` between phases. Even though
+the worker receives the whole snapshot, the supervisor and worker are
+separate cognee **users**, so ACLs still gate what each can read or write:
+
+1. **brief** (`cognee-supervisor` sandbox): stores a private note and a
+ handover briefing in its own datasets, grants the worker **read + write**
+ on the briefing with `authorized_give_permission_on_datasets(...)` (the
+ creator automatically holds `share`), and writes the handover token
+ (`demo/handover-out/handover_token.json`) carrying the dataset UUID.
+2. **work** (`cognee-worker` sandbox): redeems the token —
+ `cognee.recall(..., dataset_ids=[uuid], user=worker)`. Sharing works
+ **only by UUID**: dataset names are namespaced per user
+ (`uuid5(name + user.id + tenant_id)`), so a name never crosses a user
+ boundary. Negative checks: the private dataset raises
+ `PermissionDeniedError` (403); the shared dataset by name fails (404).
+ Then it writes its completion report back into the shared dataset
+ (`cognee.remember(..., dataset_id=uuid, user=worker)`).
+3. **review** (`cognee-supervisor` sandbox): recalls the worker's report.
+
+Phases run sequentially — the snapshot moves, it is never shared live. The
+payload, `demo/supervisor_worker_handover.py`, is
+self-contained: paste it into any repository with cognee installed and run
+`python supervisor_worker_handover.py` (all phases in-process) or
+`--phase brief|work|review` split across environments.
+
+```console
+$ export LLM_API_KEY=sk-...     # only needed the first time, for the secret
+$ ./demo/handover.sh
+$ sbx policy log                # the audit trail: per-domain allow/deny
+```
+
+Cleanup: `sbx rm -f cognee-supervisor cognee-worker && rm -rf demo/cognee-state demo/handover-out`
+
+### User permissioning: what currently supports it
+
+- Permissions are `read` / `write` / `delete` / `share` per dataset. Managing
+users and grants is **Python-SDK/REST-only** today — `cognee-cli` has no
+user/permission commands.
+- Backends supporting per-user+dataset DB isolation (source of truth:
+`supported_dataset_database_handlers.py`): graph — kuzu/ladybug (default),
+Neo4j (multi-db editions, plus a `neo4j_community` container-per-dataset
+handler), Postgres (demo), Turso; vector — LanceDB (default), PGVector,
+Turso. **Not** supported: Neptune, ladybug-remote, Neptune Analytics, and
+community vector adapters unless they register a dataset-database handler.
+
+## Inspecting memory and security
+
+```console
+$ sbx exec cognee-supervisor -- sh -lc 'echo $LLM_API_KEY'   # "proxy-managed" — never a real key
+$ sbx exec cognee-supervisor -- curl -s -o /dev/null -w "%{http_code}" https://example.com   # 403: deny-all
+$ sbx policy log                                             # every allow/deny decision
+$ ls demo/cognee-state/system/databases/<owner-user-uuid>/   # <dataset-uuid>.lbug + .lance.db per dataset
+```
+
+The relational DB (`demo/cognee-state/system/databases/cognee_db`, SQLite)
+holds users, datasets, and the ACL rows — after the demo, the worker holds
+exactly two grants (`read`, `write`) on the shared dataset and nothing on the
+private one.
+
+## Layout
+
+```
+docker-sandbox-kit/
+├── cognee-memory/         # the kit — point --kit here
+│   └── spec.yaml
+├── demo/
+│   ├── handover.sh        # 2 real sandboxes, permissioned round-trip handover
+│   ├── handover-out/      # the JSON handover token (created at runtime)
+│   ├── cognee-state/      # canonical memory snapshot between phases (runtime)
+│   └── supervisor_worker_handover.py
+└── README.md
+```
+
+## Notes
+
+- `remember` builds a knowledge graph (a few LLM calls), so the first write
+takes noticeably longer than a plain key-value store; `recall` answers from
+the graph.
+- The kit defaults to `openai/gpt-5-mini`. To use another provider, edit
+`environment.variables`, the `credentials`/`permissions.network` blocks, and
+the stored secret accordingly (see the [cognee provider docs](https://docs.cognee.ai/)).
+- For always-on cross-sandbox memory (concurrent agents, no shared workspace),
+run a central cognee API server and point sandboxes at it over the network
+allowlist instead of sharing embedded storage.

--- a/examples/integrations/docker-sandbox-kit/cognee-memory/spec.yaml
+++ b/examples/integrations/docker-sandbox-kit/cognee-memory/spec.yaml
@@ -1,0 +1,112 @@
+# Docker Sandboxes mixin kit: persistent agent memory backed by cognee.
+# Docs: https://docs.docker.com/ai/sandboxes/customize/kits/
+#
+# Usage:
+#   sbx run claude --kit ./cognee-memory
+#
+# Stackable on any agent (claude, opencode, ...). Requires an OpenAI API key
+# bound to the "openai" credential service on first run.
+schemaVersion: "2"
+kind: mixin
+name: cognee-memory
+version: 0.1.0
+displayName: Cognee Memory
+description: Persistent AI memory for sandboxed agents — knowledge graph + vector search via cognee
+sourceURL: https://github.com/topoteretes/cognee
+licenses:
+  - Apache-2.0
+
+environment:
+  variables:
+    # Keep all memory state in one stable place inside the sandbox so it
+    # survives restarts and is easy to inspect or back up.
+    DATA_ROOT_DIRECTORY: /home/agent/.cognee/data
+    SYSTEM_ROOT_DIRECTORY: /home/agent/.cognee/system
+    LLM_MODEL: openai/gpt-5-mini
+    TELEMETRY_DISABLED: "1"
+    # User permissioning: multi-tenant ACLs + per-user+dataset DB isolation.
+    # This is cognee's default; pinned here so the kit is explicit about it.
+    # Supported by the default backends (kuzu/ladybug graph + lancedb vector);
+    # also neo4j, postgres (demo), turso — NOT neptune/ladybug-remote.
+    ENABLE_BACKEND_ACCESS_CONTROL: "true"
+
+# Named cognee-openai (not "openai") on purpose: built-in agent kits (shell,
+# claude, ...) already declare common LLM services, and composition fails if
+# two kits define the same service. required is false so sandbox creation
+# never blocks. Two ways to supply the key (both proxy-side; the real key
+# never enters the sandbox):
+#   1. Bind this service (interactive run, or ~/.config/sbx/credentials.yaml);
+#      the agent then sees LLM_API_KEY=proxy-managed and the inject rule below
+#      rewrites the Authorization header for api.openai.com.
+#   2. Headless: sbx secret set-custom --host api.openai.com \
+#        --env LLM_API_KEY --value <key>
+#      Note the kit's env value ("proxy-managed") wins over the custom
+#      secret's placeholder, so commands must use the printed placeholder:
+#        LLM_API_KEY=<placeholder> cognee-cli remember ...
+credentials:
+  - service: cognee-openai
+    description: OpenAI API key used by cognee for entity extraction and embeddings
+    required: false
+    apiKey:
+      name: LLM_API_KEY
+      proxyManaged: true
+      inject:
+        - domain: api.openai.com
+          scheme: bearer
+
+# Domains below were discovered by running under a deny-all policy and
+# reading `sbx policy log` — the recommended way to derive a kit allowlist.
+permissions:
+  network:
+    allow:
+      - api.openai.com
+      - pypi.org
+      - files.pythonhosted.org
+      # ladybug (cognee's embedded graph DB) fetches its extensions on first use
+      - extension.ladybugdb.com
+      # litellm fetches its model-cost map here
+      - raw.githubusercontent.com
+
+setup:
+  install:
+    - command: "mkdir -p /home/agent/.cognee/data /home/agent/.cognee/system"
+      user: "1000"
+      description: Create memory storage directories
+    # Assumes `uv` in the base image (Docker's default sandbox images ship it;
+    # the spec floor only guarantees sh and curl).
+    - command: "uv tool install cognee"
+      user: "1000"
+      description: Install the cognee CLI (embedded SQLite + LanceDB + Kuzu, no services needed)
+
+agentInstructions:
+  content: |
+    ## Persistent memory (cognee)
+
+    This sandbox has cognee installed: a knowledge-graph memory layer with a
+    CLI. Use it as your long-term memory — it persists across tasks and
+    sandbox restarts (stored under `/home/agent/.cognee`).
+
+    - Store knowledge: `cognee-cli remember "text, a file path, or a URL"`
+    - Query memory:    `cognee-cli recall "your question"`
+    - Enrich/index:    `cognee-cli improve`
+    - Delete:          `cognee-cli forget --all` (no confirmation prompt — use with care)
+
+    Workflow:
+    1. At the start of a task, run `cognee-cli recall` with a question about
+       the task to pull in anything you already learned.
+    2. While working, `remember` durable facts worth keeping: project
+       conventions, decisions and their reasons, gotchas, user preferences.
+    3. Do not store secrets, credentials, or throwaway session details.
+
+    The first `remember` builds a knowledge graph (a few LLM calls), so it
+    takes longer than a plain write; `recall` answers from the graph.
+
+    Multi-agent memory handover (supervisor -> worker): cognee supports
+    per-user datasets with ACLs (read/write/delete/share). A supervisor
+    agent stores a briefing in its own dataset, grants another user read
+    with `authorized_give_permission_on_datasets(...)`, and hands over the
+    dataset UUID — the worker recalls with
+    `cognee.recall(..., dataset_ids=[<uuid>], user=worker)`. Dataset NAMES
+    never cross users (each name maps to a per-user UUID); share by UUID
+    only. Permission management is Python-SDK/REST-only — the CLI has no
+    user/permission commands.

--- a/examples/integrations/docker-sandbox-kit/demo/.gitignore
+++ b/examples/integrations/docker-sandbox-kit/demo/.gitignore
@@ -1,0 +1,3 @@
+handover-out/
+handover_token.json
+cognee-state/

--- a/examples/integrations/docker-sandbox-kit/demo/handover.sh
+++ b/examples/integrations/docker-sandbox-kit/demo/handover.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Multi-agent memory handover on REAL Docker Sandboxes (sbx).
+#
+# Two sandboxes — cognee-supervisor and cognee-worker — are created from the
+# cognee-memory kit and share this demo directory as their workspace. The
+# cognee state itself lives on each VM's LOCAL disk while a phase runs
+# (embedded LanceDB cannot run on the shared virtiofs workspace mount) and is
+# handed between sandboxes as a snapshot with `sbx cp` — a literal memory
+# handover. The supervisor and worker are separate cognee USERS protected by
+# cognee's ACLs, so even though the worker receives the snapshot, it can only
+# read/write the datasets it was granted:
+#
+#   sandbox 1 (cognee-supervisor): brief + grant read/write + emit token
+#   sandbox 2 (cognee-worker):     recall briefing, prove denials, report back
+#   sandbox 1 (cognee-supervisor): recall the worker's report
+#
+# Prerequisites (one-time):
+#   brew trust docker/tap && brew install docker/tap/sbx
+#   sbx daemon start        (own terminal, or nohup)
+#   sbx login
+#   sbx policy init deny-all
+#   sbx secret set-custom --host api.openai.com --env LLM_API_KEY --value "$LLM_API_KEY"
+set -euo pipefail
+cd "$(dirname "$0")"
+
+KIT="$PWD/../cognee-memory"
+SANDBOXES=(cognee-supervisor cognee-worker)
+PY=/home/agent/.local/share/uv/tools/cognee/bin/python
+STATE=cognee-state                 # canonical snapshot on the host, between phases
+SB_STATE=/home/agent/cognee-state  # VM-local working copy, during a phase
+
+# The proxy replaces this placeholder with the real key on requests to
+# api.openai.com; the key itself never enters either sandbox.
+PLACEHOLDER=$(sbx secret ls | awk '$3 == "LLM_API_KEY" {print $4}' | head -1)
+if [ -z "$PLACEHOLDER" ]; then
+  echo "No LLM_API_KEY custom secret found. Create it with:" >&2
+  echo '  sbx secret set-custom --host api.openai.com --env LLM_API_KEY --value "$LLM_API_KEY"' >&2
+  exit 1
+fi
+
+mkdir -p handover-out "$STATE"
+
+for name in "${SANDBOXES[@]}"; do
+  if ! sbx ls | awk '{print $1}' | grep -qx "$name"; then
+    echo "=== creating sandbox: $name (kit install runs inside the VM) ==="
+    sbx run shell --kit "$KIT" --name "$name" --detached .
+  fi
+done
+
+run_phase() {
+  echo
+  echo "=== sandbox: $1 (phase: $2) ==="
+  # Hand the memory snapshot in, run the phase on VM-local disk, hand it back.
+  # sbx cp preserves host ownership (your host uid), so re-own it to agent.
+  sbx exec "$1" -- sudo rm -rf "$SB_STATE"
+  sbx cp "$STATE" "$1":/home/agent/
+  sbx exec "$1" -- sudo chown -R agent:agent "$SB_STATE"
+  sbx exec "$1" -- sh -lc "
+    export LLM_API_KEY=$PLACEHOLDER LOG_LEVEL=ERROR ENABLE_BACKEND_ACCESS_CONTROL=true
+    export DATA_ROOT_DIRECTORY=$SB_STATE/data SYSTEM_ROOT_DIRECTORY=$SB_STATE/system
+    exec $PY supervisor_worker_handover.py --phase $2 --token-file handover-out/handover_token.json
+  "
+  rm -rf "$STATE"
+  sbx cp "$1":"$SB_STATE" .
+}
+
+run_phase cognee-supervisor brief
+run_phase cognee-worker work
+run_phase cognee-supervisor review
+
+echo
+echo "Handover round trip passed across two real sandboxes."
+echo "Token exchanged via: $PWD/handover-out/handover_token.json"
+echo "Memory snapshot handed over via sbx cp; final state in: $PWD/$STATE"
+echo "Inspect policy decisions with: sbx policy log"
+echo "Clean up with: sbx rm -f ${SANDBOXES[*]} && rm -rf $STATE handover-out"

--- a/examples/integrations/docker-sandbox-kit/demo/supervisor_worker_handover.py
+++ b/examples/integrations/docker-sandbox-kit/demo/supervisor_worker_handover.py
@@ -1,0 +1,189 @@
+"""Supervisor <-> worker memory handover on cognee, with user permissioning.
+
+Self-contained: paste this file into any repository where cognee is installed
+and run it with an OpenAI LLM_API_KEY in the environment. It simulates two
+agents that share ONE cognee deployment but are separate cognee users,
+protected by cognee's ACL layer (ENABLE_BACKEND_ACCESS_CONTROL, the default).
+
+The handover is a ROUND TRIP, split into three phases so each agent can run
+in its own container/sandbox (see handover.sh) — the only things crossing the
+boundary are the shared cognee storage and a small JSON handover token:
+
+  brief   (supervisor) store a private note + a handover briefing in its own
+          datasets, grant the worker read+write on the briefing dataset,
+          emit the token {"dataset_id": ...}.
+  work    (worker) redeem the token: recall the briefing by dataset UUID,
+          prove the private dataset is denied and that dataset NAMES never
+          cross users, then write a completion report back into the shared
+          dataset (cross-owner writes also require the UUID).
+  review  (supervisor) recall the worker's report from the shared dataset.
+
+Run all phases in one process:      python supervisor_worker_handover.py
+Run one phase (separate containers): python supervisor_worker_handover.py --phase brief
+
+Backends that currently support user permissioning (per user+dataset DB
+isolation, from supported_dataset_database_handlers.py):
+  graph:  ladybug/kuzu (default), neo4j (incl. neo4j_community handler),
+          postgres (demo), turso
+  vector: lancedb (default), pgvector, turso
+  NOT supported: neptune, ladybug-remote, neptune_analytics, community
+  vector adapters that don't register a dataset-database handler.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+from uuid import UUID
+
+# The auth posture is resolved when cognee is imported — configure it first.
+os.environ.setdefault("ENABLE_BACKEND_ACCESS_CONTROL", "true")
+
+import cognee
+from cognee.infrastructure.databases.relational import create_db_and_tables
+from cognee.modules.data.methods import get_datasets
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.methods import create_user, get_user_by_email
+from cognee.modules.users.permissions.methods import authorized_give_permission_on_datasets
+
+SUPERVISOR_EMAIL = "supervisor@handover.demo"
+WORKER_EMAIL = "worker@handover.demo"
+
+HANDOVER_BRIEFING = (
+    "Handover to worker: migrate the payments service to the v2 billing API. "
+    "Deploy with 'make deploy-prod' only after the contract tests pass. "
+    "The staging environment auto-deploys on merge to the dev branch. "
+    "Open question for the worker: confirm the retry policy with the SRE team."
+)
+SUPERVISOR_SECRET = (
+    "Supervisor private note: the acquisition of VendorCo closes next quarter; "
+    "do not share with worker agents."
+)
+WORKER_REPORT = (
+    "Worker report: payments service migrated to the v2 billing API and deployed "
+    "to production with make deploy-prod after contract tests passed. The SRE team "
+    "confirmed the retry policy is exponential backoff with a maximum of 5 attempts."
+)
+
+
+async def get_or_create_user(email: str, password: str):
+    try:
+        return await create_user(email, password)
+    except Exception:  # UserAlreadyExists on re-runs
+        return await get_user_by_email(email)
+
+
+async def phase_brief(token_file: Path) -> None:
+    """Supervisor: store memory, grant the worker access, emit the token."""
+    # Fresh installs: create the relational DB before touching users/ACLs
+    # (the CLI does this implicitly; the raw SDK path does not).
+    await create_db_and_tables()
+    supervisor = await get_or_create_user(SUPERVISOR_EMAIL, "supervisor-pw")
+    worker = await get_or_create_user(WORKER_EMAIL, "worker-pw")
+
+    print("[supervisor] remembering private note (dataset 'supervisor_private')...")
+    await cognee.remember(SUPERVISOR_SECRET, dataset_name="supervisor_private", user=supervisor)
+
+    print("[supervisor] remembering handover briefing (dataset 'handover')...")
+    await cognee.remember(HANDOVER_BRIEFING, dataset_name="handover", user=supervisor)
+
+    # Dataset names map to per-user UUIDs; the token must carry the UUID
+    # because that is the only cross-user address for a dataset.
+    datasets = {d.name: d.id for d in await get_datasets(supervisor.id)}
+    handover_id, private_id = datasets["handover"], datasets["supervisor_private"]
+
+    print("[supervisor] granting worker READ + WRITE on the handover dataset...")
+    for permission in ("read", "write"):
+        await authorized_give_permission_on_datasets(
+            principal_id=worker.id,
+            dataset_ids=[handover_id],
+            permission_name=permission,
+            owner_id=supervisor.id,
+        )
+
+    token = {
+        "dataset_id": str(handover_id),
+        "granted": ["read", "write"],
+        "worker": WORKER_EMAIL,
+        # Included only so the demo can prove denial; a real supervisor
+        # would never put a private dataset id in a handover token.
+        "_private_dataset_id": str(private_id),
+    }
+    token_file.write_text(json.dumps(token, indent=2))
+    print(f'[supervisor] handover token issued -> {token_file}: {{"dataset_id": "{handover_id}"}}')
+
+
+async def phase_work(token_file: Path) -> None:
+    """Worker: redeem the token, prove the boundaries, report back."""
+    token = json.loads(token_file.read_text())
+    worker = await get_user_by_email(WORKER_EMAIL)
+    dataset_id = UUID(token["dataset_id"])
+
+    print("[worker] recalling the briefing from the shared dataset (by UUID)...")
+    results = await cognee.recall(
+        "What is my task and how do I deploy?", dataset_ids=[dataset_id], user=worker
+    )
+    for r in results:
+        text = r.get("text") if isinstance(r, dict) else getattr(r, "text", r)
+        print(f"[worker] briefing recalled: {text}")
+
+    print("[worker] trying the supervisor's PRIVATE dataset (should be denied)...")
+    try:
+        await cognee.recall(
+            "What is the private note?",
+            dataset_ids=[UUID(token["_private_dataset_id"])],
+            user=worker,
+        )
+        raise AssertionError("worker read the private dataset — permissioning is broken!")
+    except PermissionDeniedError as err:
+        print(f"[worker] correctly denied: {type(err).__name__}: {err}")
+
+    print("[worker] trying the shared dataset by NAME (names don't cross users)...")
+    try:
+        await cognee.recall("What is my task?", datasets=["handover"], user=worker)
+        raise AssertionError("name resolution crossed user boundaries — unexpected!")
+    except PermissionDeniedError as err:
+        print(f"[worker] correctly denied: {type(err).__name__}: {err}")
+    except Exception as err:
+        print(f"[worker] correctly not found: {type(err).__name__}: {err}")
+
+    print("[worker] writing the completion report back into the shared dataset...")
+    await cognee.remember(WORKER_REPORT, dataset_id=dataset_id, user=worker)
+    print("[worker] report stored.")
+
+
+async def phase_review(token_file: Path) -> None:
+    """Supervisor: read the worker's report from the shared dataset."""
+    token = json.loads(token_file.read_text())
+    supervisor = await get_user_by_email(SUPERVISOR_EMAIL)
+
+    print("[supervisor] recalling the worker's report...")
+    results = await cognee.recall(
+        "What did the worker report? Was the migration deployed?",
+        dataset_ids=[UUID(token["dataset_id"])],
+        user=supervisor,
+    )
+    for r in results:
+        text = r.get("text") if isinstance(r, dict) else getattr(r, "text", r)
+        print(f"[supervisor] report recalled: {text}")
+
+
+PHASES = {"brief": phase_brief, "work": phase_work, "review": phase_review}
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--phase", choices=[*PHASES, "all"], default="all")
+    parser.add_argument("--token-file", type=Path, default=Path("handover_token.json"))
+    args = parser.parse_args()
+
+    phases = list(PHASES) if args.phase == "all" else [args.phase]
+    for name in phases:
+        await PHASES[name](args.token_file)
+    if args.phase == "all":
+        print("\nHandover round trip passed: briefing shared, private denied, report returned.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Description

Packages cognee as a [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/customize/kits/) mixin kit and adds a multi-agent demo, under `examples/integrations/docker-sandbox-kit/`.

**The kit** (`cognee-memory/spec.yaml`, schemaVersion 2 mixin — stack onto any agent with `sbx run claude --kit ./cognee-memory`):
- installs `cognee-cli` at sandbox creation; memory persists across sandbox restarts
- network allowlist derived by running under a `deny-all` policy and reading `sbx policy log`: `api.openai.com`, PyPI, `extension.ladybugdb.com` (ladybug fetches extensions at first use), `raw.githubusercontent.com` (litellm model-cost map)
- proxy-managed credential named `cognee-openai` — deliberately not `openai`, which built-in agent kits already declare (same-service composition fails); the real key never enters the sandbox VM
- pins `ENABLE_BACKEND_ACCESS_CONTROL=true` and ships agent instructions for the remember/recall workflow and the handover pattern

**The demo** (`demo/handover.sh` + `demo/supervisor_worker_handover.py`): a supervisor → worker memory handover across **two real sandboxes** exercising cognee user permissioning end-to-end — supervisor briefs and grants read/write via `authorized_give_permission_on_datasets` (sharing is by dataset UUID only; names are namespaced per user), worker recalls the briefing, is ACL-denied on the supervisor's private dataset (403) and on name-based access (404), then writes its report back cross-owner; supervisor reviews it. The memory snapshot moves between sandboxes with `sbx cp` (embedded LanceDB cannot run on the shared virtiofs workspace mount). The Python payload is self-contained and can be pasted into any repo with cognee installed.

Verified end-to-end with sbx v0.39.0 under a deny-all network policy.

Refs [COG-6264](https://linear.app/cognee/issue/COG-6264/add-docker-sandboxes-cognee-memory-kit-example)

## Type of Change
- [x] New feature (example/integration, non-breaking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)