### PR TITLE
feat: Add authority and traceability opt-ins (COG-6279)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -543,6 +543,7 @@ Configuration:
 ONTOLOGY_RESOLVER=rdflib  # Default: uses rdflib and OWL files
 MATCHING_STRATEGY=fuzzy   # Default: fuzzy matching with 80% similarity
 ONTOLOGY_FILE_PATH=/path/to/your/ontology.owl  # Full path to ontology file
+ONTOLOGY_MODE=annotate    # Default: enrich only. strict drops entities with no ontology grounding
 ```
 
 Implementation: `cognee/modules/ontology/`
@@ -695,6 +696,14 @@ await cognee.recall("my question", datasets=["my_project"])
 
 ### DataPoints
 Atomic knowledge units that form the foundation of graph structures. All graph nodes extend the `DataPoint` base class with versioning and metadata support.
+
+### Temporal Model & Assertion Authority
+Cognee's fact store is **uni-temporal**: nodes carry `created_at`/`updated_at` (ms epoch, ingestion clock) and every edge carries one ingestion-time `updated_at`. No real-world validity interval is attached to facts, and there is no as-of / point-in-time query.
+
+- **Real-world time exists only on the opt-in temporal path**: `cognify(temporal_cognify=True)` (SDK-only; replaces the default task list) extracts event occurrence times into `Timestamp`/`Interval` nodes linked from `Event` nodes, queryable via `SearchType.TEMPORAL`. This is occurrence time on events, not validity on facts/edges.
+- **Supersession is opt-in**: `cognify(functional_relationships=[...])` tags older edges of a declared single-valued relationship with `superseded=True`. The winner is chosen by authority first (`assertion_source`), then ingestion-time recency. Graph retrievers skip superseded-tagged edges when building context; precomputed triplet embeddings and raw chunk text are not filtered. Contradiction detection (below) is also opt-in and only annotates.
+- **Assertion authority**: nodes carry derivational provenance (`source_pipeline`, `source_task`, `source_user`, `source_content_hash`) plus `assertion_source` (`user_stated` for session-bridged facts / `document_extracted` / `llm_inferred`), stamped under `COGNEE_PROVENANCE_MODE` (default `lightweight`). Only the supersession resolver consults it; retrieval ranking, dedup, and entity merging do not.
+- **Dormant fields**: `DataPoint.valid_to` (and the `close_node`/`is_valid` helpers) are application-level only — no default pipeline writes or reads them. Zep-imported `valid_at`/`invalid_at` edge properties are carried but not queried (see `cognee/modules/migration/cogx.py` for the roadmap note).
 
 ### Contradiction Detection
 Opt-in LLM check that runs as the last `cognify()` task (default **off**). After the graph is stored, it gathers the facts one hop from the entities this ingestion touched — new and pre-existing alike — asks an LLM which pairs cannot both be true, and records each confident conflict as a `contradicts` edge carrying both fact texts, the reason, and the confidence. It only adds edges (never rewrites or deletes) and swallows its own errors, so it can never break ingestion.

--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -76,6 +76,10 @@ async def add(
             * Absolute paths: "/path/to/document.pdf"
             * File URLs: "file:///path/to/document.pdf" or "file://relative/path.txt"
             * S3 paths: "s3://bucket-name/path/to/file.pdf"
+
+            Local paths are referenced in place by default (no copy is made); set
+            COPY_LOCAL_FILES=true to snapshot the original bytes into cognee-managed
+            storage at add time.
         - **Binary file objects**: File handles/streams (BinaryIO)
         - **Lists**: Multiple files or text strings in a single call
 

--- a/cognee/infrastructure/engine/models/DataPoint.py
+++ b/cognee/infrastructure/engine/models/DataPoint.py
@@ -63,8 +63,10 @@ class DataPoint(BaseModel):
     ontology_uri: str | None = None
     version: int = 1  # Default version
     topological_rank: int | None = 0
-    # Bi-temporal validity: ms epoch when this fact was superseded (via close_node);
-    # None = still current. Not the same as Event/Interval time_to (when an event occurred).
+    # Ms epoch when this fact was superseded (via the close_node helper); None =
+    # still current. No default pipeline writes this today — close_node has no
+    # in-pipeline caller, so valid_to stays None unless application code sets it.
+    # Not the same as Event/Interval time_to (when an event occurred in the world).
     valid_to: int | None = None
     metadata: MetaData = {"index_fields": []}
     type: str = Field(default_factory=lambda: DataPoint.__name__)

--- a/cognee/infrastructure/engine/models/DataPoint.py
+++ b/cognee/infrastructure/engine/models/DataPoint.py
@@ -74,6 +74,11 @@ class DataPoint(BaseModel):
     source_node_set: str | None = None
     source_user: str | None = None
     source_content_hash: str | None = None
+    # Who asserted this fact: "user_stated" (from the user's own session
+    # statements), "document_extracted" (LLM extraction from ingested documents)
+    # or "llm_inferred" (LLM inference not grounded in a specific source
+    # passage). Plain str, not Literal: consumers read untyped edge dicts.
+    assertion_source: str | None = None
     feedback_weight: float = 0.5
     importance_weight: float | None = 0.5
 

--- a/cognee/modules/graph/cognee_graph/CogneeGraph.py
+++ b/cognee/modules/graph/cognee_graph/CogneeGraph.py
@@ -195,6 +195,10 @@ class CogneeGraph(CogneeAbstractGraph):
 
         # Process edges
         for source_id, target_id, relationship_type, properties in edges_data:
+            # Superseded assertions are history, not current facts: keep them
+            # out of the retrieval projection.
+            if properties.get("superseded"):
+                continue
             source_node = self.get_node(str(source_id))
             target_node = self.get_node(str(target_id))
             if source_node and target_node:

--- a/cognee/modules/graph/utils/get_graph_from_model.py
+++ b/cognee/modules/graph/utils/get_graph_from_model.py
@@ -93,7 +93,11 @@ def _extract_field_data(field_value: Any) -> List[Tuple[Optional[Edge], List[Dat
 
 
 def _create_edge_properties(
-    source_id: str, target_id: str, relationship_name: str, edge_metadata: Optional[Edge]
+    source_id: str,
+    target_id: str,
+    relationship_name: str,
+    edge_metadata: Optional[Edge],
+    assertion_source: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create edge properties dictionary with metadata if present."""
     properties = {
@@ -102,6 +106,11 @@ def _create_edge_properties(
         "relationship_name": relationship_name,
         "updated_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
     }
+
+    # Carry the source node's assertion authority onto the stored edge so the
+    # temporal conflict resolver can rank assertions it reads back later.
+    if assertion_source is not None:
+        properties["assertion_source"] = assertion_source
 
     if edge_metadata:
         # Add edge metadata
@@ -281,7 +290,11 @@ async def get_graph_from_model(
         edge_key = f"{data_point_id}_{target_datapoint.id}_{field_name}"
         if edge_key not in added_edges:
             edge_properties = _create_edge_properties(
-                data_point.id, target_datapoint.id, relationship_name, edge_metadata
+                data_point.id,
+                target_datapoint.id,
+                relationship_name,
+                edge_metadata,
+                assertion_source=data_point.assertion_source,
             )
             edges.append((data_point.id, target_datapoint.id, relationship_name, edge_properties))
             logger.debug("Added edge to graph")

--- a/cognee/modules/graph/utils/temporal_conflict_resolver.py
+++ b/cognee/modules/graph/utils/temporal_conflict_resolver.py
@@ -4,11 +4,13 @@ When a *functional* (single-valued) relationship holds more than one target for
 the same source — e.g. two documents name a different current CEO — the most
 recent assertion is the current fact and the older ones are outdated. This
 module tags the outdated ones instead of deleting them, so the history and its
-provenance stay in the graph and retrieval can tell a current fact from a
-replaced one.
+provenance stay in the graph. The tag is metadata on the stored edge; graph
+retrievers skip edges tagged superseded when building context.
 
-Ranking is deterministic (recency by the edge's own ``updated_at``, ties broken
-by position), so it stays reproducible under the mocked-LLM CI harness.
+Ranking is deterministic — authority first (``assertion_source``: user-stated
+beats document-extracted beats LLM-inferred; untagged edges rank as
+document-extracted), then recency by the edge's own ``updated_at``, ties broken
+by position — so it stays reproducible under the mocked-LLM CI harness.
 
 Nothing is applied automatically: the caller names the relationships that are
 single-valued. Most cognee relationships (``knows``, ``mentions``, ...) are
@@ -24,16 +26,24 @@ from typing import Any, Collection
 # (source_node_id, target_node_id, relationship_name, properties) tuples.
 Edge = tuple[Any, Any, str, dict]
 
+# What the user stated outranks what a document said, which outranks what an
+# LLM inferred on its own.
+_AUTHORITY_RANK = {"user_stated": 2, "document_extracted": 1, "llm_inferred": 0}
 
-def _recency_key(index: int, properties: dict) -> tuple[str, int]:
-    """Rank an edge by recency.
 
-    ``updated_at`` is a sortable ``"%Y-%m-%d %H:%M:%S"`` string stamped on every
-    edge by ``get_graph_from_model`` and refreshed each time the fact is
-    re-asserted; a missing value sorts oldest. The position breaks ties so equal
-    timestamps still resolve to a stable winner (the later assertion wins).
+def _recency_key(index: int, properties: dict) -> tuple[int, str, int]:
+    """Rank an edge by authority, then recency.
+
+    ``assertion_source`` maps to an authority rank; edges without the field
+    rank as document-extracted, so pre-existing/untagged edges resolve exactly
+    as before. ``updated_at`` is a sortable ``"%Y-%m-%d %H:%M:%S"`` string
+    stamped on every edge by ``get_graph_from_model`` and refreshed each time
+    the fact is re-asserted; a missing value sorts oldest. The position breaks
+    ties so equal timestamps still resolve to a stable winner (the later
+    assertion wins).
     """
-    return (str(properties.get("updated_at") or ""), index)
+    rank = _AUTHORITY_RANK.get(properties.get("assertion_source"), 1)
+    return (rank, str(properties.get("updated_at") or ""), index)
 
 
 def tag_superseded_edges(

--- a/cognee/modules/pipelines/operations/run_tasks_base.py
+++ b/cognee/modules/pipelines/operations/run_tasks_base.py
@@ -82,6 +82,15 @@ def _stamp_provenance(
         elif current_node_set is not None and data.source_node_set is None:
             data.source_node_set = current_node_set
 
+        # Who asserted this fact: data bridged from the session cache carries
+        # the "user_sessions_from_cache" node set (see cognify_session);
+        # everything else on this path came out of document extraction.
+        if data.assertion_source is None:
+            if current_node_set is not None and "user_sessions_from_cache" in current_node_set:
+                data.assertion_source = "user_stated"
+            else:
+                data.assertion_source = "document_extracted"
+
         # Propagate content_hash from parent or pick up from this data point
         current_hash = content_hash
         if data.source_content_hash is not None:

--- a/cognee/modules/retrieval/hybrid/entities.py
+++ b/cognee/modules/retrieval/hybrid/entities.py
@@ -93,6 +93,10 @@ def _partition_neighborhood(
             continue
         source_id, target_id = str(edge[0]), str(edge[1])
         properties = edge[3] if len(edge) > 3 and isinstance(edge[3], dict) else {}
+        # Superseded assertions are history, not current facts: keep them out
+        # of the retrieval context.
+        if properties.get("superseded"):
+            continue
         triple = (
             nodes_by_id.get(source_id, {"id": source_id}),
             {"relationship_name": edge[2], "properties": properties},

--- a/cognee/tasks/graph/detect_contradictions.py
+++ b/cognee/tasks/graph/detect_contradictions.py
@@ -229,6 +229,7 @@ async def detect_contradictions(data_points: List[DataPoint], **kwargs) -> List[
                         "second_fact": second_fact,
                         "reason": contradiction.reason,
                         "confidence": contradiction.confidence,
+                        "assertion_source": "llm_inferred",
                     },
                 )
             )

--- a/cognee/tasks/graph/resolve_temporal_contradictions.py
+++ b/cognee/tasks/graph/resolve_temporal_contradictions.py
@@ -8,7 +8,11 @@ assertion and tags the older ones as superseded.
 
 Nothing is deleted: a superseded edge stays in the graph with its provenance,
 tagged (``superseded``, ``superseded_by``, ``supersession_reason``) so the
-current fact can be told apart from the history it replaced.
+current fact can be told apart from the history it replaced. Graph retrievers
+exclude superseded edges when building context; ``contradicts`` edges remain
+visible (labeled by their relationship type in the formatted context). Not
+filtered: TRIPLET_COMPLETION's precomputed triplet embeddings and raw chunk
+text.
 
 Because it reads the stored neighbourhood rather than the batch in flight, a
 fact ingested today supersedes one ingested last month: entity node ids are

--- a/cognee/tasks/ingestion/save_data_item_to_storage.py
+++ b/cognee/tasks/ingestion/save_data_item_to_storage.py
@@ -20,6 +20,7 @@ logger = get_logger()
 
 class SaveDataSettings(BaseSettings):
     accept_local_file_path: bool = True
+    copy_local_files: bool = False
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
@@ -47,6 +48,23 @@ def _resolve_local_file_uri(
     return local_path.as_uri() if local_path.is_file() else None
 
 
+async def _stored_local_file(local_uri: str) -> StoredFile:
+    """Turn a resolved local ``file://`` URI into the StoredFile add() records.
+
+    Default (``COPY_LOCAL_FILES`` off): the user's file is referenced in place —
+    nothing is copied, and the StoredFile carries no metadata. With the flag on,
+    the file's bytes are snapshotted through :func:`save_data_to_file_detailed`
+    into cognee-managed storage (content-addressed under DATA_ROOT), and the
+    StoredFile points at that copy, metadata included.
+    """
+    if not settings.copy_local_files:
+        return StoredFile(file_path=local_uri)
+
+    local_path = Path(url2pathname(urlparse(local_uri).path))
+    with open(local_path, "rb") as file_handle:
+        return await save_data_to_file_detailed(file_handle, filename=local_path.name)
+
+
 async def save_data_item_to_storage_detailed(
     data_item: Union[BinaryIO, str, Any],
 ) -> StoredFile:
@@ -57,6 +75,13 @@ async def save_data_item_to_storage_detailed(
     while they are in hand, so ingestion never has to read the object back to
     hash it. Items that are already addressable storage (an ``s3://`` URL, a
     local path) are handed through untouched and carry no metadata.
+
+    Local paths are handed through *by reference* by default: cognee records
+    the path and its ``content_hash``, which can later verify the original but
+    cannot recover it if the file changes or disappears. Setting
+    ``COPY_LOCAL_FILES=true`` snapshots the bytes into cognee-managed storage
+    at add time instead; re-adding the same file with the flag on makes
+    ``original_data_location`` point at the cognee-managed copy.
     """
     if "llama_index" in str(type(data_item)):
         # Dynamic import is used because the llama_index module is optional.
@@ -93,7 +118,7 @@ async def save_data_item_to_storage_detailed(
             if settings.accept_local_file_path:
                 local_uri = _resolve_local_file_uri(url2pathname(parsed_url.path), strict=True)
                 if local_uri:
-                    return StoredFile(file_path=local_uri)
+                    return await _stored_local_file(local_uri)
                 raise IngestionError(message="Local file does not exist or is not a file.")
             else:
                 raise IngestionError(message="Local files are not accepted.")
@@ -118,13 +143,13 @@ async def save_data_item_to_storage_detailed(
             local_uri = _resolve_local_file_uri(data_item)
             if local_uri:
                 if settings.accept_local_file_path:
-                    return StoredFile(file_path=local_uri)
+                    return await _stored_local_file(local_uri)
                 raise IngestionError(message="Local files are not accepted.")
         # Data is a relative file path
         local_uri = _resolve_local_file_uri(data_item)
         if local_uri:
             if settings.accept_local_file_path:
-                return StoredFile(file_path=local_uri)
+                return await _stored_local_file(local_uri)
             raise IngestionError(message="Local files are not accepted.")
 
         # data is text, save it to data storage and return the file path

--- a/cognee/tasks/memify/cross_connect_entities.py
+++ b/cognee/tasks/memify/cross_connect_entities.py
@@ -232,6 +232,7 @@ def _build_edge(
             "source_node_id": source_id,
             "target_node_id": target_id,
             "inferred": True,
+            "assertion_source": "llm_inferred",
             "confidence": relation.confidence,
             "feedback_weight": INFERRED_EDGE_FEEDBACK_WEIGHT,
         },

--- a/cognee/tasks/storage/close_node.py
+++ b/cognee/tasks/storage/close_node.py
@@ -5,6 +5,11 @@ When a fact changes (e.g. "Alice works at X" -> "Alice works at Y"), call
 deleting it — and then write the replacement. Consumers filter stale facts with
 ``is_valid(node)``, which stays true while ``valid_to`` is ``None`` (never closed) or
 still lies in the future.
+
+This is an application-level helper: no default cognee pipeline or retriever calls
+``close_node`` or ``is_valid`` today, so ``valid_to`` stays ``None`` on every node
+unless your own code stamps it. It also requires a graph backend with partial node
+updates (currently Ladybug only); others log a warning and return ``False``.
 """
 
 import logging

--- a/cognee/tests/integration/tasks/test_add_ingestion_regression.py
+++ b/cognee/tests/integration/tasks/test_add_ingestion_regression.py
@@ -296,6 +296,43 @@ async def test_local_path_add_records_the_source_location(add_env):
     assert row.original_data_location == Path(os.path.realpath(source)).as_uri()
 
 
+async def test_local_path_add_with_copy_flag_snapshots_the_source(add_env, monkeypatch):
+    # Twin of the test above with COPY_LOCAL_FILES on: instead of referencing
+    # the user's file in place, add() snapshots its bytes into cognee-managed
+    # storage — original_data_location points at the copy under the data root,
+    # the copy's bytes hash to content_hash, and the content stays readable
+    # after the source file is deleted.
+    import importlib
+    import os
+    from urllib.parse import urlparse
+    from urllib.request import url2pathname
+
+    import cognee
+    from cognee.base_config import get_base_config
+
+    mod = importlib.import_module("cognee.tasks.ingestion.save_data_item_to_storage")
+    monkeypatch.setattr(mod.settings, "copy_local_files", True)
+
+    body = b"copy flag body"
+    source = add_env / "copied_note.txt"
+    source.write_bytes(body)
+
+    await cognee.add([str(source)], "reg_copyflag")
+    os.remove(source)
+
+    (row,) = await _rows("reg_copyflag")
+    location = str(row.original_data_location)
+    copy_path = (
+        Path(url2pathname(urlparse(location).path))
+        if location.startswith("file://")
+        else Path(location)
+    )
+    data_root = Path(os.path.realpath(get_base_config().data_root_directory))
+    assert Path(os.path.realpath(copy_path)).is_relative_to(data_root)
+    assert hashlib.md5(copy_path.read_bytes()).hexdigest() == str(row.content_hash)
+    assert await _read_raw(row) == body
+
+
 async def _stored_original_files():
     import os as _os
 

--- a/cognee/tests/unit/modules/graph/cognee_graph_test.py
+++ b/cognee/tests/unit/modules/graph/cognee_graph_test.py
@@ -133,6 +133,35 @@ async def test_project_graph_from_db_full_graph(setup_graph, mock_adapter):
 
 
 @pytest.mark.asyncio
+async def test_project_graph_from_db_skips_superseded_edges(setup_graph, mock_adapter):
+    """Superseded edges are dropped from the projection; untagged siblings and
+    edges with no 'superseded' key at all are projected exactly as before."""
+    graph = setup_graph
+
+    nodes_data = [
+        ("1", {"name": "Node1"}),
+        ("2", {"name": "Node2"}),
+        ("3", {"name": "Node3"}),
+    ]
+    edges_data = [
+        ("1", "2", "ceo_of", {"relationship_name": "ceo_of", "superseded": True}),
+        ("1", "3", "ceo_of", {"relationship_name": "ceo_of", "superseded": False}),
+        ("2", "3", "mentions", {"relationship_name": "mentions"}),
+    ]
+
+    mock_adapter.get_graph_data = AsyncMock(return_value=(nodes_data, edges_data))
+
+    await graph.project_graph_from_db(
+        adapter=mock_adapter,
+        node_properties_to_project=["name"],
+        edge_properties_to_project=["relationship_name"],
+    )
+
+    assert len(graph.nodes) == 3
+    assert [(edge.node1.id, edge.node2.id) for edge in graph.edges] == [("1", "3"), ("2", "3")]
+
+
+@pytest.mark.asyncio
 async def test_project_graph_from_db_id_filtered(setup_graph, mock_adapter):
     """Test projecting an ID-filtered graph from database."""
     graph = setup_graph

--- a/cognee/tests/unit/modules/graph/test_temporal_conflict_resolver.py
+++ b/cognee/tests/unit/modules/graph/test_temporal_conflict_resolver.py
@@ -122,6 +122,73 @@ def test_multiple_independent_subjects_resolved_independently():
     assert superseded_by_target == {"alice": "a-bob", "carol": "g-dave"}
 
 
+def test_older_user_stated_edge_beats_newer_llm_inferred():
+    # Authority outranks recency: the user's own statement stays current even
+    # though the LLM-inferred assertion is newer.
+    edges = [
+        _edge(
+            "c",
+            "alice",
+            "ceo_of",
+            "2020-01-01 00:00:00",
+            edge_object_id="e-alice",
+            assertion_source="user_stated",
+        ),
+        _edge(
+            "c",
+            "bob",
+            "ceo_of",
+            "2024-01-01 00:00:00",
+            edge_object_id="e-bob",
+            assertion_source="llm_inferred",
+        ),
+    ]
+    superseded = tag_superseded_edges(edges, {"ceo_of"})
+    assert [e[1] for e in superseded] == ["bob"]
+    assert superseded[0][3]["superseded_by"] == "e-alice"
+
+
+def test_untagged_edge_ranks_as_document_extracted():
+    # An edge with no assertion_source outranks a newer llm_inferred one.
+    edges = [
+        _edge("c", "alice", "ceo_of", "2020-01-01 00:00:00", edge_object_id="e-alice"),
+        _edge(
+            "c",
+            "bob",
+            "ceo_of",
+            "2024-01-01 00:00:00",
+            edge_object_id="e-bob",
+            assertion_source="llm_inferred",
+        ),
+    ]
+    superseded = tag_superseded_edges(edges, {"ceo_of"})
+    assert [e[1] for e in superseded] == ["bob"]
+    assert superseded[0][3]["superseded_by"] == "e-alice"
+
+
+def test_untagged_edges_resolve_identically_to_recency_only_behavior():
+    # Regression guard: edges with no assertion_source field must resolve
+    # byte-identically to the pre-authority behaviour — same winner, same tags.
+    edges = [
+        _edge("c", "alice", "ceo_of", "2020-01-01 00:00:00", edge_object_id="e-alice"),
+        _edge("c", "bob", "ceo_of", "2024-01-01 00:00:00", edge_object_id="e-bob"),
+    ]
+    assert tag_superseded_edges(edges, {"ceo_of"}) == [
+        (
+            "c",
+            "alice",
+            "ceo_of",
+            {
+                "updated_at": "2020-01-01 00:00:00",
+                "edge_object_id": "e-alice",
+                "superseded": True,
+                "superseded_by": "e-bob",
+                "supersession_reason": "superseded by a more recent 'ceo_of' assertion",
+            },
+        )
+    ]
+
+
 def test_superseded_edges_keep_input_order():
     edges = [
         _edge("acme", "alice", "ceo_of", "2019-01-01 00:00:00", edge_object_id="a-alice"),

--- a/cognee/tests/unit/modules/pipelines/test_provenance_stamping.py
+++ b/cognee/tests/unit/modules/pipelines/test_provenance_stamping.py
@@ -163,3 +163,51 @@ def test_stamp_provenance_no_infinite_recursion():
     circular_list = [dp]
     _stamp_provenance(circular_list, "pipe", "task")
     assert dp.source_pipeline == "pipe"
+
+
+# ── Assertion-source stamping (real implementation) ──
+#
+# The tests above exercise an inline replica; the assertion_source rules are
+# new, so they are tested against the real _stamp_provenance and the real
+# COGNEE_PROVENANCE_MODE gate used by handle_task.
+
+from cognee.infrastructure.engine import DataPoint as RealDataPoint  # noqa: E402
+from cognee.modules.pipelines.operations.run_tasks_base import (  # noqa: E402
+    _stamp_provenance as real_stamp_provenance,
+)
+from cognee.modules.pipelines.provenance_config import ProvenanceConfig  # noqa: E402
+
+
+def test_assertion_source_defaults_to_document_extracted():
+    dp = RealDataPoint()
+    real_stamp_provenance(dp, "pipe", "task")
+    assert dp.assertion_source == "document_extracted"
+
+
+def test_assertion_source_user_stated_via_session_node_set():
+    """Data bridged from the session cache carries the user_sessions_from_cache tag."""
+    dp = RealDataPoint()
+    real_stamp_provenance(dp, "pipe", "task", node_set="user_sessions_from_cache")
+    assert dp.assertion_source == "user_stated"
+
+
+def test_assertion_source_user_stated_in_joined_node_set():
+    """classify_documents joins node sets with ', '; substring matching still applies."""
+    dp = RealDataPoint()
+    real_stamp_provenance(dp, "pipe", "task", node_set="docs, user_sessions_from_cache")
+    assert dp.assertion_source == "user_stated"
+
+
+def test_assertion_source_never_overwrites_preset_value():
+    dp = RealDataPoint(assertion_source="llm_inferred")
+    real_stamp_provenance(dp, "pipe", "task", node_set="user_sessions_from_cache")
+    assert dp.assertion_source == "llm_inferred"
+
+
+def test_assertion_source_stays_none_when_gate_disabled():
+    """handle_task skips stamping entirely when COGNEE_PROVENANCE_MODE=disabled."""
+    dp = RealDataPoint()
+    _provenance_config = ProvenanceConfig(provenance_mode="disabled")
+    if not _provenance_config.is_disabled():
+        real_stamp_provenance(dp, "pipe", "task")
+    assert dp.assertion_source is None

--- a/cognee/tests/unit/modules/retrieval/hybrid/test_entities_scope.py
+++ b/cognee/tests/unit/modules/retrieval/hybrid/test_entities_scope.py
@@ -65,6 +65,29 @@ async def test_unscoped_build_keeps_out_of_set_neighbors():
 
 
 @pytest.mark.asyncio
+async def test_superseded_edges_are_dropped_from_partition():
+    """Superseded edges never reach the context; untagged siblings and edges
+    with no 'superseded' key at all are kept exactly as before."""
+    superseded_text = "Alice works at Initech."
+    edges = EDGES + [
+        (ALICE, ACME, "worked_at", {"edge_text": superseded_text, "superseded": True}),
+    ]
+
+    entities, reachable = await build_entities(
+        _graph(NODES, edges),
+        [_hit(ALICE, "Alice")],
+        max_edges_per_entity=10,
+    )
+
+    texts = _bullet_texts(entities)
+    assert superseded_text not in texts
+    assert WORKS_AT_TEXT in texts
+    assert "Alice -- is_a -- Person" in texts
+    assert str(EdgeType.id_for(superseded_text)) not in reachable
+    assert str(EdgeType.id_for(WORKS_AT_TEXT)) in reachable
+
+
+@pytest.mark.asyncio
 async def test_and_scope_requires_neighbor_to_carry_every_requested_set():
     nodes = [
         (ALICE, {"name": "Alice", "belongs_to_set": ["A", "B"]}),

--- a/cognee/tests/unit/tasks/ingestion/test_save_data_item_to_storage.py
+++ b/cognee/tests/unit/tasks/ingestion/test_save_data_item_to_storage.py
@@ -77,6 +77,32 @@ async def test_windows_style_paths_do_not_crash_and_fall_back_to_text(monkeypatc
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("as_file_uri", [False, True], ids=["absolute_path", "file_uri"])
+async def test_copy_local_files_snapshots_bytes_into_storage(tmp_path, monkeypatch, as_file_uri):
+    # With COPY_LOCAL_FILES on, a local path is no longer passed through by
+    # reference: its bytes are routed through save_data_to_file_detailed (as a
+    # binary handle, keeping the source basename) and the copy's path is
+    # returned. The flag-off default is pinned by
+    # test_existing_absolute_file_returns_file_uri above.
+    file_path = tmp_path / "note.txt"
+    file_path.write_text("hello", encoding="utf-8")
+    save_mock = AsyncMock(return_value=StoredFile(file_path="managed-copy-path"))
+    monkeypatch.setattr(mod, "save_data_to_file_detailed", save_mock)
+    # ``settings`` is a module-level import-time singleton; env vars would not
+    # be re-read here, so patch the attribute directly.
+    monkeypatch.setattr(mod.settings, "copy_local_files", True)
+
+    data_item = file_path.as_uri() if as_file_uri else str(file_path)
+    result = await save_data_item_to_storage(data_item)
+
+    assert result == "managed-copy-path"
+    save_mock.assert_awaited_once()
+    (handle,), kwargs = save_mock.await_args
+    assert handle.mode == "rb"
+    assert kwargs == {"filename": "note.txt"}
+
+
+@pytest.mark.asyncio
 async def test_existing_absolute_file_rejected_when_gate_disabled(tmp_path, monkeypatch):
     # An existing absolute local file is still rejected when
     # ACCEPT_LOCAL_FILE_PATH is off — the fix must not weaken that gate.

--- a/cognee/tests/unit/tasks/memify/test_cross_connect_entities.py
+++ b/cognee/tests/unit/tasks/memify/test_cross_connect_entities.py
@@ -85,6 +85,7 @@ async def test_overlap_candidate_gets_inferred_edge():
     source, target, relationship, props = fake_graph.added_edges[0]
     assert (source, target, relationship) == ("e1", "e2", "runs_on")
     assert props["inferred"] is True
+    assert props["assertion_source"] == "llm_inferred"
     assert props["feedback_weight"] == INFERRED_EDGE_FEEDBACK_WEIGHT
     index_mock.assert_awaited_once()
 


### PR DESCRIPTION
## Description

An external audit (right-to-reply issue on the article *"your memory has no authority model"*, audited commit `fd5045f6`) validated four gaps in cognee's authority model. This PR is the code response for two of them — the third (`ONTOLOGY_MODE=strict`) was split out to #4848 and should merge first, with the review findings on it fixed there.

The standard pipelines behave identically unless opted in, with one deliberate exception called out in §2: `assertion_source` stamping is **default-on** (it rides the existing `COGNEE_PROVENANCE_MODE` gate, whose default is `lightweight`), so every node/edge gains the new property on defaults. It is write-only on defaults — ranking, dedup, and entity merging ignore it, and untagged edges resolve byte-identically — but it is a new stored property, not a no-op.

### 1. `COPY_LOCAL_FILES` — original-bytes snapshot (default `false`)
Local file paths have always been ingested **by reference**: cognee records the path and `content_hash`, which can verify the original but not recover it once the file moves or is deleted. With the flag on, local-path originals are snapshotted content-addressed into cognee-managed storage at add time via the existing `save_data_to_file_detailed` machinery, so `original_data_location` stays resolvable and hash-verifiable. `s3://` inputs remain pass-through by design.

