### PR TITLE
feat: Add GitHub App org connector (CLO-486)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -732,6 +732,25 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #SLACK_REDIRECT_URI="http://localhost:8000/api/v1/integrations/slack/callback"
 #SLACK_FRONTEND_BASE_URL="http://localhost:3000"
 
+# Create a GitHub App at https://github.com/settings/apps to get these values.
+# Required app configuration: "Request user authorization (OAuth) during
+# installation" enabled; Callback URL pointing at this server's
+# /api/v1/integrations/github/callback; Webhook URL pointing at
+# /api/v1/integrations/github/events; repository permission
+# "Contents: Read-only"; subscribed events: Push, Installation repositories.
+# APP_ID: the numeric id from the app settings page.
+# APP_SLUG: the app's URL slug (github.com/apps/<slug>).
+# APP_PRIVATE_KEY: the app's PEM private key ("\n" escapes accepted).
+# WEBHOOK_SECRET: verifies inbound deliveries via X-Hub-Signature-256, and
+# signs the OAuth state parameter.
+#GITHUB_APP_ID=""
+#GITHUB_APP_SLUG=""
+#GITHUB_APP_PRIVATE_KEY=""
+#GITHUB_CLIENT_ID=""
+#GITHUB_CLIENT_SECRET=""
+#GITHUB_WEBHOOK_SECRET=""
+#GITHUB_FRONTEND_BASE_URL="http://localhost:3000"
+
 
 ################################################################################
 #  Docker / MCP Runtime

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -54,6 +54,13 @@ from cognee.api.v1.activity.routers import get_activity_router
 from cognee.api.v1.sessions import get_sessions_router
 from cognee.api.v1.slack.routers import get_slack_channels_router, get_slack_router
 from cognee.api.v1.integrations.routers import get_integrations_router
+
+# Registers the GitHub App integration with the integrations registry as an
+# import side effect. Slack registers via its router imports above; GitHub
+# mounts no routers of its own (webhooks arrive on the generic
+# /api/v1/integrations/github/events route), so the registration import is
+# explicit here.
+import cognee.modules.integrations.github  # noqa: F401,E402
 from cognee.modules.users.methods.get_authenticated_user import REQUIRE_AUTHENTICATION
 
 # Ensure application logging is configured for container stdout/stderr

--- a/cognee/api/v1/integrations/routers/get_integrations_router.py
+++ b/cognee/api/v1/integrations/routers/get_integrations_router.py
@@ -13,6 +13,9 @@ Route roles differ sharply in their auth model, which is the point:
 * ``GET/DELETE /{provider}/connection`` — authenticated; a user only ever
   sees or disconnects their own connection (credentials are user-scoped, not
   shared across a tenant/org).
+* ``POST /{provider}/events`` — unauthenticated webhook receiver; the
+  provider's registered ``WebhookVerifier`` (HMAC over raw bytes) is the
+  entire auth model. Providers without a verifier 404.
 
 Adding a second provider (Notion, GitHub, ...) needs none of these endpoints
 touched — only a new ``OAuthIntegration`` registered via
