### PR TITLE
fix: Recall follow-up fixes: 403 noise and telemetry leak (COG-6268)

### DIFF
--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -105,6 +105,12 @@ async def lifespan(app: FastAPI):
     _create_graph_engine.cache_clear()
     _create_vector_engine.cache_clear()
 
+    # Flush in-flight telemetry and close its shared aiohttp session on the
+    # loop that owns them, instead of leaving it to the atexit fallback.
+    from cognee.shared.utils import close_telemetry_session
+
+    await close_telemetry_session()
+
 
 app = FastAPI(debug=app_environment != "prod", lifespan=lifespan)
 

--- a/cognee/modules/users/exceptions/exceptions.py
+++ b/cognee/modules/users/exceptions/exceptions.py
@@ -44,8 +44,10 @@ class PermissionDeniedError(CogneeValidationError):
         message: str = "User does not have permission on documents.",
         name: str = "PermissionDeniedError",
         status_code=status.HTTP_403_FORBIDDEN,
+        log: bool = True,
+        log_level: str = "ERROR",
     ):
-        super().__init__(message, name, status_code)
+        super().__init__(message, name, status_code, log, log_level)
 
 
 class PermissionNotFoundError(CogneeValidationError):

--- a/cognee/modules/users/permissions/methods/get_specific_user_permission_datasets.py
+++ b/cognee/modules/users/permissions/methods/get_specific_user_permission_datasets.py
@@ -40,8 +40,14 @@ async def get_specific_user_permission_datasets(
         search_datasets = user_permission_access_datasets
 
     if len(search_datasets) == 0:
+        # A user with zero datasets is a normal state (fresh install, heartbeat
+        # recall before first ingestion) and get_readable_datasets converts this
+        # raise into an empty list — log at DEBUG so it doesn't surface as a
+        # spurious ERROR on every such call. The line-36 raise above stays at
+        # ERROR: requesting specific unpermitted datasets is a real denial.
         raise PermissionDeniedError(
-            f"Request owner does not have permission: [{permission_type}] for any dataset."
+            f"Request owner does not have permission: [{permission_type}] for any dataset.",
+            log_level="DEBUG",
         )
 
     return search_datasets

--- a/cognee/shared/utils.py
+++ b/cognee/shared/utils.py
@@ -179,10 +179,69 @@ async def _get_telemetry_session() -> aiohttp.ClientSession:
             or _telemetry_session.closed
             or _telemetry_session_loop is not loop
         ):
+            # Close the stale session instead of dropping it: aiohttp accepts
+            # close() from a different loop, and an unowned session emits
+            # "Unclosed client session" at garbage collection.
+            if _telemetry_session is not None and not _telemetry_session.closed:
+                try:
+                    await _telemetry_session.close()
+                except Exception:
+                    pass
             timeout = aiohttp.ClientTimeout(total=TELEMETRY_REQUEST_TIMEOUT)
             _telemetry_session = aiohttp.ClientSession(timeout=timeout)
             _telemetry_session_loop = loop
+            _register_telemetry_session_atexit()
         return _telemetry_session
+
+
+async def close_telemetry_session() -> None:
+    """Flush in-flight telemetry tasks and close the shared aiohttp session.
+
+    Safe to call repeatedly and from any loop; ``_get_telemetry_session``
+    rebuilds transparently if telemetry fires again afterwards. Called from the
+    FastAPI lifespan shutdown and, as a last resort, from an ``atexit`` hook so
+    SDK scripts don't print "Unclosed client session" at interpreter exit.
+    """
+    global _telemetry_session, _telemetry_session_loop
+
+    if _TELEMETRY_TASKS:
+        try:
+            await asyncio.gather(*list(_TELEMETRY_TASKS), return_exceptions=True)
+        except Exception:
+            pass
+    session = _telemetry_session
+    _telemetry_session = None
+    _telemetry_session_loop = None
+    if session is not None and not session.closed:
+        try:
+            await session.close()
+        except Exception:
+            pass
+
+
+_telemetry_atexit_registered = False
+
+
+def _register_telemetry_session_atexit() -> None:
+    global _telemetry_atexit_registered
+    if _telemetry_atexit_registered:
+        return
+    _telemetry_atexit_registered = True
+
+    import atexit
+
+    def _close_at_exit() -> None:
+        # The loop that owned the session is gone by now; run the closer on a
+        # fresh one. In-flight tasks died with their loop, so gather() over
+        # them is a no-op here — this exists purely to release the session.
+        if _telemetry_session is None or _telemetry_session.closed:
+            return
+        try:
+            asyncio.run(close_telemetry_session())
+        except Exception:
+            pass
+
+    atexit.register(_close_at_exit)
 
 
 async def _send_telemetry_request(payload: dict) -> None:

--- a/cognee/tests/unit/modules/users/test_get_readable_datasets_and_permitted_ids.py
+++ b/cognee/tests/unit/modules/users/test_get_readable_datasets_and_permitted_ids.py
@@ -98,3 +98,18 @@ async def test_get_permitted_dataset_ids_empty_when_no_datasets(monkeypatch):
     result = await permitted_ids_module.get_permitted_dataset_ids(_user_id())
 
     assert result == []
