### PR TITLE
fix(retrieval): widen the fetch when wide_search_top_k is unset

### DIFF
--- a/cognee/modules/retrieval/completion_retriever.py
+++ b/cognee/modules/retrieval/completion_retriever.py
@@ -103,7 +103,11 @@ class CompletionRetriever(BaseRetriever):
         self.user_prompt_path = user_prompt_path
         self.system_prompt_path = system_prompt_path
         self.top_k = top_k if top_k is not None else 1
-        self.wide_search_top_k = wide_search_top_k
+        # None means "not set by the caller", not "do not widen": the search
+        # path passes it through unset, and `max(top_k, None or 0)` below would
+        # silently collapse the wide fetch back to top_k. Same normalization,
+        # same default, as GraphCompletionRetriever.
+        self.wide_search_top_k = 100 if wide_search_top_k is None else wide_search_top_k
         self.system_prompt = system_prompt
         self.session_id = session_id
         self.response_model = response_model

--- a/cognee/tests/unit/modules/user_preferences/test_rag_personalization.py
+++ b/cognee/tests/unit/modules/user_preferences/test_rag_personalization.py
@@ -163,6 +163,23 @@ class TestGetRetrievedObjects:
         # a's distance grows by 1.3: 0.13 > 0.12, so it falls behind b and c.
         assert [chunk.payload["id"] for chunk in result] == ["b", "c"]
 
+    async def test_unset_wide_search_top_k_still_widens_the_fetch(self, monkeypatch):
+        # The search path builds this retriever with wide_search_top_k unset
+        # (get_search_type_retriever_instance reads it with kwargs.get and no
+        # default), so None is the value that actually reaches production.
+        # Left unnormalized, `max(top_k, None or 0)` is top_k, and the wide
+        # fetch that makes personalization change membership never happens:
+        # the re-sort can only permute the chunks top_k would have returned.
+        chunks = [_chunk("a", 0.10), _chunk("b", 0.20), _chunk("e", 0.25)]
+        engine = _patch_engine(monkeypatch, chunks)
+        _patch_lookup(monkeypatch, ("", {"e": 0.95}))
+        _patch_influence(monkeypatch)
+
+        retriever = CompletionRetriever(top_k=2, wide_search_top_k=None)
+        await retriever.get_retrieved_objects("query")
+
+        assert engine.search_calls[0]["limit"] == 100
+
     async def test_entity_only_weights_do_not_widen_the_fetch(self, monkeypatch):
         # Every weight key points at a graph entity that is not a row in
         # DocumentChunk_text, so the wide fetch could never change membership:


### PR DESCRIPTION
## Description

`CompletionRetriever` never widened its vector fetch when personalization weights were active, so
preference weights could only reorder the chunks `top_k` already returned. The comment above the
call says the opposite is the point: personalization has to change which chunks make the cut, not
just their order.

The search path reads the value with `kwargs.get("wide_search_top_k")` and no default, so `None`
reaches the retriever and the signature default of `100` never applies.
`GraphCompletionRetriever` normalizes that; `CompletionRetriever`, the one completion retriever that
does not subclass it, did not. `max(self.top_k, None or 0)` is `top_k`, so the widening disappeared.

One line, mirroring `graph_completion_retriever.py:75` exactly, same default:

```python
self.wide_search_top_k = 100 if wide_search_top_k is None else wide_search_top_k
```

Introduced in #4611, which changed the producer and normalized the graph retriever in the same diff
but not this one.

## Test

`test_unset_wide_search_top_k_still_widens_the_fetch` in the existing personalization suite,
constructing the retriever the way the search path does rather than with an explicit value. That is
the gap the existing cases left: all of them pass `wide_search_top_k=WIDE_SEARCH_TOP_K`, so `None`
was never exercised.

Fails on `main` (`limit` is 2), passes with the fix (`limit` is 100).

## Validation

```
pytest cognee/tests/unit/modules/user_preferences/test_rag_personalization.py   13 passed
pytest cognee/tests/unit/modules/retrieval cognee/tests/unit/modules/user_preferences
                                                                                10 failed, 634 passed
ruff check                                                                      All checks passed
ruff format --check                                                             2 files already formatted
```

The 10 failures are pre-existing. I ran the same selection on `origin/main` with the change stashed
and diffed the failure lists: identical, same 10 names, and the only difference is the one test this
PR adds.

Closes #4650