### PR TITLE
fix(llm): send the configured temperature on local inference servers

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -567,6 +567,9 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # -- LLM tuning ---------------------------------------------------------------
 # Sampling temperature, sent with every LLM call when set. Leave unset to use
 # the provider's default — note gpt-5 models reject any value other than 1.
+# Exception: on local inference servers (Ollama, llama.cpp, LM Studio) an unset
+# value sends 0.0, since those accept the field and extraction needs
+# deterministic output. Set a value explicitly to override.
 #LLM_TEMPERATURE=0.0
 # Sampling seed for reproducible outputs, sent when set (provider support varies).
 #LLM_SEED=42

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -235,14 +235,23 @@ class LLMConfig(BaseSettings):
         adapter merges into each completion call — without this fold the two
         fields are read by nothing and never reach the provider.
 
-        ``llm_temperature`` is folded only when set explicitly (env var or
-        kwarg): the default model family (gpt-5) rejects any temperature other
+        ``llm_temperature`` is folded when set explicitly (env var or kwarg),
+        or when the model runs on a local inference server. The gate exists
+        because the default model family (gpt-5) rejects any temperature other
         than the provider default, so an unset field must not silently send
-        ``0.0``. Keys given directly in ``LLM_ARGS`` win over the dedicated
-        fields.
+        ``0.0`` there. That restriction is specific to the hosted OpenAI
+        reasoning models: local servers (Ollama, llama.cpp, LM Studio) accept
+        the field, and leaving it unfolded means extraction silently runs at
+        whatever the model itself defaults to (1.0 for several Ollama models)
+        instead of the deterministic ``0.0`` that ``docs/ollama_models.md``
+        documents. Runs after ``infer_provider_from_model`` so the provider is
+        already resolved. Keys given directly in ``LLM_ARGS`` win over the
+        dedicated fields.
         """
         folded: dict[str, Any] = {}
-        if "llm_temperature" in self.model_fields_set:
+        if "llm_temperature" in self.model_fields_set or is_local_llm(
+            self.llm_provider, self.llm_model
+        ):
             folded["temperature"] = self.llm_temperature
         if self.llm_seed is not None:
             folded["seed"] = self.llm_seed

--- a/cognee/tests/unit/infrastructure/llm/test_llm_config.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_config.py
@@ -261,6 +261,72 @@ def test_seed_folds_into_llm_args_and_preserves_existing_keys(monkeypatch):
     assert config.llm_args == {"seed": 42, "max_tokens": 1024}
 
 
+def _build_local(monkeypatch, **kwargs):
+    """Build a config for a local inference server with sampling env cleared."""
+    _clear_sampling_env(monkeypatch)
+    defaults = {
+        "llm_api_key": "test-key",
+        "llm_endpoint": "http://localhost:11434/v1",
+        "_env_file": None,
+    }
+    defaults.update(kwargs)
+    return LLMConfig(**defaults)
+
+
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    [
+        ("ollama", "gemma4:e2b-it-qat"),
+        ("llama_cpp", "some-model"),
+        ("custom", "lm_studio/qwen2.5-7b"),
+    ],
+)
+def test_local_provider_folds_unset_temperature(monkeypatch, provider, model):
+    """
+    On a local inference server an unset llm_temperature must still reach the
+    provider. The gpt-5 restriction that gates the fold does not apply there,
+    and without this the model's own default applies (1.0 for several Ollama
+    models) even though docs/ollama_models.md documents 0.0 for extraction.
+    """
+    config = _build_local(monkeypatch, llm_provider=provider, llm_model=model)
+    assert config.llm_args == {"temperature": 0.0}
+
+
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    [
+        ("openai", "openai/gpt-5-mini"),
+        ("custom", "hosted_vllm/meta-llama/Llama-3-70B"),
+        ("custom", "vllm/some-model"),
+    ],
+)
+def test_non_local_provider_still_omits_unset_temperature(monkeypatch, provider, model):
+    """The gpt-5 guard is untouched for hosted providers, vLLM included."""
+    config = _build_local(monkeypatch, llm_provider=provider, llm_model=model)
+    assert config.llm_args is None
+
+
+def test_explicit_temperature_wins_on_local_provider(monkeypatch):
+    config = _build_local(
+        monkeypatch,
+        llm_provider="ollama",
+        llm_model="gemma4:e2b-it-qat",
+        llm_temperature=0.7,
+    )
+    assert config.llm_args == {"temperature": 0.7}
+
+
+def test_llm_args_temperature_wins_over_local_default(monkeypatch):
+    """LLM_ARGS keeps precedence over the folded local default."""
+    config = _build_local(
+        monkeypatch,
+        llm_provider="ollama",
+        llm_model="gemma4:e2b-it-qat",
+        llm_args={"temperature": 0.7, "max_tokens": 1024},
+    )
+    assert config.llm_args == {"temperature": 0.7, "max_tokens": 1024}
+
+
 def test_known_providers_match_enum():
     """
     KNOWN_LLM_PROVIDERS must stay aligned with the LLMProvider dispatch enum so

