### PR TITLE
fix: Demote to non-strict schema instead of losing native path (COG-6271)

### DIFF
--- a/cognee/infrastructure/llm/structured_output_framework/litellm_native/native_adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_native/native_adapter.py
@@ -67,6 +67,34 @@ def _strip_json_fence(text: str) -> str:
 # fails validation. Separate from the tenacity retry (transient HTTP errors).
 _MAX_VALIDATION_RETRIES: int = 3
 
+# (llm_model, response_model.__name__) pairs whose schema the provider's strict
+# mode has rejected. Once demoted, calls go straight to the non-strict payload,
+# so the failed strict request is paid once per process, not per call.
+_NONSTRICT_DEMOTIONS: set[tuple[str, str]] = set()
+
+
+def clear_nonstrict_demotions() -> None:
+    _NONSTRICT_DEMOTIONS.clear()
+
+
+def _nonstrict_response_format(response_model: type[BaseModel]) -> dict:
+    """Non-strict ``json_schema`` payload: the raw schema travels as guidance.
+
+    Without ``strict: true`` the provider does not enforce its restricted
+    schema subset, so constructs strict mode rejects (``oneOf``/``discriminator``
+    from discriminated unions, free-form dict fields, ``format``) are accepted.
+    Conformance is still checked app-side by validating against the original
+    Pydantic model.
+    """
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": response_model.__name__,
+            "schema": response_model.model_json_schema(),
+            "strict": False,
+        },
+    }
+
 
 def _attach_raw_response(instance: BaseModel, response) -> BaseModel:
     """Attach the raw litellm response as ``_raw_response``, like instructor does.
@@ -197,6 +225,7 @@ class NativeLiteLLMAdapter:
         api_key: str | None,
         endpoint: str | None,
         api_version: str | None,
+        strict: bool = True,
         **merged_kwargs: Any,
     ) -> BaseModel:
         """Pass the Pydantic model as ``response_format`` and validate the JSON."""
@@ -207,7 +236,9 @@ class NativeLiteLLMAdapter:
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": text_input},
                 ],
-                response_format=response_model,
+                response_format=(
+                    response_model if strict else _nonstrict_response_format(response_model)
+                ),
                 api_key=api_key,
                 api_base=endpoint,
                 api_version=api_version,
@@ -301,32 +332,61 @@ class NativeLiteLLMAdapter:
     ) -> BaseModel:
         """Route to the schema-native or json-object path based on the model."""
         if _supports_native_schema(model):
-            try:
-                return await self._acreate_schema_native(
-                    text_input,
-                    system_prompt,
-                    response_model,
-                    model=model,
-                    api_key=api_key,
-                    endpoint=endpoint,
-                    api_version=api_version,
-                    **merged_kwargs,
-                )
-            except BadRequestError as error:
-                # Strict schema-native mode rejects Pydantic models whose JSON
-                # schema it cannot enforce — e.g. a free-form dict field, which
-                # OpenAI 400s with "'additionalProperties' is required to be
-                # supplied and to be false". Those models still work on the
-                # prompted-JSON path, so fall through instead of failing.
-                if "schema" not in str(error).lower():
-                    raise
-                logger.warning(
-                    "litellm_native: %s rejected the schema for %s; retrying via "
-                    "json fallback (%s)",
-                    model,
-                    response_model.__name__,
-                    error,
-                )
+            demotion_key = (model, response_model.__name__)
+            attempts = [False] if demotion_key in _NONSTRICT_DEMOTIONS else [True, False]
+            for strict in attempts:
+                try:
+                    return await self._acreate_schema_native(
+                        text_input,
+                        system_prompt,
+                        response_model,
+                        model=model,
+                        api_key=api_key,
+                        endpoint=endpoint,
+                        api_version=api_version,
+                        strict=strict,
+                        **merged_kwargs,
+                    )
+                except ValidationError as error:
+                    # Output that fails app-side validation must not bubble into
+                    # the tenacity retry: that re-sends the same prompt blindly
+                    # (no error feedback) under a 240s stop floor. The
+                    # prompted-JSON path below has the self-correcting retry
+                    # loop, so route there instead.
+                    logger.warning(
+                        "litellm_native: %s native output failed validation for %s; "
+                        "using json fallback (%s)",
+                        model,
+                        response_model.__name__,
+                        error,
+                    )
+                    break
+                except BadRequestError as error:
+                    # Strict schema-native mode rejects Pydantic models whose
+                    # JSON schema it cannot enforce — e.g. a free-form dict
+                    # field, which OpenAI 400s with "'additionalProperties' is
+                    # required to be supplied and to be false". Non-strict mode
+                    # accepts those schemas as guidance, so demote and retry
+                    # once before giving up on the native path entirely.
+                    if "schema" not in str(error).lower():
+                        raise
+                    if strict:
+                        _NONSTRICT_DEMOTIONS.add(demotion_key)
+                        logger.warning(
+                            "litellm_native: %s rejected the strict schema for %s; "
+                            "demoting to non-strict json_schema for this process (%s)",
+                            model,
+                            response_model.__name__,
+                            error,
+                        )
+                    else:
+                        logger.warning(
+                            "litellm_native: %s rejected the non-strict schema for "
+                            "%s; retrying via json fallback (%s)",
+                            model,
+                            response_model.__name__,
+                            error,
+                        )
         return await self._acreate_json_fallback(
             text_input,
             system_prompt,

--- a/cognee/tests/e2e/docker_compose/README.md
+++ b/cognee/tests/e2e/docker_compose/README.md
@@ -11,7 +11,7 @@ and service log hygiene.
 | Test | Asserts |
 | --- | --- |
 | `test_golden_flow_api` | `health → login → add → datasets → data` against the API on `:8000` (cognify + search when an LLM key is provided). |
-| `test_mcp_health_and_tool_call` | `cognee-mcp` `/health` on `:8001` **and** one real MCP tool call (`list_datasets_json`) over SSE. |
+| `test_mcp_health_and_tool_call` | `cognee-mcp` `/health` on `:8001` **and** one real MCP tool call (`list_data`) over SSE. |
 | `test_service_logs_are_traceback_free` | No service emitted an unhandled Python traceback (runs before the Postgres recreate, which legitimately logs connection errors). |
 | `test_postgres_persistence_across_recreate` | Data added via the API survives a Postgres container **force-recreate** — proving the `postgres_data` volume is required. |
 

--- a/cognee/tests/e2e/docker_compose/README.md
+++ b/cognee/tests/e2e/docker_compose/README.md
@@ -11,7 +11,7 @@ and service log hygiene.
 | Test | Asserts |
 | --- | --- |
 | `test_golden_flow_api` | `health → login → add → datasets → data` against the API on `:8000` (cognify + search when an LLM key is provided). |
-| `test_mcp_health_and_tool_call` | `cognee-mcp` `/health` on `:8001` **and** one real MCP tool call (`list_data`) over SSE. |
+| `test_mcp_health_and_tool_call` | `cognee-mcp` `/health` on `:8001` **and** one real MCP tool call (`cognify_status`) over SSE. |
 | `test_service_logs_are_traceback_free` | No service emitted an unhandled Python traceback (runs before the Postgres recreate, which legitimately logs connection errors). |
 | `test_postgres_persistence_across_recreate` | Data added via the API survives a Postgres container **force-recreate** — proving the `postgres_data` volume is required. |
 

--- a/cognee/tests/e2e/docker_compose/mcp_client.py
+++ b/cognee/tests/e2e/docker_compose/mcp_client.py
@@ -3,7 +3,7 @@
 The ``cognee-mcp`` service runs with ``TRANSPORT_MODE=sse``, so it speaks the
 standard MCP SSE protocol at ``/sse``. We use the official ``mcp`` client to
 initialize a session, confirm the tool surface, and call one LLM-free tool
-(``list_data``) end to end.
+(``cognify_status``) end to end.
 """
 
 from __future__ import annotations
