### PR TITLE
COG-6291 fix: authenticate and guard the run-subscription WebSocket

### DIFF
--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -15,6 +15,9 @@ from fastapi.openapi.utils import get_openapi
 
 from cognee.exceptions import CogneeApiError
 from cognee.shared.logging_utils import get_logger, setup_logging
+from cognee.modules.users.authentication.redact_websocket_query_secrets import (
+    install_websocket_query_param_redaction,
+)
 from cognee.api.v1.cloud.routers import get_checks_router
 from cognee.api.v1.permissions.routers import get_permissions_router
 from cognee.api.v1.settings.routers import get_settings_router
@@ -59,6 +62,12 @@ from cognee.modules.users.methods.get_authenticated_user import REQUIRE_AUTHENTI
 # Ensure application logging is configured for container stdout/stderr
 setup_logging()
 logger = get_logger()
+
+# Keeps the WebSocket ?token= auth fallback out of uvicorn's own access/error
+# logs, regardless of how uvicorn was launched (this module is imported
+# either way). See redact_websocket_query_secrets.py for why this can't be
+# left to proxy-side redaction alone.
+install_websocket_query_param_redaction()
 
 app_environment = os.getenv("ENV", "prod")
 

--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -1,21 +1,22 @@
-import os
 import asyncio
 from uuid import UUID
 from pydantic import Field
 from typing import Dict, List, Optional
 from fastapi.responses import JSONResponse
 from fastapi import APIRouter, WebSocket, Depends, WebSocketDisconnect, status
-from starlette.status import WS_1000_NORMAL_CLOSURE, WS_1008_POLICY_VIOLATION
+from starlette.status import (
+    WS_1000_NORMAL_CLOSURE,
+    WS_1008_POLICY_VIOLATION,
+    WS_1011_INTERNAL_ERROR,
+)
 
 from cognee.api.DTO import InDTO
 from cognee.modules.pipelines.methods import get_pipeline_run
 from cognee.modules.users.models import User
-from cognee.modules.users.methods import get_authenticated_user
-from cognee.modules.users.get_user_db import get_user_db_context
+from cognee.modules.users.methods import get_authenticated_user, get_authenticated_websocket_user
+from cognee.modules.data.exceptions.exceptions import DatasetNotFoundError
+from cognee.modules.data.methods import get_authorized_dataset
 from cognee.modules.graph.methods import get_formatted_graph_data
-from cognee.modules.users.get_user_manager import get_user_manager_context
-from cognee.infrastructure.databases.relational import get_relational_engine
-from cognee.modules.users.authentication.default.default_jwt_strategy import DefaultJWTStrategy
 from cognee.shared.data_models import KnowledgeGraph
 from cognee.shared.graph_model_utils import graph_schema_to_graph_model
 from cognee.modules.pipelines.models.PipelineRunInfo import (
@@ -298,40 +299,62 @@ def get_cognify_router() -> APIRouter:
             )
 
     @router.websocket("/subscribe/{pipeline_run_id}")
-    async def subscribe_to_cognify_info(websocket: WebSocket, pipeline_run_id: str):
+    async def subscribe_to_cognify_info(
+        websocket: WebSocket,
+        pipeline_run_id: str,
+        user: Optional[User] = Depends(get_authenticated_websocket_user),
+    ):
+        """
+        Stream one cognify run's progress, then its finished graph.
+
+        ## Path Parameters
+        - **pipeline_run_id** (UUID): the run to follow, as returned by
+          `POST /cognify`. Must belong to a dataset you can read.
+
+        ## Close Codes
+        - **1000**: the run completed and its final payload was sent
+        - **1008**: not authenticated, not a valid run id, no such run, or no
+          read permission on the run's dataset. A retry replays the same
+          rejection, so clients should stop.
+
+        ## Notes
+        - The run's update queue is consumed, not observed: one subscriber per
+          run. Authorization is therefore checked before the queue is touched
+          at all, so a rejected caller cannot disturb the real subscriber.
+        """
         await websocket.accept()
 
-        access_token = websocket.cookies.get(os.getenv("AUTH_TOKEN_COOKIE_NAME", "auth_token"))
-
-        try:
-            secret = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
-
-            strategy = DefaultJWTStrategy(secret, lifetime_seconds=3600)
-
-            db_engine = get_relational_engine()
-
-            async with db_engine.get_async_session() as session:
-                async with get_user_db_context(session) as user_db:
-                    async with get_user_manager_context(user_db) as user_manager:
-                        user = await get_authenticated_user(
-                            cookie=access_token,
-                            strategy_cookie=strategy,
-                            user_manager=user_manager,
-                            bearer=None,
-                        )
-        except Exception as error:
-            logger.error(f"Authentication failed: {str(error)}")
+        if user is None:
             await websocket.close(code=WS_1008_POLICY_VIOLATION, reason="Unauthorized")
             return
 
-        pipeline_run_id = UUID(pipeline_run_id)
+        try:
+            run_id = UUID(pipeline_run_id)
+        except ValueError:
+            await websocket.close(code=WS_1008_POLICY_VIOLATION, reason="Invalid pipeline run id")
+            return
 
-        pipeline_run = await get_pipeline_run(pipeline_run_id)
+        pipeline_run = await get_pipeline_run(run_id)
 
-        initialize_queue(pipeline_run_id)
+        if pipeline_run is None:
+            await websocket.close(code=WS_1008_POLICY_VIOLATION, reason="Pipeline run not found")
+            return
+
+        # Before any queue call, deliberately. Subscribing consumes the run's
+        # queue and `initialize_queue` replaces it outright, so an unauthorized
+        # caller reaching either one could drain or reset another tenant's run
+        # and silently starve its rightful subscriber.
+        if not await get_authorized_dataset(user, pipeline_run.dataset_id):
+            await websocket.close(
+                code=WS_1008_POLICY_VIOLATION,
+                reason="Not authorized to read this pipeline run",
+            )
+            return
+
+        initialize_queue(run_id)
 
         while True:
-            pipeline_run_info = get_from_queue(pipeline_run_id)
+            pipeline_run_info = get_from_queue(run_id)
 
             if not pipeline_run_info:
                 await asyncio.sleep(2)
