### PR TITLE
fix: Address preflight review findings (COG-6255)

### DIFF
--- a/cognee/cli/commands/doctor_command.py
+++ b/cognee/cli/commands/doctor_command.py
@@ -77,7 +77,7 @@ Exits non-zero when any check fails, so it can gate CI and setup scripts.
         fmt.echo(
             f"  Embeddings: provider={embedding_config.embedding_provider} "
             f"model={embedding_config.embedding_model} "
-            f"api_key={'set' if (embedding_config.embedding_api_key or '').strip() else 'not set'} "
+            f"api_key={'set' if (embedding_config.embedding_api_key or '').strip() else 'NOT SET'} "
             f"dimensions={embedding_config.embedding_dimensions}"
         )
 

--- a/cognee/modules/preflight/config_preflight.py
+++ b/cognee/modules/preflight/config_preflight.py
@@ -134,11 +134,11 @@ def validate_provider_config(force: bool = False) -> None:
     global _checked
     if _checked and not force:
         return
-    if _skip_preflight():
-        _checked = True
-        return
     with _check_lock:
         if _checked and not force:
+            return
+        if _skip_preflight():
+            _checked = True
             return
         problems = check_provider_config()
         if problems:


### PR DESCRIPTION
## Description

Post-merge review follow-ups for #4598:

- **[major] Race condition** — `validate_provider_config()` set `_checked = True` in the `COGNEE_SKIP_PREFLIGHT` path outside `_check_lock`. The skip check and its write now live inside the lock (after the double-checked re-read), so every write to the shared once-per-process flag is synchronized. Low severity in practice (GIL, once-per-process), but correct and portable now.
- **[nit] Inconsistent capitalization** — the embeddings line in `cognee-cli doctor` printed `api_key=not set` while the LLM line printed `api_key=NOT SET`. Both now use `NOT SET`.

## Testing
- 18 preflight unit tests + full CLI unit suite (154, incl. 5 doctor tests) pass
- `pre-commit` (ruff lint + format) clean

Follow-up to COG-6255 / #4598

🤖 Generated with [Claude Code](https://claude.com/claude-code)