@@ -44,7 +44,10 @@ async def _call_list_datasets(sse_url: str) -> McpToolCall:
                 f"exposes: {sorted(tool_names)}"
             )
 
-            call = await session.call_tool("list_data", arguments={})
+            # The server registers exactly four tools (remember/recall/forget/
+            # cognify_status); cognify_status is the LLM-free, side-effect-free
+            # one, so it is the round-trip probe.
+            call = await session.call_tool("cognify_status", arguments={})
             assert not getattr(call, "isError", False), f"tool call errored: {call}"
 
             text = "\n".join(getattr(item, "text", str(item)) for item in (call.content or []))

--- a/cognee/tests/e2e/docker_compose/mcp_client.py
+++ b/cognee/tests/e2e/docker_compose/mcp_client.py
@@ -3,7 +3,7 @@
 The ``cognee-mcp`` service runs with ``TRANSPORT_MODE=sse``, so it speaks the
 standard MCP SSE protocol at ``/sse``. We use the official ``mcp`` client to
 initialize a session, confirm the tool surface, and call one LLM-free tool
-(``list_datasets_json``) end to end.
+(``list_data``) end to end.
 """
 
 from __future__ import annotations
@@ -44,7 +44,7 @@ async def _call_list_datasets(sse_url: str) -> McpToolCall:
                 f"exposes: {sorted(tool_names)}"
             )
 
-            call = await session.call_tool("list_datasets_json", arguments={})
+            call = await session.call_tool("list_data", arguments={})
             assert not getattr(call, "isError", False), f"tool call errored: {call}"
 
             text = "\n".join(getattr(item, "text", str(item)) for item in (call.content or []))

--- a/cognee/tests/e2e/docker_compose/test_full_stack_e2e.py
+++ b/cognee/tests/e2e/docker_compose/test_full_stack_e2e.py
@@ -50,15 +50,16 @@ def test_mcp_health_and_tool_call(mcp_ready):
     assert health.json().get("status") == "ok", health.text
 
     call = call_mcp_tool()
-    # `list_data()` without arguments renders "📂 No datasets found." (with a
-    # cognify hint) or a "📂 Available Datasets:" header followed by one
-    # numbered entry per dataset.
-    assert re.match(r"📂 (No datasets found\.|Available Datasets:)", call.result_text), (
-        f"unexpected list_data output: {call.result_text!r}"
+    # `cognify_status()` renders the pipeline-status mapping as a dict string
+    # ("{}", or "{'<dataset-uuid>': ...}" once ingestion has run) — or, in API
+    # mode before any ingestion, an explicit "❌ Dataset ... not found via API"
+    # line. Any of these proves a real LLM-free tool call round-tripped.
+    assert re.match(r"(\{|❌ Dataset )", call.result_text), (
+        f"unexpected cognify_status output: {call.result_text!r}"
     )
     # structuredContent is only forwarded for tools advertised in tools/list,
-    # and `list_data` returns plain TextContent — treat any structured payload
-    # as a bonus and only sanity-check its type when present.
+    # and `cognify_status` returns plain TextContent — treat any structured
+    # payload as a bonus and only sanity-check its type when present.
     if call.structured is not None:
         assert isinstance(call.structured, dict), call.structured
 

--- a/cognee/tests/e2e/docker_compose/test_full_stack_e2e.py
+++ b/cognee/tests/e2e/docker_compose/test_full_stack_e2e.py
@@ -50,17 +50,17 @@ def test_mcp_health_and_tool_call(mcp_ready):
     assert health.json().get("status") == "ok", health.text
 
     call = call_mcp_tool()
-    # `list_datasets_json` renders "No datasets found." or "N dataset(s):"
-    # followed by one "- name (id)" line per dataset.
-    assert re.match(r"(No datasets found\.|\d+ datasets?:)", call.result_text), (
-        f"unexpected list_datasets_json output: {call.result_text!r}"
+    # `list_data()` without arguments renders "📂 No datasets found." (with a
+    # cognify hint) or a "📂 Available Datasets:" header followed by one
+    # numbered entry per dataset.
+    assert re.match(r"📂 (No datasets found\.|Available Datasets:)", call.result_text), (
+        f"unexpected list_data output: {call.result_text!r}"
     )
-    # structuredContent ({"datasets": [...]}) is only forwarded for tools
-    # advertised in tools/list; this one is gated behind the tool-search
-    # transform, so treat it as a bonus and validate the shape when present.
+    # structuredContent is only forwarded for tools advertised in tools/list,
+    # and `list_data` returns plain TextContent — treat any structured payload
+    # as a bonus and only sanity-check its type when present.
     if call.structured is not None:
-        assert "datasets" in call.structured, call.structured
-        assert isinstance(call.structured["datasets"], list)
+        assert isinstance(call.structured, dict), call.structured
 
 
 def test_service_logs_are_traceback_free(requires_compose):

--- a/cognee/tests/unit/infrastructure/llm/test_litellm_native.py
+++ b/cognee/tests/unit/infrastructure/llm/test_litellm_native.py
@@ -570,3 +570,118 @@ class TestStripJsonFence:
 
         raw = '```json\n{"summary": "a summary", "description": ""}\n```'
         assert SummarizedContent.model_validate_json(self._strip(raw)).summary == "a summary"
+
+
+# ---- Non-strict demotion + native validation fallback (COG-6271) ----
+
+
+def _schema_400() -> Exception:
+    from litellm.exceptions import BadRequestError
+
+    return BadRequestError(
+        message="Invalid schema for response_format 'PersonModel': 'oneOf' is not permitted.",
+        model="gpt-5-mini",
+        llm_provider="openai",
+    )
+
+
+@pytest.fixture
+def _clean_demotions():
+    from cognee.infrastructure.llm.structured_output_framework.litellm_native import (
+        native_adapter,
+    )
+
+    native_adapter.clear_nonstrict_demotions()
+    yield
+    native_adapter.clear_nonstrict_demotions()
+
+
+def _schema_adapter():
+    from cognee.infrastructure.llm.structured_output_framework.litellm_native.native_adapter import (
+        NativeLiteLLMAdapter,
+    )
+
+    return NativeLiteLLMAdapter(
+        api_key="test-key",
+        model="openai/gpt-5-mini",  # supports_response_schema is True
+        max_completion_tokens=4096,
+    )
+
+
+@pytest.mark.asyncio
+async def test_schema_400_demotes_to_nonstrict_and_is_remembered(_clean_demotions):
+    """A strict rejection retries once non-strict; later calls skip the strict attempt."""
+    adapter = _schema_adapter()
+    valid = json.dumps({"name": "Eve", "age": 22})
+
+    mock_acompletion = AsyncMock(
+        side_effect=[_schema_400(), _make_mock_response(valid), _make_mock_response(valid)]
+    )
+    with patch("litellm.acompletion", mock_acompletion):
+        first = await adapter.acreate_structured_output(
+            text_input="Tell me about Eve",
+            system_prompt="Extract person info.",
+            response_model=PersonModel,
+        )
+        second = await adapter.acreate_structured_output(
+            text_input="Tell me about Eve again",
+            system_prompt="Extract person info.",
+            response_model=PersonModel,
+        )
+
+    assert first.name == "Eve" and second.name == "Eve"
+    # Call 1: strict (Pydantic class). Call 2: non-strict retry of the same
+    # request. Call 3: the next request goes straight to non-strict — the
+    # failed strict request is paid once per process, not per call.
+    assert mock_acompletion.call_count == 3
+    calls = mock_acompletion.call_args_list
+    assert calls[0].kwargs["response_format"] is PersonModel
+    for call in calls[1:]:
+        response_format = call.kwargs["response_format"]
+        assert response_format["type"] == "json_schema"
+        assert response_format["json_schema"]["strict"] is False
+        assert response_format["json_schema"]["name"] == "PersonModel"
+
+
+@pytest.mark.asyncio
+async def test_nonstrict_rejection_falls_back_to_prompted_json(_clean_demotions):
+    """If the non-strict retry is also rejected, the prompted-JSON path still answers."""
+    adapter = _schema_adapter()
+    valid = json.dumps({"name": "Eve", "age": 22})
+
+    mock_acompletion = AsyncMock(
+        side_effect=[_schema_400(), _schema_400(), _make_mock_response(valid)]
+    )
+    with patch("litellm.acompletion", mock_acompletion):
+        result = await adapter.acreate_structured_output(
+            text_input="Tell me about Eve",
+            system_prompt="Extract person info.",
+            response_model=PersonModel,
+        )
+
+    assert result.name == "Eve"
+    assert mock_acompletion.call_count == 3
+    assert mock_acompletion.call_args_list[2].kwargs["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.asyncio
+async def test_native_validation_error_routes_to_json_fallback(_clean_demotions):
+    """Invalid native output goes to the self-correcting fallback, not blind tenacity retries."""
+    adapter = _schema_adapter()
+    valid = json.dumps({"name": "Eve", "age": 22})
+
+    mock_acompletion = AsyncMock(
+        side_effect=[_make_mock_response("not json at all"), _make_mock_response(valid)]
+    )
+    with patch("litellm.acompletion", mock_acompletion):
+        result = await adapter.acreate_structured_output(
+            text_input="Tell me about Eve",
+            system_prompt="Extract person info.",
+            response_model=PersonModel,
+        )
+
+    assert result.name == "Eve"
+    # Exactly two calls: the failed native attempt, then the prompted-JSON
+    # fallback — NOT a tenacity re-send of the native request.
+    assert mock_acompletion.call_count == 2
+    assert mock_acompletion.call_args_list[1].kwargs["response_format"] == {"type": "json_object"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cognee"
 
-version = "1.5.1"
+version = "1.5.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 authors = [
     { name = "Vasilije Markovic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1214,7 +1214,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Description

Hotfix for the 1.5.x line (base: `main`), bumping the version to **1.5.2**. Two related litellm_native adapter defects:

### 1. Demote, don't disable
A strict-mode schema rejection — `SessionTurnAnalysis` (`oneOf` from its discriminated union, one failed request on **every answered session turn**), and DataPoint-derived models like `EntityList`/`RuleSet` (free-form `metadata` dict → `additionalProperties`) — dropped the adapter to prompted-JSON and re-paid the failed request per call for the process lifetime.

Now: on a schema-classified `BadRequestError`, retry the same request once with an explicit **non-strict** `json_schema` payload (raw `model_json_schema()`, `strict: false`). Non-strict mode accepts the full schema as guidance — no 400 — while conformance is still validated app-side against the original Pydantic model. The demotion is remembered in a module-level set keyed by `(llm_model, response_model.__name__)`, so the failed strict request is paid **once per process, not per call**. Compatible models (the majority, including `KnowledgeGraph` extraction) keep their strict grammar-constrained guarantee completely untouched. If non-strict is also rejected, prompted-JSON remains the final fallback.

### 2. Route native ValidationErrors to the self-correcting fallback
The native path validated with `model_validate_json` and no `ValidationError` handling — a validation failure bubbled into tenacity, which blindly re-sent the same prompt (no error feedback) under the `stop_after_attempt(2) AND stop_after_delay(240)` floor: up to 240 s of full-price LLM calls. Nearly unreachable under strict mode, but load-bearing the moment anything runs non-strict — which change 1 makes routine. Native validation failures now route to `_acreate_json_fallback`, which already has the error-feedback retry loop.

This is a deliberately small, reactive version of the systemic schema-compat design (COG-6269 follow-up): the full capability-profile work replaces demotion-on-400 with pre-flight mode resolution; nothing here needs undoing when that lands.

## Testing

Three new tests in `test_litellm_native.py` (28 total, all green; ruff clean):
- strict 400 → non-strict retry succeeds, and the **next** call skips the strict attempt entirely (payload asserted: `json_schema`, `strict: false`);
- non-strict also rejected → prompted-JSON fallback answers;
- invalid native output → exactly two calls (failed native + fallback), proving no blind tenacity re-send.

Fixes COG-6271

🤖 Generated with [Claude Code](https://claude.com/claude-code)