### PR TITLE
feat: Add daily telemetry-insights GitHub Action (COG-6288)

### DIFF
--- a/.github/scripts/telemetry_aggregate_extract.py
+++ b/.github/scripts/telemetry_aggregate_extract.py
@@ -53,9 +53,16 @@ EVENT_ALLOWLIST = (
     "Pipeline Run Errored",
 )
 
-# The pseudonymous account identity (LLM-key hash, else install user_id).
+# The pseudonymous deployment identity, in decreasing stability order:
+# LLM-key hash (org-stable) -> persistent_id (machine-stable, survives user
+# recreation; emitted since ~Apr 2026) -> user_id (recreated per install/job).
+# This collapses products that mint a fresh user per agent job, so distinct
+# counts approximate deployments rather than throwaway identities.
 # Used strictly inside COUNT(DISTINCT ...) — never selected as a column.
-_IDENT = "coalesce(nullif(json_extract_string(properties, '$.api_key_hash'), ''), user_id)"
+_IDENT = (
+    "coalesce(nullif(json_extract_string(properties, '$.api_key_hash'), ''), "
+    "nullif(json_extract_string(properties, '$.persistent_id'), ''), user_id)"
+)
 # Surface the event came from: 'sdk' (default), 'cloud', 'cli', ... Safe enum.
 _ORIGIN = "coalesce(json_extract_string(properties, '$.telemetry_origin'), 'unknown')"
 # Normalized version: strip the -local suffix so builds compare cleanly.