@@ -350,11 +373,28 @@ def get_cognify_router() -> APIRouter:
                 )
 
                 if isinstance(pipeline_run_info, PipelineRunCompleted):
-                    remove_queue(pipeline_run_id)
+                    remove_queue(run_id)
                     await websocket.close(code=WS_1000_NORMAL_CLOSURE)
                     break
             except WebSocketDisconnect:
-                remove_queue(pipeline_run_id)
+                remove_queue(run_id)
+                break
+            except DatasetNotFoundError:
+                # get_formatted_graph_data re-authorizes on every frame, so
+                # this is the dataset being deleted, or read access being
+                # revoked, mid-run. The update just popped is already lost;
+                # closing beats raising into the ASGI server.
+                logger.info("Dataset for pipeline run %s is no longer readable", run_id)
+                remove_queue(run_id)
+                await websocket.close(
+                    code=WS_1008_POLICY_VIOLATION,
+                    reason="Not authorized to read this pipeline run",
+                )
+                break
+            except Exception:
+                logger.exception("Pipeline run subscription failed for run %s", run_id)
+                remove_queue(run_id)
+                await websocket.close(code=WS_1011_INTERNAL_ERROR)
                 break
 
     return router

--- a/cognee/modules/users/authentication/api_bearer/api_bearer_transport.py
+++ b/cognee/modules/users/authentication/api_bearer/api_bearer_transport.py
@@ -1,7 +1,41 @@
+from typing import Optional
+
+from fastapi.security import OAuth2PasswordBearer
+from starlette.requests import HTTPConnection
 from fastapi_users.authentication import BearerTransport
 
-api_bearer_transport = BearerTransport(
-    tokenUrl="/api/v1/auth/token",
+from cognee.modules.users.authentication.websocket_query_param import (
+    resolve_websocket_query_param_fallback,
 )
+
+_TOKEN_URL = "/api/v1/auth/token"
+
+
+class _OAuth2PasswordBearerOrWebSocketQueryParam(OAuth2PasswordBearer):
+    """``OAuth2PasswordBearer`` that also accepts the token via ``?token=`` on
+    a WebSocket handshake.
+
+    See ``resolve_websocket_query_param_fallback`` for why the fallback is
+    scoped to WebSocket connections only.
+    """
+
+    def __init__(self, token_url: str):
+        super().__init__(tokenUrl=token_url, auto_error=False)
+
+    # HTTPConnection, not Request: FastAPI injects a parameter only when its
+    # annotation is one of the connection types it recognises, and this scheme
+    # has to serve both HTTP routes and WebSocket handshakes. Left unannotated,
+    # FastAPI read it as an ordinary query parameter named `request` and every
+    # unauthenticated HTTP call answered 422 (missing query param) instead of
+    # 401. Guarded by tests/unit/modules/users/test_transport_scheme_signature.py.
+    async def __call__(self, request: HTTPConnection) -> Optional[str]:
+        token = await super().__call__(request)
+        return await resolve_websocket_query_param_fallback(request, token)
+
+
+api_bearer_transport = BearerTransport(
+    tokenUrl=_TOKEN_URL,
+)
+api_bearer_transport.scheme = _OAuth2PasswordBearerOrWebSocketQueryParam(_TOKEN_URL)
 
 api_bearer_transport.name = "bearer"

--- a/cognee/modules/users/authentication/api_key/get_api_key_transport.py
+++ b/cognee/modules/users/authentication/api_key/get_api_key_transport.py
@@ -1,9 +1,31 @@
 from typing import Optional, Dict
 from fastapi import Response
 from fastapi.security import APIKeyHeader
+from starlette.requests import HTTPConnection
 from fastapi_users.authentication import Transport
 
 from fastapi import Request
+
+from cognee.modules.users.authentication.websocket_query_param import (
+    resolve_websocket_query_param_fallback,
+)
+
+
+class _APIKeyHeaderOrWebSocketQueryParam(APIKeyHeader):
+    """``APIKeyHeader`` that also accepts the key via ``?token=`` on a WebSocket handshake.
+
+    See ``resolve_websocket_query_param_fallback`` for why the fallback is
+    scoped to WebSocket connections only.
+    """
+
+    def __init__(self, header_name: str):
+        super().__init__(name=header_name, auto_error=False)
+
+    # See the note in api_bearer_transport.py: an unannotated parameter here
+    # turns every unauthenticated HTTP call into a 422 instead of a 401.
+    async def __call__(self, request: HTTPConnection) -> Optional[str]:
+        api_key = await super().__call__(request)
+        return await resolve_websocket_query_param_fallback(request, api_key)
 
 
 class APIKeyHeaderTransport(Transport):
@@ -13,7 +35,7 @@ class APIKeyHeaderTransport(Transport):
     @property
     def scheme(self) -> APIKeyHeader:
         # Used in OpenAPI; not security type
-        return APIKeyHeader(name=self.header_name, auto_error=False)
+        return _APIKeyHeaderOrWebSocketQueryParam(self.header_name)
 
     async def get_authentication_token(self, request: Request) -> Optional[str]:
         return request.headers.get(self.header_name)

--- a/cognee/modules/users/authentication/redact_websocket_query_secrets.py
+++ b/cognee/modules/users/authentication/redact_websocket_query_secrets.py
@@ -1,0 +1,62 @@
+"""Keep the WebSocket query-param auth fallback's credential out of uvicorn's
+own logs.
+
+``resolve_websocket_query_param_fallback`` accepts a bearer/API-key token via
+``?token=`` because browsers cannot set custom headers on a WebSocket
+handshake. That credential is not only exposed to whatever a deployment's
+reverse proxy logs (operators are told to redact it there) — uvicorn itself
+logs the full handshake path, query string included, on every accept/close at
+INFO level via the ``uvicorn.error`` logger (see
+``uvicorn.protocols.websockets.websockets_sansio_impl.WebSocketsSansIOProtocol
+.asgi_send``), regardless of any proxy in front of it. That sink is entirely
+within this codebase's control, unlike a proxy's own configuration, so it is
+redacted here rather than merely documented.
+"""
+
+import logging
+import re
+
+from .websocket_query_param import WEBSOCKET_QUERY_PARAM_NAME
+
+_QUERY_PARAM_RE = re.compile(
+    rf"([?&]){re.escape(WEBSOCKET_QUERY_PARAM_NAME)}=[^&\s\"']+", re.IGNORECASE
+)
+
+
+class _RedactWebsocketTokenFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str):
+            record.msg = _QUERY_PARAM_RE.sub(
+                rf"\1{WEBSOCKET_QUERY_PARAM_NAME}=***REDACTED***", record.msg
+            )
+        if record.args and not isinstance(record.args, dict):
+            # `%(name)s`-style logging passes a dict here instead of a
+            # positional tuple; rebuilding it as a tuple of its keys would
+            # corrupt %-formatting downstream. Nothing in uvicorn's own
+            # access/error loggers does that today, but leave dict args
+            # untouched rather than assuming the format never changes.
+            record.args = tuple(
+                _QUERY_PARAM_RE.sub(rf"\1{WEBSOCKET_QUERY_PARAM_NAME}=***REDACTED***", arg)
+                if isinstance(arg, str)
+                else arg
+                for arg in record.args
+            )
+        return True
+
+
+_installed = False
+
+
+def install_websocket_query_param_redaction() -> None:
+    """Idempotent: safe to call every time the ASGI app module is imported."""
+    global _installed
+    if _installed:
+        return
+    _installed = True
+
+    redaction_filter = _RedactWebsocketTokenFilter()
+    # uvicorn.error carries the WebSocket accept/close/status lines (with the
+    # full path+query string); uvicorn.access carries the plain HTTP request
+    # log line uvicorn emits for the handshake's initial GET/Upgrade request.
+    logging.getLogger("uvicorn.error").addFilter(redaction_filter)
+    logging.getLogger("uvicorn.access").addFilter(redaction_filter)

