### PR TITLE
fix: require query on recall and search

### DIFF
--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -46,7 +46,11 @@ class RecallPayloadDTO(InDTO):
             "when both are provided. Leave empty to resolve by name."
         ),
     )
-    query: str = Field(default="What is in the document?")
+    query: str = Field(
+        ...,
+        examples=["What is in the document?"],
+        description="The question to answer. Required; there is no default query.",
+    )
     system_prompt: Optional[str] = Field(
         default="Answer the question using the provided context. Be as brief as possible."
     )

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -46,7 +46,11 @@ class SearchPayloadDTO(InDTO):
             " When provided, the datasets name list is ignored."
         ),
     )
-    query: str = Field(default="What is in the document?")
+    query: str = Field(
+        ...,
+        examples=["What is in the document?"],
+        description="The question to answer. Required; there is no default query.",
+    )
     system_prompt: Optional[str] = Field(
         default="Answer the question using the provided context. Be as brief as possible."
     )

--- a/cognee/tests/unit/api/test_query_required_on_recall_and_search.py
+++ b/cognee/tests/unit/api/test_query_required_on_recall_and_search.py
@@ -1,0 +1,81 @@
+"""Guards that `query` is required on POST /api/v1/recall and /api/v1/search.
+
+Both DTOs once carried `query: str = Field(default="What is in the document?")`,
+an OpenAPI example wired as a functional default. A body omitting `query`
+validated, and the placeholder sentence was answered as though the caller had
+asked it, across every dataset the caller could read. A regression that
+reintroduces a default for `query` fails here.
+"""
+
+import importlib
+from types import SimpleNamespace
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# The routers package __init__ re-exports the same-named factory function, so
+# the module must be imported by its dotted path.
+recall_router_module = importlib.import_module("cognee.api.v1.recall.routers.get_recall_router")
+search_router_module = importlib.import_module("cognee.api.v1.search.routers.get_search_router")
+
+
+def _client(router_module, factory_name, prefix):
+    app = FastAPI()
+    app.include_router(getattr(router_module, factory_name)(), prefix=prefix)
+    app.dependency_overrides[router_module.get_authenticated_user] = lambda: SimpleNamespace(
+        id=uuid4(), tenant_id=None
+    )
+    return TestClient(app)
+
+
+def _spy(monkeypatch, package_path, attribute):
+    """Replace the retrieval callable with a spy recording whether it ran."""
+    calls = []
+
+    async def fake(*args, **kwargs):
+        calls.append(kwargs)
+        return []
+
+    monkeypatch.setattr(importlib.import_module(package_path), attribute, fake)
+    return calls
+
+
+def test_recall_rejects_body_without_query(monkeypatch):
+    calls = _spy(monkeypatch, "cognee.api.v1.recall", "recall")
+    client = _client(recall_router_module, "get_recall_router", "/api/v1/recall")
+
+    response = client.post("/api/v1/recall", json={})
+
+    assert response.status_code == 422, response.text
+    assert calls == [], "retrieval ran for a request that omitted query"
+
+
+def test_search_rejects_body_without_query(monkeypatch):
+    calls = _spy(monkeypatch, "cognee.api.v1.search", "search")
+    client = _client(search_router_module, "get_search_router", "/api/v1/search")
+
+    response = client.post("/api/v1/search", json={})
+
+    assert response.status_code == 422, response.text
+    assert calls == [], "retrieval ran for a request that omitted query"
+
+
+def test_recall_still_accepts_an_explicit_query(monkeypatch):
+    calls = _spy(monkeypatch, "cognee.api.v1.recall", "recall")
+    client = _client(recall_router_module, "get_recall_router", "/api/v1/recall")
+
+    response = client.post("/api/v1/recall", json={"query": "who wrote it?"})
+
+    assert response.status_code == 200, response.text
+    assert calls and calls[0]["query_text"] == "who wrote it?"
+
+
+def test_search_still_accepts_an_explicit_query(monkeypatch):
+    calls = _spy(monkeypatch, "cognee.api.v1.search", "search")
+    client = _client(search_router_module, "get_search_router", "/api/v1/search")
+
+    response = client.post("/api/v1/search", json={"query": "who wrote it?"})
+
+    assert response.status_code == 200, response.text
+    assert calls and calls[0]["query_text"] == "who wrote it?"


### PR DESCRIPTION

<img width="2272" height="765" alt="Screenshot 2026-08-24 014647" src="https://github.com/user-attachments/assets/871d1b5b-e11f-4e0f-810f-b6f86c6eb45a" />
<img width="2294" height="344" alt="Screenshot 2026-08-24 014401" src="https://github.com/user-attachments/assets/d8b191a3-421f-46d3-8cb2-ba6580715a6e" />
<!-- .github/pull_request_template.md -->

## Description

`query` was semantically required on `/v1/recall` and `/v1/search` but shipped with an OpenAPI example wired as a functional default, `Field(default="What is in the document?")`. A body omitting `query` therefore validated and was answered as though the caller had asked that placeholder question, across every dataset they could read. 

This makes the field required and moves the placeholder to `examples=`:

```python
query: str = Field(
    ...,
    examples=["What is in the document?"],
    description="The question to answer. Required; there is no default query.",
)
```

Swagger "try it out" is unaffected: `examples=[...]` still prefills the generated request body, which is precisely why #3031 chose `examples=` as its mechanism. The same edit lands in both routers.

Fixes #4641


## Testing
New file `cognee/tests/unit/api/test_query_required_on_recall_and_search.py`, four tests, two per router: a body without `query` is rejected and retrieval never runs; a body with a real `query` still reaches retrieval. Written before the fix and confirmed failing against unpatched code with `assert 200 == 422`.

```
test_query_required_on_recall_and_search.py      4 passed
cognee/tests/unit/api                          475 passed
pre-commit run --all-files                all hooks passed
```

The single teardown error in `cognee/tests/unit/api/v2/test_query_router.py` is pre-existing and unrelated; it reproduces on an unmodified tree at 471 passed and 1 error.

Against a running server:

| Request | Before | After |
|---|---|---|
| `POST /api/v1/recall {}` | 200, placeholder answered | 400 `Field required` |
| `POST /api/v1/search {}` | 200, placeholder answered | 400 `Field required` |
| `POST /api/v1/recall` with a real query | 200 | 200, unchanged |

## Not included
`{"query": ""}` can still return 200 when the session already holds prior turns. That is a separate defect: the empty string is correctly rejected by `validate_retriever_input`, but the resulting `QueryValidationError` is discarded at `session_aware_completion.py:221` whenever the conversational lane succeeds. It needs its own change.



## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