--- a/docs/ollama_models.md
+++ b/docs/ollama_models.md
@@ -34,6 +34,6 @@ Any model not listed above is treated as unvalidated/experimental. If you choose
 If you notice that `cognify()` is running but your final queries yield empty search results or no nodes are created, check the following:
 
 1. **Verify your Model**: Ensure you are using one of the recommended models (e.g., `llama3.1:8b`).
-2. **Set Temperature to 0**: Set `LLM_TEMPERATURE=0.0` in your `.env` to force deterministic output formatting. When unset, the model's own default applies.
+2. **Check Temperature**: Extraction runs at temperature `0.0` by default on Ollama, for deterministic output formatting. If you set `LLM_TEMPERATURE` to something higher, lower it back to `0.0` in your `.env`.
 3. **Verify API Connection**: Ensure Ollama is running and accessible (usually at `http://localhost:11434/v1`).
 4. **Inspect Logging**: Check the console log outputs. If Cognee catches validation errors during extraction, they will be reported as warnings.


### PR DESCRIPTION
## Description

Fixes #4631.

With a local provider and `LLM_TEMPERATURE` unset, cognee sends no `temperature` at all, so extraction runs at whatever the model itself defaults to. For several Ollama models that is `1.0`. `docs/ollama_models.md` already tells users extraction wants `0.0`, but nothing in the default path does it.

**Why the gate exists, and why it is too wide.** `fold_sampling_params_into_llm_args` only folds `llm_temperature` when it is in `model_fields_set`, and its docstring gives the reason: the default gpt-5 family rejects any temperature other than the provider default, so an unset field must not silently send `0.0`. That reason is real, but it is a property of the hosted OpenAI reasoning models, not of every provider. The gate applies to all of them, so Ollama, llama.cpp and LM Studio inherit a workaround for a restriction they do not have. `llm_temperature` already defaults to `0.0`, so the value was there the whole time; only the gate stopped it.

**The fix** is one condition, reusing the predicate this file already has:

```python
if "llm_temperature" in self.model_fields_set or is_local_llm(
    self.llm_provider, self.llm_model
):
    folded["temperature"] = self.llm_temperature
```

`is_local_llm` is not new here. The validator immediately below, `default_local_rate_limit_budget`, already uses it to give local servers a different default for the same class of reason: a default shaped for cloud endpoints being wrong for local ones. This follows that precedent rather than adding a new axis, and it runs after `infer_provider_from_model`, the same precondition that validator documents.

**Two things I deliberately did not do.**

I did not invert the gate to "everything except gpt-5", which is arguably the more principled shape since gpt-5 is the actual constraint named in the docstring. It would start sending `0.0` to every Anthropic, Gemini, Mistral and Bedrock user who never asked for it, which is a far larger behaviour change than this bug justifies.

I did not widen `is_local_llm`. It excludes vLLM because vLLM batches like a cloud endpoint, and that exclusion was written for rate limiting rather than for temperature, so a vLLM endpoint would in fact accept the field. I kept the existing predicate anyway: a vLLM user setting `LLM_TEMPERATURE` explicitly already works today, and splitting the two meanings apart is a bigger change than this bug needs. Happy to split it if you would rather.

**Docs.** The change makes two existing statements wrong, so both are updated here. `.env.template` said an unset value uses the provider's default, now qualified for local servers. `docs/ollama_models.md` troubleshooting item 2 told users to set `LLM_TEMPERATURE=0.0` themselves, which is now the default, so the item became a check rather than an instruction. This is option (a) from the issue; it is not an alternative to the code change, it is required by it.

## Acceptance Criteria

- A local provider with `LLM_TEMPERATURE` unset sends `temperature: 0.0`; hosted providers, vLLM included, are unchanged.
- Explicit configuration still wins: `LLM_TEMPERATURE` at any value is folded as before, and a `temperature` key in `LLM_ARGS` still takes precedence over the dedicated field.
- Added to `cognee/tests/unit/infrastructure/llm/test_llm_config.py`, beside the existing sampling-param tests:
  - `test_local_provider_folds_unset_temperature` (ollama, llama_cpp, lm_studio) — the bug
  - `test_non_local_provider_still_omits_unset_temperature` (gpt-5, two vLLM spellings) — pins the boundary
  - `test_explicit_temperature_wins_on_local_provider`
  - `test_llm_args_temperature_wins_over_local_default`
- Verified fail-first by reverting only `config.py` and keeping the tests: exactly the three `test_local_provider_folds_unset_temperature` cases fail. The other four pass either way, since they pin behaviour this change does not alter.
- The existing `test_unset_temperature_is_not_folded_into_llm_args` builds a default config, which is the gpt-5 path, and still passes untouched.
- `unit/infrastructure/llm/` + `unit/modules/retrieval/` run like for like against `dev`: the failure sets diff identical, with +8 passes for the tests added. The 10 failures in that set are pre-existing on `dev`.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

See the attached run.

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass — with the caveat noted above, that 10 tests in `unit/modules/retrieval/` already fail on `dev` in my environment and are unchanged by this PR
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