--- a/cognee/modules/users/authentication/websocket_query_param.py
+++ b/cognee/modules/users/authentication/websocket_query_param.py
@@ -1,0 +1,40 @@
+from typing import Optional
+
+from starlette.requests import HTTPConnection
+from starlette.websockets import WebSocket
+
+# Shared across every transport's query-param fallback so a WS client only
+# has to know one name regardless of which backend ends up matching it.
+WEBSOCKET_QUERY_PARAM_NAME = "token"
+
+
+async def resolve_websocket_query_param_fallback(
+    request: HTTPConnection, primary_token: Optional[str]
+) -> Optional[str]:
+    """Fall back to a ``?token=`` query parameter when a header-based scheme found nothing.
+
+    Browsers cannot set custom headers when opening a WebSocket, so a header
+    the scheme normally requires is simply unavailable to a browser WS
+    client — the query param is its only way to send the credential. Plain
+    HTTP requests still require the header: the query param is consulted
+    only when the connection is a WebSocket.
+
+    This does NOT keep the credential out of HTTP-layer logs: a WebSocket
+    handshake is itself an HTTP GET/Upgrade request, and its full URL
+    (including the query string) is captured by the default access-log
+    format of common reverse proxies and load balancers (e.g. nginx,
+    AWS ALB), unlike an Authorization header, which those defaults do not
+    log. Deployments that terminate WebSocket traffic through such a proxy
+    should redact the ``token`` query parameter from its access logs.
+
+    Uvicorn's own logs are covered regardless: importing
+    ``cognee.api.client`` installs a filter (see
+    ``redact_websocket_query_secrets.py``) that redacts this query param from
+    uvicorn's access/error loggers, since uvicorn logs the full handshake
+    path — proxy or not — on every WebSocket accept/close.
+    """
+    if primary_token:
+        return primary_token
+    if isinstance(request, WebSocket):
+        return request.query_params.get(WEBSOCKET_QUERY_PARAM_NAME)
+    return None

--- a/cognee/modules/users/methods/__init__.py
+++ b/cognee/modules/users/methods/__init__.py
@@ -9,6 +9,7 @@ from .get_authenticated_user import (
     get_authenticated_user,
     REQUIRE_AUTHENTICATION,
 )
+from .get_authenticated_websocket_user import get_authenticated_websocket_user
 from .get_principal_configuration import get_principal_configuration
 from .get_principal_configuration import get_principal_all_configuration
 from .store_principal_configuration import store_principal_configuration

