### PR TITLE
COG-6258 feat: add brains-summary and dataset WebSocket, on COG-6291

### DIFF
--- a/cognee/alembic/versions/b3d5f7a9c1e2_add_graph_metrics_has_full_metrics.py
+++ b/cognee/alembic/versions/b3d5f7a9c1e2_add_graph_metrics_has_full_metrics.py
@@ -1,0 +1,71 @@
+"""add_graph_metrics_has_full_metrics
+
+Revision ID: b3d5f7a9c1e2
+Revises: a7f3c9e1b5d2
+Create Date: 2026-08-21 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b3d5f7a9c1e2"
+down_revision: Union[str, None] = "c4e8a1f6b3d7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _get_column(inspector, table, name, schema=None):
+    for col in inspector.get_columns(table, schema=schema):
+        if col["name"] == name:
+            return col
+    return None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    if "graph_metrics" not in insp.get_table_names():
+        return
+
+    if _get_column(insp, "graph_metrics", "has_full_metrics"):
+        return
+
+    op.add_column(
+        "graph_metrics",
+        sa.Column(
+            "has_full_metrics",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+    # Existing rows predate the flag, so it has to be inferred. `diameter` is
+    # the discriminator, not `num_tokens`: every graph-metrics adapter always
+    # sets `diameter` on the full-computation path (a real value or a -1
+    # placeholder, never NULL), while the node/edge counting path never
+    # touches it. `num_tokens` can't be used for this: it's a SQL SUM() that
+    # legitimately comes back NULL for a fully-computed run over a dataset
+    # with no token_count data, which would misclassify that row as partial.
+    # Rows that stay False are exactly the partial ones, which the metrics
+    # endpoint will now recompute once instead of serving forever as complete.
+    op.execute(
+        sa.text("UPDATE graph_metrics SET has_full_metrics = true WHERE diameter IS NOT NULL")
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    if "graph_metrics" not in insp.get_table_names():
+        return
+
+    if _get_column(insp, "graph_metrics", "has_full_metrics"):
+        op.drop_column("graph_metrics", "has_full_metrics")

--- a/cognee/alembic/versions/b3d5f7a9c1e2_add_graph_metrics_has_full_metrics.py
+++ b/cognee/alembic/versions/b3d5f7a9c1e2_add_graph_metrics_has_full_metrics.py
@@ -1,7 +1,7 @@
 """add_graph_metrics_has_full_metrics
 
 Revision ID: b3d5f7a9c1e2
-Revises: a7f3c9e1b5d2
+Revises: c4e8a1f6b3d7
 Create Date: 2026-08-21 00:00:00.000000
 
 """

--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -17,6 +17,7 @@ from cognee.api.DTO import InDTO, OutDTO
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.data.methods import get_authorized_existing_datasets
 from cognee.modules.data.methods import get_datasets_by_name
+from cognee.modules.data.methods import get_datasets_graph_counts
 from cognee.modules.data.methods.create_authorized_dataset import create_authorized_dataset
 from cognee.shared.logging_utils import get_logger
 from cognee.api.v1.exceptions import DataNotFoundError
@@ -538,8 +539,16 @@ def get_datasets_router() -> APIRouter:
         - **pipelineRunId**: The dataset's latest cognify run, or null if it
           has never been cognified
         - **numNodes** / **numEdges**: Graph size for that run
-        - **computedAt**: When the count was cached, or null if the last
-          attempt degraded (graph store unavailable) and wasn't cached
+        - **computedAt**: When the count was cached, or null when it wasn't —
+          either the last attempt degraded (graph store unavailable, counts
+          are 0 and retried on the next poll) or a concurrent caller cached
+          the same run first (counts are exact)
+
+        ## Error Codes
+        - **409 Conflict**: The summary could not be built (generic message;
+          the detail is server-logged rather than returned). A single
+          unreadable graph store does not cause this — that dataset comes back
+          with zero counts — so this means the relational read itself failed.
         """
         send_telemetry(
             "Datasets API Endpoint Invoked",
@@ -551,116 +560,38 @@ def get_datasets_router() -> APIRouter:
             },
         )
 
-        from datetime import timezone
-        from sqlalchemy import select, func
-        from sqlalchemy.orm import aliased
-        from cognee.context_global_variables import set_database_global_context_variables
-        from cognee.infrastructure.databases.graph import get_graph_engine
-        from cognee.modules.data.models import GraphMetrics
-        from cognee.modules.pipelines.models import PipelineRun
+        try:
+            authorized_datasets = await get_authorized_existing_datasets(dataset_ids, "read", user)
 
-        authorized_datasets = await get_authorized_existing_datasets(dataset_ids, "read", user)
+            if not authorized_datasets:
+                return []
 
-        if not authorized_datasets:
-            return []
-
-        db_engine = get_relational_engine()
-
-        async with db_engine.get_async_session() as session:
-            ranked_runs = (
-                select(
-                    PipelineRun,
-                    func.row_number()
-                    .over(
-                        partition_by=PipelineRun.dataset_id,
-                        order_by=PipelineRun.created_at.desc(),
-                    )
-                    .label("rn"),
-                )
-                .filter(PipelineRun.dataset_id.in_([dataset.id for dataset in authorized_datasets]))
-                .filter(PipelineRun.pipeline_name == "cognify_pipeline")
-                .subquery()
+            counts = await get_datasets_graph_counts(authorized_datasets)
+        except Exception as error:
+            # Same posture as GET /statuses above and the sibling
+            # GET /visualize/brains-summary: a poll that fails transiently is a
+            # 409 with a generic message, not an unhandled 500 carrying
+            # internals to the client. Scoped to the two relational reads
+            # this route makes; the DTO construction below is pure Python
+            # over an already-validated shape, so a bug there still surfaces
+            # as a real 500 instead of being misreported as this endpoint's
+            # documented transient-failure case.
+            logger.error("Error retrieving dataset graph summary: %s", error)
+            return JSONResponse(
+                status_code=409,
+                content={"error": "Unable to retrieve dataset graph summary."},
             )
-            aliased_run = aliased(PipelineRun, ranked_runs)
-            latest_runs = (
-                (await session.execute(select(aliased_run).filter(ranked_runs.c.rn == 1)))
-                .scalars()
-                .all()
+
+        return [
+            DatasetGraphSummaryDTO(
+                dataset_id=dataset.id,
+                pipeline_run_id=counts[dataset.id].pipeline_run_id,
+                num_nodes=counts[dataset.id].num_nodes,
+                num_edges=counts[dataset.id].num_edges,
+                computed_at=counts[dataset.id].computed_at,
             )
-            latest_run_by_dataset = {run.dataset_id: run for run in latest_runs}
-
-        summaries = []
-        for dataset in authorized_datasets:
-            latest_run = latest_run_by_dataset.get(dataset.id)
-            if latest_run is None:
-                summaries.append(
-                    DatasetGraphSummaryDTO(dataset_id=dataset.id, num_nodes=0, num_edges=0)
-                )
-                continue
-
-            async with db_engine.get_async_session() as session:
-                cached = (
-                    (
-                        await session.execute(
-                            select(GraphMetrics).where(
-                                GraphMetrics.id == latest_run.pipeline_run_id
-                            )
-                        )
-                    )
-                    .scalars()
-                    .first()
-                )
-
-            if cached is not None:
-                summaries.append(
-                    DatasetGraphSummaryDTO(
-                        dataset_id=dataset.id,
-                        pipeline_run_id=latest_run.pipeline_run_id,
-                        num_nodes=cached.num_nodes or 0,
-                        num_edges=cached.num_edges or 0,
-                        computed_at=cached.created_at,
-                    )
-                )
-                continue
-
-            try:
-                async with set_database_global_context_variables(dataset.id, dataset.owner_id):
-                    graph_engine = await get_graph_engine()
-                    graph_metrics = await graph_engine.get_graph_metrics(include_optional=False)
-
-                async with db_engine.get_async_session() as session:
-                    session.add(
-                        GraphMetrics(
-                            id=latest_run.pipeline_run_id,
-                            num_nodes=graph_metrics.get("num_nodes"),
-                            num_edges=graph_metrics.get("num_edges"),
-                        )
-                    )
-                    await session.commit()
-
-                summaries.append(
-                    DatasetGraphSummaryDTO(
-                        dataset_id=dataset.id,
-                        pipeline_run_id=latest_run.pipeline_run_id,
-                        num_nodes=graph_metrics.get("num_nodes") or 0,
-                        num_edges=graph_metrics.get("num_edges") or 0,
-                        computed_at=datetime.now(timezone.utc),
-                    )
-                )
-            except Exception as error:
-                logger.warning(
-                    "Failed to compute graph metrics for dataset %s: %s", dataset.id, error
-                )
-                summaries.append(
-                    DatasetGraphSummaryDTO(
-                        dataset_id=dataset.id,
-                        pipeline_run_id=latest_run.pipeline_run_id,
-                        num_nodes=0,
-                        num_edges=0,
-                    )
-                )
-
-        return summaries
+            for dataset in authorized_datasets
+        ]
 
     @router.get("/{dataset_id}/data/{data_id}/raw", response_class=FileResponse)
     async def get_raw_data(

--- a/cognee/api/v1/users/routers/get_visualize_router.py
+++ b/cognee/api/v1/users/routers/get_visualize_router.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel, Field
+from starlette.status import WS_1008_POLICY_VIOLATION, WS_1011_INTERNAL_ERROR
 from uuid import UUID
 from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.shared.logging_utils import get_logger
@@ -12,7 +13,11 @@ from cognee.modules.visualization.subgraph_data import (
     DEFAULT_NEIGHBORHOOD_DEPTH,
     DEFAULT_SEED_TOP_K,
 )
-from cognee.modules.users.methods import get_authenticated_user, get_user
+from cognee.modules.users.methods import (
+    get_authenticated_user,
+    get_authenticated_websocket_user,
+    get_user,
+)
 from cognee.modules.data.methods import get_authorized_existing_datasets
 from cognee.modules.users.models import User
 
@@ -403,6 +408,66 @@ def get_visualize_router() -> APIRouter:
                 content={"error": "Failed to build the brains overview"},
             )
 
+    @router.get("/brains-summary", response_model=None)
+    async def visualize_brains_summary(
+        user: User = Depends(get_authenticated_user),
+    ):
+        """
+        Return every dataset the caller may read, described from relational metadata.
+
+        The cheap counterpart of `GET /visualize/brains`: the same datasets,
+        but only what an overview shows — name, sources, size, colors — built
+        from relational metadata and the per-cognify-run count cache instead
+        of one bounded graph read per dataset. The cost is one count query per
+        cognify run whose count is not cached yet, not a graph fetch per
+        dataset on every call, so a cold cache pays once per run and every
+        later call pays nothing. `/brains` stays the call to make when the
+        node and link arrays themselves are needed.
+
+        ## Response
+        `{dataset_id: {"name", "source_names", "node_count", "node_set_colors"}}`:
+        - **name** (str): the dataset's name
+        - **source_names** (list[str]): its distinct node set names, sorted;
+          empty when the data was ingested without node sets
+        - **node_count** (int): nodes in the dataset's graph as of its latest
+          cognify run — the whole graph, not only entity nodes, and 0 for a
+          dataset that has never been cognified
+        - **node_set_colors** (dict[str, str]): node set colors from the same
+          rule `/brains` uses. Same rule and same node sets give the same
+          colors, but the two endpoints can be looking at different node
+          sets — `/brains` takes them from a bounded graph fetch (and so sees
+          sets that exist only in the graph), this takes them from a full
+          relational scan — and where the sets differ the colors do too
+
+        ## Error Codes
+        - **409 Conflict**: Payload could not be built (generic message; full
+          detail is server-logged, not returned, to avoid leaking internals)
+
+        ## Notes
+        - Only datasets the caller has read permission on are included
+        """
+        send_telemetry(
+            "Visualize Brains Summary API Endpoint Invoked",
+            user.id,
+            additional_properties={
+                "endpoint": "GET /v1/visualize/brains-summary",
+                "cognee_version": cognee_version,
+            },
+        )
+
+        from cognee.api.v1.visualize import build_brains_summary_payload
+
+        try:
+            payload = await build_brains_summary_payload(user=user)
+            return JSONResponse(status_code=200, content=payload)
+
+        except Exception:
+            logger.exception("Brains summary payload failed")
+            return JSONResponse(
+                status_code=409,
+                content={"error": "Failed to build the brains summary"},
+            )
+
     @router.get("/live-events", response_model=None)
     async def visualize_live_events(
         dataset_id: UUID = Query(
@@ -476,6 +541,101 @@ def get_visualize_router() -> APIRouter:
                 status_code=409,
                 content={"error": "Failed to fetch live events"},
             )
+
+    @router.websocket("/subscribe/{dataset_id}")
+    async def subscribe_to_dataset_updates(
+        websocket: WebSocket,
+        dataset_id: UUID,
+        since: Optional[datetime] = Query(
+            None,
+            description=(
+                "Cursor from the last live_events frame of a previous "
+                "connection. Omit to start from every available event."
+            ),
+        ),
+        user: Optional[User] = Depends(get_authenticated_websocket_user),
+    ):
+        """
+        Stream one dataset's live events and graph growth over a WebSocket.
+
+        The push replacement for polling `GET /visualize/live-events` and
+        refetching the graph payload to notice a cognify run finished. Frames
+        are JSON objects discriminated by `kind`:
+
+        - `{"kind": "ready", "dataset_id": str, "cursor": str | null}` — sent
+          once the connection is authorized, echoing the cursor it starts from
+        - `{"kind": "live_events", "events": [...], "cursor": str}` — every
+          ~2s, only when the delta is non-empty; the events are exactly what
+          `GET /visualize/live-events` returns
+        - `{"kind": "graph_grew", "pipeline_run_id": str}` — within ~5s of a
+          cognify run for this dataset completing; the run that was already
+          complete at connect time is the baseline and is not announced
+        - `{"kind": "heartbeat", "time": str}` — every ~15s, so a quiet stream
+          is distinguishable from a dead one
+
+        Authentication is the same as every other endpoint (API key header,
+        bearer header or auth cookie, sent with the handshake). Nothing is ever
+        read from client frames.
+
+        ## Path Parameters
+        - **dataset_id** (UUID): the dataset to follow. Gates the connection
+          with the same read-permission check the other visualize routes use;
+          the events themselves are the caller's own, as on `/live-events`.
+
+        ## Query Parameters
+        - **since** (datetime, optional): reconnect cursor
+
+        ## Close Codes
+        - **1008**: not authenticated, or no read permission on this dataset —
+          a retry replays the same rejection, so clients should stop
+        - **1011**: the stream failed server-side; reconnecting is reasonable
+
+        A malformed `since` or a `dataset_id` that is not a UUID fails request
+        validation *before* the connection is accepted, so it carries no close
+        code a client can rely on: depending on the ASGI server the client sees
+        either a 1008 close or a plain HTTP rejection of the handshake. Treat a
+        handshake that never opened as a client-side bug, not a stream error.
+
+        ## Notes
+        - User must have read permissions on the dataset
+        - Permission is re-checked on every poll: access revoked mid-stream
+          closes the connection with 1008
+        """
+        await websocket.accept()
+
+        if user is None:
+            await websocket.close(code=WS_1008_POLICY_VIOLATION, reason="Unauthorized")
+            return
+
+        send_telemetry(
+            "Visualize Subscribe API Endpoint Invoked",
+            user.id,
+            additional_properties={
+                "endpoint": "WS /v1/visualize/subscribe/{dataset_id}",
+                "dataset_id": str(dataset_id),
+                "cognee_version": cognee_version,
+            },
+        )
+
+        from cognee.api.v1.visualize import stream_dataset_updates
+
+        try:
+            authorized = await get_authorized_existing_datasets([dataset_id], "read", user)
+            if not authorized:
+                raise PermissionDeniedError(message="Not authorized to read this dataset")
+
+            await stream_dataset_updates(websocket, authorized[0].id, user, since=since)
+
+        except WebSocketDisconnect:
+            logger.debug("Live updates subscriber left dataset %s", dataset_id)
+        except PermissionDeniedError:
+            await websocket.close(
+                code=WS_1008_POLICY_VIOLATION,
+                reason="Not authorized to read this dataset",
+            )
+        except Exception:
+            logger.exception("Live updates stream failed for dataset %s", dataset_id)
+            await websocket.close(code=WS_1011_INTERNAL_ERROR)
 
     @router.post("/multi", response_model=None)
     async def visualize_multi(

--- a/cognee/api/v1/visualize/__init__.py
+++ b/cognee/api/v1/visualize/__init__.py
@@ -4,8 +4,10 @@ from .visualize import (
     visualize_graph_json,
     visualize_semantic_json,
     build_brains_payload,
+    build_brains_summary_payload,
     get_live_events,
 )
+from .live_updates import stream_dataset_updates
 from .get_schema_inventory import get_schema_inventory
 
 # build_provenance_graph is an internal assembly helper (it operates on records

--- a/cognee/api/v1/visualize/live_updates.py
+++ b/cognee/api/v1/visualize/live_updates.py
@@ -1,0 +1,257 @@
+"""Server push for one dataset's visualization: live events, growth, heartbeat.
+
+The polling replacement behind ``WS /visualize/subscribe/{dataset_id}``. A
+client watching a graph otherwise has to poll ``GET /visualize/live-events``
+every second or two *and* refetch the whole graph payload periodically just to
+notice a cognify run finished. Both polls move here, to one connection per
+viewer that stays quiet until something actually happens.
+
+Deliberately not built on the cognify pipeline-run queue that
+``WS /cognify/subscribe`` reads: ``get_from_queue`` pops, so a second consumer
+would steal run updates from any client attached to that endpoint. Growth is
+detected by reading the dataset's latest completed run instead, which no other
+reader can be starved by.
+"""
+
+import asyncio
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+from uuid import UUID
+
+from fastapi import WebSocket
+
+from cognee.api.v1.visualize.visualize import get_live_events
+from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.modules.data.methods.get_datasets_graph_counts import COGNIFY_PIPELINE_NAME
+from cognee.modules.pipelines.methods import get_pipeline_run_by_dataset
+from cognee.modules.pipelines.models import PipelineRunStatus
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.models import User
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
+# The loop wakes on a fixed tick and does each job every N ticks, so the three
+# cadences stay in step instead of drifting apart on three timers. Tests
+# shorten the tick.
+TICK_SECONDS = 1.0
+LIVE_EVENTS_TICKS = 2
+GRAPH_POLL_TICKS = 5
+HEARTBEAT_TICKS = 15
+
+
+def _parse_cursor(value: Optional[str]) -> Optional[datetime]:
+    """A cursor string back into the datetime ``get_live_events`` expects.
+
+    Cursors come from event timestamps, which are written as naive UTC ISO
+    strings. An unparsable one keeps the previous cursor rather than resetting
+    the stream to "everything", which would replay the whole timeline.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        logger.warning("Ignoring unparsable live-events cursor: %r", value)
+        return None
+
+
+async def _latest_completed_run_id(dataset_id: UUID) -> Optional[UUID]:
+    """The dataset's newest cognify run id, but only once that run completed.
+
+    None while a run is in flight (or when none ever ran), so the caller can
+    treat "the id changed" as "the graph grew" without also firing when a run
+    merely started.
+    """
+    run = await get_pipeline_run_by_dataset(dataset_id, COGNIFY_PIPELINE_NAME)
+
+    if run is None or run.status != PipelineRunStatus.DATASET_PROCESSING_COMPLETED:
+        return None
+
+    return run.pipeline_run_id
+
+
+# Shared across every /subscribe/{dataset_id} connection for the same
+# dataset: without it, N concurrent viewers each run this window-function
+# query every GRAPH_POLL_TICKS, multiplying DB load by the viewer count for a
+# result that is identical for all of them at any given moment. Keyed by
+# dataset_id only (the result does not depend on the caller), TTL'd to one
+# poll interval so a real graph_grew signal is never delayed by more than
+# that. Not single-flighted: a handful of connections racing a cache refresh
+# within the same tick still collapses to a small, bounded number of queries,
+# not the exact number of viewers, and correctness is unaffected either way.
+#
+# A plain dict rather than cognee's shared CacheDBInterface (get_cache_engine)
+# on purpose: that store is string-keyed, so a (UUID, Optional[UUID]) value
+# would need serializing, get_cache_engine() can return None when caching is
+# disabled, and its default backend is itself a SQL round-trip — on that
+# backend it would trade this dataset's DB query for a cache-table one, not
+# remove it. It would only pay off under CACHE_BACKEND=redis, which this
+# feature does not otherwise require.
+_latest_run_cache: Dict[UUID, Tuple[float, Optional[UUID]]] = {}
+
+
+def _reset_latest_run_cache() -> None:
+    """Test-only: drop every cached entry so a test doesn't see another
+    test's cached run id for the same dataset_id."""
+    _latest_run_cache.clear()
+
+
+# A dataset nobody has polled in this many TTL windows almost certainly has
+# no more active subscribers, so its entry is dropped rather than kept
+# forever. The sweep only runs from a live miss, so it only fires while some
+# dataset somewhere is still being actively polled — a server with zero
+# active subscriptions across every dataset stops sweeping too, but at that
+# point the cache is idle and not growing either. Wide margin: this bounds
+# the cache to "datasets watched recently, as of the last time anything was
+# watched", not a hard cap enforced on a fixed clock.
+_STALE_ENTRY_TTL_MULTIPLE = 10
+
+
+async def _cached_latest_completed_run_id(dataset_id: UUID) -> Optional[UUID]:
+    now = time.monotonic()
+    # Read module globals at call time, not module-import time, so a test
+    # that speeds up TICK_SECONDS via monkeypatch also speeds up this TTL.
+    ttl_seconds = GRAPH_POLL_TICKS * TICK_SECONDS
+    cached = _latest_run_cache.get(dataset_id)
+    if cached is not None and now - cached[0] < ttl_seconds:
+        return cached[1]
+
+    run_id = await _latest_completed_run_id(dataset_id)
+    _latest_run_cache[dataset_id] = (now, run_id)
+
+    stale_before = now - ttl_seconds * _STALE_ENTRY_TTL_MULTIPLE
+    for stale_id in [k for k, v in _latest_run_cache.items() if v[0] < stale_before]:
+        del _latest_run_cache[stale_id]
+
+    return run_id
+
+
+async def _watch_for_disconnect(websocket: WebSocket) -> None:
+    """Return when the client goes away.
+
+    A push-only loop never notices a closed connection: nothing raises until
+    something is sent, and a send after the peer left is silently dropped. So
+    the socket is read in parallel purely to observe the disconnect — which
+    also drains whatever frames a client sends (a deployment that replaces the
+    authentication dependency may have its clients send some), instead of
+    letting them queue for a reader that never comes.
+    """
+    while True:
+        message = await websocket.receive()
+        if message["type"] == "websocket.disconnect":
+            return
+
+
+async def _push_updates(
+    websocket: WebSocket,
+    dataset_id: UUID,
+    user: User,
+    cursor: Optional[datetime],
+) -> None:
+    """Poll and push until the connection drops or a poll refuses."""
+    # Uncached: this runs once per connection, not once per tick, so it
+    # cannot contribute to the per-viewer polling load the cache exists for.
+    # Using the cache here would let a brand-new connection inherit another
+    # viewer's stale poll as its baseline, which can misreport an already-
+    # complete run as newly grown (see stream_dataset_updates's docstring).
+    last_run_id = await _latest_completed_run_id(dataset_id)
+    tick = 0
+
+    while True:
+        await asyncio.sleep(TICK_SECONDS)
+        tick += 1
+
+        if tick % LIVE_EVENTS_TICKS == 0:
+            # Re-authorizes on every poll, being the same call the HTTP
+            # endpoint serves: read access revoked mid-connection ends the
+            # stream within one poll instead of at the next reconnect.
+            payload = await get_live_events(dataset_id, since=cursor, user=user)
+            events: List[Dict[str, Any]] = payload["events"]
+            if events:
+                await websocket.send_json(
+                    {"kind": "live_events", "events": events, "cursor": payload["cursor"]}
+                )
+                cursor = _parse_cursor(payload["cursor"]) or cursor
+
+        if tick % GRAPH_POLL_TICKS == 0:
+            # Re-authorizes here too, same as the live_events tick above: this
+            # lane used to rely on that tick's check to catch a revocation,
+            # which left up to one GRAPH_POLL_TICKS window where a growth
+            # signal could still go out after access was pulled.
+            authorized = await get_authorized_existing_datasets([dataset_id], "read", user)
+            if not authorized:
+                raise PermissionDeniedError(message="Not authorized to read this dataset")
+
+            run_id = await _cached_latest_completed_run_id(dataset_id)
+            if run_id is not None and run_id != last_run_id:
+                last_run_id = run_id
+                await websocket.send_json({"kind": "graph_grew", "pipeline_run_id": str(run_id)})
+
+        if tick % HEARTBEAT_TICKS == 0:
+            await websocket.send_json(
+                {"kind": "heartbeat", "time": datetime.now(timezone.utc).isoformat()}
+            )
+
+
+async def stream_dataset_updates(
+    websocket: WebSocket,
+    dataset_id: UUID,
+    user: User,
+    since: Optional[datetime] = None,
+) -> None:
+    """Push this dataset's updates over an accepted, authorized WebSocket.
+
+    Sends a ``ready`` frame, then pushes until the client disconnects. Frames:
+
+    - ``{"kind": "ready", "dataset_id": str, "cursor": str | null}`` — once,
+      echoing the cursor the stream starts from.
+    - ``{"kind": "live_events", "events": [...], "cursor": str}`` — every ~2s,
+      but only when the delta is non-empty. ``cursor`` is what to reconnect
+      with; the stream advances its own copy from the same value.
+    - ``{"kind": "graph_grew", "pipeline_run_id": str}`` — within ~5s of a
+      cognify run for this dataset completing. A run that completed before the
+      connection opened is the baseline and is not announced.
+    - ``{"kind": "heartbeat", "time": str}`` — every ~15s, so a client can tell
+      a quiet stream from a dead one.
+
+    Args:
+        websocket: An already accepted connection. Callers own accept/close so
+            a rejection can carry a close code the client will see.
+        dataset_id: The dataset to follow. Already authorized by the caller.
+        user: The authenticated caller, whose session events are streamed.
+        since: Resume point from a previous connection's last cursor. None
+            starts from every event currently available.
+
+    Raises:
+        PermissionDeniedError: read access to the dataset was lost while the
+            stream was running.
+    """
+    await websocket.send_json(
+        {
+            "kind": "ready",
+            "dataset_id": str(dataset_id),
+            "cursor": since.isoformat() if since else None,
+        }
+    )
+
+    push_task = asyncio.create_task(_push_updates(websocket, dataset_id, user, since))
+    disconnect_task = asyncio.create_task(_watch_for_disconnect(websocket))
+
+    done, pending = await asyncio.wait(
+        {push_task, disconnect_task}, return_when=asyncio.FIRST_COMPLETED
+    )
+
+    # Cancelled but deliberately not awaited: awaiting a cancelled child would
+    # also absorb a cancellation aimed at *this* task — a server shutting the
+    # connection down — and carry on serving a socket that was told to stop.
+    # The child observes its own cancellation on the next pass regardless.
+    for task in pending:
+        task.cancel()
+
+    # Surfaces whatever ended the push loop (a lost permission, a failed poll)
+    # to the caller, which owns the close code. A finished disconnect watcher
+    # carries no result, so a client that simply left ends the stream quietly.
+    for task in done:
+        task.result()

--- a/cognee/api/v1/visualize/visualize.py
+++ b/cognee/api/v1/visualize/visualize.py
@@ -1,6 +1,11 @@
+import json
+from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Tuple, Optional, Union
 from uuid import UUID
+
+from sqlalchemy import select
+
 from cognee.modules.users.models.User import User
 
 from cognee.modules.visualization.cognee_network_visualization import (
@@ -10,6 +15,7 @@ from cognee.modules.visualization.cognee_network_visualization import (
     build_semantic_payload,
     build_brain_summary_payload,
 )
+from cognee.modules.visualization.preprocessor import build_node_set_colors
 from cognee.modules.visualization.session_events import collect_session_events
 from cognee.modules.visualization.subgraph_data import (
     DEFAULT_MAX_NODES,
@@ -18,7 +24,9 @@ from cognee.modules.visualization.subgraph_data import (
     fetch_visualization_graph_data,
 )
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.data.methods import get_authorized_existing_datasets, get_datasets_graph_counts
+from cognee.modules.data.models import Data
 from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.modules.users.permissions.methods import get_all_user_permission_datasets
 from cognee.modules.users.methods import get_default_user
@@ -322,6 +330,137 @@ async def build_brains_payload(
     for dataset in datasets:
         graph_data = await fetch_dataset_graph_data(dataset, max_nodes=max_nodes)
         payload[str(dataset.id)] = build_brain_summary_payload(dataset.name, graph_data)
+
+    return payload
+
+
+def _parse_node_set(raw: Any) -> List[str]:
+    """The node set names on one ``Data`` row, defensively.
+
+    ``Data.node_set`` is written by ingestion as ``json.dumps(list)`` — a JSON
+    string inside a JSON column — so the value read back is normally a string
+    holding a list. A row written or migrated by anything else could hold the
+    list itself, a bare name, or something unusable; none of those may break an
+    overview of every dataset a user can read, so each degrades to what it can
+    contribute instead of raising.
+
+    Order is preserved: it is the order ``classify_documents`` joins the names
+    in to build the graph's ``source_node_set`` value, which is what the node
+    set color map is keyed by.
+    """
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except ValueError:
+            return [raw.strip()] if raw.strip() else []
+
+    if isinstance(raw, str):
+        return [raw.strip()] if raw.strip() else []
+
+    if not isinstance(raw, (list, tuple)):
+        return []
+
+    return [name.strip() for name in raw if isinstance(name, str) and name.strip()]
+
+
+async def _fetch_dataset_node_sets(dataset_ids: List[UUID]) -> Dict[UUID, List[List[str]]]:
+    """Every dataset's node sets, one entry per ingested document, in one query.
+
+    Reads the two columns it needs for every dataset at once — the point of the
+    summary endpoint is that describing N datasets costs one relational query,
+    not N of anything.
+
+    Each document's names stay their own list rather than being flattened per
+    dataset: a document carrying several node sets contributes the comma-joined
+    form as a single color key (that is what the graph stores in
+    ``source_node_set``) while contributing each name separately to
+    ``source_names``.
+    """
+    if not dataset_ids:
+        return {}
+
+    db_engine = get_relational_engine()
+
+    async with db_engine.get_async_session() as session:
+        rows = (
+            await session.execute(
+                select(Data.dataset_id, Data.node_set).where(
+                    Data.dataset_id.in_(dataset_ids),
+                    Data.node_set.isnot(None),
+                )
+            )
+        ).all()
+
+    node_sets: Dict[UUID, List[List[str]]] = defaultdict(list)
+    for dataset_id, raw in rows:
+        names = _parse_node_set(raw)
+        if names:
+            node_sets[dataset_id].append(names)
+
+    return node_sets
+
+
+async def build_brains_summary_payload(user: Optional[User] = None) -> dict:
+    """Every dataset the caller may read, described from relational metadata.
+
+    ``{dataset_id: {"name", "source_names", "node_count", "node_set_colors"}}``
+    — the overview data ``build_brains_payload`` produces as a side effect of
+    fetching each dataset's graph, produced instead from relational metadata
+    plus the per-cognify-run count cache. That is the point: ``/brains`` costs
+    one bounded graph read per readable dataset on every call, which is what
+    makes it unfit for a switcher that only needs names, sources and a size.
+    This costs one count query per cognify run whose count is not cached yet
+    (see ``get_datasets_graph_counts``) — so a cold cache does open the graph
+    engine once per such dataset, and every call after that opens none.
+
+    Same authorization as ``build_brains_payload`` — the group-aware union in
+    ``get_all_user_permission_datasets`` — so both list the same datasets.
+
+    Returns:
+        dict: keyed by dataset id (as a string), each value holding
+
+        - ``name``: the dataset's name.
+        - ``source_names``: distinct node set names across the dataset's
+          ingested data, sorted; empty for data ingested without node sets.
+        - ``node_count``: nodes in the dataset's graph as of its latest cognify
+          run (see ``get_datasets_graph_counts``) — the whole graph, not only
+          entity nodes, and 0 for a dataset never cognified.
+        - ``node_set_colors``: node set colors from the same
+          ``build_node_set_colors`` rule ``/brains`` uses. Same rule and same
+          input node sets give the same colors, but the two endpoints do not
+          always have the same input: the rule assigns hues by position in the
+          sorted set of names, ``/brains`` takes that set from the nodes its
+          bounded graph fetch returned, and this takes it from every ``Data``
+          row of the dataset. Where those sets differ — notably a node set that
+          exists only in the graph, such as the memory sets ``improve()``
+          writes, which has no relational row here at all — the colors from the
+          divergence onward differ too.
+    """
+    if not user:
+        user = await get_default_user()
+
+    datasets = await get_all_user_permission_datasets(user, "read")
+    if not datasets:
+        return {}
+
+    # Independent reads against different stores; run them together so the
+    # payload costs the slower one rather than their sum.
+    node_sets, counts = await asyncio.gather(
+        _fetch_dataset_node_sets([dataset.id for dataset in datasets]),
+        get_datasets_graph_counts(datasets),
+    )
+
+    payload: dict = {}
+    for dataset in datasets:
+        dataset_node_sets = node_sets.get(dataset.id, [])
+        payload[str(dataset.id)] = {
+            "name": dataset.name,
+            "source_names": sorted({name for names in dataset_node_sets for name in names}),
+            "node_count": counts[dataset.id].num_nodes,
+            "node_set_colors": build_node_set_colors(
+                ", ".join(names) for names in dataset_node_sets
+            ),
+        }
 
     return payload
 

--- a/cognee/modules/cognify/recovery.py
+++ b/cognee/modules/cognify/recovery.py
@@ -1,15 +1,15 @@
 import os
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import func, select
-from sqlalchemy.orm import aliased
-
 from cognee.context_global_variables import set_database_global_context_variables
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.cognify.rollback import cognify_rollback_handler
 from cognee.modules.data.models import Dataset
-from cognee.modules.pipelines.methods import reset_pipeline_run_status
-from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus
+from cognee.modules.pipelines.methods import (
+    get_latest_pipeline_runs_by_datasets,
+    reset_pipeline_run_status,
+)
+from cognee.modules.pipelines.models import PipelineRunStatus
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("cognify.recovery")
@@ -56,33 +56,12 @@ async def recover_stale_cognify_runs_on_startup() -> None:
     db_engine = get_relational_engine()
 
     try:
-        async with db_engine.get_async_session() as session:
-            latest_per_dataset = (
-                select(
-                    PipelineRun,
-                    func.row_number()
-                    .over(
-                        partition_by=PipelineRun.dataset_id,
-                        order_by=PipelineRun.created_at.desc(),
-                    )
-                    .label("rn"),
-                )
-                .where(PipelineRun.pipeline_name == "cognify_pipeline")
-                .subquery()
-            )
-
-            latest_run = aliased(PipelineRun, latest_per_dataset)
-            recovery_candidates = (
-                (
-                    await session.execute(
-                        select(latest_run)
-                        .where(latest_per_dataset.c.rn == 1)
-                        .where(latest_run.status == PipelineRunStatus.DATASET_PROCESSING_STARTED)
-                    )
-                )
-                .scalars()
-                .all()
-            )
+        latest_per_dataset = await get_latest_pipeline_runs_by_datasets(None, "cognify_pipeline")
+        recovery_candidates = [
+            run
+            for run in latest_per_dataset.values()
+            if run.status == PipelineRunStatus.DATASET_PROCESSING_STARTED
+        ]
     except Exception:
         logger.error("Failed to recover latest cognify run which did not successfully finish.")
         return

--- a/cognee/modules/data/methods/__init__.py
+++ b/cognee/modules/data/methods/__init__.py
@@ -25,6 +25,7 @@ from .load_or_create_datasets import load_or_create_datasets
 from .create_authorized_dataset import create_authorized_dataset
 
 # Check
+from .get_datasets_graph_counts import DatasetGraphCounts, get_datasets_graph_counts
 from .check_dataset_name import check_dataset_name
 
 # Boolean check

--- a/cognee/modules/data/methods/get_datasets_graph_counts.py
+++ b/cognee/modules/data/methods/get_datasets_graph_counts.py
@@ -1,0 +1,201 @@
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Dict, List, Optional
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from cognee.context_global_variables import set_database_global_context_variables
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.data.models import Dataset, GraphMetrics
+from cognee.shared.logging_utils import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - import-time cycle guard
+    from cognee.modules.pipelines.models import PipelineRun
+
+logger = get_logger()
+
+# The only pipeline whose completion changes a dataset's graph size. Counts are
+# keyed by its run id, which is what makes them cacheable: the graph cannot
+# grow without a new run, so a cached count for the latest run is exact.
+COGNIFY_PIPELINE_NAME = "cognify_pipeline"
+
+
+@dataclass(frozen=True)
+class DatasetGraphCounts:
+    """One dataset's graph size, as of its latest cognify run.
+
+    Attributes:
+        pipeline_run_id: The latest cognify run these counts describe, or None
+            when the dataset has never been cognified (counts are then 0).
+        num_nodes: Nodes in the dataset's graph.
+        num_edges: Edges in the dataset's graph.
+        computed_at: When the counts were cached. None means the counts were
+            not cached — either the graph store was unavailable (counts are 0
+            and will be retried on the next call) or the cache write lost a
+            race with a concurrent caller (counts are still exact).
+    """
+
+    pipeline_run_id: Optional[UUID] = None
+    num_nodes: int = 0
+    num_edges: int = 0
+    computed_at: Optional[datetime] = None
+
+
+async def _get_latest_cognify_runs(dataset_ids: List[UUID]) -> Dict[UUID, "PipelineRun"]:
+    """The newest cognify run row per dataset, in one query.
+
+    Delegates to the same query get_pipeline_run_by_dataset uses for the
+    single-dataset case, so run-ranking semantics live in one place. Imported
+    here, not at module scope: cognee.modules.pipelines' package __init__
+    reaches back into cognee.modules.data.methods, so importing it while this
+    package is still initialising leaves that package's other re-exports
+    bound to their submodules instead of their functions -- which surfaced as
+    "'module' object is not callable" on every add.
+    """
+    from cognee.modules.pipelines.methods import get_latest_pipeline_runs_by_datasets
+
+    return await get_latest_pipeline_runs_by_datasets(dataset_ids, COGNIFY_PIPELINE_NAME)
+
+
+async def _get_cached_metrics(run_ids: List[UUID]) -> Dict[UUID, GraphMetrics]:
+    """Already-computed counts for these runs, in one query."""
+    if not run_ids:
+        return {}
+
+    db_engine = get_relational_engine()
+
+    async with db_engine.get_async_session() as session:
+        cached = (
+            (await session.execute(select(GraphMetrics).where(GraphMetrics.id.in_(run_ids))))
+            .scalars()
+            .all()
+        )
+
+    return {metrics.id: metrics for metrics in cached}
+
+
+async def _count_and_cache(dataset: Dataset, pipeline_run_id: UUID) -> DatasetGraphCounts:
+    """Count one dataset's graph and cache the result against its run id."""
+    try:
+        async with set_database_global_context_variables(dataset.id, dataset.owner_id):
+            graph_engine = await get_graph_engine()
+            graph_metrics = await graph_engine.get_graph_metrics(include_optional=False) or {}
+    except Exception as error:
+        logger.warning("Failed to compute graph metrics for dataset %s: %s", dataset.id, error)
+        return DatasetGraphCounts(pipeline_run_id=pipeline_run_id)
+
+    num_nodes = graph_metrics.get("num_nodes") or 0
+    num_edges = graph_metrics.get("num_edges") or 0
+
+    # A concurrent caller may have cached the same run id between the read
+    # above and this write, which collides on the GraphMetrics primary key
+    # (id=pipeline_run_id). The counts are already correct either way, so a
+    # losing race reports them uncached rather than throwing them away.
+    #
+    # This dataset's write failing must never fail the whole batch — the
+    # caller runs one _count_and_cache per cache miss concurrently via
+    # asyncio.gather, so an uncaught exception here would cancel every other
+    # dataset's already-correct counts too. IntegrityError (the anticipated
+    # race) degrades quietly at warning level; anything else still degrades
+    # this one dataset to uncached rather than propagating, but is logged as
+    # an error so a real bug stays visible instead of reading as a benign race.
+    computed_at = None
+    try:
+        db_engine = get_relational_engine()
+        async with db_engine.get_async_session() as session:
+            # has_full_metrics stays False: this row holds counts and nothing
+            # else, so `get_pipeline_run_metrics` has to keep seeing that run
+            # as still owing it a full computation.
+            session.add(
+                GraphMetrics(
+                    id=pipeline_run_id,
+                    has_full_metrics=False,
+                    num_nodes=num_nodes,
+                    num_edges=num_edges,
+                )
+            )
+            await session.commit()
+        computed_at = datetime.now(timezone.utc)
+    except IntegrityError as error:
+        logger.warning("Lost the caching race for dataset %s: %s", dataset.id, error)
+    except Exception as error:
+        logger.error("Failed to cache graph metrics for dataset %s: %s", dataset.id, error)
+
+    return DatasetGraphCounts(
+        pipeline_run_id=pipeline_run_id,
+        num_nodes=num_nodes,
+        num_edges=num_edges,
+        computed_at=computed_at,
+    )
+
+
+async def get_datasets_graph_counts(
+    datasets: List[Dataset],
+) -> Dict[UUID, DatasetGraphCounts]:
+    """Node/edge counts per dataset, cached per cognify run.
+
+    Counts are computed once per dataset's latest cognify run and cached in
+    ``GraphMetrics`` keyed by that run's ``pipeline_run_id`` — orders of
+    magnitude cheaper on repeat calls than a full graph traversal, and the
+    reason both ``GET /datasets/graph-summary`` and
+    ``GET /visualize/brains-summary`` can be polled.
+
+    The cached row is a partial one (``has_full_metrics=False``): it holds the
+    two counts and nothing else, so ``get_pipeline_run_metrics`` still knows it
+    owes that run a full computation.
+
+    Callers are expected to have authorized the datasets already; this does no
+    permission checking of its own.
+
+    Args:
+        datasets: Authorized datasets to count. An empty list returns ``{}``.
+
+    Returns:
+        dict: One ``DatasetGraphCounts`` per input dataset, keyed by dataset
+        id. Never partial — a dataset whose graph could not be read is present
+        with zero counts rather than missing, so one unavailable graph store
+        cannot silently drop a dataset from a caller's response.
+    """
+    if not datasets:
+        return {}
+
+    latest_runs = await _get_latest_cognify_runs([dataset.id for dataset in datasets])
+    cached_metrics = await _get_cached_metrics(
+        [run.pipeline_run_id for run in latest_runs.values() if run.pipeline_run_id]
+    )
+
+    counts: Dict[UUID, DatasetGraphCounts] = {}
+    misses: List[UUID] = []
+    miss_calls = []
+    for dataset in datasets:
+        latest_run = latest_runs.get(dataset.id)
+        if latest_run is None or latest_run.pipeline_run_id is None:
+            counts[dataset.id] = DatasetGraphCounts()
+            continue
+
+        cached = cached_metrics.get(latest_run.pipeline_run_id)
+        if cached is not None:
+            counts[dataset.id] = DatasetGraphCounts(
+                pipeline_run_id=latest_run.pipeline_run_id,
+                num_nodes=cached.num_nodes or 0,
+                num_edges=cached.num_edges or 0,
+                computed_at=cached.created_at,
+            )
+            continue
+
+        # Each miss opens its own graph engine and does its own traversal —
+        # independent per dataset, so they run concurrently rather than
+        # paying the sum of every miss's latency.
+        misses.append(dataset.id)
+        miss_calls.append(_count_and_cache(dataset, latest_run.pipeline_run_id))
+
+    if miss_calls:
+        computed = await asyncio.gather(*miss_calls)
+        for dataset_id, result in zip(misses, computed):
+            counts[dataset_id] = result
+
+    return counts

--- a/cognee/modules/data/models/GraphMetrics.py
+++ b/cognee/modules/data/models/GraphMetrics.py
@@ -1,17 +1,31 @@
 from datetime import datetime, timezone
 from sqlalchemy.sql import func
 
-from sqlalchemy import Column, DateTime, Float, Integer, JSON, UUID
+from sqlalchemy import Boolean, Column, DateTime, Float, Integer, JSON, UUID, false
 
 from cognee.infrastructure.databases.relational import Base
 from uuid import uuid4
 
 
 class GraphMetrics(Base):
+    """One pipeline run's graph metrics, cached under that run's id.
+
+    Rows are written by two paths with different appetites: the full
+    computation in ``get_pipeline_run_metrics``, and the node/edge count in
+    ``get_datasets_graph_counts``, which only ever fills ``num_nodes`` and
+    ``num_edges`` because that is all the graph-summary endpoints read.
+    ``has_full_metrics`` tells the two apart — see the column's comment.
+    """
+
     __tablename__ = "graph_metrics"
 
     # TODO: Change ID to reflect unique id of graph database
     id = Column(UUID, primary_key=True, default=uuid4)
+    # False on a row holding only node/edge counts. Without it, the cheap
+    # counting path would look to `get_pipeline_run_metrics` like a finished
+    # cache entry, and that run's token count and connectivity metrics would
+    # read as NULL forever, with nothing reporting they were never computed.
+    has_full_metrics = Column(Boolean, nullable=False, default=False, server_default=false())
     num_tokens = Column(Integer, nullable=True)
     num_nodes = Column(Integer, nullable=True)
     num_edges = Column(Integer, nullable=True)

--- a/cognee/modules/metrics/operations/get_pipeline_run_metrics.py
+++ b/cognee/modules/metrics/operations/get_pipeline_run_metrics.py
@@ -30,6 +30,22 @@ async def fetch_token_count(db_engine) -> int:
 
 
 async def get_pipeline_run_metrics(pipeline_run: PipelineRunInfo, include_optional: bool):
+    """Compute (or read from cache) the full metrics for one pipeline run.
+
+    Only a row flagged ``has_full_metrics`` counts as a cache hit. A row left
+    by the node/edge counting path (``get_datasets_graph_counts``) holds those
+    two numbers and nothing else; treating it as a hit would return NULL for
+    the token count and every connectivity metric for the rest of that run's
+    life. Such a row is completed in place instead, so the cheap path can keep
+    caching what it knows without deciding this one's answer.
+
+    ``has_full_metrics`` is only ever set when ``include_optional`` is True:
+    with it False, the graph engine fills diameter/avg_clustering/etc. with
+    -1 sentinels rather than computing them, so a row written that way is not
+    a complete answer for a later caller that does want the optional metrics.
+    Leaving the flag False makes such a row a cache miss on every subsequent
+    call until one finally runs with include_optional=True.
+    """
     logger.debug("Computing metrics for pipeline run ID: %s", pipeline_run.pipeline_run_id)
     start_time = time.time()
     db_engine = get_relational_engine()
@@ -42,7 +58,7 @@ async def get_pipeline_run_metrics(pipeline_run: PipelineRunInfo, include_option
             select(GraphMetrics).where(GraphMetrics.id == pipeline_run.pipeline_run_id)
         )
         existing_metrics = existing_metrics.scalars().first()
-        if existing_metrics:
+        if existing_metrics is not None and existing_metrics.has_full_metrics:
             metrics_for_pipeline_runs.append(existing_metrics)
             cache_status = "cache hit"
         else:
@@ -53,6 +69,7 @@ async def get_pipeline_run_metrics(pipeline_run: PipelineRunInfo, include_option
             num_tokens = (await session.execute(select(func.sum(Data.token_count)))).scalar()
             metrics = GraphMetrics(
                 id=pipeline_run.pipeline_run_id,
+                has_full_metrics=include_optional,
                 num_tokens=num_tokens,
                 num_nodes=graph_metrics["num_nodes"],
                 num_edges=graph_metrics["num_edges"],
@@ -65,8 +82,10 @@ async def get_pipeline_run_metrics(pipeline_run: PipelineRunInfo, include_option
                 avg_shortest_path_length=graph_metrics["avg_shortest_path_length"],
                 avg_clustering=graph_metrics["avg_clustering"],
             )
-            metrics_for_pipeline_runs.append(metrics)
-            session.add(metrics)
+            # merge, not add: the counting path may already hold this primary
+            # key with a partial row, which is filled in rather than collided
+            # with.
+            metrics_for_pipeline_runs.append(await session.merge(metrics))
         await session.commit()
     response_time = time.time() - start_time
     logger.info(

--- a/cognee/modules/pipelines/methods/__init__.py
+++ b/cognee/modules/pipelines/methods/__init__.py
@@ -1,4 +1,7 @@
 from .get_pipeline_run import get_pipeline_run
-from .get_pipeline_run_by_dataset import get_pipeline_run_by_dataset
+from .get_pipeline_run_by_dataset import (
+    get_pipeline_run_by_dataset,
+    get_latest_pipeline_runs_by_datasets,
+)
 from .get_pipeline_runs_by_dataset import get_pipeline_runs_by_dataset
 from .reset_pipeline_run_status import reset_pipeline_run_status

--- a/cognee/modules/pipelines/methods/get_pipeline_run_by_dataset.py
+++ b/cognee/modules/pipelines/methods/get_pipeline_run_by_dataset.py
@@ -1,3 +1,4 @@
+from typing import Dict, List, Optional
 from uuid import UUID
 from sqlalchemy import select, func
 from cognee.infrastructure.databases.relational import get_relational_engine
@@ -5,29 +6,53 @@ from ..models import PipelineRun
 from sqlalchemy.orm import aliased
 
 
+def _latest_run_per_dataset_query(dataset_ids: Optional[List[UUID]], pipeline_name: str):
+    """The newest PipelineRun row per dataset, ranked by created_at desc.
+
+    dataset_ids=None means every dataset, not none of them.
+    """
+    query = select(
+        PipelineRun,
+        func.row_number()
+        .over(
+            partition_by=PipelineRun.dataset_id,
+            order_by=PipelineRun.created_at.desc(),
+        )
+        .label("rn"),
+    ).filter(PipelineRun.pipeline_name == pipeline_name)
+    if dataset_ids is not None:
+        query = query.filter(PipelineRun.dataset_id.in_(dataset_ids))
+    ranked_runs = query.subquery()
+    aliased_run = aliased(PipelineRun, ranked_runs)
+    return select(aliased_run).filter(ranked_runs.c.rn == 1)
+
+
 async def get_pipeline_run_by_dataset(dataset_id: UUID, pipeline_name: str):
     db_engine = get_relational_engine()
 
     async with db_engine.get_async_session() as session:
-        query = (
-            select(
-                PipelineRun,
-                func.row_number()
-                .over(
-                    partition_by=PipelineRun.dataset_id,
-                    order_by=PipelineRun.created_at.desc(),
-                )
-                .label("rn"),
-            )
-            .filter(PipelineRun.dataset_id == dataset_id)
-            .filter(PipelineRun.pipeline_name == pipeline_name)
-            .subquery()
-        )
-
-        aliased_pipeline_run = aliased(PipelineRun, query)
-
-        latest_run = select(aliased_pipeline_run).filter(query.c.rn == 1)
-
-        run = (await session.execute(latest_run)).scalars().first()
+        query = _latest_run_per_dataset_query([dataset_id], pipeline_name)
+        run = (await session.execute(query)).scalars().first()
 
         return run
+
+
+async def get_latest_pipeline_runs_by_datasets(
+    dataset_ids: Optional[List[UUID]], pipeline_name: str
+) -> Dict[UUID, PipelineRun]:
+    """The batched sibling of get_pipeline_run_by_dataset: the newest run per
+    dataset, in one query, keyed by dataset_id.
+
+    dataset_ids=None returns the latest run for every dataset that has one,
+    not an empty result — pass a list (possibly empty) to scope it.
+    """
+    if dataset_ids is not None and not dataset_ids:
+        return {}
+
+    db_engine = get_relational_engine()
+
+    async with db_engine.get_async_session() as session:
+        query = _latest_run_per_dataset_query(dataset_ids, pipeline_name)
+        runs = (await session.execute(query)).scalars().all()
+
+    return {run.dataset_id: run for run in runs}

--- a/cognee/modules/pipelines/operations/get_pipeline_status.py
+++ b/cognee/modules/pipelines/operations/get_pipeline_status.py
@@ -1,35 +1,9 @@
 from uuid import UUID
-from sqlalchemy import select, func
-from cognee.infrastructure.databases.relational import get_relational_engine
-from ..models import PipelineRun
-from sqlalchemy.orm import aliased
+
+from ..methods import get_latest_pipeline_runs_by_datasets
 
 
 async def get_pipeline_status(dataset_ids: list[UUID], pipeline_name: str):
-    db_engine = get_relational_engine()
+    runs = await get_latest_pipeline_runs_by_datasets(dataset_ids, pipeline_name)
 
-    async with db_engine.get_async_session() as session:
-        query = (
-            select(
-                PipelineRun,
-                func.row_number()
-                .over(
-                    partition_by=PipelineRun.dataset_id,
-                    order_by=PipelineRun.created_at.desc(),
-                )
-                .label("rn"),
-            )
-            .filter(PipelineRun.dataset_id.in_(dataset_ids))
-            .filter(PipelineRun.pipeline_name == pipeline_name)
-            .subquery()
-        )
-
-        aliased_pipeline_run = aliased(PipelineRun, query)
-
-        latest_runs = select(aliased_pipeline_run).filter(query.c.rn == 1)
-
-        runs = (await session.execute(latest_runs)).scalars().all()
-
-        pipeline_statuses = {str(run.dataset_id): run.status for run in runs}
-
-        return pipeline_statuses
+    return {str(dataset_id): run.status for dataset_id, run in runs.items()}

--- a/cognee/modules/visualization/preprocessor.py
+++ b/cognee/modules/visualization/preprocessor.py
@@ -186,6 +186,28 @@ def generate_provenance_colors(values):
     return color_map
 
 
+def build_node_set_colors(values) -> Dict[str, str]:
+    """The ``node_set`` color map: hue rotation, with memory sets pinned.
+
+    Split out of ``preprocess`` so a caller that derives the same map from
+    somewhere other than fetched graph nodes — ``build_brains_summary_payload``
+    reads the node sets relationally, without touching the graph — produces
+    colors identical to the ones the rendered graph uses, instead of
+    re-deriving the rule and drifting from it.
+
+    ``values`` are raw ``source_node_set`` values (a node set name, or the
+    comma-joined string a multi-set document carries); the returned map is
+    keyed by those same raw values.
+    """
+    color_map = generate_provenance_colors(values)
+    # Pin stable, meaningful colors for self-improvement node sets, overriding
+    # the hue-rotation only for sets actually present.
+    for set_name, color in _MEMORY_NODESET_COLORS.items():
+        if set_name in color_map:
+            color_map[set_name] = color
+    return color_map
+
+
 # UUID- or content-hash-shaped strings: never useful as display names.
 _IDENTIFIER_LIKE_RE = re.compile(
     r"^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32,64})$",
@@ -1373,14 +1395,9 @@ def preprocess(graph_data, schema_data: Optional[Dict[str, Any]] = None) -> Prep
     color_maps = {
         "task": generate_provenance_colors([n.get("source_task") for n in nodes]),
         "pipeline": generate_provenance_colors([n.get("source_pipeline") for n in nodes]),
-        "node_set": generate_provenance_colors([n.get("source_node_set") for n in nodes]),
+        "node_set": build_node_set_colors([n.get("source_node_set") for n in nodes]),
         "user": generate_provenance_colors([n.get("source_user") for n in nodes]),
     }
-    # Pin stable, meaningful colors for self-improvement node sets, overriding the
-    # hue-rotation only for sets actually present in this graph.
-    for set_name, color in _MEMORY_NODESET_COLORS.items():
-        if set_name in color_maps["node_set"]:
-            color_maps["node_set"][set_name] = color
 
     schema_graph = extract_schema_graph_data(nodes, links)
     build_operation_layer(schema_graph, nodes, links)

--- a/cognee/tests/unit/api/test_brains_summary.py
+++ b/cognee/tests/unit/api/test_brains_summary.py
@@ -1,0 +1,252 @@
+"""build_brains_summary_payload: the overview that never reads a graph.
+
+Patches at the two boundaries the payload is assembled from — the relational
+node-set read and the cached graph counts — because both are covered by their
+own tests (test_get_datasets_graph_counts.py) and neither is what this adds.
+What is new, and what this pins, is the assembly: the per-dataset shape, node
+sets parsed out of the way ingestion writes them, and colors that agree with
+the ones GET /visualize/brains hands out for the same node sets — the whole
+point of the endpoint being a cheaper *substitute* for it.
+"""
+
+import sys
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from cognee.api.v1.visualize.visualize import (  # noqa: F401
+    build_brains_summary_payload as _build_brains_summary_payload,
+)
+from cognee.modules.data.methods import DatasetGraphCounts
+from cognee.modules.visualization.cognee_network_visualization import build_brain_summary_payload
+
+visualize_module = sys.modules["cognee.api.v1.visualize.visualize"]
+counts_module = sys.modules["cognee.modules.data.methods.get_datasets_graph_counts"]
+
+
+def _dataset(name: str):
+    return SimpleNamespace(id=uuid4(), name=name, owner_id=uuid4())
+
+
+@asynccontextmanager
+async def _no_op_context(*_args, **_kwargs):
+    yield
+
+
+def _discarding_engine():
+    """A relational engine whose session accepts the count-cache write and
+    drops it: what gets cached is get_datasets_graph_counts' own test's
+    business, not this file's."""
+
+    @asynccontextmanager
+    async def get_async_session():
+        yield SimpleNamespace(add=lambda _instance: None, commit=AsyncMock())
+
+    return SimpleNamespace(get_async_session=get_async_session)
+
+
+def _patches(datasets, node_sets, counts=None):
+    if counts is None:
+        counts = {dataset.id: DatasetGraphCounts() for dataset in datasets}
+    return (
+        patch.object(
+            visualize_module,
+            "get_all_user_permission_datasets",
+            AsyncMock(return_value=datasets),
+        ),
+        patch.object(
+            visualize_module, "_fetch_dataset_node_sets", AsyncMock(return_value=node_sets)
+        ),
+        patch.object(visualize_module, "get_datasets_graph_counts", AsyncMock(return_value=counts)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_each_readable_dataset_gets_the_documented_shape_keyed_by_id():
+    billing, support = _dataset("billing"), _dataset("support")
+    counts = {
+        billing.id: DatasetGraphCounts(pipeline_run_id=uuid4(), num_nodes=42, num_edges=99),
+        support.id: DatasetGraphCounts(),
+    }
+
+    ctx_a, ctx_b, ctx_c = _patches(
+        [billing, support], {billing.id: [["slack"], ["notion"]]}, counts
+    )
+    with ctx_a, ctx_b, ctx_c:
+        payload = await visualize_module.build_brains_summary_payload(user=MagicMock())
+
+    assert set(payload) == {str(billing.id), str(support.id)}
+    assert set(payload[str(billing.id)]) == {
+        "name",
+        "source_names",
+        "node_count",
+        "node_set_colors",
+    }
+    assert payload[str(billing.id)]["name"] == "billing"
+    assert payload[str(billing.id)]["source_names"] == ["notion", "slack"]
+    assert payload[str(billing.id)]["node_count"] == 42
+    # A dataset that has never been cognified is present with a zero count,
+    # not missing — a switcher still has to list it.
+    assert payload[str(support.id)]["node_count"] == 0
+    assert payload[str(support.id)]["source_names"] == []
+
+
+@pytest.mark.asyncio
+async def test_no_datasets_is_an_empty_payload_not_an_error():
+    with patch.object(
+        visualize_module, "get_all_user_permission_datasets", AsyncMock(return_value=[])
+    ):
+        payload = await visualize_module.build_brains_summary_payload(user=MagicMock())
+
+    assert payload == {}
+
+
+def _summary_patches(dataset):
+    """Everything above the count cache, so the cost tests below can let the
+    real get_datasets_graph_counts run."""
+    return (
+        patch.object(
+            visualize_module,
+            "get_all_user_permission_datasets",
+            AsyncMock(return_value=[dataset]),
+        ),
+        patch.object(
+            visualize_module, "_fetch_dataset_node_sets", AsyncMock(return_value={dataset.id: []})
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_warm_count_cache_makes_the_summary_cost_no_graph_access_at_all():
+    """Half the reason this endpoint exists. Driven through the REAL
+    get_datasets_graph_counts: patching that out would put the graph access
+    behind the mock and prove nothing about it."""
+    dataset = _dataset("billing")
+    run_id = uuid4()
+    cached = SimpleNamespace(id=run_id, num_nodes=42, num_edges=99, created_at=None)
+    datasets_patch, node_sets_patch = _summary_patches(dataset)
+
+    with (
+        datasets_patch,
+        node_sets_patch,
+        patch.object(
+            counts_module,
+            "_get_latest_cognify_runs",
+            AsyncMock(return_value={dataset.id: SimpleNamespace(pipeline_run_id=run_id)}),
+        ),
+        patch.object(
+            counts_module, "_get_cached_metrics", AsyncMock(return_value={run_id: cached})
+        ),
+        patch.object(counts_module, "get_graph_engine", AsyncMock()) as graph_engine,
+        patch.object(visualize_module, "fetch_dataset_graph_data", AsyncMock()) as fetch_graph,
+    ):
+        payload = await visualize_module.build_brains_summary_payload(user=MagicMock())
+
+    graph_engine.assert_not_called()
+    fetch_graph.assert_not_called()
+    assert payload[str(dataset.id)]["node_count"] == 42
+
+
+@pytest.mark.asyncio
+async def test_a_cold_count_cache_costs_one_count_query_and_no_traversal():
+    """The other half, stated honestly: the first call after an uncached
+    cognify run does open the graph engine — for a count, once per run — not
+    for the bounded node/link fetch /brains does on every single call."""
+    dataset = _dataset("billing")
+    run_id = uuid4()
+    get_graph_metrics = AsyncMock(return_value={"num_nodes": 42, "num_edges": 99})
+    get_graph_data = AsyncMock()
+    datasets_patch, node_sets_patch = _summary_patches(dataset)
+
+    with (
+        datasets_patch,
+        node_sets_patch,
+        patch.object(
+            counts_module,
+            "_get_latest_cognify_runs",
+            AsyncMock(return_value={dataset.id: SimpleNamespace(pipeline_run_id=run_id)}),
+        ),
+        patch.object(counts_module, "_get_cached_metrics", AsyncMock(return_value={})),
+        patch.object(counts_module, "set_database_global_context_variables", _no_op_context),
+        patch.object(
+            counts_module,
+            "get_graph_engine",
+            AsyncMock(
+                return_value=SimpleNamespace(
+                    get_graph_metrics=get_graph_metrics, get_graph_data=get_graph_data
+                )
+            ),
+        ),
+        patch.object(counts_module, "get_relational_engine", lambda: _discarding_engine()),
+        patch.object(visualize_module, "fetch_dataset_graph_data", AsyncMock()) as fetch_graph,
+    ):
+        payload = await visualize_module.build_brains_summary_payload(user=MagicMock())
+
+    get_graph_metrics.assert_awaited_once_with(include_optional=False)
+    get_graph_data.assert_not_awaited()
+    fetch_graph.assert_not_called()
+    assert payload[str(dataset.id)]["node_count"] == 42
+
+
+@pytest.mark.asyncio
+async def test_colors_match_the_ones_brains_gives_the_same_node_sets():
+    dataset = _dataset("billing")
+
+    ctx_a, ctx_b, ctx_c = _patches([dataset], {dataset.id: [["slack"], ["notion"]]})
+    with ctx_a, ctx_b, ctx_c:
+        payload = await visualize_module.build_brains_summary_payload(user=MagicMock())
+
+    # The same two node sets, as /brains would see them on graph nodes.
+    graph_data = (
+        [
+            ("n1", {"type": "Entity", "name": "a", "source_node_set": "slack"}),
+            ("n2", {"type": "Entity", "name": "b", "source_node_set": "notion"}),
+        ],
+        [],
+    )
+    brains_colors = build_brain_summary_payload("billing", graph_data)["node_set_colors"]
+
+    assert payload[str(dataset.id)]["node_set_colors"] == brains_colors
+
+
+@pytest.mark.asyncio
+async def test_a_multi_set_document_colors_the_joined_key_and_lists_names_apart():
+    """Ingestion writes a multi-set document's sets to the graph comma-joined,
+    so that joined string is the color key — while each name is its own
+    source."""
+    dataset = _dataset("billing")
+
+    ctx_a, ctx_b, ctx_c = _patches([dataset], {dataset.id: [["slack", "notion"]]})
+    with ctx_a, ctx_b, ctx_c:
+        payload = await visualize_module.build_brains_summary_payload(user=MagicMock())
+
+    assert payload[str(dataset.id)]["source_names"] == ["notion", "slack"]
+    assert list(payload[str(dataset.id)]["node_set_colors"]) == ["slack, notion"]
+
+
+def test_node_sets_are_parsed_from_the_json_string_ingestion_writes():
+    assert visualize_module._parse_node_set('["slack", "notion"]') == ["slack", "notion"]
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, []),
+        ("", []),
+        ("[]", []),
+        ("   ", []),
+        ("not json", ["not json"]),
+        ('"slack"', ["slack"]),
+        (["slack", "notion"], ["slack", "notion"]),
+        (["slack", None, 7, "  notion  "], ["slack", "notion"]),
+        ('{"slack": 1}', []),
+        (42, []),
+    ],
+)
+def test_malformed_node_set_rows_degrade_instead_of_breaking_the_overview(raw, expected):
+    """One unparsable row must not take down a payload covering every dataset
+    the caller can read."""
+    assert visualize_module._parse_node_set(raw) == expected

--- a/cognee/tests/unit/api/test_brains_summary.py
+++ b/cognee/tests/unit/api/test_brains_summary.py
@@ -95,6 +95,23 @@ async def test_each_readable_dataset_gets_the_documented_shape_keyed_by_id():
 
 
 @pytest.mark.asyncio
+async def test_a_dataset_the_caller_cannot_read_never_reaches_the_payload():
+    """Scoping is entirely delegated to get_all_user_permission_datasets — this
+    endpoint does no filtering of its own. Pin that contract here: if a caller
+    is not authorized for a dataset, get_all_user_permission_datasets simply
+    never returns it, and the payload must not mention its id."""
+    readable = _dataset("billing")
+    unreadable = _dataset("someone_elses_dataset")
+
+    ctx_a, ctx_b, ctx_c = _patches([readable], {})
+    with ctx_a, ctx_b, ctx_c:
+        payload = await visualize_module.build_brains_summary_payload(user=MagicMock())
+
+    assert set(payload) == {str(readable.id)}
+    assert str(unreadable.id) not in payload
+
+
+@pytest.mark.asyncio
 async def test_no_datasets_is_an_empty_payload_not_an_error():
     with patch.object(
         visualize_module, "get_all_user_permission_datasets", AsyncMock(return_value=[])

--- a/cognee/tests/unit/api/test_datasets_graph_summary.py
+++ b/cognee/tests/unit/api/test_datasets_graph_summary.py
@@ -1,0 +1,115 @@
+"""GET /datasets/graph-summary: the poll-friendly counts endpoint.
+
+The endpoint is meant to be polled, so a transient relational failure has to
+come back the way its siblings' do — a 409 with a generic message — instead of
+an unhandled 500 that puts the exception text in front of the caller. These
+pin the two shapes a client sees: the summary itself, and that failure.
+"""
+
+import importlib
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cognee.modules.data.methods import DatasetGraphCounts
+from cognee.modules.users.methods import get_authenticated_user
+
+router_module = importlib.import_module("cognee.api.v1.datasets.routers.get_datasets_router")
+
+DATASET_ID = uuid4()
+RUN_ID = uuid4()
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(router_module, "send_telemetry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        router_module,
+        "get_authorized_existing_datasets",
+        AsyncMock(return_value=[SimpleNamespace(id=DATASET_ID, name="billing")]),
+    )
+
+    app = FastAPI()
+    app.include_router(router_module.get_datasets_router(), prefix="/api/v1/datasets")
+    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(
+        id=uuid4(), email="user@example.com", is_active=True, tenant_id=None
+    )
+    return TestClient(app)
+
+
+def test_a_dataset_is_summarized_with_its_cached_counts(client, monkeypatch):
+    cached_at = datetime(2026, 8, 3, 9, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        router_module,
+        "get_datasets_graph_counts",
+        AsyncMock(
+            return_value={
+                DATASET_ID: DatasetGraphCounts(
+                    pipeline_run_id=RUN_ID, num_nodes=12, num_edges=34, computed_at=cached_at
+                )
+            }
+        ),
+    )
+
+    response = client.get(f"/api/v1/datasets/graph-summary?dataset_ids={DATASET_ID}")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "datasetId": str(DATASET_ID),
+            "pipelineRunId": str(RUN_ID),
+            "numNodes": 12,
+            "numEdges": 34,
+            # The API's own UTC encoding, not datetime.isoformat()'s "+00:00".
+            "computedAt": "2026-08-03T09:00:00Z",
+        }
+    ]
+
+
+def test_no_readable_datasets_is_an_empty_list_not_an_error(client, monkeypatch):
+    monkeypatch.setattr(
+        router_module, "get_authorized_existing_datasets", AsyncMock(return_value=[])
+    )
+
+    response = client.get("/api/v1/datasets/graph-summary")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_a_failed_count_read_is_a_409_that_leaks_nothing(client, monkeypatch):
+    """A transient DB fault on a polled endpoint must not surface as a 500
+    carrying the driver's error text."""
+    monkeypatch.setattr(
+        router_module,
+        "get_datasets_graph_counts",
+        AsyncMock(side_effect=RuntimeError("connection pool exhausted at 10.0.0.4:5432")),
+    )
+
+    response = client.get(f"/api/v1/datasets/graph-summary?dataset_ids={DATASET_ID}")
+
+    assert response.status_code == 409
+    assert response.json() == {"error": "Unable to retrieve dataset graph summary."}
+    assert "10.0.0.4" not in response.text
+
+
+def test_a_failed_authorization_read_is_also_a_409_not_a_500(client, monkeypatch):
+    """The authorization lookup is the same kind of relational read as the
+    counts lookup — a transient fault there must get the same 409, not an
+    unhandled 500."""
+    monkeypatch.setattr(
+        router_module,
+        "get_authorized_existing_datasets",
+        AsyncMock(side_effect=RuntimeError("connection pool exhausted at 10.0.0.4:5432")),
+    )
+
+    response = client.get(f"/api/v1/datasets/graph-summary?dataset_ids={DATASET_ID}")
+
+    assert response.status_code == 409
+    assert response.json() == {"error": "Unable to retrieve dataset graph summary."}
+    assert "10.0.0.4" not in response.text

--- a/cognee/tests/unit/api/test_visualize_subscribe.py
+++ b/cognee/tests/unit/api/test_visualize_subscribe.py
@@ -1,0 +1,270 @@
+"""WS /visualize/subscribe/{dataset_id}: the push replacement for polling.
+
+Driven through the real router over a TestClient, with the polls themselves
+patched (get_live_events has its own tests, and the pipeline-run read is one
+existing query) and the loop's tick shortened. What this pins is the wire
+protocol a client is written against — the frame shapes, that a delta is only
+sent when it is non-empty, that a run already complete at connect time is not
+announced as growth, that the cursor advances so nothing replays — and the
+close codes that tell a client whether to retry.
+"""
+
+from datetime import datetime
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.methods import get_authenticated_websocket_user
+from cognee.modules.pipelines.models import PipelineRunStatus
+
+router_module = import_module("cognee.api.v1.users.routers.get_visualize_router")
+live_updates = import_module("cognee.api.v1.visualize.live_updates")
+
+DATASET_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _no_events(_dataset_id, since=None, user=None):
+    return {"events": [], "cursor": since.isoformat() if since else None}
+
+
+@pytest.fixture
+def app(monkeypatch):
+    """The real router, with the loop sped up and its polls neutralized."""
+    monkeypatch.setattr(router_module, "send_telemetry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        router_module,
+        "get_authorized_existing_datasets",
+        AsyncMock(side_effect=lambda ids, _permission, _user: [SimpleNamespace(id=ids[0])]),
+    )
+    monkeypatch.setattr(
+        live_updates,
+        "get_authorized_existing_datasets",
+        AsyncMock(side_effect=lambda ids, _permission, _user: [SimpleNamespace(id=ids[0])]),
+    )
+    monkeypatch.setattr(live_updates, "TICK_SECONDS", 0.005)
+    monkeypatch.setattr(live_updates, "get_live_events", AsyncMock(side_effect=_no_events))
+    monkeypatch.setattr(live_updates, "get_pipeline_run_by_dataset", AsyncMock(return_value=None))
+    # Every test reuses the same DATASET_ID: without this, one test's cached
+    # latest-run-id would leak into the next via the shared module-level
+    # cache that collapses duplicate polling across concurrent viewers.
+    live_updates._reset_latest_run_cache()
+
+    application = FastAPI()
+    application.include_router(router_module.get_visualize_router(), prefix="/api/v1/visualize")
+    application.dependency_overrides[get_authenticated_websocket_user] = lambda: SimpleNamespace(
+        id=uuid4(), tenant_id=None
+    )
+    return application
+
+
+def _connect(app, query: str = ""):
+    return TestClient(app).websocket_connect(f"/api/v1/visualize/subscribe/{DATASET_ID}{query}")
+
+
+def _completed_run(pipeline_run_id):
+    return SimpleNamespace(
+        pipeline_run_id=pipeline_run_id,
+        status=PipelineRunStatus.DATASET_PROCESSING_COMPLETED,
+    )
+
+
+def test_ready_is_the_first_frame_and_echoes_the_starting_cursor(app):
+    with _connect(app) as connection:
+        assert connection.receive_json() == {
+            "kind": "ready",
+            "dataset_id": DATASET_ID,
+            "cursor": None,
+        }
+
+    with _connect(app, "?since=2026-08-03T09:00:05") as connection:
+        assert connection.receive_json() == {
+            "kind": "ready",
+            "dataset_id": DATASET_ID,
+            "cursor": "2026-08-03T09:00:05",
+        }
+
+
+def test_a_reconnect_cursor_is_passed_through_to_the_events_query(app, monkeypatch):
+    seen = []
+
+    async def record(dataset_id, since=None, user=None):
+        seen.append(since)
+        return {"events": [], "cursor": None}
+
+    monkeypatch.setattr(live_updates, "get_live_events", record)
+
+    with _connect(app, "?since=2026-08-03T09:00:05") as connection:
+        connection.receive_json()
+        # Wait for a frame that can only follow several poll cycles.
+        while connection.receive_json()["kind"] != "heartbeat":
+            pass
+
+    assert seen and seen[0] == datetime(2026, 8, 3, 9, 0, 5)
+
+
+def test_events_are_pushed_only_when_the_delta_is_non_empty(app, monkeypatch):
+    events = [{"kind": "search", "time": "2026-08-03T09:00:10.000000", "qa_id": "a"}]
+    deliveries = iter([{"events": events, "cursor": "2026-08-03T09:00:10.000000"}])
+
+    async def once(_dataset_id, since=None, user=None):
+        try:
+            return next(deliveries)
+        except StopIteration:
+            return {"events": [], "cursor": since.isoformat() if since else None}
+
+    monkeypatch.setattr(live_updates, "get_live_events", once)
+
+    with _connect(app) as connection:
+        connection.receive_json()
+        frames = [connection.receive_json() for _ in range(2)]
+
+    assert frames[0] == {
+        "kind": "live_events",
+        "events": events,
+        "cursor": "2026-08-03T09:00:10.000000",
+    }
+    # The empty polls that follow send nothing; the next frame is the
+    # heartbeat, not a second (empty) live_events.
+    assert frames[1]["kind"] == "heartbeat"
+
+
+def test_the_cursor_advances_so_the_same_event_is_never_delivered_twice(app, monkeypatch):
+    seen = []
+    events = [{"kind": "search", "time": "2026-08-03T09:00:10.000000", "qa_id": "a"}]
+    delivered = False
+
+    async def once(_dataset_id, since=None, user=None):
+        nonlocal delivered
+        seen.append(since)
+        if not delivered:
+            delivered = True
+            return {"events": events, "cursor": "2026-08-03T09:00:10.000000"}
+        return {"events": [], "cursor": since.isoformat() if since else None}
+
+    monkeypatch.setattr(live_updates, "get_live_events", once)
+
+    with _connect(app) as connection:
+        connection.receive_json()
+        while connection.receive_json()["kind"] != "heartbeat":
+            pass
+
+    assert seen[0] is None
+    assert seen[1] == datetime(2026, 8, 3, 9, 0, 10)
+
+
+def test_a_run_completing_is_announced_but_one_already_complete_is_not(app, monkeypatch):
+    baseline_run, new_run = uuid4(), uuid4()
+    reads = {"count": 0}
+
+    async def current_run(_dataset_id, _pipeline_name):
+        # The connection's baseline read and the first poll see the run that
+        # was already complete; a later one sees a newer run finish.
+        reads["count"] += 1
+        return _completed_run(baseline_run if reads["count"] <= 2 else new_run)
+
+    monkeypatch.setattr(live_updates, "get_pipeline_run_by_dataset", current_run)
+
+    with _connect(app) as connection:
+        connection.receive_json()
+        frame = connection.receive_json()
+
+    # The baseline run is never announced — only the one that completed while
+    # the client was watching.
+    assert frame == {"kind": "graph_grew", "pipeline_run_id": str(new_run)}
+
+
+def test_a_run_still_in_flight_is_not_announced_as_growth(app, monkeypatch):
+    started = SimpleNamespace(
+        pipeline_run_id=uuid4(), status=PipelineRunStatus.DATASET_PROCESSING_STARTED
+    )
+    monkeypatch.setattr(
+        live_updates, "get_pipeline_run_by_dataset", AsyncMock(return_value=started)
+    )
+
+    with _connect(app) as connection:
+        connection.receive_json()
+        assert connection.receive_json()["kind"] == "heartbeat"
+
+
+def test_heartbeats_keep_arriving_on_an_otherwise_silent_stream(app):
+    with _connect(app) as connection:
+        connection.receive_json()
+        frames = [connection.receive_json() for _ in range(2)]
+
+    assert [frame["kind"] for frame in frames] == ["heartbeat", "heartbeat"]
+    assert datetime.fromisoformat(frames[0]["time"])
+
+
+def test_an_unauthenticated_connection_is_closed_with_1008(app):
+    app.dependency_overrides[get_authenticated_websocket_user] = lambda: None
+
+    with pytest.raises(WebSocketDisconnect) as closed:
+        with _connect(app) as connection:
+            connection.receive_json()
+
+    assert closed.value.code == 1008
+
+
+def test_a_dataset_the_caller_cannot_read_is_closed_with_1008(app, monkeypatch):
+    monkeypatch.setattr(
+        router_module, "get_authorized_existing_datasets", AsyncMock(return_value=[])
+    )
+
+    with pytest.raises(WebSocketDisconnect) as closed:
+        with _connect(app) as connection:
+            connection.receive_json()
+
+    assert closed.value.code == 1008
+
+
+def test_read_access_lost_mid_stream_closes_with_1008(app, monkeypatch):
+    """Permission is re-checked on every poll, so a revoked grant ends the
+    stream rather than streaming on until the client reconnects."""
+    monkeypatch.setattr(
+        live_updates,
+        "get_live_events",
+        AsyncMock(side_effect=PermissionDeniedError(message="nope")),
+    )
+
+    with pytest.raises(WebSocketDisconnect) as closed:
+        with _connect(app) as connection:
+            connection.receive_json()
+            connection.receive_json()
+
+    assert closed.value.code == 1008
+
+
+def test_read_access_lost_before_a_graph_poll_tick_closes_with_1008(app, monkeypatch):
+    """The graph_grew tick re-checks permission on its own cadence too, not
+    only via the live_events tick — a revocation is caught within one
+    GRAPH_POLL_TICKS window instead of waiting on the events poll."""
+    monkeypatch.setattr(
+        live_updates, "get_authorized_existing_datasets", AsyncMock(return_value=[])
+    )
+
+    with pytest.raises(WebSocketDisconnect) as closed:
+        with _connect(app) as connection:
+            connection.receive_json()
+            connection.receive_json()
+
+    assert closed.value.code == 1008
+
+
+def test_an_unexpected_stream_failure_closes_with_1011_so_clients_retry(app, monkeypatch):
+    monkeypatch.setattr(
+        live_updates, "get_live_events", AsyncMock(side_effect=RuntimeError("db is down"))
+    )
+
+    with pytest.raises(WebSocketDisconnect) as closed:
+        with _connect(app) as connection:
+            connection.receive_json()
+            connection.receive_json()
+
+    assert closed.value.code == 1011

--- a/cognee/tests/unit/modules/cognify/test_recovery.py
+++ b/cognee/tests/unit/modules/cognify/test_recovery.py
@@ -9,29 +9,9 @@ from cognee.modules.cognify import recovery as recovery_module
 from cognee.modules.pipelines.models import PipelineRunStatus
 
 
-class _FakeScalarsResult:
-    def __init__(self, items):
-        self._items = items
-
-    def all(self):
-        return self._items
-
-
-class _FakeExecuteResult:
-    def __init__(self, items):
-        self._items = items
-
-    def scalars(self):
-        return _FakeScalarsResult(self._items)
-
-
 class _FakeSession:
-    def __init__(self, execute_result=None, dataset=None):
-        self._execute_result = execute_result
+    def __init__(self, dataset=None):
         self._dataset = dataset
-
-    async def execute(self, _statement):
-        return self._execute_result
 
     async def get(self, _model, _dataset_id):
         return self._dataset
@@ -71,9 +51,8 @@ async def test_recover_stale_cognify_runs_executes_rollback_for_latest_candidate
     )
     dataset = SimpleNamespace(id=dataset_id, owner_id=owner_id)
 
-    discovery_session = _FakeSession(execute_result=_FakeExecuteResult([stale_run]))
     dataset_session = _FakeSession(dataset=dataset)
-    engine = _FakeEngine([discovery_session, dataset_session])
+    engine = _FakeEngine([dataset_session])
 
     rollback_calls = []
     reset_calls = []
@@ -84,7 +63,11 @@ async def test_recover_stale_cognify_runs_executes_rollback_for_latest_candidate
     async def _reset_status(**kwargs):
         reset_calls.append(kwargs)
 
+    async def _fake_latest_runs(_dataset_ids, _pipeline_name):
+        return {dataset_id: stale_run}
+
     monkeypatch.setattr(recovery_module, "get_relational_engine", lambda: engine)
+    monkeypatch.setattr(recovery_module, "get_latest_pipeline_runs_by_datasets", _fake_latest_runs)
     monkeypatch.setattr(recovery_module, "set_database_global_context_variables", _no_op_context)
     monkeypatch.setattr(recovery_module, "cognify_rollback_handler", _rollback_handler)
     monkeypatch.setattr(recovery_module, "reset_pipeline_run_status", _reset_status)
@@ -111,16 +94,19 @@ async def test_recover_stale_cognify_runs_skips_missing_dataset(monkeypatch):
         created_at=datetime.now(timezone.utc) - timedelta(hours=2),
     )
 
-    discovery_session = _FakeSession(execute_result=_FakeExecuteResult([stale_run]))
     dataset_session = _FakeSession(dataset=None)
-    engine = _FakeEngine([discovery_session, dataset_session])
+    engine = _FakeEngine([dataset_session])
 
     rollback_calls = []
 
     async def _rollback_handler(**kwargs):
         rollback_calls.append(kwargs)
 
+    async def _fake_latest_runs(_dataset_ids, _pipeline_name):
+        return {dataset_id: stale_run}
+
     monkeypatch.setattr(recovery_module, "get_relational_engine", lambda: engine)
+    monkeypatch.setattr(recovery_module, "get_latest_pipeline_runs_by_datasets", _fake_latest_runs)
     monkeypatch.setattr(recovery_module, "set_database_global_context_variables", _no_op_context)
     monkeypatch.setattr(recovery_module, "cognify_rollback_handler", _rollback_handler)
 
@@ -142,16 +128,19 @@ async def test_recover_stale_cognify_runs_skips_recent_run(monkeypatch):
         created_at=datetime.now(timezone.utc),
     )
 
-    discovery_session = _FakeSession(execute_result=_FakeExecuteResult([recent_run]))
     # No dataset session is consumed because the run is skipped before lookup.
-    engine = _FakeEngine([discovery_session])
+    engine = _FakeEngine([])
 
     rollback_calls = []
 
     async def _rollback_handler(**kwargs):
         rollback_calls.append(kwargs)
 
+    async def _fake_latest_runs(_dataset_ids, _pipeline_name):
+        return {dataset_id: recent_run}
+
     monkeypatch.setattr(recovery_module, "get_relational_engine", lambda: engine)
+    monkeypatch.setattr(recovery_module, "get_latest_pipeline_runs_by_datasets", _fake_latest_runs)
     monkeypatch.setattr(recovery_module, "set_database_global_context_variables", _no_op_context)
     monkeypatch.setattr(recovery_module, "cognify_rollback_handler", _rollback_handler)
     monkeypatch.setattr(recovery_module, "STALE_RUN_MIN_AGE_SECONDS", 3600)

--- a/cognee/tests/unit/modules/data/test_get_datasets_graph_counts.py
+++ b/cognee/tests/unit/modules/data/test_get_datasets_graph_counts.py
@@ -1,0 +1,293 @@
+"""get_datasets_graph_counts: the per-cognify-run count cache both graph
+summaries read.
+
+The relational reads are patched (they are two plain queries); what this pins
+is the decision table around them — never cognified, cache hit, cache miss
+computes and caches, an unavailable graph store degrading to zeros instead of
+failing the whole batch, and a lost caching race keeping the counts it already
+computed. GET /datasets/graph-summary and GET /visualize/brains-summary both
+answer from this, so a regression here shows up in two endpoints at once.
+"""
+
+import sys
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+# The methods package rebinds `get_datasets_graph_counts` to the function, so
+# the module itself has to come from sys.modules (same gotcha as the visualize
+# API tests) for patch.object to reach its globals.
+from cognee.modules.data.methods import get_datasets_graph_counts
+from cognee.modules.data.methods.get_datasets_graph_counts import DatasetGraphCounts
+from cognee.modules.pipelines.models import PipelineRunStatus
+
+counts_module = sys.modules["cognee.modules.data.methods.get_datasets_graph_counts"]
+
+
+def _dataset():
+    return SimpleNamespace(id=uuid4(), name="billing", owner_id=uuid4())
+
+
+def _run(dataset_id, pipeline_run_id):
+    return SimpleNamespace(
+        dataset_id=dataset_id,
+        pipeline_run_id=pipeline_run_id,
+        status=PipelineRunStatus.DATASET_PROCESSING_COMPLETED,
+    )
+
+
+class _FakeSession:
+    """Records what would have been cached; optionally fails the commit."""
+
+    def __init__(self, added, commit_fails=False, commit_error=None):
+        self._added = added
+        self._commit_fails = commit_fails
+        self._commit_error = commit_error or IntegrityError(
+            "INSERT INTO graph_metrics ...", {}, Exception("unique violation")
+        )
+
+    def add(self, instance):
+        self._added.append(instance)
+
+    async def commit(self):
+        if self._commit_fails:
+            raise self._commit_error
+
+
+def _fake_engine(added, commit_fails=False, commit_error=None):
+    @asynccontextmanager
+    async def get_async_session():
+        yield _FakeSession(added, commit_fails=commit_fails, commit_error=commit_error)
+
+    return SimpleNamespace(get_async_session=get_async_session)
+
+
+def _graph_engine(num_nodes=12, num_edges=34):
+    return AsyncMock(
+        return_value=SimpleNamespace(
+            get_graph_metrics=AsyncMock(
+                return_value={"num_nodes": num_nodes, "num_edges": num_edges}
+            )
+        )
+    )
+
+
+@asynccontextmanager
+async def _no_op_context(*_args, **_kwargs):
+    yield
+
+
+@pytest.mark.asyncio
+async def test_no_datasets_short_circuits_without_querying():
+    with patch.object(counts_module, "_get_latest_cognify_runs", AsyncMock()) as latest_runs:
+        assert await get_datasets_graph_counts([]) == {}
+
+    latest_runs.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_never_cognified_dataset_counts_zero_and_names_no_run():
+    dataset = _dataset()
+
+    with (
+        patch.object(counts_module, "_get_latest_cognify_runs", AsyncMock(return_value={})),
+        patch.object(counts_module, "_get_cached_metrics", AsyncMock(return_value={})),
+    ):
+        counts = await get_datasets_graph_counts([dataset])
+
+    assert counts == {dataset.id: DatasetGraphCounts()}
+    assert counts[dataset.id].pipeline_run_id is None
+
+
+@pytest.mark.asyncio
+async def test_a_cached_run_is_answered_without_touching_the_graph():
+    dataset = _dataset()
+    run_id = uuid4()
+    cached_at = datetime(2026, 8, 3, 9, 0, tzinfo=timezone.utc)
+    cached = SimpleNamespace(id=run_id, num_nodes=7, num_edges=9, created_at=cached_at)
+
+    with (
+        patch.object(
+            counts_module,
+            "_get_latest_cognify_runs",
+            AsyncMock(return_value={dataset.id: _run(dataset.id, run_id)}),
+        ),
+        patch.object(
+            counts_module, "_get_cached_metrics", AsyncMock(return_value={run_id: cached})
+        ),
+        patch.object(counts_module, "get_graph_engine", AsyncMock()) as graph_engine,
+    ):
+        counts = await get_datasets_graph_counts([dataset])
+
+    graph_engine.assert_not_called()
+    assert counts[dataset.id] == DatasetGraphCounts(
+        pipeline_run_id=run_id, num_nodes=7, num_edges=9, computed_at=cached_at
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_cache_miss_counts_the_graph_and_caches_it_against_the_run():
+    dataset = _dataset()
+    run_id = uuid4()
+    added = []
+
+    with (
+        patch.object(
+            counts_module,
+            "_get_latest_cognify_runs",
+            AsyncMock(return_value={dataset.id: _run(dataset.id, run_id)}),
+        ),
+        patch.object(counts_module, "_get_cached_metrics", AsyncMock(return_value={})),
+        patch.object(counts_module, "set_database_global_context_variables", _no_op_context),
+        patch.object(counts_module, "get_graph_engine", _graph_engine()),
+        patch.object(counts_module, "get_relational_engine", lambda: _fake_engine(added)),
+    ):
+        counts = await get_datasets_graph_counts([dataset])
+
+    assert counts[dataset.id].num_nodes == 12
+    assert counts[dataset.id].num_edges == 34
+    assert counts[dataset.id].computed_at is not None
+    # Cached against the run id, which is what makes the next call free.
+    assert [(entry.id, entry.num_nodes, entry.num_edges) for entry in added] == [(run_id, 12, 34)]
+    # Flagged partial, so caching counts here cannot make get_pipeline_run_metrics
+    # believe that run's token count and connectivity metrics were computed too.
+    assert added[0].has_full_metrics is False
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_graph_degrades_to_zero_without_dropping_the_dataset():
+    """One unavailable graph store must not fail, or silently shrink, a batch."""
+    readable, unreadable = _dataset(), _dataset()
+    readable_run, unreadable_run = uuid4(), uuid4()
+    cached = SimpleNamespace(id=readable_run, num_nodes=5, num_edges=6, created_at=None)
+
+    with (
+        patch.object(
+            counts_module,
+            "_get_latest_cognify_runs",
+            AsyncMock(
+                return_value={
+                    readable.id: _run(readable.id, readable_run),
+                    unreadable.id: _run(unreadable.id, unreadable_run),
+                }
+            ),
+        ),
+        patch.object(
+            counts_module, "_get_cached_metrics", AsyncMock(return_value={readable_run: cached})
+        ),
+        patch.object(counts_module, "set_database_global_context_variables", _no_op_context),
+        patch.object(
+            counts_module, "get_graph_engine", AsyncMock(side_effect=RuntimeError("graph is down"))
+        ),
+    ):
+        counts = await get_datasets_graph_counts([readable, unreadable])
+
+    assert counts[readable.id].num_nodes == 5
+    assert counts[unreadable.id] == DatasetGraphCounts(pipeline_run_id=unreadable_run)
+
+
+@pytest.mark.asyncio
+async def test_losing_the_caching_race_still_reports_the_counts_it_computed():
+    """A concurrent caller may cache the same run first. The numbers are
+    already correct — only computed_at reports that they went uncached."""
+    dataset = _dataset()
+    run_id = uuid4()
+
+    with (
+        patch.object(
+            counts_module,
+            "_get_latest_cognify_runs",
+            AsyncMock(return_value={dataset.id: _run(dataset.id, run_id)}),
+        ),
+        patch.object(counts_module, "_get_cached_metrics", AsyncMock(return_value={})),
+        patch.object(counts_module, "set_database_global_context_variables", _no_op_context),
+        patch.object(counts_module, "get_graph_engine", _graph_engine(num_nodes=3, num_edges=4)),
+        patch.object(
+            counts_module, "get_relational_engine", lambda: _fake_engine([], commit_fails=True)
+        ),
+    ):
+        counts = await get_datasets_graph_counts([dataset])
+
+    assert counts[dataset.id] == DatasetGraphCounts(
+        pipeline_run_id=run_id, num_nodes=3, num_edges=4, computed_at=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unexpected_cache_write_failure_degrades_that_dataset_only():
+    """A non-IntegrityError commit failure (e.g. a lock/connection error) must
+    still degrade to uncached counts for that dataset, not propagate and fail
+    the whole batch via asyncio.gather."""
+    from sqlalchemy.exc import OperationalError
+
+    dataset_a = _dataset()
+    dataset_b = _dataset()
+    run_id_a = uuid4()
+    run_id_b = uuid4()
+
+    with (
+        patch.object(
+            counts_module,
+            "_get_latest_cognify_runs",
+            AsyncMock(
+                return_value={
+                    dataset_a.id: _run(dataset_a.id, run_id_a),
+                    dataset_b.id: _run(dataset_b.id, run_id_b),
+                }
+            ),
+        ),
+        patch.object(counts_module, "_get_cached_metrics", AsyncMock(return_value={})),
+        patch.object(counts_module, "set_database_global_context_variables", _no_op_context),
+        patch.object(counts_module, "get_graph_engine", _graph_engine(num_nodes=3, num_edges=4)),
+        patch.object(
+            counts_module,
+            "get_relational_engine",
+            lambda: _fake_engine(
+                [],
+                commit_fails=True,
+                commit_error=OperationalError("COMMIT", {}, Exception("database is locked")),
+            ),
+        ),
+    ):
+        counts = await get_datasets_graph_counts([dataset_a, dataset_b])
+
+    # Both datasets still get their correct, freshly-computed counts — the
+    # write failure only cost them the cache, not the response.
+    assert counts[dataset_a.id] == DatasetGraphCounts(
+        pipeline_run_id=run_id_a, num_nodes=3, num_edges=4, computed_at=None
+    )
+    assert counts[dataset_b.id] == DatasetGraphCounts(
+        pipeline_run_id=run_id_b, num_nodes=3, num_edges=4, computed_at=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_metric_keys_read_as_zero_rather_than_none():
+    """An adapter that omits a key must not put None into an int field."""
+    dataset = _dataset()
+    run_id = uuid4()
+
+    empty_metrics = AsyncMock(
+        return_value=SimpleNamespace(get_graph_metrics=AsyncMock(return_value={}))
+    )
+
+    with (
+        patch.object(
+            counts_module,
+            "_get_latest_cognify_runs",
+            AsyncMock(return_value={dataset.id: _run(dataset.id, run_id)}),
+        ),
+        patch.object(counts_module, "_get_cached_metrics", AsyncMock(return_value={})),
+        patch.object(counts_module, "set_database_global_context_variables", _no_op_context),
+        patch.object(counts_module, "get_graph_engine", empty_metrics),
+        patch.object(counts_module, "get_relational_engine", lambda: _fake_engine([])),
+    ):
+        counts = await get_datasets_graph_counts([dataset])
+
+    assert counts[dataset.id].num_nodes == 0
+    assert counts[dataset.id].num_edges == 0

--- a/cognee/tests/unit/modules/data/test_methods_package_has_no_import_cycle.py
+++ b/cognee/tests/unit/modules/data/test_methods_package_has_no_import_cycle.py
@@ -1,0 +1,86 @@
+"""`cognee.modules.data.methods` must stay importable without a cycle.
+
+Re-exporting a submodule from this package's ``__init__`` is only safe while
+that submodule imports nothing that leads back here. When one did, the cycle
+was invisible to every existing test and to a full-suite run, because they all
+reach the package directly: ``__init__`` then runs to completion and every
+name resolves to the function it should.
+
+The failure needed the *other* order. ``cognee.add`` pulls in
+``cognee.modules.pipelines.layers`` first, which does
+``from cognee.modules.data.methods import load_or_create_datasets`` while this
+package's ``__init__`` is still part-way through its own imports. At that
+moment the function does not exist yet, so Python falls back to binding the
+name to the same-named *submodule* -- and never rebinds it once ``__init__``
+finishes. The call site then raised ``TypeError: 'module' object is not
+callable`` on every add, while the package itself looked perfectly fine.
+
+So these import in that order, in a subprocess with a clean module table:
+importing them here would prove nothing, since pytest has already imported
+half the tree.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+# Every name this package re-exports that a cycle could silently turn into a
+# module. Kept explicit rather than derived from __all__: the point is to
+# assert against a written-down expectation, not against whatever the package
+# currently happens to expose.
+REEXPORTED_CALLABLES = (
+    "load_or_create_datasets",
+    "get_authorized_existing_datasets",
+    "check_dataset_name",
+)
+
+
+def _probe(source: str) -> str:
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr[-3000:]
+    return result.stdout.strip()
+
+
+def test_pipelines_layers_first_still_binds_functions_not_modules():
+    """The import order `cognee.add` actually uses must not degrade a name."""
+    names = ", ".join(repr(n) for n in REEXPORTED_CALLABLES)
+    out = _probe(
+        f"""
+        import inspect
+
+        # The order that broke it: the pipelines layer resolves first, so it
+        # reaches into data.methods while that package is mid-initialisation.
+        import cognee.modules.pipelines.layers.resolve_authorized_user_datasets as layer
+        import cognee.modules.data.methods as methods
+
+        bad = []
+        for name in ({names},):
+            for holder, label in ((layer, "layer"), (methods, "package")):
+                obj = getattr(holder, name, None)
+                if obj is not None and inspect.ismodule(obj):
+                    bad.append(f"{{label}}.{{name}}")
+        print(",".join(bad) if bad else "clean")
+        """
+    )
+    assert out == "clean", f"bound to a module instead of a function: {out}"
+
+
+def test_package_import_alone_is_still_clean():
+    """The direct order has always worked; keep it covered so a fix can't
+    trade one for the other."""
+    names = ", ".join(repr(n) for n in REEXPORTED_CALLABLES)
+    out = _probe(
+        f"""
+        import inspect
+        import cognee.modules.data.methods as methods
+
+        missing = [n for n in ({names},) if not callable(getattr(methods, n, None))]
+        print(",".join(missing) if missing else "clean")
+        """
+    )
+    assert out == "clean", f"not callable when imported directly: {out}"

--- a/cognee/tests/unit/modules/metrics/test_get_pipeline_run_metrics.py
+++ b/cognee/tests/unit/modules/metrics/test_get_pipeline_run_metrics.py
@@ -1,0 +1,190 @@
+"""get_pipeline_run_metrics: a counts-only cache row is not a finished one.
+
+Two paths write ``graph_metrics`` under the same primary key, the pipeline run
+id: the full computation here, and ``get_datasets_graph_counts``, which fills
+only ``num_nodes``/``num_edges`` because that is all the graph-summary
+endpoints read. The cache check used to accept *any* row for the run, so once
+the cheap path had written one, this function returned it forever and that
+run's token count and connectivity metrics read as NULL with nothing reporting
+they had never been computed.
+
+Driven against a real SQLite-backed relational engine so the round-trip — the
+flag's default, the write, the re-read — is the real one, with only the graph
+engine mocked.
+"""
+
+import sys
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter import (
+    SQLAlchemyAdapter,
+)
+from cognee.modules.data.models import GraphMetrics
+from cognee.modules.metrics.operations import get_pipeline_run_metrics
+
+# The package re-exports the function under its module's name, which shadows
+# the submodule, so the module has to come from sys.modules for patch.object to
+# reach its globals.
+metrics_module = sys.modules["cognee.modules.metrics.operations.get_pipeline_run_metrics"]
+
+PIPELINE_RUN_ID = uuid4()
+
+FULL_METRICS = {
+    "num_nodes": 12,
+    "num_edges": 34,
+    "mean_degree": 5.6,
+    "edge_density": 0.25,
+    "num_connected_components": 2,
+    "sizes_of_connected_components": [8, 4],
+    "num_selfloops": 1,
+    "diameter": 3,
+    "avg_shortest_path_length": 1.5,
+    "avg_clustering": 0.75,
+}
+
+
+async def _make_engine():
+    """A throwaway SQLite-backed relational engine with the real schema."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    engine = SQLAlchemyAdapter(f"sqlite+aiosqlite:///{tmp.name}")
+    await engine.create_database()
+    return engine
+
+
+def _graph_engine():
+    """A graph engine whose get_graph_metrics call can be asserted on."""
+    return AsyncMock(
+        return_value=SimpleNamespace(get_graph_metrics=AsyncMock(return_value=FULL_METRICS))
+    )
+
+
+async def _stored_rows(engine):
+    async with engine.get_async_session() as session:
+        return (
+            (await session.execute(select(GraphMetrics).where(GraphMetrics.id == PIPELINE_RUN_ID)))
+            .scalars()
+            .all()
+        )
+
+
+async def _write_counts_only_row(engine):
+    """The row the graph-summary counting path leaves behind: the two counts it
+    reads, and nothing else set."""
+    async with engine.get_async_session() as session:
+        session.add(GraphMetrics(id=PIPELINE_RUN_ID, num_nodes=12, num_edges=34))
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_a_row_written_without_the_flag_defaults_to_partial():
+    """The column has to default False, or the counting path would have to
+    remember to say so and a future writer could forget."""
+    engine = await _make_engine()
+    await _write_counts_only_row(engine)
+
+    (row,) = await _stored_rows(engine)
+    assert row.has_full_metrics is False
+    assert row.num_nodes == 12
+    assert row.num_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_a_counts_only_row_is_not_a_cache_hit_and_is_completed_in_place():
+    """The bug this exists for: the cheap write must not end up answering for
+    metrics it never computed."""
+    engine = await _make_engine()
+    await _write_counts_only_row(engine)
+    graph_engine = _graph_engine()
+
+    with (
+        patch.object(metrics_module, "get_relational_engine", lambda: engine),
+        patch.object(metrics_module, "get_graph_engine", graph_engine),
+    ):
+        [metrics] = await get_pipeline_run_metrics(
+            SimpleNamespace(pipeline_run_id=PIPELINE_RUN_ID), include_optional=True
+        )
+
+    # It recomputed rather than serving the partial row.
+    graph_engine.return_value.get_graph_metrics.assert_awaited_once_with(True)
+    assert metrics.avg_clustering == 0.75
+
+    # Completed in place: still one row under this run id, now flagged whole.
+    (row,) = await _stored_rows(engine)
+    assert row.has_full_metrics is True
+    assert row.diameter == 3
+    assert row.mean_degree == 5.6
+
+
+@pytest.mark.asyncio
+async def test_a_completed_row_is_still_served_from_cache():
+    """The flag must not turn every call into a recompute."""
+    engine = await _make_engine()
+    await _write_counts_only_row(engine)
+
+    with (
+        patch.object(metrics_module, "get_relational_engine", lambda: engine),
+        patch.object(metrics_module, "get_graph_engine", _graph_engine()),
+    ):
+        await get_pipeline_run_metrics(
+            SimpleNamespace(pipeline_run_id=PIPELINE_RUN_ID), include_optional=True
+        )
+
+    second_call = _graph_engine()
+    with (
+        patch.object(metrics_module, "get_relational_engine", lambda: engine),
+        patch.object(metrics_module, "get_graph_engine", second_call),
+    ):
+        [metrics] = await get_pipeline_run_metrics(
+            SimpleNamespace(pipeline_run_id=PIPELINE_RUN_ID), include_optional=True
+        )
+
+    second_call.return_value.get_graph_metrics.assert_not_awaited()
+    assert metrics.avg_clustering == 0.75
+
+
+@pytest.mark.asyncio
+async def test_a_row_computed_without_optional_metrics_stays_a_cache_miss():
+    """include_optional=False fills diameter/avg_clustering/etc. with -1
+    sentinels rather than computing them, so such a row must not be flagged
+    has_full_metrics — otherwise a later include_optional=True caller for the
+    same run would serve those sentinels back forever instead of computing
+    the real optional metrics."""
+    engine = await _make_engine()
+    await _write_counts_only_row(engine)
+
+    sentinel_metrics = {**FULL_METRICS, "num_selfloops": -1, "diameter": -1}
+    graph_engine = AsyncMock(
+        return_value=SimpleNamespace(get_graph_metrics=AsyncMock(return_value=sentinel_metrics))
+    )
+
+    with (
+        patch.object(metrics_module, "get_relational_engine", lambda: engine),
+        patch.object(metrics_module, "get_graph_engine", graph_engine),
+    ):
+        await get_pipeline_run_metrics(
+            SimpleNamespace(pipeline_run_id=PIPELINE_RUN_ID), include_optional=False
+        )
+
+    (row,) = await _stored_rows(engine)
+    assert row.has_full_metrics is False
+
+    # A later include_optional=True call must recompute rather than trust
+    # the sentinel-filled row.
+    second_call = _graph_engine()
+    with (
+        patch.object(metrics_module, "get_relational_engine", lambda: engine),
+        patch.object(metrics_module, "get_graph_engine", second_call),
+    ):
+        [metrics] = await get_pipeline_run_metrics(
+            SimpleNamespace(pipeline_run_id=PIPELINE_RUN_ID), include_optional=True
+        )
+
+    second_call.return_value.get_graph_metrics.assert_awaited_once_with(True)
+    assert metrics.avg_clustering == 0.75

--- a/cognee/tests/unit/modules/operations/test_record_operation.py
+++ b/cognee/tests/unit/modules/operations/test_record_operation.py
@@ -29,6 +29,12 @@ record_operation_mod = importlib.import_module("cognee.modules.operations.record
 get_pipeline_status_mod = importlib.import_module(
     "cognee.modules.pipelines.operations.get_pipeline_status"
 )
+# get_pipeline_status delegates its query to this module now, so the real
+# DB call this test needs to intercept happens here, not in either module
+# above.
+get_pipeline_run_by_dataset_mod = importlib.import_module(
+    "cognee.modules.pipelines.methods.get_pipeline_run_by_dataset"
+)
 
 record_operation = record_operation_mod.record_operation
 get_current_operation = record_operation_mod.get_current_operation
@@ -50,7 +56,7 @@ async def ops_engine(tmp_path, monkeypatch):
     async with engine.engine.begin() as connection:
         await connection.run_sync(Base.metadata.create_all, tables=[PipelineRun.__table__])
 
-    for module in (record_operation_mod, get_pipeline_status_mod):
+    for module in (record_operation_mod, get_pipeline_run_by_dataset_mod):
         monkeypatch.setattr(module, "get_relational_engine", lambda: engine)
 
     yield engine

--- a/cognee/tests/unit/modules/visualization/test_preprocessor.py
+++ b/cognee/tests/unit/modules/visualization/test_preprocessor.py
@@ -21,6 +21,8 @@ from cognee.modules.visualization.preprocessor import (
     SCHEMA_MAX_ENTITY_TYPES,
     STAGE_ORDER,
     PreprocessedGraph,
+    build_node_set_colors,
+    generate_provenance_colors,
     preprocess,
 )
 
@@ -225,6 +227,31 @@ def test_color_maps_have_expected_keys():
     # task color map should contain both tasks
     assert "extract_chunks_from_documents" in result.color_maps["task"]
     assert "extract_graph_from_data" in result.color_maps["task"]
+
+
+def test_node_set_colors_pin_the_memory_sets_and_rotate_the_rest():
+    """The rule preprocess() colors node sets by, callable on its own so a
+    caller deriving the same map from outside a graph (the brains summary
+    reads node sets relationally) cannot drift from what gets rendered."""
+    colors = build_node_set_colors(["slack", "session_learnings", None, "slack"])
+
+    # Pinned so distilled lessons stay recognizable across graphs.
+    assert colors["session_learnings"] == "#FFC53D"
+    assert colors["slack"] == generate_provenance_colors(["session_learnings", "slack"])["slack"]
+    # Empty values never become a color key.
+    assert set(colors) == {"slack", "session_learnings"}
+
+
+def test_node_set_colors_are_the_ones_preprocess_puts_in_its_color_map():
+    graph = (
+        [
+            ("n1", {"type": "Entity", "name": "a", "source_node_set": "slack"}),
+            ("n2", {"type": "Entity", "name": "b", "source_node_set": "notion"}),
+        ],
+        [],
+    )
+
+    assert preprocess(graph).color_maps["node_set"] == build_node_set_colors(["slack", "notion"])
 
 
 def test_pipeline_stages_in_canonical_order():

--- a/cognee/tests/unit/test_add_graph_metrics_has_full_metrics_migration.py
+++ b/cognee/tests/unit/test_add_graph_metrics_has_full_metrics_migration.py
@@ -1,0 +1,174 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "b3d5f7a9c1e2_add_graph_metrics_has_full_metrics.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "graph_metrics_has_full_metrics_migration", _MIGRATION_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+migration = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(migration)
+
+
+def _make_inspector(*, tables=None, columns=None):
+    inspector = MagicMock()
+    inspector.get_table_names.return_value = tables if tables is not None else ["graph_metrics"]
+    inspector.get_columns.return_value = columns or [{"name": "id"}]
+    return inspector
+
+
+def test_upgrade_is_a_noop_when_the_graph_metrics_table_does_not_exist(monkeypatch):
+    """A deployment that never ran the GraphMetrics-creating migration (or
+    whose relational DB simply has no such table yet) must not crash here."""
+    inspector = _make_inspector(tables=[])
+    monkeypatch.setattr(migration.sa, "inspect", lambda _: inspector)
+    monkeypatch.setattr(migration.op, "get_bind", lambda: object())
+
+    add_column = MagicMock()
+    execute = MagicMock()
+    monkeypatch.setattr(migration.op, "add_column", add_column)
+    monkeypatch.setattr(migration.op, "execute", execute)
+
+    migration.upgrade()
+
+    add_column.assert_not_called()
+    execute.assert_not_called()
+
+
+def test_downgrade_is_a_noop_when_the_graph_metrics_table_does_not_exist(monkeypatch):
+    inspector = _make_inspector(tables=[])
+    monkeypatch.setattr(migration.sa, "inspect", lambda _: inspector)
+    monkeypatch.setattr(migration.op, "get_bind", lambda: object())
+
+    drop_column = MagicMock()
+    monkeypatch.setattr(migration.op, "drop_column", drop_column)
+
+    migration.downgrade()
+
+    drop_column.assert_not_called()
+
+
+def test_upgrade_skips_when_has_full_metrics_column_already_exists(monkeypatch):
+    inspector = _make_inspector(columns=[{"name": "id"}, {"name": "has_full_metrics"}])
+    monkeypatch.setattr(migration.sa, "inspect", lambda _: inspector)
+    monkeypatch.setattr(migration.op, "get_bind", lambda: object())
+
+    add_column = MagicMock()
+    execute = MagicMock()
+    monkeypatch.setattr(migration.op, "add_column", add_column)
+    monkeypatch.setattr(migration.op, "execute", execute)
+
+    migration.upgrade()
+
+    add_column.assert_not_called()
+    execute.assert_not_called()
+
+
+def test_upgrade_adds_the_column_when_the_table_exists_without_it(monkeypatch):
+    inspector = _make_inspector()
+    monkeypatch.setattr(migration.sa, "inspect", lambda _: inspector)
+    monkeypatch.setattr(migration.op, "get_bind", lambda: object())
+
+    add_column = MagicMock()
+    execute = MagicMock()
+    monkeypatch.setattr(migration.op, "add_column", add_column)
+    monkeypatch.setattr(migration.op, "execute", execute)
+
+    migration.upgrade()
+
+    add_column.assert_called_once()
+    execute.assert_called_once()
+
+
+def _run_upgrade_against_real_sqlite(rows):
+    """Exercise upgrade() against a real in-memory SQLite DB (not mocks), so
+    the backfill's actual SQL — not a mocked call — is what gets checked."""
+    engine = sa.create_engine("sqlite://")
+    meta = sa.MetaData()
+    graph_metrics = sa.Table(
+        "graph_metrics",
+        meta,
+        sa.Column("id", sa.String, primary_key=True),
+        sa.Column("num_tokens", sa.Integer, nullable=True),
+        sa.Column("diameter", sa.Integer, nullable=True),
+    )
+    meta.create_all(engine)
+
+    with engine.begin() as conn:
+        conn.execute(graph_metrics.insert(), rows)
+
+    with engine.begin() as conn:
+        ctx = MigrationContext.configure(conn)
+        with Operations.context(ctx):
+            migration.upgrade()
+
+    with engine.begin() as conn:
+        result = conn.execute(sa.text("SELECT id, has_full_metrics FROM graph_metrics"))
+        return dict(result.fetchall())
+
+
+def test_backfill_marks_a_full_metrics_row_even_when_its_token_sum_is_null():
+    """The bug this migration used to have: num_tokens is a SQL SUM() that
+    legitimately comes back NULL for a fully-computed run over a dataset with
+    no token_count data. diameter is always set on the full path (a real
+    value or -1), so it — not num_tokens — is what backfill keys on."""
+    has_full_metrics = _run_upgrade_against_real_sqlite(
+        [{"id": "full-null-tokens", "num_tokens": None, "diameter": -1}]
+    )
+
+    assert has_full_metrics["full-null-tokens"] == 1
+
+
+def test_backfill_marks_a_partial_counting_only_row_as_not_full():
+    has_full_metrics = _run_upgrade_against_real_sqlite(
+        [{"id": "partial-row", "num_tokens": None, "diameter": None}]
+    )
+
+    assert has_full_metrics["partial-row"] == 0
+
+
+def test_backfill_marks_an_ordinary_full_metrics_row_as_full():
+    has_full_metrics = _run_upgrade_against_real_sqlite(
+        [{"id": "full-with-tokens", "num_tokens": 42, "diameter": 3}]
+    )
+
+    assert has_full_metrics["full-with-tokens"] == 1
+
+
+def test_upgrade_is_idempotent_against_a_real_database():
+    """Running upgrade() twice must not fail on "column already exists"."""
+    engine = sa.create_engine("sqlite://")
+    meta = sa.MetaData()
+    graph_metrics = sa.Table(
+        "graph_metrics",
+        meta,
+        sa.Column("id", sa.String, primary_key=True),
+        sa.Column("num_tokens", sa.Integer, nullable=True),
+        sa.Column("diameter", sa.Integer, nullable=True),
+    )
+    meta.create_all(engine)
+
+    with engine.begin() as conn:
+        conn.execute(graph_metrics.insert(), [{"id": "row", "num_tokens": 1, "diameter": 1}])
+
+    for _ in range(2):
+        with engine.begin() as conn:
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.upgrade()
+
+    with engine.begin() as conn:
+        ctx = MigrationContext.configure(conn)
+        with Operations.context(ctx):
+            migration.downgrade()


### PR DESCRIPTION
## Description

The SaaS Mindmap polls `GET /visualize/brains` every 8s and `GET /visualize/live-events` every
1.5s. `/brains` builds the full graph of every readable dataset on every call, so that is
O(datasets) graph reads per poll with no caching. Per the architecture decision that pod-level
functionality lives in cognee core rather than cloud-backend, this is the SDK side of CLO-598.

**This PR carries COG-6291 as its base.** Changeset C imports `get_authenticated_websocket_user`
from that fix, so the two cannot be separated without stubbing the dependency. If COG-6291 lands
on its own first, rebasing this branch drops those two commits and the diff shrinks accordingly.
Reviewing COG-6291 separately is fine; merging this without it is not.

Three changesets, each its own commit, in dependency order.

**A. `fix: stop counts-only cache rows from answering as full metrics`**

Pre-existing bug, surfaced while building C. `get_datasets_graph_counts` writes a counts-only row
to the metrics cache, and `get_pipeline_run_metrics` treated that row as a complete cache hit. The
result was `num_tokens`, `mean_degree` and `diameter` permanently nulled for that run, silently,
with no error anywhere. Adds a `has_full_metrics` column to `GraphMetrics` (migration included) so
a partial row is distinguishable from a complete one.

**B. `refactor: extract get_datasets_graph_counts from the graph-summary route`**

Pulls the pipeline-run and count-cache lookup out of `GET /datasets/graph-summary` into a reusable
method that C needs, and wraps the route in try/except returning 409 instead of the unhandled 500
it produced before.

Also deduplicates the "newest PipelineRun per dataset" window query into
`get_latest_pipeline_runs_by_datasets`. It had been written out three separate times
(`get_pipeline_run_by_dataset`, `get_pipeline_status`, `cognify/recovery.py`) and this changeset
needed it a fourth, so it became one method with four call sites. Worth knowing when reviewing:
that is why a visualization PR touches `cognify/recovery.py` and
`pipelines/operations/get_pipeline_status.py`. Behaviour is unchanged and both keep their existing
tests.

One fix here was not in the original plan. Re-exporting `get_datasets_graph_counts` from
`cognee/modules/data/methods/__init__.py` created an import cycle: reaching the package via
`cognee.modules.pipelines.layers` first left the name bound to the *submodule* rather than the
function, so every `add` raised `TypeError: 'module' object is not callable`. Fixed by deferring
the `PipelineRun` import inside the function rather than by dropping the re-export, since dropping
it would leave the natural import silently returning a module. Guarded by a test that reproduces
the failing import order in a subprocess.

**C. `feat: add brains-summary and a WebSocket dataset subscription`**

* `GET /visualize/brains-summary`: per-dataset overview (name, source_names, node_count,
  node_set_colors) that costs zero graph reads on a warm cache.
* `WS /visualize/subscribe/{dataset_id}?since=<iso>`: pushes live session events, a `graph_grew`
  signal on cognify completion, and heartbeats, so the client can stop polling entirely.

**Flagging one thing for review.** A browser cannot set headers on a WebSocket handshake, so the
auth dependency accepts the API key as a `?token=` query parameter, which puts a credential in a
URL that uvicorn logs by default. `install_websocket_query_param_redaction` keeps it out of the
access and error logs, but it patches uvicorn's logging at import time, which is invasive for a
library. It is the most arguable piece of this work. It arrives via COG-6291 rather than this
branch, but the argument belongs to the feature that needs it.

Relates to CLO-598. Fixes COG-6258.

## Acceptance Criteria

* `GET /visualize/brains-summary` returns per-dataset name, source_names, node_count and
  node_set_colors without a full graph read on a warm cache.
* `WS /visualize/subscribe/{dataset_id}` accepts a `since` cursor, streams session events and
  heartbeats, and emits `graph_grew` when a cognify run completes for that dataset.
* A metrics row written by the counts-only path no longer answers as a complete cache hit:
  `num_tokens`, `mean_degree` and `diameter` survive.
* `GET /datasets/graph-summary` returns 409 on failure instead of an unhandled 500.
* `get_latest_pipeline_runs_by_datasets` behaves identically at all four call sites.
* Importing `cognee.modules.data.methods` via `cognee.modules.pipelines.layers` first does not
  break `add`.

Proof: end to end against a local kind cluster running a wheel built from this branch. Gateway
handshake returned `101`, `ready` then `heartbeat` frames arrived, and the frontend's 1.5s
`live-events` poll dropped from 21 calls to 0.

Unit coverage added or extended:

| Test file | Changeset |
|---|---|
| `cognee/tests/unit/modules/metrics/test_get_pipeline_run_metrics.py` | A |
| `alembic/../test_add_graph_metrics_has_full_metrics_migration.py` | A |
| `cognee/tests/unit/modules/data/test_get_datasets_graph_counts.py` | B |
| `cognee/tests/unit/api/test_datasets_graph_summary.py` | B |
| `cognee/tests/unit/modules/data/test_methods_package_has_no_import_cycle.py` | B |
| `cognee/tests/unit/modules/cognify/test_recovery.py` | B (extended) |
| `cognee/tests/unit/api/test_brains_summary.py` | C |
| `cognee/tests/unit/api/test_visualize_subscribe.py` | C |
| `cognee/tests/unit/modules/visualization/test_preprocessor.py` | C (extended) |

Full unit suite: 4499 passed, 69 skipped, 2 failed. Both failures are in
`test_llm_config_rate_limit_defaults.py` and are environmental rather than code: the repo `.env`
sets `LLM_API_KEY` without `LLM_MODEL`/`LLM_ENDPOINT`, and `LLMConfig` requires all three or none.
Supplying the other two makes that file pass 13/13.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [x] Other (please specify): also carries one metrics bug fix (A), one refactor (B), and the COG-6291 WebSocket auth fix as its base

## Screenshots

<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING -->

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.