+
+
+def test_permission_denied_error_threads_log_kwargs(caplog):
+    """The zero-datasets raise is expected and handled — it must be quietable.
+
+    PermissionDeniedError has to accept the base class's log/log_level kwargs
+    (COG-6268); without the passthrough, log_level="DEBUG" raised TypeError and
+    every zero-dataset lookup emitted a spurious ERROR at construction time.
+    """
+    import logging
+
+    with caplog.at_level(logging.ERROR):
+        PermissionDeniedError(message="no datasets", log_level="DEBUG")
+
+    assert not [r for r in caplog.records if "PermissionDeniedError" in r.getMessage()]

--- a/cognee/tests/unit/shared/test_telemetry_session.py
+++ b/cognee/tests/unit/shared/test_telemetry_session.py
@@ -1,0 +1,73 @@
+"""Tests for the shared telemetry aiohttp session lifecycle.
+
+The session is a process-wide singleton reused across telemetry calls. It used
+to leak: nothing closed it at interpreter exit, and a loop change dropped the
+old session without closing it — both printed "Unclosed client session" from
+aiohttp's destructor in SDK scripts.
+"""
+
+import asyncio
+
+import pytest
+
+from cognee.shared import utils as shared_utils
+
+
+@pytest.fixture(autouse=True)
+def _reset_session_state():
+    yield
+    # Never leave a session behind for other tests (or the test runner's exit).
+    session = shared_utils._telemetry_session
+    if session is not None and not session.closed:
+        asyncio.run(session.close())
+    shared_utils._telemetry_session = None
+    shared_utils._telemetry_session_loop = None
+
+
+@pytest.mark.asyncio
+async def test_close_telemetry_session_closes_and_resets():
+    session = await shared_utils._get_telemetry_session()
+    assert not session.closed
+
+    await shared_utils.close_telemetry_session()
+
+    assert session.closed
+    assert shared_utils._telemetry_session is None
+    assert shared_utils._telemetry_session_loop is None
+
+    # Repeated close is a no-op, and the getter rebuilds transparently after.
+    await shared_utils.close_telemetry_session()
+    rebuilt = await shared_utils._get_telemetry_session()
+    assert not rebuilt.closed and rebuilt is not session
+    await shared_utils.close_telemetry_session()
+
+
+def test_loop_change_closes_stale_session_instead_of_dropping_it():
+    async def get_session():
+        return await shared_utils._get_telemetry_session()
+
+    first = asyncio.run(get_session())
+    assert not first.closed
+
+    # New asyncio.run = new loop: the getter must rebuild AND close the stale
+    # session (aiohttp accepts close() from a different loop).
+    second = asyncio.run(get_session())
+
+    assert second is not first
+    assert first.closed
+    assert not second.closed
+
+
+@pytest.mark.asyncio
+async def test_atexit_hook_registered_once(monkeypatch):
+    registered = []
+    import atexit
+
+    monkeypatch.setattr(shared_utils, "_telemetry_atexit_registered", False)
+    monkeypatch.setattr(atexit, "register", lambda fn: registered.append(fn))
+
+    await shared_utils._get_telemetry_session()
+    await shared_utils.close_telemetry_session()
+    await shared_utils._get_telemetry_session()
+
+    assert len(registered) == 1


### PR DESCRIPTION
## Description

Two independent defects surfaced while release-testing the recall warm-up short-circuit (#4593) with the demo script (#4618). One commit per issue.

> **Scope note:** this PR originally also carried a litellm_native strict-schema sanitizer (COG-6269). That commit has been dropped: the schema problem is now handled by the non-strict demotion hotfix in #4621 (COG-6271, targeting main/1.5.2), with the full capability-profile design tracked under COG-6269.

### 1. Spurious 403 ERROR on every zero-dataset lookup — COG-6268
`get_specific_user_permission_datasets` raises `PermissionDeniedError` when a user simply has no datasets; `get_readable_datasets` deliberately converts it to `[]`, but cognee exceptions log at **construction**, so every heartbeat recall on a fresh install printed an ERROR line anyway. `PermissionDeniedError` now threads the base class's `log`/`log_level` kwargs (mirroring `DatabaseNotCreatedError`), and the zero-datasets raise logs at DEBUG. The unpermitted-specific-datasets raise is untouched — 9 production call sites and several tests rely on it at ERROR.

### 2. Telemetry aiohttp session leak ("Unclosed client session" at exit) — COG-6270
The process-wide telemetry `ClientSession` (regression from `89c38cf41`) was never closed, and the loop-change rebuild dropped stale sessions without closing them. Added `close_telemetry_session()` (drains in-flight telemetry tasks, closes, resets; idempotent), an atexit fallback registered on first session creation (verified empirically that aiohttp accepts `close()` from a fresh loop and the destructor warnings disappear), a deterministic close in the FastAPI lifespan shutdown, and close-before-replace on loop change.

## Testing

- New unit tests per fix: `PermissionDeniedError` kwarg passthrough + no-ERROR pin; telemetry session close/reset, loop-change close, atexit-registered-once.
- users (6), telemetry session (3), litellm_native (26, unchanged from dev) — all green; `pre-commit` clean.
- End-to-end: the warm-up demo runs with **zero** `PermissionDeniedError raised` lines (previously one per recall), and a live-telemetry script exits with **no** "Unclosed client session/connector" output.

Fixes COG-6268
Fixes COG-6270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