--- a/cognee/modules/users/methods/get_authenticated_websocket_user.py
+++ b/cognee/modules/users/methods/get_authenticated_websocket_user.py
@@ -1,0 +1,148 @@
+from typing import Optional
+
+import jwt
+from fastapi import HTTPException, WebSocket
+from fastapi_users import exceptions as fastapi_users_exceptions
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.shared.logging_utils import get_logger
+
+from ..get_fastapi_users import get_fastapi_users
+from ..get_user_db import get_user_db_context
+from ..get_user_manager import get_user_manager_context
+from ..models import User
+from .get_authenticated_user import REQUIRE_AUTHENTICATION
+from .get_default_user import get_default_user
+from .get_user import get_user
+
+logger = get_logger("get_authenticated_websocket_user")
+
+# What a credential being wrong looks like, as opposed to the server being
+# broken. The strategies shipped here already fold this into a None return —
+# fastapi-users' JWTStrategy swallows PyJWTError/UserNotExists/InvalidID, and
+# ApiKeyJWTStrategy returns None for an unknown key — so this only matters for
+# a deployment that plugs in a strategy which signals a bad credential by
+# raising. Everything else (a dead database, a broken identity provider) is a
+# server fault and must not be dressed up as a rejected credential.
+BAD_CREDENTIAL_ERRORS = (
+    fastapi_users_exceptions.FastAPIUsersException,
+    jwt.PyJWTError,
+)
+
+
+async def _read_handshake_user(websocket: WebSocket) -> Optional[User]:
+    """Resolve a user from the credentials carried by the WebSocket handshake.
+
+    Walks the configured authentication backends in registration order and
+    returns the first active user one of them yields — the same order and the
+    same "first backend to yield a user wins" rule fastapi-users applies to
+    HTTP requests, so a WebSocket accepts exactly the credentials the HTTP API
+    accepts (API key header, bearer header, auth cookie) and no others.
+
+    Each backend's ``transport.scheme`` reads only cookies, headers or query
+    parameters, all of which a handshake carries: a Starlette ``WebSocket`` and
+    a ``Request`` are both ``HTTPConnection``s, which is why the schemes can be
+    called with one here even though they annotate ``Request``.
+
+    Only a bad credential is absorbed. Anything else a backend raises — the
+    strategies here reach the database to resolve a token — propagates, so a
+    database outage fails the handshake as the server fault it is instead of
+    being reported to every client as a permanent "Unauthorized".
+
+    Raises:
+        Exception: whatever a backend raised that was not a bad credential. It
+            is logged here first, since a propagating dependency leaves no
+            other trace of which backend failed.
+    """
+    db_engine = get_relational_engine()
+
+    async with db_engine.get_async_session() as session:
+        async with get_user_db_context(session) as user_db:
+            async with get_user_manager_context(user_db) as user_manager:
+                for backend in get_fastapi_users().authenticator.backends:
+                    try:
+                        # auto_error=False on every scheme here means "no
+                        # credential" is a None return; a custom transport that
+                        # sets auto_error raises instead, which is the same
+                        # answer.
+                        token = await backend.transport.scheme(websocket)
+                    except HTTPException:
+                        continue
+
+                    if not token:
+                        continue
+
+                    try:
+                        user = await backend.get_strategy().read_token(token, user_manager)
+                    except BAD_CREDENTIAL_ERRORS as error:
+                        # A failed authentication attempt: try the next backend
+                        # and let the caller reject the connection if none
+                        # match.
+                        logger.debug(
+                            "WebSocket authentication via %s failed: %s", backend.name, error
+                        )
+                        continue
+                    except Exception:
+                        logger.warning(
+                            "WebSocket authentication backend %s failed to read a token",
+                            backend.name,
+                            exc_info=True,
+                        )
+                        raise
+
+                    if user is not None and user.is_active:
+                        return user
+
+    return None
+
+
+async def get_authenticated_websocket_user(websocket: WebSocket) -> Optional[User]:
+    """Authenticate a WebSocket connection. The counterpart of ``get_authenticated_user``.
+
+    A WebSocket route cannot depend on ``get_authenticated_user``: every
+    ``fastapi.security`` scheme behind it takes a ``Request``, which FastAPI
+    never supplies for a WebSocket connection, so the dependency raises before
+    it ever reads a credential. This resolves the same credentials off the
+    handshake instead, with the same posture as the HTTP dependency:
+
+    - ``REQUIRE_AUTHENTICATION=true``: an unauthenticated connection returns
+      None, and the route is expected to close it.
+    - ``REQUIRE_AUTHENTICATION=false``: an unauthenticated connection falls
+      back to the default user, so single-user deployments work without
+      credentials exactly as their HTTP routes do.
+
+    Returning None rather than raising is deliberate. A close frame sent before
+    the handshake is accepted reaches the client as an HTTP rejection with no
+    close code, so a route that wants clients to see *why* they were rejected
+    (1008, "do not retry this") has to accept the connection first and close it
+    itself — which it can only do if this returns instead of raising.
+
+    Declared as a dependency so a deployment with its own scheme can replace it
+    through ``app.dependency_overrides[get_authenticated_websocket_user]``,
+    the same override point ``get_authenticated_user`` offers HTTP routes.
+
+    Returns:
+        The authenticated user, or None when authentication is required and the
+        handshake carried no usable credential.
+
+    Raises:
+        Exception: any server fault met while resolving the credential — a
+            backend failing for a reason other than a bad credential, the
+            user re-fetch, or the default-user fallback. Deliberately not
+            converted into None: a dependency resolves before the route can
+            accept the connection, so the handshake simply fails and the
+            client retries, instead of the client being told 1008
+            ("Unauthorized", terminal, do not retry) because a database
+            blinked. The failure is logged before it propagates.
+    """
+    user = await _read_handshake_user(websocket)
+
+    if user is None:
+        if REQUIRE_AUTHENTICATION:
+            return None
+        return await get_default_user()
+
+    # Re-fetch for the same reason get_authenticated_user does: the instance a
+    # strategy returns has no eagerly loaded relationships, and a long-lived
+    # socket outlives the session it was read in.
+    return await get_user(user.id)

