### PR TITLE
COG-6289 chore: bump version to 1.5.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cognee"
 
-version = "1.5.2"
+version = "1.5.3"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 authors = [
     { name = "Vasilije Markovic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1214,7 +1214,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.5.2"
+version = "1.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Description

Bumps the package version 1.5.2 → 1.5.3 (pyproject + uv.lock, 2 lines) so the release workflow can run: v1.5.2 is already tagged/on PyPI, and `release.yml` derives the git tag from `uv version --short`, so yesterday's dispatch failed at **Create and push git tag** with the existing v1.5.2.

1.5.3 ships the cryptography cap relax from #4636 (COG-6289) — after release, downstream consumers with `cryptography>=50` security floors can move off cognee 1.4.0.

## Type of change

- Chore (release version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)