### 2. Assertion authority + superseded-edge filtering
- `DataPoint.assertion_source` (`user_stated` / `document_extracted` / `llm_inferred`) is stamped whenever provenance is not disabled — i.e. **on by default** under `COGNEE_PROVENANCE_MODE=lightweight`: `user_stated` for session-bridged facts, `document_extracted` otherwise; `cross_connect_entities` and `detect_contradictions` write `llm_inferred`. Copied onto edge properties so the conflict resolver can see it.
- The `functional_relationships` temporal conflict resolver now ranks **authority first, then recency** — an older user-stated fact beats a newer LLM inference. Untagged/pre-existing edges rank as `document_extracted` and resolve **byte-identically to today** (locked by a regression test).
- Graph retrieval skips edges tagged `superseded=True` at both choke points (`CogneeGraph` projection and the hybrid entity lane). Safe by construction: the tag only ever exists for callers who opted into `functional_relationships`. `contradicts` edges stay visible; precomputed triplet embeddings and raw chunk text are unfiltered (documented).

## Known review follow-ups (to address before merge)
- **Stale `superseded` tag on re-assertion**: nothing clears the tag, and Neo4j's `SET rel += edge.properties` merges rather than replaces, so a re-asserted edge that later wins can keep `superseded=True` from an earlier round — with the retrieval filter on, both edges in a group can end up hidden. Fix: `tag_superseded_edges` should write the winner back with `superseded=False`.
- **`supersession_reason` wording**: hardcoded "superseded by a more recent ... assertion", but with authority-first ranking the winner is often the *older* edge — the audit string can contradict the timestamps on the same edges.

## Test plan
- [x] Unit tests across the touched areas (ingestion, resolver, provenance stamping, memify, CogneeGraph, hybrid entities) — all pass on this branch
- [x] 12 ingestion integration tests, including the new snapshot test: copy survives `os.remove(source)` with md5 == `content_hash`
- [x] Byte-identity regression tests at every hook site (untagged edges, flag-off ingestion)
- [x] `pre-commit run --all-files` clean

Linear: COG-6279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