--- a/cognee/tests/unit/api/test_cognify_subscribe_auth.py
+++ b/cognee/tests/unit/api/test_cognify_subscribe_auth.py
@@ -1,0 +1,146 @@
+"""WS /cognify/subscribe/{pipeline_run_id}: it authenticates, and it guards.
+
+The route used to call get_authenticated_user with keyword arguments that
+function does not accept, so every connection raised TypeError inside its own
+try/except and was closed 1008 — nobody could subscribe to a run at all, which
+means nothing past that check had ever run in production. Fixing the auth makes
+the rest of the route reachable for the first time, and the rest of the route
+takes a caller-supplied run id straight to a process-global queue.
+
+Subscribing *consumes* that queue (`get_from_queue` pops, `initialize_queue`
+replaces it wholesale), so reaching it for someone else's run is not a read of
+another tenant's data — it is taking their updates away from them. Hence the
+guards these pin: a valid id, a run that exists, and a run whose dataset the
+caller may read, all settled before the queue is touched at all.
+"""
+
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from cognee.modules.data.exceptions.exceptions import DatasetNotFoundError
+from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunCompleted
+from cognee.modules.users.methods import get_authenticated_websocket_user
+
+router_module = import_module("cognee.api.v1.cognify.routers.get_cognify_router")
+
+PIPELINE_RUN_ID = uuid4()
+DATASET_ID = uuid4()
+
+
+@pytest.fixture
+def queue_calls(monkeypatch):
+    """Records every queue operation the route performs.
+
+    A refused caller must leave this empty: that, not the close code alone, is
+    what proves the rightful subscriber's updates were left alone.
+    """
+    calls = []
+    completed = PipelineRunCompleted(
+        pipeline_run_id=PIPELINE_RUN_ID, dataset_id=DATASET_ID, dataset_name="billing"
+    )
+
+    def _record(name, result=None):
+        def _call(run_id):
+            calls.append((name, run_id))
+            return result
+
+        return _call
+
+    monkeypatch.setattr(router_module, "initialize_queue", _record("initialize"))
+    monkeypatch.setattr(router_module, "remove_queue", _record("remove"))
+    monkeypatch.setattr(router_module, "get_from_queue", _record("get", result=completed))
+    return calls
+
+
+@pytest.fixture
+def app(monkeypatch, queue_calls):
+    monkeypatch.setattr(
+        router_module,
+        "get_pipeline_run",
+        AsyncMock(return_value=SimpleNamespace(dataset_id=DATASET_ID)),
+    )
+    monkeypatch.setattr(
+        router_module,
+        "get_authorized_dataset",
+        AsyncMock(return_value=SimpleNamespace(id=DATASET_ID)),
+    )
+    monkeypatch.setattr(
+        router_module, "get_formatted_graph_data", AsyncMock(return_value={"nodes": []})
+    )
+
+    application = FastAPI()
+    application.include_router(router_module.get_cognify_router(), prefix="/api/v1/cognify")
+    application.dependency_overrides[get_authenticated_websocket_user] = lambda: SimpleNamespace(
+        id=uuid4(), tenant_id=None
+    )
+    return application
+
+
+def _connect(app, run_id=PIPELINE_RUN_ID):
+    return TestClient(app).websocket_connect(f"/api/v1/cognify/subscribe/{run_id}")
+
+
+def _closed_code(app, run_id=PIPELINE_RUN_ID):
+    with pytest.raises(WebSocketDisconnect) as closed:
+        with _connect(app, run_id) as connection:
+            connection.receive_json()
+    return closed.value.code
+
+
+def test_an_authenticated_subscriber_receives_pipeline_run_info(app):
+    with _connect(app) as connection:
+        assert connection.receive_json() == {
+            "pipeline_run_id": str(PIPELINE_RUN_ID),
+            "status": "PipelineRunCompleted",
+            "payload": {"nodes": []},
+        }
+
+
+def test_an_unauthenticated_subscriber_is_still_closed_with_1008(app, queue_calls):
+    app.dependency_overrides[get_authenticated_websocket_user] = lambda: None
+
+    assert _closed_code(app) == 1008
+    assert queue_calls == []
+
+
+def test_a_run_id_that_is_not_a_uuid_is_refused_rather_than_crashing(app, queue_calls):
+    """Previously an unhandled ValueError after accept(), i.e. an ASGI error."""
+    assert _closed_code(app, "not-a-uuid") == 1008
+    assert queue_calls == []
+
+
+def test_an_unknown_run_is_refused_rather_than_dereferencing_none(app, monkeypatch, queue_calls):
+    """get_pipeline_run is a scalar read: no row means None, and the route used
+    to take .dataset_id straight off it."""
+    monkeypatch.setattr(router_module, "get_pipeline_run", AsyncMock(return_value=None))
+
+    assert _closed_code(app) == 1008
+    assert queue_calls == []
+
+
+def test_another_tenants_run_is_refused_before_its_queue_is_touched(app, monkeypatch, queue_calls):
+    """The theft this guard exists for: the intruder is closed out, and the
+    rightful subscriber's queue is neither reset nor drained."""
+    monkeypatch.setattr(router_module, "get_authorized_dataset", AsyncMock(return_value=None))
+
+    assert _closed_code(app) == 1008
+    assert queue_calls == []
+
+
+def test_losing_read_access_mid_stream_closes_instead_of_raising(app, monkeypatch):
+    """get_formatted_graph_data re-authorizes on every frame and raises when
+    the dataset goes away; only WebSocketDisconnect used to be caught."""
+    monkeypatch.setattr(
+        router_module,
+        "get_formatted_graph_data",
+        AsyncMock(side_effect=DatasetNotFoundError(message="Dataset not found.")),
+    )
+
+    assert _closed_code(app) == 1008

