### PR TITLE
fix(llm): recompute the local rate-limit default on a stage-routed config

### DIFF
--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -56,6 +56,22 @@ def is_local_llm(provider: str | None, model: str | None) -> bool:
     return (model or "").lower().startswith(LOCAL_LLM_MODEL_PREFIXES)
 
 
+def _apply_local_rate_limit_default(config: "LLMConfig") -> "LLMConfig":
+    """Apply the local-server RPM default to ``config`` unless it was set explicitly.
+
+    Lives outside the class so both the ``default_local_rate_limit_budget``
+    validator and ``stage_config`` can use it: a ``@model_validator`` is a
+    descriptor proxy on the class, not a plain callable.
+    """
+    if "llm_rate_limit_requests" in config.model_fields_set:
+        return config
+
+    if is_local_llm(config.llm_provider, config.llm_model):
+        config.llm_rate_limit_requests = LOCAL_DEFAULT_RATE_LIMIT_REQUESTS
+
+    return config
+
+
 class LLMConfig(BaseSettings):
     """
     Configuration settings for the LLM (Large Language Model) provider and related options.
@@ -263,13 +279,7 @@ class LLMConfig(BaseSettings):
         after ``infer_provider_from_model`` so the provider is already
         resolved.
         """
-        if "llm_rate_limit_requests" in self.model_fields_set:
-            return self
-
-        if is_local_llm(self.llm_provider, self.llm_model):
-            self.llm_rate_limit_requests = LOCAL_DEFAULT_RATE_LIMIT_REQUESTS
-
-        return self
+        return _apply_local_rate_limit_default(self)
 
     def model_post_init(self, __context) -> None:
         """Initialize the BAML registry after the model is created."""
@@ -398,6 +408,11 @@ class LLMConfig(BaseSettings):
         any set llm_<stage>_* fields. Unset stage fields fall back to the base
         values, so a config with no stage overrides returns an equivalent config
         (single-model behavior preserved).