@@ -30,13 +33,14 @@ generic ``{provider}`` routes so ``plugins`` is never captured as a
 provider name.
 """
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Optional
 from urllib.parse import quote
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from fastapi_users.exceptions import UserAlreadyExists
 from sqlalchemy.exc import IntegrityError
@@ -85,6 +89,26 @@ from cognee.modules.users.methods.store_principal_configuration import (
 from cognee.modules.users.models import User
 
 logger = logging.getLogger(__name__)
+
+# Detached post-install / webhook work (initial syncs, event handling) runs
+# off the request path; strong references keep the tasks alive until done —
+# same pattern as remember()'s _BACKGROUND_REMEMBER_TASKS.
+_BACKGROUND_INTEGRATION_TASKS: set = set()
+
+
+def _spawn_background(coro, *, description: str) -> None:
+    """Run ``coro`` detached, logging (never raising) on failure."""
+
+    async def _guarded():
+        try:
+            await coro
+        except Exception:  # noqa: BLE001 - detached work must log, not crash the loop
+            logger.exception("%s failed", description)
+
+    task = asyncio.create_task(_guarded())
+    _BACKGROUND_INTEGRATION_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_INTEGRATION_TASKS.discard)
+
 
 # Plugin keys with a native AgentConnectionType; anything else registers as
 # a generic "sdk" connection in the agent-connection registry.
@@ -458,7 +482,9 @@ def get_integrations_router():
                 )
 
     @integrations_router.get("/{provider}/callback", include_in_schema=False)
-    async def callback(provider: str, code: str = "", state: str = "", error: str = ""):
+    async def callback(
+        provider: str, request: Request, code: str = "", state: str = "", error: str = ""
+    ):
         """OAuth redirect target — state-authenticated, browser-facing."""
         with new_span("cognee.integrations.callback") as span:
             span.set_attribute("cognee.integrations.provider", provider)
@@ -477,7 +503,15 @@ def get_integrations_router():
                 return _frontend_redirect(integration, "error_invalid_state")
 
             try:
-                credential = await complete_installation(integration, code=code, user_id=user_id)
+                credential = await complete_installation(
+                    integration,
+                    code=code,
+                    user_id=user_id,
+                    # The full query string, for providers whose redirect
+                    # carries more than a code (GitHub's installation_id).
+                    # The adapter decides what in here it trusts.
+                    callback_params=dict(request.query_params),
+                )
             except CrossUserConflictError:
                 # The account is already connected to another user; refuse
                 # rather than silently reassign it (see upsert_credential).
@@ -496,8 +530,47 @@ def get_integrations_router():
                 credential.provider_account_id,
                 user_id,
             )
+            # Post-install work (e.g. GitHub's initial repo sync) runs
+            # detached — the browser gets its redirect now, not after.
+            _spawn_background(
+                integration.on_installed(credential),
+                description=f"{provider} on_installed hook",
+            )
             span.set_attribute("cognee.integrations.outcome", "connected")
             return _frontend_redirect(integration, "connected")
+
+    @integrations_router.post("/{provider}/events", include_in_schema=False)
+    async def provider_events(provider: str, request: Request):
+        """Generic webhook receiver, one URL per provider.
+
+        Unauthenticated by design — providers can't send a bearer token, so
+        the provider's own ``WebhookVerifier`` (HMAC over the raw bytes) is
+        the entire auth model, exactly like the Slack routes. A provider
+        that registers no verifier simply doesn't accept webhooks: 404, the
+        same answer an unknown provider gets, so the route leaks nothing
+        about which providers are configured.
+
+        The delivery is acked as soon as the signature checks out; the
+        actual handling (which may clone repositories or run pipelines) runs
+        detached so the provider's delivery timeout is never in play.
+        """
+        with new_span("cognee.integrations.events") as span:
+            span.set_attribute("cognee.integrations.provider", provider)
+            integration = _integration_or_404(provider)
+            verifier = integration.webhook_verifier()
+            if verifier is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"{provider} does not accept webhook deliveries.",
+                )
+
+            raw_body = await verifier.verify(request)
+            headers = {key.lower(): value for key, value in request.headers.items()}
+            _spawn_background(
+                integration.handle_webhook(raw_body, headers),
+                description=f"{provider} webhook handling",
+            )
+            return {"ok": True}
 
     @integrations_router.get("/{provider}/connection", response_model_exclude_none=True)
     async def connection_status(

--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -66,6 +66,7 @@ class RememberKwargs(TypedDict, total=False):
     content_type: Literal["skills", "code"]
     skill_improvement: dict[str, Any]
     index_vectors: bool
+    repo_credentials: str
     skills_text: str
     skill_name: str
     primary_key: str
@@ -974,8 +975,12 @@ async def _remember_inner(
     # normal remember), so they must be consumed here regardless of content_type.
     skills_text = kwargs.pop("skills_text", None)
     skill_name = kwargs.pop("skill_name", None)
-    # code-only kwarg, consumed here for the same reason as the skills ones.
+    # code-only kwargs, consumed here for the same reason as the skills ones.
     index_vectors = kwargs.pop("index_vectors", None)
+    # Out-of-band auth token for private https remotes (e.g. a GitHub App
+    # installation token). Kept out of the repo URLs so no secret ever rides
+    # a loggable string — see resolve_repo_source.
+    repo_credentials = kwargs.pop("repo_credentials", None)
 
     def _requested_node_set(default: str) -> str:
         requested_node_set = kwargs.get("node_set") or [default]
@@ -993,6 +998,8 @@ async def _remember_inner(
         )
     if index_vectors is not None and content_type != "code":
         raise ValueError("index_vectors is supported only for content_type='code'.")
+    if repo_credentials is not None and content_type != "code":
+        raise ValueError("repo_credentials is supported only for content_type='code'.")
     if content_type == "code" and session_id is not None:
         raise ValueError(
             "session_id is not applicable to content_type='code'; code graphs are "
@@ -1060,7 +1067,7 @@ async def _remember_inner(
                     result.error = f"code_graph_pipeline errored for repository '{item['source']}'"
 
         async def _run_one_repo(spec) -> dict:
-            repo_path = await resolve_repo_source(spec)
+            repo_path = await resolve_repo_source(spec, credentials=repo_credentials)
             # redact: connector-supplied URLs may carry a token in the
             # userinfo, which must not surface in results or logs.
             item = {

--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -1006,7 +1006,7 @@ async def _remember_inner(
         from cognee.modules.run_custom_pipeline import run_custom_pipeline
         from cognee.shared.utils import send_telemetry
         from cognee.tasks.code_graph import get_code_graph_tasks
-        from cognee.tasks.code_graph.resolve_repo import resolve_repo_source
+        from cognee.tasks.code_graph.resolve_repo import redact_repo_spec, resolve_repo_source
 
         repo_specs = data if isinstance(data, list) else [data]
         if not repo_specs or not all(isinstance(spec, (str, _Path)) for spec in repo_specs):
@@ -1061,7 +1061,13 @@ async def _remember_inner(
 
         async def _run_one_repo(spec) -> dict:
             repo_path = await resolve_repo_source(spec)
-            item = {"kind": "code_repository", "source": str(spec), "path": str(repo_path)}
+            # redact: connector-supplied URLs may carry a token in the
+            # userinfo, which must not surface in results or logs.
+            item = {
+                "kind": "code_repository",
+                "source": redact_repo_spec(spec),
+                "path": str(repo_path),
+            }
             pipeline_result = await run_custom_pipeline(
                 tasks=get_code_graph_tasks(str(repo_path), index_vectors=bool(index_vectors)),
                 data=str(repo_path),
@@ -1096,14 +1102,15 @@ async def _remember_inner(
                     try:
                         item = await _run_one_repo(spec)
                     except Exception as exc:
-                        logger.exception("Background code-graph run failed for '%s'", spec)
+                        source = redact_repo_spec(spec)
+                        logger.exception("Background code-graph run failed for '%s'", source)
                         item = {
                             "kind": "code_repository",
-                            "source": str(spec),
+                            "source": source,
                             "status": "errored",
                             "error": str(exc),
                         }
-                        errors.append(f"{spec}: {exc}")
+                        errors.append(f"{source}: {exc}")
                     result.items.append(item)
                 result.items_processed = len(
                     [item for item in result.items if item.get("status") != "errored"]

--- a/cognee/modules/integrations/base.py
+++ b/cognee/modules/integrations/base.py
@@ -117,6 +117,47 @@ class OAuthIntegration(ABC):
     def frontend_base_url(self) -> str:
         """Where the browser lands once the OAuth round-trip completes."""
 
+    async def exchange_callback(self, code: str, params: dict[str, str]) -> dict[str, Any]:
+        """Exchange one provider callback into the raw token response.
+
+        Default delegates to ``exchange_code`` — the plain OAuth2 shape where
+        ``code`` is the only thing the callback carries. Override when the
+        provider sends more than a code (GitHub App installs carry an
+        ``installation_id`` alongside it); ``params`` is the callback's full
+        query string, minus nothing — the adapter picks what it trusts.
+        """
+        return await self.exchange_code(code)
+
+    def webhook_verifier(self) -> Optional["WebhookVerifier"]:
+        """The verifier for this provider's inbound webhooks, if it has any.
+
+        Default ``None``: the generic ``POST /{provider}/events`` route
+        rejects deliveries for a provider that doesn't opt in. Returning a
+        verifier turns that route on for this provider; pair it with a
+        ``handle_webhook`` override that actually does something.
+        """
+        return None
+
+    async def handle_webhook(self, raw_body: bytes, headers: dict[str, str]) -> None:
+        """Process one verified webhook delivery.
+
+        Called off the request path (the route acks the provider first), so
+        implementations may do slow work but must not assume a live request.
+        ``headers`` are lower-cased — providers put the event name in a
+        header (GitHub's ``x-github-event``), not the body.
+        """
+        return None
+
+    async def on_installed(self, credential: IntegrationCredential) -> None:
+        """Post-install hook, fired in the background after a successful connect.
+
+        Default no-op. Override for providers whose connect should kick off
+        work beyond storing the credential (an initial content sync, say).
+        Runs detached from the callback request — failures log, they never
+        break the install redirect.
+        """
+        return None
+
     async def revoke_remote(self, credential: IntegrationCredential) -> None:
         """Best-effort remote token revoke, called on disconnect.
 

--- a/cognee/modules/integrations/connect.py
+++ b/cognee/modules/integrations/connect.py
@@ -9,6 +9,7 @@ see :mod:`cognee.api.v1.integrations.routers.get_integrations_router`, whose
 callback endpoint calls this for whichever provider is in the URL.
 """
 
+from typing import Optional
 from uuid import UUID
 
 from cognee.modules.integrations.base import OAuthIntegration
@@ -17,18 +18,27 @@ from cognee.modules.integrations.models.IntegrationCredential import Integration
 
 
 async def complete_installation(
-    integration: OAuthIntegration, *, code: str, user_id: UUID
+    integration: OAuthIntegration,
+    *,
+    code: str,
+    user_id: UUID,
+    callback_params: Optional[dict[str, str]] = None,
 ) -> IntegrationCredential:
     """Exchange ``code`` for tokens and persist the resulting credential.
 
-    Raises whatever ``exchange_code``/``parse_installation`` raise (a
+    ``callback_params`` is the callback's full query string, for providers
+    whose redirect carries more than a code (GitHub's ``installation_id``) —
+    ``exchange_callback`` defaults to plain ``exchange_code(code)`` so
+    code-only providers never see it.
+
+    Raises whatever ``exchange_callback``/``parse_installation`` raise (a
     provider-specific ``RuntimeError``/``ValueError`` for a rejected or
     malformed exchange) or
     :class:`~cognee.modules.integrations.credentials.CrossUserConflictError`
     from the upsert — callers (the callback endpoint) translate both into a
     redirect outcome, never a raw 500.
     """
-    token_response = await integration.exchange_code(code)
+    token_response = await integration.exchange_callback(code, callback_params or {})
     installation = integration.parse_installation(token_response)
 
     return await upsert_credential(

--- a/cognee/modules/integrations/github/__init__.py
+++ b/cognee/modules/integrations/github/__init__.py
@@ -1,0 +1,13 @@
+"""GitHub App integration package.
+
+Importing this package registers the GitHub adapter with the integrations
+registry as a side effect — the same pattern as the Slack package. Unlike
+Slack, GitHub mounts no routers of its own (its webhooks arrive on the
+generic ``POST /api/v1/integrations/github/events`` route), so the API app
+imports this package explicitly to trigger registration.
+"""
+
+from cognee.modules.integrations.github.adapter import GithubIntegration
+from cognee.modules.integrations.registry import use_integration
+
+use_integration(GithubIntegration())

--- a/cognee/modules/integrations/github/adapter.py
+++ b/cognee/modules/integrations/github/adapter.py
@@ -1,0 +1,151 @@
+"""GitHub (App) as an ``OAuthIntegration`` adapter.
+
+Connects a GitHub org (or user account) through a GitHub App installation
+rather than a plain OAuth app: the org admin installs the app once, picks
+which repositories it covers, and cognee holds only the installation id —
+short-lived access tokens are minted on demand from the app's private key
+(:mod:`cognee.modules.integrations.github.app_auth`), so the stored
+credential carries an empty token payload.
+
+The install callback differs from the plain-OAuth shape in two ways, both
+absorbed by ``exchange_callback``:
+
+* GitHub's redirect carries an ``installation_id`` alongside the ``code``.
+* That id arrives on an unauthenticated endpoint and is a small guessable
+  integer, so it is never trusted directly: the ``code`` is first exchanged
+  for a user token ("Request user authorization during installation" must
+  be enabled on the app) and the user's access to the installation is
+  confirmed, then the authoritative installation record is fetched with the
+  app JWT. Without that check, anyone could bind another org's installation
+  — and read access to its private repositories — to their own account.
+
+``revoke_remote`` stays the default no-op on purpose: the GitHub-side
+equivalent would be deleting the installation, i.e. uninstalling the app
+from the whole org — too destructive for a cognee-side disconnect. Once the
+local credential is revoked no further tokens are minted, which is the
+actual access cut-off.
+"""
+
+import logging
+from typing import Any, Optional
+from urllib.parse import urlencode
+
+import aiohttp
+
+from cognee.modules.integrations.base import (
+    OAuthInstallation,
+    OAuthIntegration,
+    WebhookVerifier,
+)
+from cognee.modules.integrations.github import app_auth
+from cognee.modules.integrations.github.github_settings import GithubSettings, require
+from cognee.modules.integrations.github.handle_github_event import handle_github_event
+from cognee.modules.integrations.github.sync import sync_repositories
+from cognee.modules.integrations.github.verify_github_signature import GithubWebhookVerifier
+from cognee.modules.integrations.models.IntegrationCredential import IntegrationCredential
+
+logger = logging.getLogger(__name__)
+
+_INSTALL_URL = "https://github.com/apps/{app_slug}/installations/new"
+_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+
+_TIMEOUT = aiohttp.ClientTimeout(total=30)
+
+
+class GithubIntegration(OAuthIntegration):
+    provider = "github"
+    settings_cls = GithubSettings
+
+    def authorize_url(self, state: str) -> str:
+        # The app-installation flow, not an OAuth consent screen: GitHub
+        # passes ``state`` through to the app's callback URL along with the
+        # installation id (and a code, with request-user-authorization on).
+        return f"{_INSTALL_URL.format(app_slug=require('app_slug'))}?{urlencode({'state': state})}"
+
+    async def exchange_code(self, code: str) -> dict[str, Any]:
+        """Exchange the OAuth code for a *user* token.
+
+        Only used to prove who completed the install flow — the user token
+        is checked against the installation and discarded, never stored.
+        GitHub returns errors as HTTP 200 with an ``error`` field, so the
+        body, not the status, is what's checked.
+        """
+        async with aiohttp.ClientSession(timeout=_TIMEOUT) as session:
+            async with session.post(
+                _ACCESS_TOKEN_URL,
+                data={
+                    "client_id": require("client_id"),
+                    "client_secret": require("client_secret"),
+                    "code": code,
+                },
+                headers={"Accept": "application/json"},
+            ) as response:
+                payload = await response.json()
+
+        if payload.get("error") or not payload.get("access_token"):
+            raise RuntimeError(
+                f"GitHub code exchange failed: {payload.get('error', 'no access_token')}"
+            )
+        return payload
+
+    async def exchange_callback(self, code: str, params: dict[str, str]) -> dict[str, Any]:
+        installation_id = params.get("installation_id", "")
+        if not installation_id.isdigit():
+            raise ValueError("GitHub callback carried no installation_id")
+
+        user_token_response = await self.exchange_code(code)
+        if not await app_auth.user_can_access_installation(
+            user_token_response["access_token"], int(installation_id)
+        ):
+            raise PermissionError(
+                f"GitHub user completing the install has no access to "
+                f"installation {installation_id}"
+            )
+
+        # The authoritative record, fetched as the app — nothing from the
+        # unauthenticated query string beyond the (now verified) id is used.
+        return await app_auth.get_installation(int(installation_id))
+
+    def parse_installation(self, token_response: dict[str, Any]) -> OAuthInstallation:
+        installation_id = token_response.get("id")
+        if installation_id is None:
+            raise ValueError("GitHub installation record carries no id")
+
+        account = token_response.get("account") or {}
+        return OAuthInstallation(
+            provider_account_id=str(installation_id),
+            # No durable per-installation secret exists — tokens are minted
+            # on demand from the app private key (see module docstring).
+            token_payload={},
+            provider_metadata={
+                "account_login": account.get("login"),
+                "account_id": account.get("id"),
+                "account_type": account.get("type"),
+                "repository_selection": token_response.get("repository_selection"),
+                "app_id": token_response.get("app_id"),
+            },
+            account_label=account.get("login"),
+            auth_type="github_app",
+        )
+
+    def state_signing_secret(self) -> str:
+        return require("webhook_secret")
+
+    def frontend_base_url(self) -> str:
+        return require("frontend_base_url")
+
+    def webhook_verifier(self) -> Optional[WebhookVerifier]:
+        return GithubWebhookVerifier()
+
+    async def handle_webhook(self, raw_body: bytes, headers: dict[str, str]) -> None:
+        await handle_github_event(raw_body, headers)
+
+    async def on_installed(self, credential: IntegrationCredential) -> None:
+        """Index every repository the fresh installation covers.
+
+        The ``installation.created`` webhook usually races ahead of the
+        OAuth callback storing the credential and is dropped as unknown —
+        this hook, firing after the upsert, is what actually performs the
+        initial sync.
+        """
+        await sync_repositories(credential)

--- a/cognee/modules/integrations/github/app_auth.py
+++ b/cognee/modules/integrations/github/app_auth.py
@@ -1,0 +1,147 @@
+"""GitHub App authentication: app JWT and short-lived installation tokens.
+
+A GitHub App holds no durable per-installation secret — the durable secret
+is the app's RS256 private key (env), from which a ~9-minute JWT is signed,
+which in turn mints a ~1-hour installation access token scoped to one
+installation's repositories
+(https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app).
+That's why the stored ``IntegrationCredential`` for GitHub carries an empty
+token payload: tokens are minted here on demand, never persisted.
+
+The JWT is built by hand with ``cryptography`` (already a core dependency)
+rather than pulling in a JWT library for one fixed-shape, fixed-alg token.
+"""
+
+import base64
+import json
+import time
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import aiohttp
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+
+from cognee.modules.integrations.github.github_settings import private_key_pem, require
+
+API_BASE_URL = "https://api.github.com"
+
+_TIMEOUT = aiohttp.ClientTimeout(total=30)
+
+# GitHub caps app JWTs at 10 minutes; 9 leaves clock-skew headroom on top of
+# the 60-second iat backdate GitHub itself recommends.
+_JWT_BACKDATE_SECONDS = 60
+_JWT_LIFETIME_SECONDS = 9 * 60
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def build_app_jwt(*, now: Optional[int] = None) -> str:
+    """Sign a short-lived RS256 JWT identifying the app itself.
+
+    ``now`` is injectable for tests; production callers omit it.
+    """
+    issued_at = int(now if now is not None else time.time())
+    header = {"alg": "RS256", "typ": "JWT"}
+    payload = {
+        "iat": issued_at - _JWT_BACKDATE_SECONDS,
+        "exp": issued_at + _JWT_LIFETIME_SECONDS,
+        "iss": require("app_id"),
+    }
+    signing_input = (
+        f"{_b64url(json.dumps(header, separators=(',', ':')).encode())}"
+        f".{_b64url(json.dumps(payload, separators=(',', ':')).encode())}"
+    )
+    private_key = serialization.load_pem_private_key(private_key_pem().encode(), password=None)
+    if not isinstance(private_key, RSAPrivateKey):
+        raise RuntimeError("GITHUB_APP_PRIVATE_KEY is not an RSA private key")
+    signature = private_key.sign(signing_input.encode(), padding.PKCS1v15(), hashes.SHA256())
+    return f"{signing_input}.{_b64url(signature)}"
+
+
+def _api_headers(bearer: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {bearer}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+async def get_installation(installation_id: int) -> dict[str, Any]:
+    """Fetch one installation of *this* app, authenticated as the app.
+
+    The authoritative source for install metadata (org login, repository
+    selection): querying it with the app JWT proves the installation id
+    belongs to our app, so nothing from an unauthenticated callback's query
+    string is ever trusted directly.
+
+    Raises ``RuntimeError`` when GitHub rejects the lookup (unknown id,
+    suspended installation, bad app credentials).
+    """
+    async with aiohttp.ClientSession(timeout=_TIMEOUT) as session:
+        async with session.get(
+            f"{API_BASE_URL}/app/installations/{installation_id}",
+            headers=_api_headers(build_app_jwt()),
+        ) as response:
+            if response.status != 200:
+                raise RuntimeError(
+                    f"GitHub installation lookup failed for {installation_id}: "
+                    f"HTTP {response.status}"
+                )
+            return await response.json()
+
+
+async def mint_installation_token(installation_id: int) -> tuple[str, Optional[datetime]]:
+    """Mint a fresh installation access token (valid ~1 hour).
+
+    Returns ``(token, expires_at)``. Callers use the token immediately and
+    discard it — it is never written to the credential store.
+    """
+    async with aiohttp.ClientSession(timeout=_TIMEOUT) as session:
+        async with session.post(
+            f"{API_BASE_URL}/app/installations/{installation_id}/access_tokens",
+            headers=_api_headers(build_app_jwt()),
+        ) as response:
+            if response.status != 201:
+                raise RuntimeError(
+                    f"GitHub installation token mint failed for {installation_id}: "
+                    f"HTTP {response.status}"
+                )
+            payload = await response.json()
+
+    expires_at = None
+    expires_raw = payload.get("expires_at")
+    if expires_raw:
+        expires_at = datetime.fromisoformat(expires_raw.replace("Z", "+00:00")).astimezone(
+            timezone.utc
+        )
+    return payload["token"], expires_at
+
+
+async def user_can_access_installation(user_token: str, installation_id: int) -> bool:
+    """Whether the GitHub user behind ``user_token`` can access the installation.
+
+    The install callback is unauthenticated and ``installation_id`` arrives
+    in its query string, where anyone can put any (small, guessable) integer.
+    This check — GitHub's documented mitigation — confirms the person who
+    completed the OAuth leg actually has access to that installation, so a
+    user can't bind another org's installation to their own cognee account.
+    """
+    url: Optional[str] = f"{API_BASE_URL}/user/installations?per_page=100"
+    async with aiohttp.ClientSession(timeout=_TIMEOUT) as session:
+        while url:
+            async with session.get(url, headers=_api_headers(user_token)) as response:
+                if response.status != 200:
+                    raise RuntimeError(
+                        f"GitHub user-installations lookup failed: HTTP {response.status}"
+                    )
+                payload = await response.json()
+                for installation in payload.get("installations", []):
+                    if installation.get("id") == installation_id:
+                        return True
+                next_link = response.links.get("next", {}).get("url")
+                url = str(next_link) if next_link else None
+    return False

--- a/cognee/modules/integrations/github/github_settings.py
+++ b/cognee/modules/integrations/github/github_settings.py
@@ -1,0 +1,60 @@
+from pydantic_settings import SettingsConfigDict
+
+from cognee.modules.integrations.base import IntegrationSettings
+
+
+class GithubSettings(IntegrationSettings):
+    """Configuration for the GitHub App integration.
+
+    One GitHub App is installed into many orgs/accounts; these values
+    identify that single app. Secrets default to empty strings rather than
+    failing at import so that deployments without GitHub configured (and
+    unit tests) still boot — consumers call :func:`require` at use time
+    instead, which fails loudly per missing value.
+
+    ``client_id``/``client_secret``/``redirect_uri``/``frontend_base_url``
+    come from :class:`IntegrationSettings`; the fields below are what a
+    GitHub *App* (as opposed to a plain OAuth app) needs beyond that shape.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="GITHUB_", extra="ignore")
+
+    # The app's numeric id, from the app settings page. Issues the app JWT
+    # that mints installation tokens. Env: GITHUB_APP_ID
+    app_id: str = ""
+
+    # The app's URL slug (github.com/apps/<slug>), used to build the
+    # installation URL the connect flow redirects to. Env: GITHUB_APP_SLUG
+    app_slug: str = ""
+
+    # The app's RS256 private key, PEM-encoded. Accepts literal "\n" escapes
+    # so it survives single-line env files. Env: GITHUB_APP_PRIVATE_KEY
+    app_private_key: str = ""
+
+    # Keys every inbound delivery's X-Hub-Signature-256 HMAC. Also keys the
+    # OAuth state parameter — both are server-side-only uses of the same
+    # secret (same doubling-up as Slack's signing_secret).
+    # Env: GITHUB_WEBHOOK_SECRET
+    webhook_secret: str = ""
+
+
+github_settings = GithubSettings()
+
+
+def require(field_name: str) -> str:
+    """Return a settings value, refusing to proceed when it is unset.
+
+    A missing GitHub secret must never degrade into a signature check
+    against an empty key or a JWT signed with an empty PEM — both would fail
+    in confusing, downstream ways instead of naming the actual problem.
+    """
+    value = getattr(github_settings, field_name)
+    if not value:
+        env_name = f"GITHUB_{field_name.upper()}"
+        raise RuntimeError(f"{env_name} is not configured")
+    return value
+
+
+def private_key_pem() -> str:
+    """The app private key with env-file "\\n" escapes restored to newlines."""
+    return require("app_private_key").replace("\\n", "\n")

--- a/cognee/modules/integrations/github/handle_github_event.py
+++ b/cognee/modules/integrations/github/handle_github_event.py
@@ -1,0 +1,92 @@
+"""Handle one verified GitHub webhook delivery.
+
+Runs detached from the request (the generic events route acks first), so
+handlers here may clone repositories and run pipelines. Every delivery
+carries an ``installation.id`` that routes back to the connecting cognee
+user via the credential store — an unknown or revoked installation is
+logged and dropped, never an error: GitHub retries deliveries and gives no
+ordering guarantee, so an ``installation.created`` racing ahead of the
+OAuth callback's credential upsert is a normal, self-healing state (the
+post-install hook covers the initial sync).
+
+Deliberately narrow event coverage for the first cut:
+
+* ``installation`` deleted/suspend -> revoke the stored credential.
+* ``installation_repositories`` added -> index the new repos. Removed repos
+  are logged only — deleting indexed data on a webhook would be a silent,
+  destructive surprise; ``forget()`` stays a human decision.
+* ``push`` to the default branch -> re-index that repo (the clone is a
+  shallow copy of the default branch, so other refs change nothing we hold).
+"""
+
+import json
+import logging
+
+from cognee.modules.integrations.credentials import (
+    STATUS_ACTIVE,
+    get_credential_by_account,
+    revoke_credential_by_account,
+)
+from cognee.modules.integrations.github.sync import sync_repositories
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER = "github"
+
+
+async def handle_github_event(raw_body: bytes, headers: dict[str, str]) -> None:
+    event = headers.get("x-github-event", "")
+    try:
+        payload = json.loads(raw_body)
+    except json.JSONDecodeError:
+        logger.warning("GitHub delivery with unparseable body (event=%s)", event)
+        return
+
+    installation_id = str((payload.get("installation") or {}).get("id") or "")
+    if not installation_id:
+        logger.info("GitHub %s delivery without installation id; ignoring", event)
+        return
+
+    action = payload.get("action")
+
+    if event == "installation" and action in ("deleted", "suspend"):
+        # The org removed (or suspended) the app on GitHub's side — the
+        # local credential must stop minting tokens. Idempotent, so
+        # redelivery is harmless.
+        await revoke_credential_by_account(_PROVIDER, installation_id)
+        logger.info("GitHub installation %s %s; credential revoked", installation_id, action)
+        return
+
+    credential = await get_credential_by_account(_PROVIDER, installation_id)
+    if credential is None or credential.status != STATUS_ACTIVE:
+        logger.info(
+            "GitHub %s delivery for unconnected installation %s; ignoring",
+            event,
+            installation_id,
+        )
+        return
+
+    if event == "installation_repositories":
+        added = [repo["full_name"] for repo in payload.get("repositories_added", []) if repo]
+        removed = [repo["full_name"] for repo in payload.get("repositories_removed", []) if repo]
+        if removed:
+            logger.info(
+                "GitHub installation %s removed repos %s; indexed data retained "
+                "(use forget() to drop it)",
+                installation_id,
+                removed,
+            )
+        if added:
+            await sync_repositories(credential, added)
+        return
+
+    if event == "push":
+        repository = payload.get("repository") or {}
+        full_name = repository.get("full_name")
+        default_branch = repository.get("default_branch")
+        if not full_name or payload.get("ref") != f"refs/heads/{default_branch}":
+            return
+        await sync_repositories(credential, [full_name])
+        return
+
+    logger.debug("GitHub %s delivery for installation %s ignored", event, installation_id)

--- a/cognee/modules/integrations/github/sync.py
+++ b/cognee/modules/integrations/github/sync.py
@@ -1,0 +1,129 @@
+"""Sync a GitHub installation's repositories into the code graph.
+
+Thin orchestration over the existing ``remember(content_type="code")`` path:
+mint a fresh installation token, resolve which repositories to index, and
+hand authenticated clone URLs to the code-graph pipeline. All the heavy
+lifting — clone reuse, snapshot-identity skip on unchanged repos, per-repo
+failure isolation — already lives in ``resolve_repo_source`` and the
+pipeline, which is what makes re-running this on every webhook cheap and
+idempotent.
+
+The indexed graph is searchable via ``SearchType.CODE`` (the code route
+produces no chunks or embeddings by design); ``index_vectors`` stays off.
+
+One dataset per installation (``github_<org>``), not per repository —
+``remember`` already accepts a list of repo specs targeting one dataset, and
+per-repo datasets would mean one isolated database per repo under backend
+access control.
+"""
+
+import logging
+import re
+from typing import Any, Optional
+
+import aiohttp
+
+from cognee.modules.integrations.github.app_auth import (
+    API_BASE_URL,
+    _api_headers,
+    mint_installation_token,
+)
+from cognee.modules.integrations.models.IntegrationCredential import IntegrationCredential
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = aiohttp.ClientTimeout(total=30)
+
+GITHUB_DATASET_PREFIX = "github"
+
+
+def dataset_name_for_account(account_login: str) -> str:
+    """The one dataset an installation's repositories land in."""
+    slug = re.sub(r"[^A-Za-z0-9_]+", "_", account_login).strip("_").lower()
+    return f"{GITHUB_DATASET_PREFIX}_{slug or 'account'}"
+
+
+def authenticated_clone_url(full_name: str, token: str) -> str:
+    """An https clone URL carrying the (hour-lived) installation token.
+
+    ``resolve_repo_source`` strips the userinfo before computing the clone
+    slug, persisting the remote, or logging — the token is used for the
+    clone/fetch itself and nowhere else.
+    """
+    return f"https://x-access-token:{token}@github.com/{full_name}.git"
+
+
+async def list_installation_repositories(token: str) -> list[str]:
+    """Full names (``org/repo``) of every repository the installation covers."""
+    full_names: list[str] = []
+    url: Optional[str] = f"{API_BASE_URL}/installation/repositories?per_page=100"
+    async with aiohttp.ClientSession(timeout=_TIMEOUT) as session:
+        while url:
+            async with session.get(url, headers=_api_headers(token)) as response:
+                if response.status != 200:
+                    raise RuntimeError(
+                        f"GitHub installation repository listing failed: HTTP {response.status}"
+                    )
+                payload: dict[str, Any] = await response.json()
+                full_names.extend(
+                    repo["full_name"] for repo in payload.get("repositories", []) if repo
+                )
+                next_link = response.links.get("next", {}).get("url")
+                url = str(next_link) if next_link else None
+    return full_names
+
+
+async def sync_repositories(
+    credential: IntegrationCredential,
+    repo_full_names: Optional[list[str]] = None,
+) -> None:
+    """Index ``repo_full_names`` (default: every repo the installation covers).
+
+    Runs the code-graph pipeline to completion — callers are already off the
+    request path (the post-install hook and webhook handling both run
+    detached), so there is nothing to hand off to.
+
+    The minted token lives ~1 hour and repos are cloned sequentially as the
+    pipeline reaches them, so a very large installation can outlive the
+    token mid-batch; the affected repos surface as per-repo errors and the
+    next webhook (or manual re-sync) picks them up with a fresh token.
+    """
+    # Imported here, not at module top: this module is imported at API
+    # startup (via the adapter registration), and cognee's package root is
+    # heavyweight.
+    from cognee.api.v1.remember.remember import remember as cognee_remember
+    from cognee.modules.users.methods import get_user
+
+    token, _expires_at = await mint_installation_token(int(credential.provider_account_id))
+
+    if repo_full_names is None:
+        repo_full_names = await list_installation_repositories(token)
+    if not repo_full_names:
+        logger.info(
+            "GitHub installation %s has no repositories to sync", credential.provider_account_id
+        )
+        return
+
+    account_login = (credential.provider_metadata or {}).get("account_login") or str(
+        credential.provider_account_id
+    )
+    owner = await get_user(credential.user_id)
+
+    logger.info(
+        "Syncing %d GitHub repositories for %s into dataset %s",
+        len(repo_full_names),
+        account_login,
+        dataset_name_for_account(account_login),
+    )
+    result = await cognee_remember(
+        [authenticated_clone_url(full_name, token) for full_name in repo_full_names],
+        dataset_name=dataset_name_for_account(account_login),
+        user=owner,
+        content_type="code",
+    )
+    if getattr(result, "status", None) == "errored":
+        logger.warning(
+            "GitHub sync for %s finished with errors: %s",
+            account_login,
+            getattr(result, "error", None),
+        )

--- a/cognee/modules/integrations/github/sync.py
+++ b/cognee/modules/integrations/github/sync.py
@@ -43,14 +43,15 @@ def dataset_name_for_account(account_login: str) -> str:
     return f"{GITHUB_DATASET_PREFIX}_{slug or 'account'}"
 
 
-def authenticated_clone_url(full_name: str, token: str) -> str:
-    """An https clone URL carrying the (hour-lived) installation token.
+def clone_url(full_name: str) -> str:
+    """The credential-free https clone URL for a repository.
 
-    ``resolve_repo_source`` strips the userinfo before computing the clone
-    slug, persisting the remote, or logging — the token is used for the
-    clone/fetch itself and nowhere else.
+    Deliberately carries no token: auth travels out-of-band as
+    ``repo_credentials`` (injected into git via environment config by
+    ``resolve_repo_source``), so no URL-derived string — clone slugs, result
+    items, logs, git error output — can ever leak a secret.
     """
-    return f"https://x-access-token:{token}@github.com/{full_name}.git"
+    return f"https://github.com/{full_name}.git"
 
 
 async def list_installation_repositories(token: str) -> list[str]:
@@ -116,10 +117,11 @@ async def sync_repositories(
         dataset_name_for_account(account_login),
     )
     result = await cognee_remember(
-        [authenticated_clone_url(full_name, token) for full_name in repo_full_names],
+        [clone_url(full_name) for full_name in repo_full_names],
         dataset_name=dataset_name_for_account(account_login),
         user=owner,
         content_type="code",
+        repo_credentials=token,
     )
     if getattr(result, "status", None) == "errored":
         logger.warning(

--- a/cognee/modules/integrations/github/verify_github_signature.py
+++ b/cognee/modules/integrations/github/verify_github_signature.py
@@ -1,0 +1,52 @@
+"""GitHub webhook delivery verification.
+
+Every inbound delivery is authenticated by an HMAC-SHA256 over the raw body
+keyed with the app's webhook secret, compared against the
+``X-Hub-Signature-256`` header
+(https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries).
+
+The check MUST run over the raw request bytes, before any parsing —
+re-serializing a parsed JSON body changes key order/escaping and breaks the
+HMAC (same rule as Slack's verifier). Unlike Slack, GitHub's scheme carries
+no timestamp, so there is no replay window to enforce here; handlers are
+idempotent instead (revokes are no-ops on revoked rows, syncs skip unchanged
+snapshots).
+"""
+
+import hashlib
+import hmac
+
+from fastapi import HTTPException, Request
+
+from cognee.modules.integrations.base import WebhookVerifier
+from cognee.modules.integrations.github.github_settings import require
+
+_SIGNATURE_PREFIX = "sha256="
+
+
+def is_valid_github_signature(raw_body: bytes, signature: str) -> bool:
+    """Whether ``signature`` is an authentic GitHub signature for ``raw_body``.
+
+    Pure function of its inputs — the verifier and the unit tests share it.
+    """
+    if not signature or not signature.startswith(_SIGNATURE_PREFIX):
+        return False
+
+    expected = (
+        _SIGNATURE_PREFIX
+        + hmac.new(require("webhook_secret").encode(), raw_body, hashlib.sha256).hexdigest()
+    )
+    # compare_digest, not ==: a timing-safe comparison so the signature cannot
+    # be brute-forced byte by byte from response latencies.
+    return hmac.compare_digest(expected, signature)
+
+
+class GithubWebhookVerifier(WebhookVerifier):
+    async def verify(self, request: Request) -> bytes:
+        raw_body = await request.body()
+        signature = request.headers.get("x-hub-signature-256", "")
+
+        if not is_valid_github_signature(raw_body, signature):
+            raise HTTPException(status_code=401, detail="Invalid GitHub signature")
+
+        return raw_body

--- a/cognee/tasks/code_graph/resolve_repo.py
+++ b/cognee/tasks/code_graph/resolve_repo.py
@@ -7,6 +7,7 @@ calls; an existing clone is refreshed with a best-effort ``git pull``.
 """
 
 import asyncio
+import base64
 import os
 import re
 import shutil
@@ -71,7 +72,23 @@ def _clone_slug(url: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]+", "-", tail).strip("-.")
 
 
-async def _run_git(args, cwd: Optional[Path] = None) -> tuple:
+def _credential_env(token: str) -> dict:
+    """Auth for git over https, injected as environment-level git config.
+
+    The environment channel (git >= 2.31) keeps the token out of argv (which
+    any local process can read from the process listing), out of every
+    URL-shaped string (so nothing derived from the URL can leak it into
+    logs or error messages), and out of the on-disk remote config.
+    """
+    basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+    return {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.extraHeader",
+        "GIT_CONFIG_VALUE_0": f"Authorization: Basic {basic}",
+    }
+
+
+async def _run_git(args, cwd: Optional[Path] = None, env: Optional[dict] = None) -> tuple:
     git_binary = shutil.which("git")
     if git_binary is None:
         raise CodeRepositoryError(
@@ -81,6 +98,7 @@ async def _run_git(args, cwd: Optional[Path] = None) -> tuple:
         git_binary,
         *args,
         cwd=str(cwd) if cwd else None,
+        env={**os.environ, **env} if env else None,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
@@ -98,6 +116,7 @@ async def _run_git(args, cwd: Optional[Path] = None) -> tuple:
 async def resolve_repo_source(
     spec: Union[str, Path],
     clones_dir: Optional[Path] = None,
+    credentials: Optional[str] = None,
 ) -> Path:
     """Return a local directory for the repo spec, shallow-cloning remote URLs.
 
@@ -105,6 +124,13 @@ async def resolve_repo_source(
     ``--depth 1`` into ``clones_dir`` (default ``~/.cognee/repos``); an
     existing clone is reused after a best-effort ``git pull --ff-only``.
     Remote resolution honors ``ALLOW_HTTP_REQUESTS=false``.
+
+    ``credentials`` is the preferred way to authenticate against a private
+    https remote (e.g. a GitHub App installation token): it reaches git only
+    through environment-level config (see :func:`_credential_env`), so the
+    URL — and everything derived from it (slug, remote, logs, errors) —
+    never carries a secret. Embedding credentials in the URL userinfo still
+    works but is the legacy path.
     """
     if not is_remote_repo(spec):
         path = Path(spec).expanduser()
@@ -132,14 +158,17 @@ async def resolve_repo_source(
         # git error output often echoes the URL, token included.
         return text.replace(url, clean_url) if has_credentials else text
 
+    auth_env = _credential_env(credentials) if credentials else None
+
     target = Path(clones_dir) if clones_dir else DEFAULT_CLONES_DIR
     target = target / _clone_slug(clean_url)
 
     if (target / ".git").is_dir():
-        # With credentials in hand, fetch from the explicit URL instead of
-        # the stored remote (which is deliberately credential-free).
+        # Legacy URL-embedded credentials: fetch from the explicit URL
+        # instead of the stored remote (which is deliberately
+        # credential-free). Out-of-band credentials ride the environment.
         pull_args = ["pull", "--ff-only"] + ([url] if has_credentials else [])
-        returncode, stderr = await _run_git(pull_args, cwd=target)
+        returncode, stderr = await _run_git(pull_args, cwd=target, env=auth_env)
         if returncode != 0:
             # A stale clone is still indexable; the caller asked for the repo,
             # not for freshness guarantees.
@@ -150,7 +179,7 @@ async def resolve_repo_source(
 
     target.parent.mkdir(parents=True, exist_ok=True)
     logger.info("Cloning %s into %s", clean_url, target)
-    returncode, stderr = await _run_git(["clone", "--depth", "1", url, str(target)])
+    returncode, stderr = await _run_git(["clone", "--depth", "1", url, str(target)], env=auth_env)
     if returncode != 0:
         raise CodeRepositoryError(
             message=f"Failed to clone '{clean_url}': {_scrub(stderr[-1000:])}"

--- a/cognee/tasks/code_graph/resolve_repo.py
+++ b/cognee/tasks/code_graph/resolve_repo.py
@@ -12,6 +12,7 @@ import re
 import shutil
 from pathlib import Path
 from typing import Optional, Union
+from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import status
 
@@ -42,6 +43,24 @@ class CodeRepositoryError(CogneeSystemError):
 def is_remote_repo(spec) -> bool:
     """Whether the spec is a remote git URL rather than a local path."""
     return isinstance(spec, str) and spec.startswith(_REMOTE_PREFIXES)
+
+
+def redact_repo_spec(spec: Union[str, Path]) -> str:
+    """The spec with any URL-embedded credentials removed.
+
+    Connectors pass short-lived tokens in the URL userinfo
+    (``https://x-access-token:<token>@github.com/...``); anything persisted
+    or logged — clone slugs, the stored git remote, result items, error
+    messages — must use this form instead of the raw spec.
+    """
+    url = str(spec)
+    if "://" not in url:
+        return url
+    parts = urlsplit(url)
+    if "@" not in parts.netloc:
+        return url
+    host = parts.netloc.rsplit("@", 1)[1]
+    return urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))
 
 
 def _clone_slug(url: str) -> str:
@@ -103,22 +122,39 @@ async def resolve_repo_source(
         )
 
     url = str(spec)
+    # Slug, remote, logs, and errors all use the credential-free URL: tokens
+    # in the userinfo are short-lived, so persisting one anywhere would both
+    # leak it and (via the slug) mint a new clone dir per sync.
+    clean_url = redact_repo_spec(url)
+    has_credentials = clean_url != url
+
+    def _scrub(text: str) -> str:
+        # git error output often echoes the URL, token included.
+        return text.replace(url, clean_url) if has_credentials else text
+
     target = Path(clones_dir) if clones_dir else DEFAULT_CLONES_DIR
-    target = target / _clone_slug(url)
+    target = target / _clone_slug(clean_url)
 
     if (target / ".git").is_dir():
-        returncode, stderr = await _run_git(["pull", "--ff-only"], cwd=target)
+        # With credentials in hand, fetch from the explicit URL instead of
+        # the stored remote (which is deliberately credential-free).
+        pull_args = ["pull", "--ff-only"] + ([url] if has_credentials else [])
+        returncode, stderr = await _run_git(pull_args, cwd=target)
         if returncode != 0:
             # A stale clone is still indexable; the caller asked for the repo,
             # not for freshness guarantees.
             logger.warning(
-                "Reusing existing clone at %s (git pull failed: %s)", target, stderr[-500:]
+                "Reusing existing clone at %s (git pull failed: %s)", target, _scrub(stderr[-500:])
             )
         return target
 
     target.parent.mkdir(parents=True, exist_ok=True)
-    logger.info("Cloning %s into %s", url, target)
+    logger.info("Cloning %s into %s", clean_url, target)
     returncode, stderr = await _run_git(["clone", "--depth", "1", url, str(target)])
     if returncode != 0:
-        raise CodeRepositoryError(message=f"Failed to clone '{url}': {stderr[-1000:]}")
+        raise CodeRepositoryError(
+            message=f"Failed to clone '{clean_url}': {_scrub(stderr[-1000:])}"
+        )
+    if has_credentials:
+        await _run_git(["remote", "set-url", "origin", clean_url], cwd=target)
     return target

--- a/cognee/tests/unit/modules/integrations/test_github_adapter.py
+++ b/cognee/tests/unit/modules/integrations/test_github_adapter.py
@@ -1,0 +1,115 @@
+"""Unit tests for cognee.modules.integrations.github.adapter.
+
+Network calls (code exchange, installation lookup) are mocked at the
+adapter/app_auth seam — what's under test is the install-flow logic: the
+installation_id must be verified against the completing user before it is
+trusted, and the stored credential must carry no token material.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.modules.integrations.github import app_auth
+from cognee.modules.integrations.github.adapter import GithubIntegration
+from cognee.modules.integrations.github.verify_github_signature import GithubWebhookVerifier
+
+_INSTALLATION = {
+    "id": 12345,
+    "app_id": 7,
+    "repository_selection": "selected",
+    "account": {"login": "acme-org", "id": 99, "type": "Organization"},
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings(monkeypatch):
+    settings = "cognee.modules.integrations.github.github_settings.github_settings"
+    monkeypatch.setattr(f"{settings}.app_slug", "cognee-app")
+    monkeypatch.setattr(f"{settings}.client_id", "Iv1.abc")
+    monkeypatch.setattr(f"{settings}.client_secret", "shhh")
+    monkeypatch.setattr(f"{settings}.webhook_secret", "hook-secret")
+    monkeypatch.setattr(f"{settings}.frontend_base_url", "https://app.example.com")
+
+
+def test_authorize_url_is_the_app_installation_flow():
+    url = GithubIntegration().authorize_url("the-state")
+    assert url == "https://github.com/apps/cognee-app/installations/new?state=the-state"
+
+
+def test_state_signing_secret_is_the_webhook_secret():
+    assert GithubIntegration().state_signing_secret() == "hook-secret"
+
+
+def test_webhook_verifier_is_registered():
+    assert isinstance(GithubIntegration().webhook_verifier(), GithubWebhookVerifier)
+
+
+@pytest.mark.asyncio
+async def test_exchange_callback_rejects_a_missing_installation_id():
+    with pytest.raises(ValueError, match="installation_id"):
+        await GithubIntegration().exchange_callback("code", {})
+    with pytest.raises(ValueError, match="installation_id"):
+        await GithubIntegration().exchange_callback("code", {"installation_id": "not-a-number"})
+
+
+@pytest.mark.asyncio
+async def test_exchange_callback_verifies_user_access_before_trusting_the_id():
+    integration = GithubIntegration()
+    with (
+        patch.object(
+            integration, "exchange_code", new=AsyncMock(return_value={"access_token": "user-tok"})
+        ),
+        patch.object(
+            app_auth, "user_can_access_installation", new=AsyncMock(return_value=True)
+        ) as access_check,
+        patch.object(
+            app_auth, "get_installation", new=AsyncMock(return_value=_INSTALLATION)
+        ) as lookup,
+    ):
+        result = await integration.exchange_callback("code", {"installation_id": "12345"})
+
+    assert result == _INSTALLATION
+    access_check.assert_awaited_once_with("user-tok", 12345)
+    # The credential comes from the app-authenticated lookup, never from the
+    # unauthenticated callback query string.
+    lookup.assert_awaited_once_with(12345)
+
+
+@pytest.mark.asyncio
+async def test_exchange_callback_refuses_an_installation_the_user_cannot_access():
+    integration = GithubIntegration()
+    with (
+        patch.object(
+            integration, "exchange_code", new=AsyncMock(return_value={"access_token": "user-tok"})
+        ),
+        patch.object(app_auth, "user_can_access_installation", new=AsyncMock(return_value=False)),
+        patch.object(app_auth, "get_installation", new=AsyncMock()) as lookup,
+    ):
+        with pytest.raises(PermissionError):
+            await integration.exchange_callback("code", {"installation_id": "12345"})
+
+    lookup.assert_not_awaited()
+
+
+def test_parse_installation_stores_no_token_material():
+    installation = GithubIntegration().parse_installation(_INSTALLATION)
+
+    assert installation.provider_account_id == "12345"
+    # No durable per-installation secret exists — tokens are minted on
+    # demand from the app private key, so the encrypted payload stays empty.
+    assert installation.token_payload == {}
+    assert installation.auth_type == "github_app"
+    assert installation.account_label == "acme-org"
+    assert installation.provider_metadata == {
+        "account_login": "acme-org",
+        "account_id": 99,
+        "account_type": "Organization",
+        "repository_selection": "selected",
+        "app_id": 7,
+    }
+
+
+def test_parse_installation_without_id_raises():
+    with pytest.raises(ValueError, match="no id"):
+        GithubIntegration().parse_installation({"account": {"login": "acme-org"}})

--- a/cognee/tests/unit/modules/integrations/test_github_app_auth.py
+++ b/cognee/tests/unit/modules/integrations/test_github_app_auth.py
@@ -1,0 +1,77 @@
+"""Unit tests for cognee.modules.integrations.github.app_auth.build_app_jwt.
+
+A real RSA keypair is generated per run and the token verified with the
+public half — proving the hand-rolled JWT is a signature GitHub would
+accept, not just three base64 blobs.
+"""
+
+import base64
+import json
+
+import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
+
+from cognee.modules.integrations.github.app_auth import build_app_jwt
+
+_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PEM = _PRIVATE_KEY.private_bytes(
+    Encoding.PEM, PrivateFormat.TraditionalOpenSSL, NoEncryption()
+).decode()
+
+
+@pytest.fixture(autouse=True)
+def _settings(monkeypatch):
+    settings = "cognee.modules.integrations.github.github_settings.github_settings"
+    monkeypatch.setattr(f"{settings}.app_id", "314159")
+    # Stored with literal \n escapes, the way a single-line env file carries it.
+    monkeypatch.setattr(f"{settings}.app_private_key", _PEM.replace("\n", "\\n"))
+
+
+def _b64url_decode(segment: str) -> bytes:
+    return base64.urlsafe_b64decode(segment + "=" * (-len(segment) % 4))
+
+
+def test_jwt_claims_and_signature():
+    token = build_app_jwt(now=1_700_000_000)
+    header_b64, payload_b64, signature_b64 = token.split(".")
+
+    assert json.loads(_b64url_decode(header_b64)) == {"alg": "RS256", "typ": "JWT"}
+
+    payload = json.loads(_b64url_decode(payload_b64))
+    assert payload["iss"] == "314159"
+    assert payload["iat"] == 1_700_000_000 - 60
+    assert payload["exp"] == 1_700_000_000 + 9 * 60
+
+    # raises InvalidSignature if the RS256 signature is wrong
+    _PRIVATE_KEY.public_key().verify(
+        _b64url_decode(signature_b64),
+        f"{header_b64}.{payload_b64}".encode(),
+        padding.PKCS1v15(),
+        hashes.SHA256(),
+    )
+
+
+def test_missing_private_key_fails_loudly(monkeypatch):
+    monkeypatch.setattr(
+        "cognee.modules.integrations.github.github_settings.github_settings.app_private_key", ""
+    )
+    with pytest.raises(RuntimeError, match="GITHUB_APP_PRIVATE_KEY"):
+        build_app_jwt()
+
+
+def test_non_rsa_key_is_rejected(monkeypatch):
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+
+    ed_pem = (
+        ed25519.Ed25519PrivateKey.generate()
+        .private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+        .decode()
+    )
+    monkeypatch.setattr(
+        "cognee.modules.integrations.github.github_settings.github_settings.app_private_key",
+        ed_pem,
+    )
+    with pytest.raises(RuntimeError, match="RSA"):
+        build_app_jwt()

--- a/cognee/tests/unit/modules/integrations/test_github_sync.py
+++ b/cognee/tests/unit/modules/integrations/test_github_sync.py
@@ -41,9 +41,10 @@ def test_dataset_name_is_one_per_account_and_identifier_safe():
     assert sync_module.dataset_name_for_account("---") == "github_account"
 
 
-def test_authenticated_clone_url_shape():
-    url = sync_module.authenticated_clone_url("acme/api", "tok123")
-    assert url == "https://x-access-token:tok123@github.com/acme/api.git"
+def test_clone_url_carries_no_credentials():
+    # Auth travels out-of-band as repo_credentials; a token in the URL would
+    # taint every URL-derived string (slugs, logs, git errors) with a secret.
+    assert sync_module.clone_url("acme/api") == "https://github.com/acme/api.git"
 
 
 @pytest.fixture
@@ -72,12 +73,13 @@ async def test_default_sync_covers_every_installation_repo(mocks):
     mocks.list_repos.assert_awaited_once_with("tok123")
     mocks.remember.assert_awaited_once_with(
         [
-            "https://x-access-token:tok123@github.com/acme/api.git",
-            "https://x-access-token:tok123@github.com/acme/web.git",
+            "https://github.com/acme/api.git",
+            "https://github.com/acme/web.git",
         ],
         dataset_name="github_acme_org",
         user=mocks.owner,
         content_type="code",
+        repo_credentials="tok123",
     )
 
 
@@ -88,7 +90,8 @@ async def test_explicit_repo_list_skips_the_listing_call(mocks):
     mocks.list_repos.assert_not_awaited()
     mocks.remember.assert_awaited_once()
     (urls,) = mocks.remember.await_args.args
-    assert urls == ["https://x-access-token:tok123@github.com/acme/api.git"]
+    assert urls == ["https://github.com/acme/api.git"]
+    assert mocks.remember.await_args.kwargs["repo_credentials"] == "tok123"
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/integrations/test_github_sync.py
+++ b/cognee/tests/unit/modules/integrations/test_github_sync.py
@@ -1,0 +1,107 @@
+"""Unit tests for cognee.modules.integrations.github.sync.
+
+Token minting, repo listing, and remember() are mocked — what's under test
+is the orchestration: one dataset per installation, authenticated clone
+URLs handed to the code path, and the full-installation default when no
+explicit repo list is given.
+"""
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+sync_module = importlib.import_module("cognee.modules.integrations.github.sync")
+
+# The remember package's __init__ rebinds `remember` to the function,
+# shadowing the submodule — string-target monkeypatching resolves the
+# function and fails. Importing the submodule explicitly sidesteps it (same
+# workaround as test_get_integrations_router.py).
+_remember_module = importlib.import_module("cognee.api.v1.remember.remember")
+_users_methods = importlib.import_module("cognee.modules.users.methods")
+
+_USER_ID = uuid4()
+
+
+def _credential(**overrides):
+    defaults = {
+        "status": "active",
+        "provider_account_id": "42",
+        "provider_metadata": {"account_login": "Acme-Org"},
+        "user_id": _USER_ID,
+    }
+    return SimpleNamespace(**{**defaults, **overrides})
+
+
+def test_dataset_name_is_one_per_account_and_identifier_safe():
+    assert sync_module.dataset_name_for_account("Acme-Org") == "github_acme_org"
+    assert sync_module.dataset_name_for_account("user.name") == "github_user_name"
+    assert sync_module.dataset_name_for_account("---") == "github_account"
+
+
+def test_authenticated_clone_url_shape():
+    url = sync_module.authenticated_clone_url("acme/api", "tok123")
+    assert url == "https://x-access-token:tok123@github.com/acme/api.git"
+
+
+@pytest.fixture
+def mocks(monkeypatch):
+    owner = SimpleNamespace(id=_USER_ID)
+    mocked = SimpleNamespace(
+        mint=AsyncMock(return_value=("tok123", None)),
+        list_repos=AsyncMock(return_value=["acme/api", "acme/web"]),
+        remember=AsyncMock(return_value=SimpleNamespace(status="completed", error=None)),
+        get_user=AsyncMock(return_value=owner),
+        owner=owner,
+    )
+    monkeypatch.setattr(sync_module, "mint_installation_token", mocked.mint)
+    monkeypatch.setattr(sync_module, "list_installation_repositories", mocked.list_repos)
+    # Patched at their home modules: sync_repositories imports both lazily.
+    monkeypatch.setattr(_remember_module, "remember", mocked.remember)
+    monkeypatch.setattr(_users_methods, "get_user", mocked.get_user)
+    return mocked
+
+
+@pytest.mark.asyncio
+async def test_default_sync_covers_every_installation_repo(mocks):
+    await sync_module.sync_repositories(_credential())
+
+    mocks.mint.assert_awaited_once_with(42)
+    mocks.list_repos.assert_awaited_once_with("tok123")
+    mocks.remember.assert_awaited_once_with(
+        [
+            "https://x-access-token:tok123@github.com/acme/api.git",
+            "https://x-access-token:tok123@github.com/acme/web.git",
+        ],
+        dataset_name="github_acme_org",
+        user=mocks.owner,
+        content_type="code",
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_repo_list_skips_the_listing_call(mocks):
+    await sync_module.sync_repositories(_credential(), ["acme/api"])
+
+    mocks.list_repos.assert_not_awaited()
+    mocks.remember.assert_awaited_once()
+    (urls,) = mocks.remember.await_args.args
+    assert urls == ["https://x-access-token:tok123@github.com/acme/api.git"]
+
+
+@pytest.mark.asyncio
+async def test_empty_installation_syncs_nothing(mocks):
+    mocks.list_repos.return_value = []
+
+    await sync_module.sync_repositories(_credential())
+
+    mocks.remember.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_account_login_falls_back_to_the_installation_id(mocks):
+    await sync_module.sync_repositories(_credential(provider_metadata=None), ["acme/api"])
+
+    assert mocks.remember.await_args.kwargs["dataset_name"] == "github_42"

--- a/cognee/tests/unit/modules/integrations/test_handle_github_event.py
+++ b/cognee/tests/unit/modules/integrations/test_handle_github_event.py
@@ -1,0 +1,143 @@
+"""Unit tests for cognee.modules.integrations.github.handle_github_event.
+
+The credential store and the sync layer are mocked — what's under test is
+the routing: which deliveries revoke, which sync, and which are dropped
+(unknown installation, non-default-branch push, malformed body) without
+raising, since the handler runs detached and GitHub retries on errors.
+"""
+
+import importlib
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+handle_module = importlib.import_module("cognee.modules.integrations.github.handle_github_event")
+handle_github_event = handle_module.handle_github_event
+
+_ACTIVE_CREDENTIAL = SimpleNamespace(status="active", provider_account_id="42")
+
+
+@pytest.fixture
+def mocks(monkeypatch):
+    mocked = SimpleNamespace(
+        revoke=AsyncMock(return_value=True),
+        get_credential=AsyncMock(return_value=_ACTIVE_CREDENTIAL),
+        sync=AsyncMock(),
+    )
+    monkeypatch.setattr(handle_module, "revoke_credential_by_account", mocked.revoke)
+    monkeypatch.setattr(handle_module, "get_credential_by_account", mocked.get_credential)
+    monkeypatch.setattr(handle_module, "sync_repositories", mocked.sync)
+    return mocked
+
+
+def _body(payload: dict) -> bytes:
+    return json.dumps(payload).encode()
+
+
+@pytest.mark.asyncio
+async def test_installation_deleted_revokes_the_credential(mocks):
+    await handle_github_event(
+        _body({"action": "deleted", "installation": {"id": 42}}),
+        {"x-github-event": "installation"},
+    )
+
+    mocks.revoke.assert_awaited_once_with("github", "42")
+    mocks.sync.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_push_to_default_branch_resyncs_that_repo(mocks):
+    await handle_github_event(
+        _body(
+            {
+                "ref": "refs/heads/main",
+                "installation": {"id": 42},
+                "repository": {"full_name": "acme/api", "default_branch": "main"},
+            }
+        ),
+        {"x-github-event": "push"},
+    )
+
+    mocks.sync.assert_awaited_once_with(_ACTIVE_CREDENTIAL, ["acme/api"])
+
+
+@pytest.mark.asyncio
+async def test_push_to_another_branch_is_ignored(mocks):
+    await handle_github_event(
+        _body(
+            {
+                "ref": "refs/heads/feature-x",
+                "installation": {"id": 42},
+                "repository": {"full_name": "acme/api", "default_branch": "main"},
+            }
+        ),
+        {"x-github-event": "push"},
+    )
+
+    mocks.sync.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_added_repositories_are_synced_removed_only_logged(mocks):
+    await handle_github_event(
+        _body(
+            {
+                "action": "added",
+                "installation": {"id": 42},
+                "repositories_added": [{"full_name": "acme/new"}],
+                "repositories_removed": [{"full_name": "acme/old"}],
+            }
+        ),
+        {"x-github-event": "installation_repositories"},
+    )
+
+    # Removed repos never trigger deletion — indexed data outlives the
+    # webhook; forget() stays a human decision.
+    mocks.sync.assert_awaited_once_with(_ACTIVE_CREDENTIAL, ["acme/new"])
+
+
+@pytest.mark.asyncio
+async def test_unknown_installation_is_dropped(mocks):
+    mocks.get_credential.return_value = None
+
+    await handle_github_event(
+        _body({"ref": "refs/heads/main", "installation": {"id": 999}}),
+        {"x-github-event": "push"},
+    )
+
+    mocks.sync.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_revoked_installation_is_dropped(mocks):
+    mocks.get_credential.return_value = SimpleNamespace(status="revoked")
+
+    await handle_github_event(
+        _body(
+            {
+                "ref": "refs/heads/main",
+                "installation": {"id": 42},
+                "repository": {"full_name": "acme/api", "default_branch": "main"},
+            }
+        ),
+        {"x-github-event": "push"},
+    )
+
+    mocks.sync.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delivery_without_installation_id_is_dropped(mocks):
+    await handle_github_event(_body({"zen": "Design for failure."}), {"x-github-event": "ping"})
+
+    mocks.get_credential.assert_not_awaited()
+    mocks.sync.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unparseable_body_never_raises(mocks):
+    await handle_github_event(b"not json", {"x-github-event": "push"})
+
+    mocks.sync.assert_not_awaited()

--- a/cognee/tests/unit/modules/integrations/test_integrations_events_route.py
+++ b/cognee/tests/unit/modules/integrations/test_integrations_events_route.py
@@ -1,0 +1,221 @@
+"""Unit tests for the generic POST /{provider}/events route and the
+callback extensions (callback_params passthrough, on_installed dispatch).
+
+Same fake-provider approach as test_get_integrations_router.py: what's
+under test is the router's generic logic, not any real provider. Detached
+work is intercepted at the _spawn_background seam so the tests can run the
+captured coroutines deterministically instead of racing the event loop.
+"""
+
+import asyncio
+import importlib
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from cognee.api.v1.integrations.routers.get_integrations_router import get_integrations_router
+from cognee.modules.integrations.base import (
+    OAuthInstallation,
+    OAuthIntegration,
+    WebhookVerifier,
+)
+from cognee.modules.integrations.oauth_flow import make_state
+from cognee.modules.integrations.registry import supported_integrations, use_integration
+from cognee.modules.users.methods import get_authenticated_user
+
+USER_ID = uuid4()
+
+_router_module = importlib.import_module(
+    "cognee.api.v1.integrations.routers.get_integrations_router"
+)
+
+
+class _FakeUser:
+    id = USER_ID
+
+
+class _FakeVerifier(WebhookVerifier):
+    def __init__(self, fail: bool = False):
+        self._fail = fail
+
+    async def verify(self, request):
+        if self._fail:
+            raise HTTPException(status_code=401, detail="Invalid signature")
+        return await request.body()
+
+
+class _FakeIntegration(OAuthIntegration):
+    provider = "fake"
+    settings_cls = None
+
+    def __init__(self):
+        self.webhook_calls = []
+        self.callback_params_seen = []
+        self.verifier: WebhookVerifier = _FakeVerifier()
+
+    def authorize_url(self, state):
+        return f"https://fake.example/authorize?state={state}"
+
+    async def exchange_code(self, code):
+        return {"code": code}
+
+    async def exchange_callback(self, code, params):
+        self.callback_params_seen.append(params)
+        return await self.exchange_code(code)
+
+    def parse_installation(self, token_response):
+        return OAuthInstallation(provider_account_id="ACC1", token_payload={})
+
+    def state_signing_secret(self):
+        return "fake-secret"
+
+    def frontend_base_url(self):
+        return "https://app.example.com"
+
+    def webhook_verifier(self):
+        return self.verifier
+
+    async def handle_webhook(self, raw_body, headers):
+        self.webhook_calls.append((raw_body, headers))
+
+
+class _NoWebhookIntegration(_FakeIntegration):
+    provider = "mute"
+
+    def webhook_verifier(self):
+        return None
+
+
+@pytest.fixture
+def spawned():
+    """Capture detached work instead of racing the TestClient's event loop."""
+    captured = []
+
+    def fake_spawn(coro, *, description):
+        captured.append((coro, description))
+
+    with patch.object(_router_module, "_spawn_background", side_effect=fake_spawn):
+        yield captured
+
+    for coro, _description in captured:
+        coro.close()
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(get_integrations_router(), prefix="/api/v1/integrations")
+    app.dependency_overrides[get_authenticated_user] = lambda: _FakeUser()
+
+    before = dict(supported_integrations)
+    supported_integrations.clear()
+    use_integration(_FakeIntegration())
+    use_integration(_NoWebhookIntegration())
+
+    yield TestClient(app)
+
+    supported_integrations.clear()
+    supported_integrations.update(before)
+
+
+def test_events_unknown_provider_404s(client, spawned):
+    assert client.post("/api/v1/integrations/notreal/events").status_code == 404
+
+
+def test_events_provider_without_verifier_404s(client, spawned):
+    # Same answer as an unknown provider, so the route leaks nothing about
+    # which providers exist but opted out of webhooks.
+    assert client.post("/api/v1/integrations/mute/events").status_code == 404
+    assert spawned == []
+
+
+def test_events_failed_verification_is_rejected_before_any_handling(client, spawned):
+    supported_integrations["fake"].verifier = _FakeVerifier(fail=True)
+
+    response = client.post("/api/v1/integrations/fake/events", content=b"payload")
+
+    assert response.status_code == 401
+    assert spawned == []
+
+
+def test_events_verified_delivery_is_acked_and_handled_detached(client, spawned):
+    integration = supported_integrations["fake"]
+
+    response = client.post(
+        "/api/v1/integrations/fake/events",
+        content=b'{"action":"created"}',
+        headers={"X-GitHub-Event": "installation"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+    (coro, description) = spawned.pop()
+    assert description == "fake webhook handling"
+    asyncio.run(coro)
+    ((raw_body, headers),) = integration.webhook_calls
+    assert raw_body == b'{"action":"created"}'
+    # Header keys are lower-cased for the handler.
+    assert headers["x-github-event"] == "installation"
+
+
+def test_callback_passes_the_full_query_string_to_the_adapter(client, spawned):
+    integration = supported_integrations["fake"]
+    state = make_state(USER_ID, signing_secret="fake-secret")
+
+    # complete_installation is real here — the point is the wiring from the
+    # route's query string down to exchange_callback. Only the credential
+    # upsert underneath it is stubbed out.
+    with patch(
+        "cognee.modules.integrations.connect.upsert_credential",
+        new=AsyncMock(return_value=type("C", (), {"provider_account_id": "ACC1"})()),
+    ):
+        response = client.get(
+            f"/api/v1/integrations/fake/callback"
+            f"?code=abc&state={state}&installation_id=12345&setup_action=install",
+            follow_redirects=False,
+        )
+
+    assert "fake=connected" in response.headers["location"]
+    (params,) = integration.callback_params_seen
+    assert params["installation_id"] == "12345"
+    assert params["setup_action"] == "install"
+
+
+def test_callback_success_fires_on_installed_detached(client, spawned):
+    state = make_state(USER_ID, signing_secret="fake-secret")
+    credential = type("C", (), {"provider_account_id": "ACC1"})()
+
+    with patch.object(
+        _router_module,
+        "complete_installation",
+        new=AsyncMock(return_value=credential),
+    ):
+        response = client.get(
+            f"/api/v1/integrations/fake/callback?code=abc&state={state}",
+            follow_redirects=False,
+        )
+
+    assert "fake=connected" in response.headers["location"]
+    descriptions = [description for _coro, description in spawned]
+    assert descriptions == ["fake on_installed hook"]
+
+
+def test_callback_failure_fires_no_on_installed(client, spawned):
+    state = make_state(USER_ID, signing_secret="fake-secret")
+
+    with patch.object(
+        _router_module,
+        "complete_installation",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        response = client.get(
+            f"/api/v1/integrations/fake/callback?code=abc&state={state}",
+            follow_redirects=False,
+        )
+
+    assert "fake=error_exchange_failed" in response.headers["location"]
+    assert spawned == []

--- a/cognee/tests/unit/modules/integrations/test_verify_github_signature.py
+++ b/cognee/tests/unit/modules/integrations/test_verify_github_signature.py
@@ -1,0 +1,56 @@
+"""Unit tests for cognee.modules.integrations.github.verify_github_signature.
+
+Pure function — no DB, no network. The invariant that matters: only an
+HMAC-SHA256 keyed with the webhook secret over the exact raw bytes, carried
+in GitHub's ``sha256=`` header format, passes.
+"""
+
+import hashlib
+import hmac
+
+import pytest
+
+from cognee.modules.integrations.github.verify_github_signature import is_valid_github_signature
+
+_SECRET = "It's a Secret to Everybody"
+
+
+@pytest.fixture(autouse=True)
+def _webhook_secret(monkeypatch):
+    monkeypatch.setattr(
+        "cognee.modules.integrations.github.github_settings.github_settings.webhook_secret",
+        _SECRET,
+    )
+
+
+def _sign(body: bytes) -> str:
+    return "sha256=" + hmac.new(_SECRET.encode(), body, hashlib.sha256).hexdigest()
+
+
+def test_valid_signature_passes():
+    body = b'{"action":"created","installation":{"id":42}}'
+    assert is_valid_github_signature(body, _sign(body))
+
+
+def test_tampered_body_fails():
+    signature = _sign(b'{"action":"created"}')
+    assert not is_valid_github_signature(b'{"action":"deleted"}', signature)
+
+
+def test_wrong_secret_fails():
+    body = b"payload"
+    wrong = "sha256=" + hmac.new(b"other-secret", body, hashlib.sha256).hexdigest()
+    assert not is_valid_github_signature(body, wrong)
+
+
+def test_missing_prefix_fails():
+    body = b"payload"
+    bare_hex = hmac.new(_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    assert not is_valid_github_signature(body, bare_hex)
+    # sha1= is GitHub's legacy header, deliberately unsupported.
+    assert not is_valid_github_signature(body, "sha1=" + bare_hex)
+
+
+def test_missing_signature_fails():
+    assert not is_valid_github_signature(b"payload", "")
+    assert not is_valid_github_signature(b"payload", None)

--- a/cognee/tests/unit/tasks/code_graph/test_remember_code_graph.py
+++ b/cognee/tests/unit/tasks/code_graph/test_remember_code_graph.py
@@ -40,7 +40,9 @@ async def test_single_repo_runs_code_graph_pipeline(code_remember_env):
         content_type="code",
     )
 
-    code_remember_env["resolve"].assert_awaited_once_with("https://github.com/org/repo")
+    code_remember_env["resolve"].assert_awaited_once_with(
+        "https://github.com/org/repo", credentials=None
+    )
     code_remember_env["pipeline"].assert_awaited_once()
     call = code_remember_env["pipeline"].await_args
     assert call.kwargs["dataset"] == "my_code"

--- a/cognee/tests/unit/tasks/code_graph/test_resolve_repo.py
+++ b/cognee/tests/unit/tasks/code_graph/test_resolve_repo.py
@@ -51,7 +51,7 @@ async def test_remote_refused_when_http_disabled(monkeypatch, tmp_path):
 async def test_remote_is_shallow_cloned(monkeypatch, tmp_path):
     git_calls = []
 
-    async def fake_run_git(args, cwd=None):
+    async def fake_run_git(args, cwd=None, env=None):
         git_calls.append((args, cwd))
         return 0, ""
 
@@ -74,7 +74,7 @@ async def test_existing_clone_is_reused_with_pull(monkeypatch, tmp_path):
     (clone_dir / ".git").mkdir(parents=True)
     git_calls = []
 
-    async def fake_run_git(args, cwd=None):
+    async def fake_run_git(args, cwd=None, env=None):
         git_calls.append((args, cwd))
         return 0, ""
 
@@ -93,7 +93,7 @@ async def test_failed_pull_still_reuses_stale_clone(monkeypatch, tmp_path):
     clone_dir = tmp_path / "github.com-org-repo"
     (clone_dir / ".git").mkdir(parents=True)
 
-    async def fake_run_git(args, cwd=None):
+    async def fake_run_git(args, cwd=None, env=None):
         return 1, "fatal: not fast-forward"
 
     monkeypatch.setattr(resolve_module, "_run_git", fake_run_git)
@@ -107,7 +107,7 @@ async def test_failed_pull_still_reuses_stale_clone(monkeypatch, tmp_path):
 
 @pytest.mark.asyncio
 async def test_failed_clone_raises_with_stderr(monkeypatch, tmp_path):
-    async def fake_run_git(args, cwd=None):
+    async def fake_run_git(args, cwd=None, env=None):
         return 128, "fatal: repository not found"
 
     monkeypatch.setattr(resolve_module, "_run_git", fake_run_git)

--- a/cognee/tests/unit/tasks/code_graph/test_resolve_repo_credentials.py
+++ b/cognee/tests/unit/tasks/code_graph/test_resolve_repo_credentials.py
@@ -35,7 +35,7 @@ def test_redact_repo_spec_leaves_credential_free_specs_alone():
 async def test_clone_slug_and_remote_never_carry_the_token(monkeypatch, tmp_path):
     git_calls = []
 
-    async def fake_run_git(args, cwd=None):
+    async def fake_run_git(args, cwd=None, env=None):
         git_calls.append((args, cwd))
         return 0, ""
 
@@ -61,7 +61,7 @@ async def test_existing_clone_pulls_from_the_credentialed_url(monkeypatch, tmp_p
     (clone_dir / ".git").mkdir(parents=True)
     git_calls = []
 
-    async def fake_run_git(args, cwd=None):
+    async def fake_run_git(args, cwd=None, env=None):
         git_calls.append((args, cwd))
         return 0, ""
 
@@ -80,7 +80,7 @@ async def test_credential_free_urls_keep_the_bare_pull(monkeypatch, tmp_path):
     (clone_dir / ".git").mkdir(parents=True)
     git_calls = []
 
-    async def fake_run_git(args, cwd=None):
+    async def fake_run_git(args, cwd=None, env=None):
         git_calls.append((args, cwd))
         return 0, ""
 
@@ -92,8 +92,61 @@ async def test_credential_free_urls_keep_the_bare_pull(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_out_of_band_credentials_ride_the_environment(monkeypatch, tmp_path):
+    """The preferred path (connectors): token via ``credentials=``, not the URL.
+
+    The URL stays clean everywhere — argv, slug, remote — and the token
+    reaches git only as environment-level config, so no URL-derived string
+    can leak it.
+    """
+    git_calls = []
+
+    async def fake_run_git(args, cwd=None, env=None):
+        git_calls.append((args, cwd, env))
+        return 0, ""
+
+    monkeypatch.setattr(resolve_module, "_run_git", fake_run_git)
+
+    resolved = await resolve_module.resolve_repo_source(
+        _CLEAN_URL, clones_dir=tmp_path, credentials="tok-SECRET"
+    )
+
+    assert resolved == tmp_path / "github.com-org-repo"
+    ((clone_args, _cwd, clone_env),) = git_calls
+    # argv carries only the clean URL; the token is nowhere in it.
+    assert clone_args == ["clone", "--depth", "1", _CLEAN_URL, str(resolved)]
+    assert "tok-SECRET" not in " ".join(clone_args)
+    # ...and rides GIT_CONFIG_* as a basic-auth header instead.
+    assert clone_env["GIT_CONFIG_KEY_0"] == "http.extraHeader"
+    assert clone_env["GIT_CONFIG_VALUE_0"].startswith("Authorization: Basic ")
+
+
+@pytest.mark.asyncio
+async def test_out_of_band_credentials_apply_to_pulls_too(monkeypatch, tmp_path):
+    clone_dir = tmp_path / "github.com-org-repo"
+    (clone_dir / ".git").mkdir(parents=True)
+    git_calls = []
+
+    async def fake_run_git(args, cwd=None, env=None):
+        git_calls.append((args, cwd, env))
+        return 0, ""
+
+    monkeypatch.setattr(resolve_module, "_run_git", fake_run_git)
+
+    await resolve_module.resolve_repo_source(
+        _CLEAN_URL, clones_dir=tmp_path, credentials="tok-SECRET"
+    )
+
+    ((pull_args, pull_cwd, pull_env),) = git_calls
+    # Bare pull against the (clean) stored remote; auth via the environment.
+    assert pull_args == ["pull", "--ff-only"]
+    assert pull_cwd == clone_dir
+    assert pull_env["GIT_CONFIG_KEY_0"] == "http.extraHeader"
+
+
+@pytest.mark.asyncio
 async def test_failed_clone_error_is_scrubbed(monkeypatch, tmp_path):
-    async def fake_run_git(args, cwd=None):
+    async def fake_run_git(args, cwd=None, env=None):
         # git echoes the full URL, token included, in its error output.
         return 128, f"fatal: unable to access '{_TOKEN_URL}': 403"
 

--- a/cognee/tests/unit/tasks/code_graph/test_resolve_repo_credentials.py
+++ b/cognee/tests/unit/tasks/code_graph/test_resolve_repo_credentials.py
@@ -1,0 +1,107 @@
+"""Unit tests for credentialed-URL handling in resolve_repo.
+
+Connectors (the GitHub App integration) pass short-lived tokens in the URL
+userinfo. The invariants that matter: the token is used for the clone/fetch
+itself and nowhere else — not the clone slug (which must stay stable across
+token rotations), not the stored git remote, not error messages.
+"""
+
+import importlib
+
+import pytest
+
+resolve_module = importlib.import_module("cognee.tasks.code_graph.resolve_repo")
+
+_TOKEN_URL = "https://x-access-token:tok-SECRET@github.com/org/repo.git"
+_CLEAN_URL = "https://github.com/org/repo.git"
+
+
+def test_redact_repo_spec_strips_userinfo():
+    assert resolve_module.redact_repo_spec(_TOKEN_URL) == _CLEAN_URL
+    assert resolve_module.redact_repo_spec("https://user@host/path") == "https://host/path"
+
+
+def test_redact_repo_spec_leaves_credential_free_specs_alone():
+    assert resolve_module.redact_repo_spec(_CLEAN_URL) == _CLEAN_URL
+    assert resolve_module.redact_repo_spec("/local/path/repo") == "/local/path/repo"
+    # scp-style git URLs have no "://", so the "@" is not URL userinfo.
+    assert (
+        resolve_module.redact_repo_spec("git@github.com:org/repo.git")
+        == "git@github.com:org/repo.git"
+    )
+
+
+@pytest.mark.asyncio
+async def test_clone_slug_and_remote_never_carry_the_token(monkeypatch, tmp_path):
+    git_calls = []
+
+    async def fake_run_git(args, cwd=None):
+        git_calls.append((args, cwd))
+        return 0, ""
+
+    monkeypatch.setattr(resolve_module, "_run_git", fake_run_git)
+
+    resolved = await resolve_module.resolve_repo_source(_TOKEN_URL, clones_dir=tmp_path)
+
+    # Slug comes from the clean URL — same directory a credential-free call
+    # (or a later sync with a rotated token) would use.
+    assert resolved == tmp_path / "github.com-org-repo"
+
+    clone_args, _ = git_calls[0]
+    assert clone_args[:3] == ["clone", "--depth", "1"]
+    assert _TOKEN_URL in clone_args
+
+    # The persisted remote is rewritten to the credential-free URL.
+    assert git_calls[1] == (["remote", "set-url", "origin", _CLEAN_URL], resolved)
+
+
+@pytest.mark.asyncio
+async def test_existing_clone_pulls_from_the_credentialed_url(monkeypatch, tmp_path):
+    clone_dir = tmp_path / "github.com-org-repo"
+    (clone_dir / ".git").mkdir(parents=True)
+    git_calls = []
+
+    async def fake_run_git(args, cwd=None):
+        git_calls.append((args, cwd))
+        return 0, ""
+
+    monkeypatch.setattr(resolve_module, "_run_git", fake_run_git)
+
+    resolved = await resolve_module.resolve_repo_source(_TOKEN_URL, clones_dir=tmp_path)
+
+    assert resolved == clone_dir
+    # Explicit URL argument: the stored remote is credential-free on purpose.
+    assert git_calls == [(["pull", "--ff-only", _TOKEN_URL], clone_dir)]
+
+
+@pytest.mark.asyncio
+async def test_credential_free_urls_keep_the_bare_pull(monkeypatch, tmp_path):
+    clone_dir = tmp_path / "github.com-org-repo"
+    (clone_dir / ".git").mkdir(parents=True)
+    git_calls = []
+
+    async def fake_run_git(args, cwd=None):
+        git_calls.append((args, cwd))
+        return 0, ""
+
+    monkeypatch.setattr(resolve_module, "_run_git", fake_run_git)
+
+    await resolve_module.resolve_repo_source(_CLEAN_URL, clones_dir=tmp_path)
+
+    assert git_calls == [(["pull", "--ff-only"], clone_dir)]
+
+
+@pytest.mark.asyncio
+async def test_failed_clone_error_is_scrubbed(monkeypatch, tmp_path):
+    async def fake_run_git(args, cwd=None):
+        # git echoes the full URL, token included, in its error output.
+        return 128, f"fatal: unable to access '{_TOKEN_URL}': 403"
+
+    monkeypatch.setattr(resolve_module, "_run_git", fake_run_git)
+
+    with pytest.raises(resolve_module.CodeRepositoryError) as exc_info:
+        await resolve_module.resolve_repo_source(_TOKEN_URL, clones_dir=tmp_path)
+
+    message = str(exc_info.value)
+    assert "tok-SECRET" not in message
+    assert _CLEAN_URL in message


### PR DESCRIPTION
## Description

Connect a GitHub **org** to cognee through a **GitHub App installation** and index every covered repository into the code graph — searchable via `SearchType.CODE` (graph-only, no LLM/embedding calls). Closes the first non-Slack tenant of the integrations platform (CLO-231).

### Generic seam extensions (additive — Slack and third-party adapters unaffected)

- `OAuthIntegration` gains four optional hooks: `exchange_callback()` (for callbacks carrying more than a code), `webhook_verifier()` + `handle_webhook()`, and `on_installed()` (post-connect background work).
- **One** new endpoint, `POST /api/v1/integrations/{provider}/events`: a generic webhook receiver dispatched on the provider's registered `WebhookVerifier` (HMAC over raw bytes, same auth model as the Slack routes). Providers without a verifier 404 — the same answer an unknown provider gets. Deliveries are acked after verification and handled detached, so provider delivery timeouts are never in play. Future providers get webhooks with zero router changes.

### GitHub provider (`cognee/modules/integrations/github/`)

- **Connect** = app installation flow (`github.com/apps/<slug>/installations/new`), reusing the generic authorize/callback/connection/status routes and the encrypted credential store unchanged.
- **Trust model**: the callback's `installation_id` arrives on an unauthenticated endpoint and is a guessable integer — it is never trusted directly. The OAuth code is exchanged for a user token, the user's access to that installation is confirmed (`GET /user/installations`), and the credential is built from the app-JWT-authenticated installation record. Requires "Request user authorization (OAuth) during installation" on the app.
- **No stored tokens**: the credential's encrypted payload is empty; hour-lived installation tokens are minted on demand from the app private key (hand-rolled RS256 JWT via the existing `cryptography` dep — no new dependencies).
- **Initial sync** fires from `on_installed`; **webhooks** keep it fresh: `push` to the default branch re-indexes that repo, `installation_repositories` syncs additions (removals are logged only — `forget()` stays a human decision), `installation` deleted/suspend revokes the credential. All idempotent: snapshot-identity skip makes re-syncs cheap, revokes are no-ops on revoked rows.
- One dataset per installation (`github_<org>`), so backend access control isolates per org rather than per repo.

### Token-leak hardening in the existing code path

`resolve_repo_source` now strips URL userinfo from clone slugs (stable across hourly token rotations), rewrites the persisted git remote to the credential-free URL, pulls from the explicit credentialed URL, and scrubs tokens from logs and git error output. `remember()` redacts repo specs in result items and failure logs.

### Configuration

New env block documented in `.env.template`: `GITHUB_APP_ID`, `GITHUB_APP_SLUG`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_FRONTEND_BASE_URL`. App needs `Contents: Read-only`, Push + Installation repositories events, callback → `/api/v1/integrations/github/callback`, webhook → `/api/v1/integrations/github/events`.

### Out of scope (deliberate)

- Frontend wiring (backend `/status` already reports the provider generically).
- Semantic/document search over repo content — code search only for this cut.
- Write-back to GitHub.
- `revoke_remote` stays a no-op: the GitHub-side equivalent would uninstall the app from the whole org, too destructive for a cognee-side disconnect.

## Testing

- 7 new unit test suites (adapter trust model, JWT signature verified against a real RSA keypair, webhook signature, event routing, sync orchestration, generic events route, credentialed-URL redaction) — plus the full existing integrations and code-graph suites: **260 passed**.
- `ruff check` / `ruff format` clean under the pinned 0.15.11.

Fixes CLO-486

🤖 Generated with [Claude Code](https://claude.com/claude-code)