--- a/cognee/tests/unit/modules/users/test_authenticated_websocket_user.py
+++ b/cognee/tests/unit/modules/users/test_authenticated_websocket_user.py
@@ -1,0 +1,250 @@
+"""get_authenticated_websocket_user: authenticating a handshake.
+
+A WebSocket route cannot depend on get_authenticated_user — the security
+schemes behind it require a Request FastAPI never supplies for a WebSocket —
+so this is the seam both WS routes authenticate through instead. What it must
+guarantee, and what these pin: the same credentials the HTTP API accepts are
+accepted here in the same backend order, an inactive or unknown user does not
+authenticate, a broken backend cannot take the others down with it, and the
+REQUIRE_AUTHENTICATION posture behaves exactly as it does over HTTP.
+"""
+
+import sys
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import jwt
+import pytest
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import OperationalError
+
+from cognee.modules.users.methods import get_authenticated_websocket_user
+
+ws_auth_module = sys.modules["cognee.modules.users.methods.get_authenticated_websocket_user"]
+
+
+def _user(is_active: bool = True):
+    return SimpleNamespace(id=uuid4(), email="user@example.com", is_active=is_active)
+
+
+def _backend(name: str, token, user=None, read_token=None):
+    """A fastapi-users-shaped backend: a scheme that reads the handshake and a
+    strategy that resolves whatever it found."""
+    if read_token is None:
+
+        async def read_token(_token, _user_manager):
+            return user
+
+    async def scheme(_connection):
+        return token
+
+    return SimpleNamespace(
+        name=name,
+        transport=SimpleNamespace(scheme=scheme),
+        get_strategy=lambda: SimpleNamespace(read_token=read_token),
+    )
+
+
+@asynccontextmanager
+async def _context(value=None):
+    yield value
+
+
+@pytest.fixture
+def handshake(monkeypatch):
+    """Patch away the user-manager plumbing; return a hook for the backends."""
+
+    def _configure(backends, require_authentication=True):
+        monkeypatch.setattr(
+            ws_auth_module,
+            "get_fastapi_users",
+            lambda: SimpleNamespace(authenticator=SimpleNamespace(backends=backends)),
+        )
+        monkeypatch.setattr(
+            ws_auth_module,
+            "get_relational_engine",
+            lambda: SimpleNamespace(get_async_session=_context),
+        )
+        monkeypatch.setattr(ws_auth_module, "get_user_db_context", lambda _session: _context())
+        monkeypatch.setattr(ws_auth_module, "get_user_manager_context", lambda _db: _context())
+        monkeypatch.setattr(ws_auth_module, "REQUIRE_AUTHENTICATION", require_authentication)
+        # get_user re-fetches for eagerly loaded relationships; identity is all
+        # these tests care about.
+        monkeypatch.setattr(
+            ws_auth_module, "get_user", AsyncMock(side_effect=lambda user_id: ("fetched", user_id))
+        )
+
+    return _configure
+
+
+@pytest.mark.asyncio
+async def test_the_first_backend_with_a_credential_wins(handshake):
+    api_key_user, cookie_user = _user(), _user()
+    handshake(
+        [
+            _backend("apikey", token="key-token", user=api_key_user),
+            _backend("cookie", token="cookie-token", user=cookie_user),
+        ]
+    )
+
+    resolved = await get_authenticated_websocket_user(SimpleNamespace())
+
+    assert resolved == ("fetched", api_key_user.id)
+
+
+@pytest.mark.asyncio
+async def test_a_backend_without_a_credential_is_skipped_not_failed(handshake):
+    cookie_user = _user()
+    handshake(
+        [
+            _backend("apikey", token=None),
+            _backend("cookie", token="cookie-token", user=cookie_user),
+        ]
+    )
+
+    resolved = await get_authenticated_websocket_user(SimpleNamespace())
+
+    assert resolved == ("fetched", cookie_user.id)
+
+
+@pytest.mark.asyncio
+async def test_a_bad_credential_does_not_stop_the_other_backends(handshake):
+    """A malformed token is a failed attempt, not a server fault."""
+
+    async def explode(_token, _user_manager):
+        raise jwt.DecodeError("not a valid jwt")
+
+    cookie_user = _user()
+    handshake(
+        [
+            _backend("bearer", token="garbage", read_token=explode),
+            _backend("cookie", token="cookie-token", user=cookie_user),
+        ]
+    )
+
+    resolved = await get_authenticated_websocket_user(SimpleNamespace())
+
+    assert resolved == ("fetched", cookie_user.id)
+
+
+@pytest.mark.asyncio
+async def test_a_server_fault_propagates_instead_of_reading_as_unauthorized(handshake, caplog):
+    """The distinction this file exists to protect: a database that is down is
+    not a client whose credential was rejected. Swallowing it would close every
+    connection with 1008 — documented as terminal, do not retry — while the
+    fault is transient, so clients would give up exactly when they should not.
+    """
+
+    async def database_is_down(_token, _user_manager):
+        raise OperationalError("SELECT 1", {}, Exception("connection refused"))
+
+    handshake(
+        [
+            _backend("apikey", token="valid-looking-key", read_token=database_is_down),
+            _backend("cookie", token="cookie-token", user=_user()),
+        ]
+    )
+
+    with pytest.raises(OperationalError):
+        await get_authenticated_websocket_user(SimpleNamespace())
+
+    # A propagating dependency leaves no other trace of which backend broke.
+    assert "apikey" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_an_inactive_user_does_not_authenticate(handshake):
+    """HTTP routes ask for active=True; a socket must not be a way around it."""
+    handshake([_backend("cookie", token="cookie-token", user=_user(is_active=False))])
+
+    assert await get_authenticated_websocket_user(SimpleNamespace()) is None
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_token_returns_none_when_authentication_is_required(handshake):
+    handshake([_backend("apikey", token="revoked-key", user=None)])
+
+    assert await get_authenticated_websocket_user(SimpleNamespace()) is None
+
+
+@pytest.mark.asyncio
+async def test_no_credentials_falls_back_to_the_default_user_when_auth_is_off(
+    handshake, monkeypatch
+):
+    """Single-user deployments reach their WebSockets exactly as their HTTP
+    routes do — which the cookie-only path never allowed."""
+    default_user = _user()
+    handshake([_backend("cookie", token=None)], require_authentication=False)
+    monkeypatch.setattr(ws_auth_module, "get_default_user", AsyncMock(return_value=default_user))
+
+    assert await get_authenticated_websocket_user(SimpleNamespace()) is default_user
+
+
+# The tests above hand-roll the backends, which proves the walk but assumes the
+# thing most likely to break silently: that a fastapi-users security scheme,
+# annotated for a Request, can in fact be called with a Starlette WebSocket.
+# The tests below make no such assumption — real registered backends, a real
+# APIKeyHeader scheme, a real handshake — so a fastapi or fastapi-users bump
+# that ends the duck-typing fails here instead of degrading every socket in
+# the product to 1008.
+
+API_KEY = "cognee-test-api-key"
+
+
+@pytest.fixture
+def transport_app(monkeypatch):
+    """A WebSocket route behind the real dependency and the real backends.
+
+    Only the persistence under the backends is replaced: the user manager the
+    api-key strategy resolves its token through, and the re-fetch afterwards.
+    """
+    key_holder = _user()
+
+    async def get_by_token(token):
+        return key_holder if token == API_KEY else None
+
+    monkeypatch.setattr(
+        ws_auth_module,
+        "get_relational_engine",
+        lambda: SimpleNamespace(get_async_session=_context),
+    )
+    monkeypatch.setattr(ws_auth_module, "get_user_db_context", lambda _session: _context())
+    monkeypatch.setattr(
+        ws_auth_module,
+        "get_user_manager_context",
+        lambda _db: _context(SimpleNamespace(get_by_token=get_by_token)),
+    )
+    monkeypatch.setattr(ws_auth_module, "REQUIRE_AUTHENTICATION", True)
+    monkeypatch.setattr(ws_auth_module, "get_user", AsyncMock(return_value=key_holder))
+
+    application = FastAPI()
+
+    @application.websocket("/subscribe")
+    async def subscribe(websocket: WebSocket):
+        user = await get_authenticated_websocket_user(websocket)
+        await websocket.accept()
+        await websocket.send_json({"email": user.email if user else None})
+
+    return application
+
+
+def test_a_real_x_api_key_handshake_authenticates_through_the_real_schemes(transport_app):
+    with TestClient(transport_app).websocket_connect(
+        "/subscribe", headers={"X-Api-Key": API_KEY}
+    ) as connection:
+        assert connection.receive_json() == {"email": "user@example.com"}
+
+
+def test_a_real_handshake_without_a_credential_authenticates_nobody(transport_app):
+    with TestClient(transport_app).websocket_connect("/subscribe") as connection:
+        assert connection.receive_json() == {"email": None}
+
+
+def test_a_real_handshake_with_an_unknown_api_key_authenticates_nobody(transport_app):
+    with TestClient(transport_app).websocket_connect(
+        "/subscribe", headers={"X-Api-Key": "revoked"}
+    ) as connection:
+        assert connection.receive_json() == {"email": None}

