### PR TITLE
COG-6293: Fix ollama env-var check to judge resolved LLMConfig

### DIFF
--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -1,5 +1,4 @@
 import json
-import os
 from functools import lru_cache
 from typing import Any, ClassVar
 
@@ -335,29 +334,28 @@ class LLMConfig(BaseSettings):
             # Skip checks unless provider is "ollama"
             return self
 
-        def is_env_set(var_name: str) -> bool:
-            """
-            Check if a given environment variable is set and non-empty.
+        # Judge the resolved config, not os.environ. pydantic-settings has
+        # already merged env vars and constructor kwargs into these fields by
+        # the time an "after" validator runs, so checking os.environ here
+        # would ignore a config built entirely from kwargs (as every test in
+        # test_llm_config.py does) and would also stay fooled by a caller's
+        # ambient .env that has nothing to do with the config under
+        # construction. See COG-6293.
+        #
+        # llm_endpoint/llm_api_key default to blank ("" / None), so "has a
+        # non-blank value" alone tells us whether they were configured.
+        # llm_model defaults to a real model id ("openai/gpt-5-mini"), so the
+        # same non-blank check can't tell "configured, happens to match the
+        # default" from "left unset" - that also needs `model_fields_set`
+        # (populated by pydantic-settings whether the value came from a kwarg
+        # or an env var, even when it matches the default).
+        def _is_configured(value: str | None) -> bool:
+            return isinstance(value, str) and value.strip() != ""
 
-            Parameters:
-            -----------
-
-                - var_name (str): The name of the environment variable to check.
-
-            Returns:
-            --------
-
-                - bool: True if the environment variable exists and is not empty, otherwise False.
-            """
-            val = os.environ.get(var_name)
-            return val is not None and val.strip() != ""
-
-        # Only LLM env vars are validated here; embedding env vars are
-        # EmbeddingConfig's responsibility, not LLMConfig's.
         llm_env_vars = {
-            "LLM_MODEL": is_env_set("LLM_MODEL"),
-            "LLM_ENDPOINT": is_env_set("LLM_ENDPOINT"),
-            "LLM_API_KEY": is_env_set("LLM_API_KEY"),
+            "LLM_MODEL": "llm_model" in self.model_fields_set and _is_configured(self.llm_model),
+            "LLM_ENDPOINT": _is_configured(self.llm_endpoint),
+            "LLM_API_KEY": _is_configured(self.llm_api_key),
         }
         if any(llm_env_vars.values()) and not all(llm_env_vars.values()):
             missing_llm = [key for key, is_set in llm_env_vars.items() if not is_set]
@@ -366,12 +364,11 @@ class LLMConfig(BaseSettings):
                 f"for LLM usage (LLM_MODEL, LLM_ENDPOINT, LLM_API_KEY). Missing: {missing_llm}"
             )
 
-        # Check model support matrix if LLM_MODEL is configured
-        model_name = os.environ.get("LLM_MODEL") or self.llm_model
-        if model_name:
+        # Check model support matrix if a model is configured
+        if self.llm_model:
             from cognee.infrastructure.llm.ollama_support import check_model_support
 
-            check_model_support(model_name)
+            check_model_support(self.llm_model)
 
         return self
 

--- a/cognee/tests/unit/infrastructure/llm/test_llm_config.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_config.py
@@ -209,13 +209,14 @@ def test_instructor_mode_table_and_adapter_wiring():
 
 def _clear_sampling_env(monkeypatch):
     # LLM_ENDPOINT and LLM_API_KEY belong here even though no test reads them:
-    # cognee loads .env into os.environ at import, and LLMConfig's
-    # ensure_env_vars_for_ollama inspects os.environ rather than the values it
-    # was constructed with. Leaving either one set makes an ollama config raise
-    # "some but not all of the required environment variables" no matter what
-    # the test passes as kwargs. _env_file=None does not help: it disables
-    # pydantic's dotenv reading, not the environment already populated at
-    # import time.
+    # cognee loads .env into os.environ at import, and pydantic-settings fills
+    # any field not passed as a kwarg from the environment - so an ambient
+    # LLM_ENDPOINT/LLM_API_KEY reaches LLMConfig.ensure_env_vars_for_ollama the
+    # same as a kwarg would. Leaving either one set makes an ollama config
+    # raise "some but not all of the required environment variables" no
+    # matter what the test passes as kwargs. _env_file=None does not help: it
+    # disables pydantic's dotenv reading, not the environment already
+    # populated at import time.
     for var in (
         "LLM_TEMPERATURE",
         "LLM_SEED",
@@ -354,3 +355,118 @@ def test_known_providers_match_enum():
     )
 
     assert KNOWN_LLM_PROVIDERS == {provider.value for provider in LLMProvider}
