### PR TITLE
COG-6289 ci(release): open a sync PR for the MCP lock bump instead of pushing to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,7 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     permissions:
       contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.push.outputs.sha }}
@@ -205,9 +206,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.ref_name }}
-          # The push back to main below must authenticate with a token that is
-          # allowed to push to the protected branch; the default workflow token
-          # is not. GH_RELEASE_TOKEN already creates the GitHub release.
+          # Prefer GH_RELEASE_TOKEN (it already creates the GitHub release):
+          # PRs opened with the default workflow token do not trigger other
+          # workflows, so the sync PR's required checks would never run and
+          # auto-merge would never fire.
           token: ${{ secrets.GH_RELEASE_TOKEN || github.token }}
 
       - name: Install uv
@@ -249,10 +251,11 @@ jobs:
             exit 1
           fi
 
-      - name: Commit and push the lock bump
+      - name: Commit the lock bump and open a sync PR
         id: push
         env:
           VERSION: ${{ needs.release-github.outputs.version }}
+          GH_TOKEN: ${{ secrets.GH_RELEASE_TOKEN || github.token }}
         run: |
           git config user.name "Cognee Team"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -261,9 +264,23 @@ jobs:
           else
             git add cognee-mcp/uv.lock
             git commit -m "chore: Sync cognee-mcp lock to cognee ${VERSION} [release]"
-            # Rebase in case main moved while the release was running.
-            git pull --rebase origin main
-            git push origin HEAD:main
+            # main is protected (changes must go through a pull request), so a
+            # direct `git push origin HEAD:main` is rejected with GH006 — the
+            # v1.5.3 release stalled on exactly that. Push a release branch and
+            # open an auto-merging sync PR instead. --force keeps re-runs of
+            # this job idempotent.
+            BRANCH="release/mcp-lock-v${VERSION}"
+            git push --force origin "HEAD:${BRANCH}"
+            if [ -z "$(gh pr list --head "${BRANCH}" --base main --state open --json number --jq '.[].number')" ]; then
+              gh pr create --base main --head "${BRANCH}" \
+                --title "chore: sync cognee-mcp lock to cognee ${VERSION} [release]" \
+                --body "Automated by release.yml: pins cognee-mcp/uv.lock to the just-released cognee ${VERSION} so the MCP image matches its tag (issue #4360)."
+            fi
+            # Best effort: merges once required checks pass. If auto-merge is
+            # disabled on the repo, the PR stays open for a manual merge — the
+            # MCP image build below does not wait for the merge, it builds from
+            # this commit's SHA directly.
+            gh pr merge "${BRANCH}" --auto --squash || gh pr merge "${BRANCH}" --auto --merge || true
           fi
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/require-linear-issue.yml
+++ b/.github/workflows/require-linear-issue.yml
@@ -34,6 +34,11 @@ jobs:
           KEYS='COG|SDK|CLO|COM|ENG'
           if echo "$PR_TITLE $HEAD_REF" | grep -Eiq "\b(${KEYS})-[0-9]+\b"; then
             echo "Linear issue reference found."
+          # Automated release-pipeline PRs (release.yml's bump-mcp-lock sync PR)
+          # have no ticket; they are marked with a "[release]" title suffix and
+          # come from release/* branches.
+          elif echo "$PR_TITLE" | grep -q "\[release\]" && echo "$HEAD_REF" | grep -q "^release/"; then
+            echo "Automated release PR; Linear reference not required."
           else
             echo "::error::PR title or branch must reference a Linear issue, e.g. COG-123."
             exit 1


### PR DESCRIPTION
## Description

The v1.5.3 release stalled in `bump-mcp-lock`: its `git push origin HEAD:main` was rejected with GH006 because main's branch protection now requires changes via pull request (and the release token has no bypass). That also blocked `release-mcp-docker-image`.

This makes the pipeline compatible with the protection instead of fighting it:

- **`release.yml`** — the lock-bump commit is pushed to `release/mcp-lock-v<version>` (force-push keeps job re-runs idempotent) and an auto-merging sync PR is opened (`gh pr merge --auto`, squash with merge-commit fallback; harmless no-op if repo auto-merge is disabled). The MCP Docker build already checks out the bumped commit by SHA, so it does not wait for the merge — no tag/library skew (issue #4360) either way. Uses `GH_RELEASE_TOKEN` when present so the sync PR's required checks actually trigger (PRs created with the default workflow token don't start workflows).
- **`require-linear-issue.yml`** — exempts these automated PRs (`[release]` title suffix **and** `release/*` head branch); they have no Linear ticket.

Immediate unblock for 1.5.3 itself is #4638 (the lock sync that failed to push, landed via PR).

## Type of change

- CI fix (release pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)