--- a/cognee/tests/unit/modules/users/test_redact_websocket_query_secrets.py
+++ b/cognee/tests/unit/modules/users/test_redact_websocket_query_secrets.py
@@ -1,0 +1,74 @@
+"""The WebSocket ?token= fallback must not leak into uvicorn's own logs.
+
+Uvicorn logs the full handshake path (query string included) on every
+WebSocket accept/close via the uvicorn.error logger, independent of any
+reverse proxy. This pins the filter that redacts it there.
+"""
+
+import logging
+
+import pytest
+
+from cognee.modules.users.authentication.redact_websocket_query_secrets import (
+    _RedactWebsocketTokenFilter,
+)
+
+
+@pytest.fixture
+def redaction_filter():
+    return _RedactWebsocketTokenFilter()
+
+
+def _make_record(msg, args=()):
+    return logging.LogRecord(
+        name="uvicorn.error",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=args,
+        exc_info=None,
+    )
+
+
+def test_token_in_a_percent_style_arg_is_redacted(redaction_filter):
+    record = _make_record(
+        '%s - "WebSocket %s" [accepted]',
+        ("127.0.0.1:54321", "/api/v1/visualize/subscribe/abc?token=eyJhbGciOiJIUzI1NiJ9.secret"),
+    )
+
+    redaction_filter.filter(record)
+
+    assert "eyJhbGciOiJIUzI1NiJ9.secret" not in record.args[1]
+    assert "token=***REDACTED***" in record.args[1]
+    assert record.args[1].startswith("/api/v1/visualize/subscribe/abc?")
+
+
+def test_token_as_a_non_final_query_param_is_still_redacted(redaction_filter):
+    record = _make_record(
+        '%s - "WebSocket %s" [accepted]',
+        ("127.0.0.1:54321", "/subscribe/abc?since=2026-01-01&token=secret123&other=1"),
+    )
+
+    redaction_filter.filter(record)
+
+    assert "secret123" not in record.args[1]
+    assert "since=2026-01-01" in record.args[1]
+    assert "other=1" in record.args[1]
+
+
+def test_a_message_with_no_token_is_left_untouched(redaction_filter):
+    record = _make_record(
+        '%s - "WebSocket %s" [accepted]',
+        ("127.0.0.1:54321", "/subscribe/abc?since=2026-01-01"),
+    )
+
+    redaction_filter.filter(record)
+
+    assert record.args[1] == "/subscribe/abc?since=2026-01-01"
+
+
+def test_filter_always_returns_true_so_the_record_is_still_emitted(redaction_filter):
+    record = _make_record("plain message with no args")
+
+    assert redaction_filter.filter(record) is True

--- a/cognee/tests/unit/modules/users/test_transport_scheme_signature.py
+++ b/cognee/tests/unit/modules/users/test_transport_scheme_signature.py
@@ -1,0 +1,77 @@
+"""The auth schemes' ``__call__`` must stay annotated with a connection type.
+
+Both transports subclass a FastAPI security scheme to add the WebSocket
+``?token=`` fallback. FastAPI decides what to pass a dependency parameter by
+its annotation: only a handful of types (Request, WebSocket, HTTPConnection,
+Response, ...) are injected as the connection, and anything else is read as an
+ordinary request field. So an override written as ``async def __call__(self,
+request)`` -- no annotation -- silently becomes a *required query parameter
+named "request"*, and every unauthenticated HTTP call answers 422 (missing
+query param) instead of 401.
+
+Nothing about that is visible in the transport's own tests: the scheme still
+works when called directly with a connection object. It only shows up through
+a route, which is why it survived once already and had to be fixed twice.
+
+HTTPConnection rather than Request because the same scheme serves HTTP routes
+and WebSocket handshakes, and it is the common base FastAPI injects for both.
+"""
+
+import inspect
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import HTTPConnection
+
+from cognee.modules.users.authentication.api_bearer.api_bearer_transport import (
+    api_bearer_transport,
+)
+from cognee.modules.users.authentication.api_key.get_api_key_transport import (
+    get_api_key_transport,
+)
+
+# The types FastAPI injects as the connection itself rather than parsing out of
+# the request. Kept as an explicit tuple: the point is to assert against a
+# written-down expectation, not against whatever FastAPI happens to accept.
+CONNECTION_TYPES = (HTTPConnection,)
+
+
+def _schemes():
+    yield "bearer", api_bearer_transport.scheme
+    yield "api_key", get_api_key_transport().scheme
+
+
+@pytest.mark.parametrize("name,scheme", list(_schemes()))
+def test_scheme_call_annotates_its_connection_parameter(name, scheme):
+    signature = inspect.signature(scheme.__call__)
+    parameters = [p for p in signature.parameters.values() if p.name != "self"]
+    assert len(parameters) == 1, f"{name}: expected one parameter, got {parameters}"
+
+    annotation = parameters[0].annotation
+    assert annotation is not inspect.Parameter.empty, (
+        f"{name}: unannotated -- FastAPI will treat this as a query parameter"
+    )
+    assert annotation in CONNECTION_TYPES, (
+        f"{name}: annotated {annotation!r}, expected one of {CONNECTION_TYPES}"
+    )
+
+
+@pytest.mark.parametrize("name,scheme", list(_schemes()))
+def test_route_using_the_scheme_rejects_rather_than_failing_validation(name, scheme):
+    """The behavioural half: a missing credential must not read as a bad request."""
+    app = FastAPI()
+
+    @app.get("/probe")
+    async def probe(token=Depends(scheme)):
+        # auto_error=False on both schemes, so a missing credential arrives as
+        # None and the route -- not the scheme -- decides the status.
+        return {"token": token}
+
+    response = TestClient(app).get("/probe")
+
+    assert response.status_code == 200, (
+        f"{name}: {response.status_code} -- a 422 here means the connection "
+        f"parameter was parsed as a request field: {response.text}"
+    )
+    assert response.json() == {"token": None}