+
+
+class TestEnsureEnvVarsForOllama:
+    """The ollama all-or-nothing guard must judge the resolved config, not os.environ.
+
+    COG-6293: this validator used to check os.environ directly, so a config
+    built entirely from kwargs (as every case below does) was invisible to
+    it, and a caller's unrelated ambient .env could trip or silence it by
+    accident. It now reads self.llm_model / self.llm_endpoint / self.llm_api_key
+    after pydantic-settings has already merged env and kwargs into them.
+    """
+
+    def test_all_three_provided_as_kwargs_is_fine(self, monkeypatch):
+        for var in ("LLM_PROVIDER", "LLM_MODEL", "LLM_ENDPOINT", "LLM_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+        config = LLMConfig(
+            _env_file=None,
+            llm_provider="ollama",
+            llm_model="gemma4:e2b-it-qat",
+            llm_endpoint="http://localhost:11434/v1",
+            llm_api_key="test-key",
+        )
+
+        assert config.llm_model == "gemma4:e2b-it-qat"
+
+    def test_none_provided_is_fine(self, monkeypatch):
+        """Only llm_provider set: no partial state to complain about."""
+        for var in ("LLM_MODEL", "LLM_ENDPOINT", "LLM_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+        LLMConfig(_env_file=None, llm_provider="ollama")
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"llm_endpoint": "http://localhost:11434/v1"},
+            {"llm_api_key": "test-key"},
+            {"llm_model": "gemma4:e2b-it-qat"},
+        ],
+    )
+    def test_exactly_one_provided_raises(self, monkeypatch, kwargs):
+        for var in ("LLM_MODEL", "LLM_ENDPOINT", "LLM_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+        with pytest.raises(ValueError, match="some but not all"):
+            LLMConfig(_env_file=None, llm_provider="ollama", **kwargs)
+
+    def test_ambient_env_unrelated_to_the_kwargs_still_raises(self, monkeypatch):
+        """An LLM_API_KEY left over from the caller's own .env must still count.
+
+        Guards against overcorrecting into ignoring env entirely: the fields
+        are resolved from env-or-kwarg by pydantic-settings before this
+        validator runs, so an ambient LLM_API_KEY combined with a kwarg-only
+        llm_model is exactly the "some but not all" case, and must still raise.
+        """
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        monkeypatch.delenv("LLM_ENDPOINT", raising=False)
+        monkeypatch.setenv("LLM_API_KEY", "from-ambient-env")
+
+        with pytest.raises(ValueError, match="some but not all"):
+            LLMConfig(_env_file=None, llm_provider="ollama", llm_model="gemma4:e2b-it-qat")
+
+    def test_non_ollama_provider_is_never_checked(self, monkeypatch):
+        for var in ("LLM_MODEL", "LLM_ENDPOINT", "LLM_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+        LLMConfig(_env_file=None, llm_provider="openai", llm_api_key="test-key")
+
+    def test_llm_model_explicitly_set_to_the_default_value_still_counts_as_set(self, monkeypatch):
+        """A kwarg/env value that happens to match the field default is still 'set'.
+
+        llm_model's default ("openai/gpt-5-mini") is a real, non-blank model
+        id, so a plain non-blank check can't tell "explicitly configured,
+        coincidentally matches the default" apart from "left unset". This
+        must key off model_fields_set instead, the same way
+        infer_provider_from_model already does for llm_provider.
+        """
+        for var in ("LLM_PROVIDER", "LLM_MODEL", "LLM_ENDPOINT", "LLM_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+        default_model = LLMConfig.model_fields["llm_model"].default
+        config = LLMConfig(
+            _env_file=None,
+            llm_provider="ollama",
+            llm_model=default_model,
+            llm_endpoint="http://localhost:11434/v1",
+            llm_api_key="test-key",
+        )
+
+        assert config.llm_model == default_model
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"llm_endpoint": "   "},
+            {"llm_api_key": "   "},
+            {"llm_model": "   "},
+        ],
+    )
+    def test_whitespace_only_value_counts_as_unset(self, monkeypatch, kwargs):
+        """A whitespace-only value carries no real configuration, so it must not
+        satisfy the "this field is set" side of the all-or-nothing check."""
+        for var in ("LLM_MODEL", "LLM_ENDPOINT", "LLM_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+        config_kwargs = {
+            "llm_endpoint": "http://localhost:11434/v1",
+            "llm_api_key": "test-key",
+            "llm_model": "gemma4:e2b-it-qat",
+        }
+        config_kwargs.update(kwargs)
+
+        with pytest.raises(ValueError, match="some but not all"):
+            LLMConfig(_env_file=None, llm_provider="ollama", **config_kwargs)

--- a/cognee/tests/unit/infrastructure/llm/test_llm_config.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_config.py
@@ -208,7 +208,23 @@ def test_instructor_mode_table_and_adapter_wiring():
 
 
 def _clear_sampling_env(monkeypatch):
