### PR TITLE
fix: qualify namespaced Ollama model names

### DIFF
--- a/cognee/infrastructure/llm/structured_output_framework/litellm_native/get_native_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_native/get_native_client.py
@@ -47,8 +47,12 @@ def _qualify_model(model: str, provider: str) -> str:
     bare name litellm can already resolve on its own are returned untouched, so
     this cannot re-route a configuration that works today. It only rescues the
     case that currently raises BadRequestError before a request is even sent.
+
+    A slash does not by itself mean the name carries a provider. Ollama accepts
+    namespaced names ("library/phi4") and Hugging Face GGUF paths
+    ("hf.co/user/repo"), so litellm decides instead.
     """
-    if not model or "/" in model:
+    if not model:
         return model
 
     import litellm

--- a/cognee/tests/unit/infrastructure/llm/test_litellm_native.py
+++ b/cognee/tests/unit/infrastructure/llm/test_litellm_native.py
@@ -527,6 +527,22 @@ class TestQualifyModel:
         qualified = self._qualify("phi4", "ollama")
         assert litellm.get_llm_provider(model=qualified)[1] == "ollama"
 
+    def test_namespaced_ollama_model_gets_prefixed(self):
+        """A slash is not a provider: Ollama accepts namespaced names."""
+        assert self._qualify("library/phi4", "ollama") == "ollama/library/phi4"
+
+    def test_hugging_face_gguf_path_gets_prefixed(self):
+        """The documented way to run a GGUF under Ollama keeps its full path."""
+        model = "hf.co/bartowski/Llama-3.2-1B-Instruct-GGUF"
+        assert self._qualify(model, "ollama") == f"ollama/{model}"
+
+    def test_namespaced_name_is_routable_by_litellm(self):
+        """Same end of the chain, for a name that contains a slash."""
+        import litellm
+
+        qualified = self._qualify("library/phi4", "ollama")
+        assert litellm.get_llm_provider(model=qualified)[1] == "ollama"
+
 
 # ── markdown-fenced JSON on the fallback path (CLO-596) ──────────────────────
 # The prompted-JSON path hands the model's reply straight to


### PR DESCRIPTION
Fixes #4617.

## Problem

`_qualify_model` returns any model name containing a slash unchanged:

```python
if not model or "/" in model:
    return model
```

The assumption is that a slash means the name already carries a provider. Ollama names don't follow that rule — they can be namespaced (`library/phi4`), and a GGUF pulled from Hugging Face keeps its full path (`hf.co/bartowski/Llama-3.2-1B-Instruct-GGUF`), which is the documented way to run one under Ollama.

Those names reach litellm unqualified and raise the same error that CLO-594 fixed for bare names:

```
litellm.BadRequestError: LLM Provider NOT provided.
You passed model=hf.co/bartowski/Llama-3.2-1B-Instruct-GGUF
```

Since `litellm_native` is the default `STRUCTURED_OUTPUT_FRAMEWORK` on `dev`, this fails before a request is sent.

## Fix

Drop the slash check and let litellm decide.

The `get_llm_provider` probe immediately below it already does the job the shortcut was there for: `ollama/phi4` and `openai/gpt-5-mini` resolve successfully and are returned untouched. So the conservative guarantee in the docstring is preserved — the only names whose behaviour changes are the ones that were unroutable before.

```
'phi4'                                        -> 'ollama/phi4'                    (unchanged)
'ollama/phi4'                                 -> 'ollama/phi4'                    (unchanged)
'openai/gpt-5-mini'                           -> 'openai/gpt-5-mini'              (unchanged)
'gpt-4o'                                      -> 'gpt-4o'                         (unchanged)
'library/phi4'                                -> 'ollama/library/phi4'            (fixed)
'hf.co/bartowski/Llama-3.2-1B-Instruct-GGUF'  -> 'ollama/hf.co/bartowski/...'     (fixed)
```

The cost is one extra `get_llm_provider` call for slash-containing names, which is a local lookup.

## Tests

Three cases added to the existing `TestQualifyModel`, matching its style:

- `test_namespaced_ollama_model_gets_prefixed`
- `test_hugging_face_gguf_path_gets_prefixed`
- `test_namespaced_name_is_routable_by_litellm`

All three fail before the change, for the right reason:

```
assert self._qualify("library/phi4", "ollama") == "ollama/library/phi4"
E   AssertionError: assert 'library/phi4' == 'ollama/library/phi4'

assert litellm.get_llm_provider(model=qualified)[1] == "ollama"
E   Raises Error - if unable to map model to a provider
```

`test_already_qualified_is_untouched` and `test_name_litellm_already_resolves_is_untouched` — the back-compat canaries — pass unchanged.

Full run of `cognee/tests/unit/infrastructure/llm/`:

| | passed | failed |
|---|---|---|
| with this change | **168** | 1 |
| clean `dev` | 165 | 4 |

The delta is exactly the three new tests. The one remaining failure is `test_local_ollama_example_executes_offline`, which fails identically on clean `dev` — it's `ModuleNotFoundError: No module named 'lancedb'`, an optional dependency missing from my local env, not related to this change.

---

> [!NOTE]
> This contribution was AI-assisted (Claude Code). Every result above was executed, and I verified the revert actually applied before trusting the failing run.
> I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin

