### PR TITLE
docs: State memory authority model honestly (COG-6279)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -543,6 +543,7 @@ Configuration:
 ONTOLOGY_RESOLVER=rdflib  # Default: uses rdflib and OWL files
 MATCHING_STRATEGY=fuzzy   # Default: fuzzy matching with 80% similarity
 ONTOLOGY_FILE_PATH=/path/to/your/ontology.owl  # Full path to ontology file
+ONTOLOGY_MODE=annotate    # Default: enrich only. strict drops entities with no ontology grounding
 ```
 
 Implementation: `cognee/modules/ontology/`
@@ -695,6 +696,14 @@ await cognee.recall("my question", datasets=["my_project"])
 
 ### DataPoints
 Atomic knowledge units that form the foundation of graph structures. All graph nodes extend the `DataPoint` base class with versioning and metadata support.
+
+### Temporal Model & Assertion Authority
+Cognee's fact store is **uni-temporal**: nodes carry `created_at`/`updated_at` (ms epoch, ingestion clock) and every edge carries one ingestion-time `updated_at`. No real-world validity interval is attached to facts, and there is no as-of / point-in-time query.
+
+- **Real-world time exists only on the opt-in temporal path**: `cognify(temporal_cognify=True)` (SDK-only; replaces the default task list) extracts event occurrence times into `Timestamp`/`Interval` nodes linked from `Event` nodes, queryable via `SearchType.TEMPORAL`. This is occurrence time on events, not validity on facts/edges.
+- **Supersession is opt-in**: `cognify(functional_relationships=[...])` tags older edges of a declared single-valued relationship with `superseded=True`. The winner is chosen by authority first (`assertion_source`), then ingestion-time recency. Graph retrievers skip superseded-tagged edges when building context; precomputed triplet embeddings and raw chunk text are not filtered. Contradiction detection (below) is also opt-in and only annotates.
+- **Assertion authority**: nodes carry derivational provenance (`source_pipeline`, `source_task`, `source_user`, `source_content_hash`) plus `assertion_source` (`user_stated` for session-bridged facts / `document_extracted` / `llm_inferred`), stamped under `COGNEE_PROVENANCE_MODE` (default `lightweight`). Only the supersession resolver consults it; retrieval ranking, dedup, and entity merging do not.
+- **Dormant fields**: `DataPoint.valid_to` (and the `close_node`/`is_valid` helpers) are application-level only — no default pipeline writes or reads them. Zep-imported `valid_at`/`invalid_at` edge properties are carried but not queried (see `cognee/modules/migration/cogx.py` for the roadmap note).
 
 ### Contradiction Detection
 Opt-in LLM check that runs as the last `cognify()` task (default **off**). After the graph is stored, it gathers the facts one hop from the entities this ingestion touched — new and pre-existing alike — asks an LLM which pairs cannot both be true, and records each confident conflict as a `contradicts` edge carrying both fact texts, the reason, and the confidence. It only adds edges (never rewrites or deletes) and swallows its own errors, so it can never break ingestion.

--- a/cognee/infrastructure/engine/models/DataPoint.py
+++ b/cognee/infrastructure/engine/models/DataPoint.py
@@ -63,8 +63,10 @@ class DataPoint(BaseModel):
     ontology_uri: str | None = None
     version: int = 1  # Default version
     topological_rank: int | None = 0
-    # Bi-temporal validity: ms epoch when this fact was superseded (via close_node);
-    # None = still current. Not the same as Event/Interval time_to (when an event occurred).
+    # Ms epoch when this fact was superseded (via the close_node helper); None =
+    # still current. No default pipeline writes this today — close_node has no
+    # in-pipeline caller, so valid_to stays None unless application code sets it.
+    # Not the same as Event/Interval time_to (when an event occurred in the world).
     valid_to: int | None = None
     metadata: MetaData = {"index_fields": []}
     type: str = Field(default_factory=lambda: DataPoint.__name__)

--- a/cognee/tasks/storage/close_node.py
+++ b/cognee/tasks/storage/close_node.py
@@ -5,6 +5,11 @@ When a fact changes (e.g. "Alice works at X" -> "Alice works at Y"), call
 deleting it — and then write the replacement. Consumers filter stale facts with
 ``is_valid(node)``, which stays true while ``valid_to`` is ``None`` (never closed) or
 still lies in the future.
+
+This is an application-level helper: no default cognee pipeline or retriever calls
+``close_node`` or ``is_valid`` today, so ``valid_to`` stays ``None`` on every node
+unless your own code stamps it. It also requires a graph backend with partial node
+updates (currently Ladybug only); others log a warning and return ``False``.
 """
 
 import logging


### PR DESCRIPTION
## Description

Stacked on #4628 — documentation follow-up to the audit-response features. Retarget to `dev` (or let GitHub retarget automatically) once #4628 merges.

An external audit validated that cognee's docs overclaimed in places and left the temporal/authority model undocumented. This PR makes the documentation state the boundaries precisely:

- **CLAUDE.md**: new *Temporal Model & Assertion Authority* subsection — uni-temporal default (ingestion clock), opt-in event time via `temporal_cognify`, authority-then-recency supersession with retrieval-side filtering of `superseded` edges, dormant `valid_to`/Zep `valid_at` fields — plus the `ONTOLOGY_MODE` line in the ontology config block.
- **`DataPoint.valid_to` comment**: states that no default pipeline writes it (`close_node` has no in-pipeline caller).
- **`close_node.py` docstring**: application-level helper only; requires a backend with partial node updates (currently Ladybug).

No behavior change; documentation and comments only.

## Test plan
- [x] `pre-commit run --all-files` clean
- [x] Comments/docs only — no production code touched

Linear: COG-6279

🤖 Generated with [Claude Code](https://claude.com/claude-code)