-    for var in ("LLM_TEMPERATURE", "LLM_SEED", "LLM_ARGS", "LLM_PROVIDER", "LLM_MODEL"):
+    # LLM_ENDPOINT and LLM_API_KEY belong here even though no test reads them:
+    # cognee loads .env into os.environ at import, and LLMConfig's
+    # ensure_env_vars_for_ollama inspects os.environ rather than the values it
+    # was constructed with. Leaving either one set makes an ollama config raise
+    # "some but not all of the required environment variables" no matter what
+    # the test passes as kwargs. _env_file=None does not help: it disables
+    # pydantic's dotenv reading, not the environment already populated at
+    # import time.
+    for var in (
+        "LLM_TEMPERATURE",
+        "LLM_SEED",
+        "LLM_ARGS",
+        "LLM_PROVIDER",
+        "LLM_MODEL",
+        "LLM_ENDPOINT",
+        "LLM_API_KEY",
+    ):
         monkeypatch.delenv(var, raising=False)
 
 

--- a/cognee/tests/unit/infrastructure/llm/test_llm_config_rate_limit_defaults.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_config_rate_limit_defaults.py
@@ -5,8 +5,27 @@ import pytest
 from cognee.infrastructure.llm.config import LOCAL_DEFAULT_RATE_LIMIT_REQUESTS, LLMConfig
 
 
+@pytest.fixture(autouse=True)
+def _isolate_llm_env(monkeypatch):
+    """Build every config in this file from kwargs alone, never the ambient env.
+
+    Same trap as test_llm_config.py: cognee loads .env into os.environ at
+    import, and ensure_env_vars_for_ollama inspects os.environ rather than the
+    values the config was constructed with. A developer whose .env sets only
+    LLM_API_KEY therefore gets "some but not all of the required environment
+    variables" on every ollama case here, while CI (which sets all three)
+    passes. Clearing all three makes the file hermetic either way.
+    """
+    for var in ("LLM_PROVIDER", "LLM_MODEL", "LLM_ENDPOINT", "LLM_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
 def _build(**kwargs):
-    defaults = dict(llm_api_key="test-key", llm_endpoint="http://localhost:11434/v1")
+    defaults = dict(
+        llm_api_key="test-key",
+        llm_endpoint="http://localhost:11434/v1",
+        _env_file=None,
+    )
     defaults.update(kwargs)
     return LLMConfig(**defaults)
 

--- a/cognee/tests/unit/infrastructure/llm/test_llm_config_rate_limit_defaults.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_config_rate_limit_defaults.py
@@ -10,11 +10,12 @@ def _isolate_llm_env(monkeypatch):
     """Build every config in this file from kwargs alone, never the ambient env.
 
     Same trap as test_llm_config.py: cognee loads .env into os.environ at
-    import, and ensure_env_vars_for_ollama inspects os.environ rather than the
-    values the config was constructed with. A developer whose .env sets only
-    LLM_API_KEY therefore gets "some but not all of the required environment
-    variables" on every ollama case here, while CI (which sets all three)
-    passes. Clearing all three makes the file hermetic either way.
+    import, and pydantic-settings fills any field not passed as a kwarg from
+    the environment, so ensure_env_vars_for_ollama sees an ambient env var the
+    same as a kwarg. A developer whose .env sets only LLM_API_KEY therefore
+    gets "some but not all of the required environment variables" on every
+    ollama case here, while CI (which sets all three) passes. Clearing all
+    three makes the file hermetic either way.
     """
     for var in ("LLM_PROVIDER", "LLM_MODEL", "LLM_ENDPOINT", "LLM_API_KEY"):
         monkeypatch.delenv(var, raising=False)


### PR DESCRIPTION
## Description

`LLMConfig.ensure_env_vars_for_ollama` (the all-or-nothing guard for `LLM_MODEL`/`LLM_ENDPOINT`/`LLM_API_KEY` on the ollama provider) checked `os.environ` directly instead of the resolved `self.*` fields. pydantic-settings already merges kwargs and env vars into those fields before an "after" validator runs, so this made the check blind to any config built from kwargs (every unit test) and vulnerable to an unrelated ambient `.env`.

A prior commit (71f89ab30) fixed the resulting test failures by isolating env in the tests, but flagged the validator itself as unfinished ("step 2" on COG-6293). This PR is that step 2: the validator now reads `self.llm_model` / `self.llm_endpoint` / `self.llm_api_key`.

`llm_endpoint`/`llm_api_key` default to blank, so a shared `_is_configured()` helper (treats whitespace-only as unset too) is enough. `llm_model` defaults to a real model id (`"openai/gpt-5-mini"`), so a blank check alone can't tell "explicitly set to the default" from "left unset" — that also needs `"llm_model" in self.model_fields_set`, the same pattern `infer_provider_from_model` already uses for `llm_provider`.

Also corrected two stale test comments that described the old (already-incorrect) os.environ-inspection behavior.

## Acceptance Criteria

* `ensure_env_vars_for_ollama` judges the config it was constructed with (kwargs or env), not `os.environ` directly.
* A value that happens to equal a field's default still counts as "explicitly set" when it came from a kwarg or env var.
* A whitespace-only value counts as "unset" for `LLM_MODEL`/`LLM_ENDPOINT`/`LLM_API_KEY`.
* No behavior change for the real (env-only, no kwargs) construction path used in production.
* All existing and new unit tests pass.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.