--- a/.github/scripts/telemetry_aggregate_extract.py
+++ b/.github/scripts/telemetry_aggregate_extract.py
@@ -1,0 +1,206 @@
+"""Extract ANONYMIZED AGGREGATES from the MotherDuck telemetry warehouse.
+
+This script is the privacy boundary of the daily telemetry-insights Action:
+the analysis model (Claude Code) never receives warehouse credentials and
+never sees a raw event — only the CSV aggregates this script emits.
+
+Hard rules enforced here:
+- Only the queries below run; every SELECT lists explicit output columns.
+- Free-text / PII-bearing fields are NEVER selected: search_query,
+  system_prompt, dataset names, raw properties, tenant ids, endpoints'
+  query strings, error text.
+- Identity columns (user_id, api_key_hash, anonymous_id, persistent_id)
+  are used ONLY inside COUNT(DISTINCT ...); their values are never emitted.
+- A post-write guard fails the job if any output header matches the
+  denylist or any cell matches identifier patterns (email, UUID, ak_ hash).
+
+Output: telemetry_aggregates/*.csv covering the last WINDOW_DAYS days
+(default 70, so the analyzer can compute week-over-week and month-over-month
+comparisons inside the window).
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import re
+import sys
+from pathlib import Path
+
+import duckdb
+
+WINDOW_DAYS = int(os.getenv("TELEMETRY_WINDOW_DAYS", "70"))
+OUT_DIR = Path(os.getenv("TELEMETRY_OUT_DIR", "telemetry_aggregates"))
+
+# Events worth analyzing; everything else (internal task/coroutine spam) is skipped.
+EVENT_ALLOWLIST = (
+    "cognee.search EXECUTION STARTED",
+    "cognee.search EXECUTION COMPLETED",
+    "cognee.add EXECUTION STARTED",
+    "cognee.add EXECUTION COMPLETED",
+    "cognee.cognify EXECUTION STARTED",
+    "cognee.cognify EXECUTION COMPLETED",
+    "cognee.cognify EXECUTION ERRORED",
+    "cognee.remember",
+    "cognee.session.add_qa",
+    "Search API Endpoint Invoked",
+    "Add API Endpoint Invoked",
+    "Cognify API Endpoint Invoked",
+    "Remember API Endpoint Invoked",
+    "Remember Entry API Endpoint Invoked",
+    "Pipeline Run Started",
+    "Pipeline Run Completed",
+    "Pipeline Run Errored",
+)
+
+# The pseudonymous account identity (LLM-key hash, else install user_id).
+# Used strictly inside COUNT(DISTINCT ...) — never selected as a column.
+_IDENT = "coalesce(nullif(json_extract_string(properties, '$.api_key_hash'), ''), user_id)"
+# Surface the event came from: 'sdk' (default), 'cloud', 'cli', ... Safe enum.
+_ORIGIN = "coalesce(json_extract_string(properties, '$.telemetry_origin'), 'unknown')"
+# Normalized version: strip the -local suffix so builds compare cleanly.
+_VERSION = "coalesce(regexp_replace(cognee_version, '-local$', ''), 'unknown')"
+
+_EVENTS_SQL = "(" + ",".join(f"'{e}'" for e in EVENT_ALLOWLIST) + ")"
+_BASE_FILTER = (
+    f"ingestion_date >= current_date - INTERVAL {WINDOW_DAYS} DAY "
+    f"AND tracking_event IN {_EVENTS_SQL}"
+)
+
+QUERIES: dict[str, str] = {
+    # Daily volume + reach per event, per surface, per version.
+    "daily_event_volumes": f"""
+        SELECT ingestion_date AS day, tracking_event, {_VERSION} AS version,
+               {_ORIGIN} AS origin,
+               (cognee_version LIKE '%-local') AS self_hosted,
+               count(*) AS events,
+               count(DISTINCT {_IDENT}) AS distinct_identities
+        FROM analytics.main.pipeline_events
+        WHERE {_BASE_FILTER}
+        GROUP BY ALL ORDER BY day, tracking_event
+    """,
+    # Graph-build pipeline health by day and version.
+    "pipeline_outcomes_daily": f"""
+        SELECT ingestion_date AS day, {_VERSION} AS version,
+               count(*) FILTER (tracking_event = 'Pipeline Run Started')   AS started,
+               count(*) FILTER (tracking_event = 'Pipeline Run Completed') AS completed,
+               count(*) FILTER (tracking_event = 'Pipeline Run Errored')   AS errored,
+               count(DISTINCT {_IDENT}) FILTER (tracking_event = 'Pipeline Run Errored')
+                   AS identities_with_errors
+        FROM analytics.main.pipeline_events
+        WHERE {_BASE_FILTER} AND tracking_event LIKE 'Pipeline Run%'
+        GROUP BY ALL ORDER BY day, version
+    """,
+    # SDK-level operation health (search/add/cognify) by day and version.
+    "sdk_exec_outcomes_daily": f"""
+        SELECT ingestion_date AS day, {_VERSION} AS version,
+               regexp_extract(tracking_event, 'cognee\\.(\\w+) EXECUTION', 1) AS operation,
+               count(*) FILTER (tracking_event LIKE '%STARTED')   AS started,
+               count(*) FILTER (tracking_event LIKE '%COMPLETED') AS completed,
+               count(*) FILTER (tracking_event LIKE '%ERRORED')   AS errored
+        FROM analytics.main.pipeline_events
+        WHERE {_BASE_FILTER} AND tracking_event LIKE 'cognee.% EXECUTION%'
+        GROUP BY ALL ORDER BY day, operation, version
+    """,
+    # FastAPI surface: which routes are hit (endpoint is a route template
+    # constant like 'POST /v1/search' — no user data), by day.
+    "api_endpoint_daily": f"""
+        SELECT ingestion_date AS day, endpoint, {_VERSION} AS version,
+               count(*) AS events,
+               count(DISTINCT {_IDENT}) AS distinct_identities
+        FROM analytics.main.pipeline_events
+        WHERE {_BASE_FILTER} AND tracking_event LIKE '%API Endpoint Invoked'
+              AND endpoint IS NOT NULL
+        GROUP BY ALL ORDER BY day, events DESC
+    """,
+    # Provider stack correlation (from completed pipeline runs).
+    "provider_stack_daily": f"""
+        SELECT ingestion_date AS day,
+               json_extract_string(properties, '$.llm.provider')   AS llm_provider,
+               left(lower(json_extract_string(properties, '$.llm.model')), 60) AS llm_model,
+               json_extract_string(properties, '$.graph.provider') AS graph_provider,
+               json_extract_string(properties, '$.vector.provider') AS vector_provider,
+               json_extract_string(properties, '$.relational.provider') AS relational_provider,
+               {_VERSION} AS version,
+               count(*) AS completed_runs,
+               count(DISTINCT {_IDENT}) AS distinct_identities
+        FROM analytics.main.pipeline_events
+        WHERE {_BASE_FILTER} AND tracking_event = 'Pipeline Run Completed'
+        GROUP BY ALL ORDER BY day, completed_runs DESC
+    """,
+    # Search-type mix (SearchType enum values only).
+    "search_type_daily": f"""
+        SELECT ingestion_date AS day, search_type, {_VERSION} AS version,
+               count(*) AS events
+        FROM analytics.main.pipeline_events
+        WHERE {_BASE_FILTER} AND tracking_event = 'Search API Endpoint Invoked'
+              AND search_type IS NOT NULL
+        GROUP BY ALL ORDER BY day, events DESC
+    """,
+    # Version lifecycle within the window (adoption/abandonment).
+    "version_lifecycle": f"""
+        SELECT {_VERSION} AS version,
+               (cognee_version LIKE '%-local') AS self_hosted,
+               min(ingestion_date) AS first_seen,
+               max(ingestion_date) AS last_seen,
+               count(*) AS events,
+               count(DISTINCT {_IDENT}) AS distinct_identities
+        FROM analytics.main.pipeline_events
+        WHERE {_BASE_FILTER}
+        GROUP BY ALL ORDER BY events DESC
+    """,
+}
+
+# ---- Output guards -----------------------------------------------------------
+
+HEADER_DENYLIST = re.compile(
+    r"(search_query|system_prompt|properties|dataset|user_id|api_key|anonymous"
+    r"|persistent|tenant|email|error_text|query)",
+    re.IGNORECASE,
+)
+CELL_PATTERNS = (
+    re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"),  # email
+    re.compile(r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"),  # uuid
+    re.compile(r"\bak_[0-9a-f]{16,}\b"),  # key hash
+)
+
+
+def _guard(path: Path) -> None:
+    """Fail hard if an output file leaks a denylisted column or identifier-shaped cell."""
+    with path.open(newline="") as handle:
+        reader = csv.reader(handle)
+        header = next(reader, [])
+        for column in header:
+            if HEADER_DENYLIST.search(column):
+                sys.exit(f"PRIVACY GUARD: denylisted column '{column}' in {path.name}")
+        for row_number, row in enumerate(reader, start=2):
+            for cell in row:
+                for pattern in CELL_PATTERNS:
+                    if pattern.search(cell):
+                        sys.exit(
+                            f"PRIVACY GUARD: identifier-shaped value in {path.name}:"
+                            f"{row_number} — refusing to publish aggregates"
+                        )
+
+
+def main() -> None:
+    token = os.environ.get("MOTHERDUCK_TOKEN")
+    if not token:
+        sys.exit("MOTHERDUCK_TOKEN is not set")
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    connection = duckdb.connect(f"md:?motherduck_token={token}", read_only=True)
+
+    for name, sql in QUERIES.items():
+        out_path = OUT_DIR / f"{name}.csv"
+        connection.execute(f"COPY ({sql}) TO '{out_path}' (HEADER, DELIMITER ',')")
+        _guard(out_path)
+        print(f"wrote {out_path} ({out_path.stat().st_size} bytes)")
+
+    (OUT_DIR / "WINDOW.txt").write_text(
+        f"window_days={WINDOW_DAYS}\nnote=aggregates only; identities counted, never exported\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/telemetry_insights_prompt.md
+++ b/.github/scripts/telemetry_insights_prompt.md
@@ -1,0 +1,48 @@
+# Daily telemetry-insights analysis
+
+You are running inside a scheduled GitHub Action for the cognee repository. Your job: analyze **anonymized aggregate CSVs** of cognee's usage telemetry, detect meaningful pattern changes, diagnose likely product issues, propose fixes, and file exactly one deduplicated GitHub issue with new findings.
+
+## Inputs
+
+`telemetry_aggregates/*.csv` (already extracted for you; covers the last ~70 days so you can compute day-over-day, week-over-week, and month-over-month comparisons yourself):
+
+- `daily_event_volumes.csv` — day, tracking_event, version, origin (`sdk`/`cloud`/`cli`/unknown — the surface split), self_hosted, events, distinct_identities
+- `pipeline_outcomes_daily.csv` — day, version, started/completed/errored counts for graph-build pipeline runs (+ identities_with_errors)
+- `sdk_exec_outcomes_daily.csv` — day, version, operation (search/add/cognify), started/completed/errored
+- `api_endpoint_daily.csv` — day, endpoint route, version, events, distinct_identities (the FastAPI surface)
+- `provider_stack_daily.csv` — day, llm/graph/vector/relational provider (+ llm_model), version, completed_runs, identities
+- `search_type_daily.csv` — day, SearchType enum, version, events
+- `version_lifecycle.csv` — version, self_hosted, first_seen/last_seen, events, identities
+
+These are **fully anonymized aggregates**. There are no user identifiers, no query texts, no dataset names — and you must not attempt to obtain any. You have **no warehouse access and no credentials**; do not try to query MotherDuck or any external data source. Work only from the CSVs and the git history/PRs of this repository.
+
+## Analyses to run (compute, don't guess)
+
+1. **Trend breaks by surface.** For each surface (origin sdk/cloud/cli; plus the SDK-execution vs API-endpoint event families): DoD and WoW changes in events and distinct_identities. Flag |WoW| > 25% on any series averaging >1,000 events/day, and any new/disappeared event type.
+2. **Failure-rate regressions by version.** For pipeline runs and each SDK operation: errored/started and the **silent-gap ratio** (started − completed − errored)/started, per version per week. Flag any version whose failure or silent-gap ratio is ≥1.5× the fleet median with meaningful volume (>500 started/week). Pay special attention to versions whose first_seen is inside the window — a new release with elevated errors is a regression candidate.
+3. **Provider-stack correlations.** Are failures/volume shifts concentrated on a particular graph/vector/relational/LLM provider combination? (e.g. errors only on neo4j + specific version.)
+4. **Adoption anomalies.** Version lifecycle: releases with unusually slow adoption, abrupt abandonment of a version, or a pinned old version suddenly growing (embedded-product signal).
+5. **Search-mix shifts.** SearchType distribution changes (a type collapsing or exploding often indicates a routing or fork change).
+
+## Diagnosing and proposing fixes
+
+For each flagged pattern, form a hypothesis about the cause. Use the repository itself as evidence: `git log --oneline --since=<window>` around the version's release date, relevant source paths, and recently merged PRs. A proposed fix must name the suspected area (file/module) and the observable that would confirm it.
+
+## Duplicate detection (mandatory, before filing anything)
+
+1. `gh issue list --label telemetry-insights --state all --limit 100 --json number,title,state,closedAt,url`
+2. For each candidate finding, also search closed PRs: `gh pr list --state closed --search "<2-3 keywords>" --limit 20 --json number,title,mergedAt,url`
+3. Suppress a finding if: (a) an existing telemetry-insights issue already reports the same pattern (reference it instead), or (b) a merged PR plausibly fixed it **and** the pattern's last occurrence predates the merge (say so explicitly: "addressed by #NNNN, verifying trend post-merge"). If a pattern persists **after** a fix was merged, that is itself a finding ("fix did not take").
+
+## Output
+
+1. Write `telemetry-insights-report.md`: a dated report with (a) a 5-line executive summary, (b) each finding with the computed numbers, hypothesis, proposed fix, and duplicate-check result, (c) a "watching" section for near-threshold trends, (d) explicit data-window and privacy note.
+2. If there is **at least one new, non-duplicate finding**: create one issue —
+   `gh issue create --title "Telemetry insights: <date> — <top finding>" --label telemetry-insights --body-file telemetry-insights-report.md`
+   If everything is quiet or duplicate: do NOT create an issue; end the report with "No new findings."
+
+## Constraints
+
+- Never fabricate a number; every figure in the report must be computable from the CSVs.
+- Prefer few, well-evidenced findings (max 5 per run) over exhaustive noise.
+- No network access beyond `gh`. No attempts to read secrets, env vars, or non-aggregate data.

--- a/.github/scripts/telemetry_insights_prompt.md
+++ b/.github/scripts/telemetry_insights_prompt.md
@@ -14,7 +14,7 @@ You are running inside a scheduled GitHub Action for the cognee repository. Your
 - `search_type_daily.csv` — day, SearchType enum, version, events
 - `version_lifecycle.csv` — version, self_hosted, first_seen/last_seen, events, identities
 
-These are **fully anonymized aggregates**. There are no user identifiers, no query texts, no dataset names — and you must not attempt to obtain any. You have **no warehouse access and no credentials**; do not try to query MotherDuck or any external data source. Work only from the CSVs and the git history/PRs of this repository.
+These are **fully anonymized aggregates**. There are no user identifiers, no query texts, no dataset names — and you must not attempt to obtain any. `distinct_identities` counts deployments (LLM-key hash → machine-stable persistent_id → user_id fallback); note that persistent_id only exists on events from ~April 2026 builds onward, so identity counts on older-version rows skew high — treat cross-version identity comparisons accordingly. You have **no warehouse access and no credentials**; do not try to query MotherDuck or any external data source. Work only from the CSVs and the git history/PRs of this repository.
 
 ## Analyses to run (compute, don't guess)
 

--- a/.github/workflows/telemetry-insights.yml
+++ b/.github/workflows/telemetry-insights.yml
@@ -1,0 +1,88 @@
+# Daily telemetry-insights: extract anonymized aggregates from MotherDuck,
+# have Claude Code analyze pattern changes / version correlations, and file a
+# deduplicated GitHub issue with findings.
+#
+# Privacy design (do not weaken):
+#   - Step "extract" is the ONLY step with warehouse access (MOTHERDUCK_TOKEN).
+#     It runs a fixed, allowlisted aggregate script; a guard fails the job if
+#     any output contains identifier-shaped values or denylisted columns.
+#   - Step "analyze" (Claude) gets NO warehouse credentials and a restricted
+#     tool allowlist: it can only read the aggregate CSVs, the repo, and call
+#     `gh issue` / `gh pr` for duplicate detection.
+#
+# Required repository secrets: MOTHERDUCK_TOKEN (read-only token recommended),
+# ANTHROPIC_API_KEY.
+
+name: Telemetry Insights (daily)
+
+on:
+  schedule:
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+    inputs:
+      window_days:
+        description: "Days of telemetry to aggregate"
+        required: false
+        default: "70"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: telemetry-insights
+  cancel-in-progress: false
+
+jobs:
+  telemetry-insights:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 200 # git history is evidence for version-correlation analysis
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install duckdb client
+        run: pip install "duckdb>=1.1"
+
+      - name: Extract anonymized aggregates (only step with warehouse access)
+        env:
+          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          TELEMETRY_WINDOW_DAYS: ${{ github.event.inputs.window_days || '70' }}
+        run: python .github/scripts/telemetry_aggregate_extract.py
+
+      - name: Upload aggregates artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: telemetry-aggregates-${{ github.run_id }}
+          path: telemetry_aggregates/
+          retention-days: 14
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Analyze with Claude Code (no warehouse access)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          claude -p "$(cat .github/scripts/telemetry_insights_prompt.md)" \
+            --permission-mode acceptEdits \
+            --allowedTools "Read,Glob,Grep,Write,Bash(gh issue:*),Bash(gh pr:*),Bash(git log:*),Bash(git show:*)" \
+            --max-turns 80
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: telemetry-insights-report-${{ github.run_id }}
+          path: telemetry-insights-report.md
+          if-no-files-found: warn
+          retention-days: 90


### PR DESCRIPTION
## Description

A scheduled Action that turns warehouse telemetry into a daily diagnostic loop: extract **anonymized aggregates** from MotherDuck, have Claude Code analyze pattern changes, and file one deduplicated GitHub issue with findings. Motivation: reliability regressions currently sit invisible for months (e.g. the 57% first-run cognify failure rate found only in a manual deep-dive); a daily automated pass catches trend breaks the day they appear.

## Privacy architecture (the core design constraint)

- **Step-level credential isolation**: the extract step is the only step with `MOTHERDUCK_TOKEN`; the Claude step has no warehouse access and a restricted tool allowlist (`Read/Glob/Grep/Write` + `gh issue`/`gh pr`/`git log`) — no web, no arbitrary shell.
- **Aggregates only**: fixed, allowlisted SQL emits seven CSVs (daily counts/rates by event, version, provider stack, FastAPI route, telemetry origin). No query text, system prompts, dataset names, raw properties, tenant ids, or error text is ever selected. Identity fields (LLM-key hash / install id) are used strictly inside `COUNT(DISTINCT …)` — values never exported.
- **Post-write guard**: the job hard-fails if any output header matches the denylist or any cell matches identifier patterns (email, UUID, `ak_` key hash). All three guard paths are unit-exercised.

## What the analysis covers

Over a 70-day window (DoD/WoW/MoM computed by the analyzer):
- Trend breaks per **surface** — SDK execution events vs FastAPI routes vs `telemetry_origin` (sdk/cloud/cli)
- **Failure-rate and silent-gap regressions per cognee version** (started − completed − errored — the metric that would have surfaced the first-cognify failure problem months earlier)
- Provider-stack correlations (graph/vector/relational/LLM provider + model)
- Version adoption anomalies and SearchType mix shifts
- Proposed fixes anchored in `git log` around the suspect release

## Duplicate detection

Before filing, the analyzer reads existing `telemetry-insights` issues and recently **closed PRs**; it suppresses already-reported patterns, marks findings "addressed by #NNNN" when a merged fix predates the pattern's end, and flags "fix did not take" when a pattern persists after the merge. At most one labeled issue per run; none when quiet. The report is always uploaded as an artifact (90-day retention).

## Setup required (not in this PR)

- Repo secrets: `MOTHERDUCK_TOKEN` (**read-only, analytics-share-scoped token recommended**) and `ANTHROPIC_API_KEY`
- Create the `telemetry-insights` issue label

## Testing

- Extraction script compiles; privacy guard unit-exercised for all three failure modes (clean pass, identifier-shaped cell, denylisted header)
- The heaviest aggregate query dry-run against the live warehouse returns clean, identifier-free aggregates
- Workflow YAML parse-validated; ruff clean

## Known limitation

CLI-origin attribution relies on `telemetry_origin`, which only newer builds emit — older events appear as `sdk`/`unknown`, so the CLI series is a floor until the fleet upgrades (noted in the analysis prompt so the model doesn't misread it as a trend).

Fixes COG-6288

🤖 Generated with [Claude Code](https://claude.com/claude-code)