--- a/cognee/tests/unit/modules/users/test_websocket_query_param.py
+++ b/cognee/tests/unit/modules/users/test_websocket_query_param.py
@@ -1,0 +1,58 @@
+"""resolve_websocket_query_param_fallback: the ?token= WS-only fallback.
+
+A browser cannot set a custom header when opening a WebSocket, so a
+header-based scheme (API key, bearer) has no way to see a credential on a
+WS handshake unless it also accepts one via a query parameter. These pin
+that the fallback only ever applies to a WebSocket connection, and only
+when the header-based scheme found nothing.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from starlette.websockets import WebSocket
+
+from cognee.modules.users.authentication.websocket_query_param import (
+    WEBSOCKET_QUERY_PARAM_NAME,
+    resolve_websocket_query_param_fallback,
+)
+
+
+def _websocket(query_string: bytes = b"") -> WebSocket:
+    scope = {
+        "type": "websocket",
+        "query_string": query_string,
+        "headers": [],
+        "path": "/ws",
+    }
+    return WebSocket(scope, receive=None, send=None)
+
+
+@pytest.mark.asyncio
+async def test_primary_token_wins_over_the_query_param():
+    ws = _websocket(f"{WEBSOCKET_QUERY_PARAM_NAME}=from-query".encode())
+    assert await resolve_websocket_query_param_fallback(ws, "from-header") == "from-header"
+
+
+@pytest.mark.asyncio
+async def test_websocket_falls_back_to_the_query_param_when_no_header_token():
+    ws = _websocket(f"{WEBSOCKET_QUERY_PARAM_NAME}=from-query".encode())
+    assert await resolve_websocket_query_param_fallback(ws, None) == "from-query"
+
+
+@pytest.mark.asyncio
+async def test_websocket_with_no_query_param_and_no_header_token_yields_none():
+    ws = _websocket(b"")
+    assert await resolve_websocket_query_param_fallback(ws, None) is None
+
+
+@pytest.mark.asyncio
+async def test_http_request_never_consults_the_query_param():
+    # A plain object is enough here: the fallback only special-cases
+    # `isinstance(request, WebSocket)`, so any non-WebSocket connection -
+    # including a real Request - must fall through to None regardless of
+    # what it carries, so a credential can never leak into an HTTP URL.
+    http_request = SimpleNamespace(
+        query_params={WEBSOCKET_QUERY_PARAM_NAME: "should-never-be-read"}
+    )
+    assert await resolve_websocket_query_param_fallback(http_request, None) is None


### PR DESCRIPTION
## Description

`WS /cognify/subscribe/{pipeline_run_id}` called `get_authenticated_user` with arguments it does
not accept. Every connection raised `TypeError`, the handler caught it, and closed with 1008. No
client has ever authenticated through this route, which means every line after the auth block is
code that has never run against a real caller.

Fixing the auth call is two lines. Making the body behind it safe to reach is the actual work, and
that is most of this PR. Once the handshake works, the following all become reachable:

1. **Cross-tenant queue drain.** `pipeline_run_id` was a path parameter with no ownership check,
   so any authenticated user could subscribe to another tenant's run. `get_from_queue` *pops*, so
   the rightful subscriber loses the events. The graph payload itself was safe
   (`get_formatted_graph_data` re-authorizes) but it raises `DatasetNotFoundError`, which the
   handler did not catch, so the attacker got an unhandled error after the item was already
   consumed.
2. `initialize_queue` replaces the queue outright, so a subscriber connecting mid-run discarded
   everything already queued.
3. `UUID(pipeline_run_id)` ran after `websocket.accept()`, so a malformed path segment raised
   `ValueError` from an accepted socket: an unhandled ASGI error rather than a close code.
4. `get_pipeline_run` can return `None`, unchecked.

The fix authenticates via a new injectable `get_authenticated_websocket_user` dependency, then
parses and validates the run id and checks dataset ownership **before any queue call**. That
ordering is deliberate: both `initialize_queue` and `get_from_queue` mutate state a rejected
caller must not be able to touch. Every rejection is a clean 1008 with a reason.

Two supporting pieces came out of getting the handshake to work at all. A WebSocket client cannot
set headers, so the transports accept a `?token=` query-param fallback, and
`install_websocket_query_param_redaction()` keeps that token out of uvicorn's access and error
logs. Separately, both transports overrode `__call__(self, request)` with no annotation; FastAPI
reads an unannotated dependency parameter as an ordinary query field, so every unauthenticated
HTTP call answered 422 instead of 401. Both are now annotated `HTTPConnection`, the common base
FastAPI injects for HTTP routes and WebSocket handshakes alike.

**Known limitation, deliberately not fixed here.** `initialize_queue` still replaces the queue, so
two *authorized* subscribers to the same run still fight over it: the route consumes rather than
observes, and is one-subscriber-per-run by construction. The docstring now says so. Making it a
real fan-out is a design change, not a security fix, and belongs in its own ticket.

Split out of COG-6258, where this was changeset D. It is a security fix on an endpoint that has
nothing to do with visualization, and bundling it into a feature ticket buried it.

Fixes COG-6291.

## Acceptance Criteria

* An unauthenticated WebSocket handshake closes 1008 instead of raising `TypeError`, and an
  authenticated one connects.
* A malformed or unknown `pipeline_run_id` closes 1008 before any queue call, not after
  `accept()` with an unhandled `ValueError`.
* A user subscribing to another tenant's run is rejected 1008, and that run's queue is left
  untouched: the rightful subscriber still receives its events.
* A retry replays the same rejection rather than succeeding on a second attempt, so clients stop.
* An unauthenticated HTTP call to a route using either transport answers 401, not 422.

Proof: 61 unit tests across five files, all passing locally.

| Test file | Covers |
|---|---|
| `cognee/tests/unit/api/test_cognify_subscribe_auth.py` | route-level auth, run-id validation, ownership, close codes |
| `cognee/tests/unit/modules/users/test_authenticated_websocket_user.py` | the dependency: API key, bearer, cookie, decode failure vs DB fault |
| `cognee/tests/unit/modules/users/test_websocket_query_param.py` | the `?token=` fallback |
| `cognee/tests/unit/modules/users/test_redact_websocket_query_secrets.py` | token redaction in uvicorn logs |
| `cognee/tests/unit/modules/users/test_transport_scheme_signature.py` | the 422-vs-401 regression, by signature and through a live route |

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING -->

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.