+
+        ``model_copy`` does not re-run validators, so the provider-dependent
+        defaults on the copy would still be the ones derived for the *base*
+        provider. Routing a stage to a different provider is the whole point of
+        this method, so those defaults are recomputed below.
         """
         if stage not in _STAGE_NAMES:
             return self
@@ -408,7 +423,17 @@ class LLMConfig(BaseSettings):
                 update[f"llm_{field}"] = value
         if not update:
             return self
-        return self.model_copy(update=update)
+
+        stage_config = self.model_copy(update=update)
+
+        # Re-derive the RPM default from the stage's own provider.
+        # infer_provider_from_model is not re-run: llm_provider is always in
+        # model_fields_set by this point (set explicitly, or assigned by that
+        # validator on the base config), so it would return early every time.
+        # ensure_env_vars_for_ollama is not re-run either, because it validates
+        # the environment rather than deriving a default, and running it here
+        # would move where a misconfiguration is raised.
+        return _apply_local_rate_limit_default(stage_config)
 
 
 @lru_cache

--- a/cognee/tests/unit/infrastructure/llm/test_stage_routing.py
+++ b/cognee/tests/unit/infrastructure/llm/test_stage_routing.py
@@ -19,7 +19,11 @@ from cognee.context_global_variables import (
     llm_config as llm_config_ctx,
     current_pipeline_stage,
 )
-from cognee.infrastructure.llm.config import LLMConfig, get_llm_context_config
+from cognee.infrastructure.llm.config import (
+    LLMConfig,
+    LOCAL_DEFAULT_RATE_LIMIT_REQUESTS,
+    get_llm_context_config,
+)
 from cognee.infrastructure.llm.LLMGateway import _record_session_usage_after
 from cognee.infrastructure.llm.pipeline_stage import pipeline_stage
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.get_llm_client import (
@@ -122,3 +126,67 @@ def test_pipeline_stage_labels_the_current_stage():
     with pipeline_stage("extraction"):
         assert current_pipeline_stage.get() == "extraction"
     assert current_pipeline_stage.get() is None
+
+
+# ===========================================================================
+# Provider-dependent defaults on a stage-routed config
+# ===========================================================================
+
+
+def _clear_llm_env(monkeypatch):
+    for var in (
+        "LLM_PROVIDER",
+        "LLM_MODEL",
+        "LLM_RATE_LIMIT_REQUESTS",
+        "LLM_TEMPERATURE",
+        "LLM_ARGS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_stage_routed_to_a_local_provider_gets_the_local_rate_limit_budget(monkeypatch):
+    """
+    Routing extraction to Ollama while the base stays on a cloud provider is the
+    headline use case for stage routing. The stage config must therefore pick up
+    the local RPM budget: model_copy does not re-run validators, so without the
+    recompute the copy keeps the cloud default of 60 and the limiter would flood
+    a serial local server.
+    """
+    _clear_llm_env(monkeypatch)
+    config = _base_config(
+        llm_extraction_provider="ollama",
+        llm_extraction_model="phi4:latest",
+        llm_extraction_endpoint="http://localhost:11434/v1",
+    )
+
+    assert config.llm_rate_limit_requests == 60  # base is a cloud provider
+
+    stage = config.stage_config("extraction")
+    assert stage.llm_provider == "ollama"
+    assert stage.llm_rate_limit_requests == LOCAL_DEFAULT_RATE_LIMIT_REQUESTS
+
+
+def test_explicit_rate_limit_survives_stage_routing(monkeypatch):
+    """An explicitly configured budget still wins over the local default."""
+    _clear_llm_env(monkeypatch)
+    config = _base_config(
+        llm_rate_limit_requests=90,
+        llm_extraction_provider="ollama",
+        llm_extraction_model="phi4:latest",
+        llm_extraction_endpoint="http://localhost:11434/v1",
+    )
+
+    stage = config.stage_config("extraction")
+    assert stage.llm_rate_limit_requests == 90
+
+
+def test_stage_routing_to_a_cloud_provider_keeps_the_regular_budget(monkeypatch):
+    """The recompute must not hand the local budget to a non-local stage."""
+    _clear_llm_env(monkeypatch)
+    config = _base_config(
+        llm_extraction_provider="anthropic",
+        llm_extraction_model="claude-3-5-sonnet",
+    )
+
+    stage = config.stage_config("extraction")
+    assert stage.llm_rate_limit_requests == 60


### PR DESCRIPTION
## Description

`stage_config()` builds the per-stage config with `model_copy(update=...)`, which does not re-run validators. The copy therefore keeps the provider-dependent defaults that were derived for the **base** provider, even though pointing a stage at a different provider is the reason the method exists.

Self-found while reading `LLMConfig` for #4631, so there is no issue to link.

**The visible effect.** `.env.template` gives this as the worked example for stage routing, under the comment *"Route a cheap or local model to extraction"*:

```
LLM_EXTRACTION_MODEL="ollama_chat/llama3.1"
LLM_EXTRACTION_PROVIDER="ollama"
LLM_EXTRACTION_ENDPOINT="http://localhost:11434"
```

With a cloud provider as the base, that configuration comes back wrong:

```
base   provider: openai | rate_limit: 60
stage  provider: ollama | rate_limit: 60     <- keeps the cloud default
direct provider: ollama | rate_limit: 10     <- same config, built directly
```

`default_local_rate_limit_budget` exists precisely so local inference servers get a smaller RPM budget, because they process requests near-serially and the cloud default of 60 would flood them. A stage routed to Ollama is exactly the case it was written for, and it is the one case that never gets it.

**The fix** re-derives that default on the copy:

```python
stage_config = self.model_copy(update=update)
return _apply_local_rate_limit_default(stage_config)
```

The rate-limit logic moves from the body of `default_local_rate_limit_budget` into a module-level `_apply_local_rate_limit_default`, which the validator now calls too, so there is one implementation and no duplication. It has to live outside the class because a `@model_validator` is a `PydanticDescriptorProxy` on the class rather than a plain callable: calling it as `LLMConfig.default_local_rate_limit_budget(cfg)` works at runtime but `ty` rejects it, which is how I found this shape.

Two validators are deliberately **not** re-run, and the code says why. `infer_provider_from_model` would be dead code here: by the time `stage_config` runs, `llm_provider` is always in `model_fields_set`, either set explicitly or assigned by that validator on the base config, so it returns early every time. I checked that rather than including it for symmetry. `ensure_env_vars_for_ollama` validates the environment rather than deriving a default, so running it here would move where a misconfiguration is raised, which is a behaviour change unrelated to this bug.

`fold_sampling_params_into_llm_args` is left alone on purpose. On `dev` today re-running it on a stage copy is a no-op, and #4634 (open, same file) changes that function, so touching it here would only put the two PRs in conflict for no behavioural gain. If both land and you want the folded temperature to follow a stage's provider too, that is a one-line follow-up and I am happy to send it.

**Scope.** A stage that sets only a model, without `LLM_EXTRACTION_PROVIDER`, is unchanged. Because `llm_provider` is always already in `model_fields_set`, such a stage keeps the base provider and therefore the base's defaults. That is pre-existing behaviour and follows the documented "an explicit `llm_provider` always wins" rule; changing it would mean changing that rule, which is a separate call this bug does not require. The documented way to route a stage sets the provider explicitly, and that path is fixed here.

## Acceptance Criteria

- A stage routed to a local provider gets the local RPM budget instead of the cloud default, matching a directly-constructed config for the same provider.
- `ty check .` reports the same diagnostics as `dev`, and `ruff check` / `ruff format --check` are clean.
- An explicitly configured `LLM_RATE_LIMIT_REQUESTS` still wins, and a stage routed to another cloud provider keeps the regular budget.
- Added to `cognee/tests/unit/infrastructure/llm/test_stage_routing.py`:
  - `test_stage_routed_to_a_local_provider_gets_the_local_rate_limit_budget` — the bug
  - `test_explicit_rate_limit_survives_stage_routing`
  - `test_stage_routing_to_a_cloud_provider_keeps_the_regular_budget`
- Verified fail-first by reverting only `config.py` and keeping the tests: exactly the first of those fails. The other two pass either way, since they pin behaviour this change does not alter, as do the four pre-existing stage-routing tests.
- `unit/infrastructure/llm/` + `unit/modules/retrieval/` run like for like against `dev`: the failure sets diff identical, with +3 passes for the tests added. `modules/retrieval/completion.py` is one of the three `pipeline_stage()` call sites, and its 10 failures are pre-existing on `dev` and unchanged here.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

See the attached run.

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable) — the reasoning is in the method docstring and an inline comment
- [x] All new and existing tests pass — with the caveat noted above, that 10 tests in `unit/modules/retrieval/` already fail on `dev` in my environment and are unchanged by this PR
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
