### PR TITLE
chore(alembic): enforce generated, unique, filename-matched revision ids

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,14 @@ repos:
       # Run the formatter.
       - id: ruff-format
         types_or: [python, pyi]
+  - repo: local
+    hooks:
+      # A revision id is stamped into every deployed database and can never be
+      # changed afterwards, so it must be GENERATED, never typed. See
+      # tools/check_alembic_revision_ids.py and cognee/alembic/README.
+      - id: alembic-revision-ids
+        name: Alembic revision ids are generated, unique, filename-matched
+        entry: python tools/check_alembic_revision_ids.py
+        language: system
+        files: ^cognee/alembic/versions/.*\.py$
+        pass_filenames: false

--- a/cognee/alembic/README
+++ b/cognee/alembic/README
@@ -1,1 +1,44 @@
 Generic single-database configuration with an async dbapi.
+
+Authoring a migration
+---------------------
+
+Always let Alembic mint the revision id:
+
+    uv run alembic revision -m "short description"
+
+Never type a revision id by hand. The id is not a label — it is the value
+written into every deployed database's `alembic_version` table, which is the
+only record of where that database sits in the chain. Once a release ships, the
+id can never be changed: renaming it orphans every database already stamped
+with it.
+
+Hand-typed ids look like `a1b2c3d4e5f6` or `d4e5f6a7b8c9`, and they collide.
+`b2c3d4e5f6a7` already names two different migrations — `add_search_history_indexes`
+here and `add_renewal_amount_currency_to_user_subscription` in the Cloud
+migration trees that vendor a copy of this chain. That collision was only
+fixable because no production database had stamped the losing id yet.
+
+`tools/check_alembic_revision_ids.py` enforces this. It runs from pre-commit and
+in the unit-test suite, and checks that:
+
+  * the module's `revision` matches its filename prefix;
+  * the id is 12 lowercase hex characters (the format `rev_id()` produces);
+  * no two migrations share an id;
+  * every `down_revision` resolves and the chain has exactly one head;
+  * newly added ids do not look hand-typed (existing ids are exempt — they are
+    already stamped in real databases).
+
+Downstream consumers
+--------------------
+
+This chain is vendored and re-chained by the Cloud migration trees, so a
+migration added here becomes someone else's port. Two habits keep that cheap:
+
+  * guard DDL with an existence check (`if "table" in inspector.get_table_names(): return`)
+    so the migration composes with a database that already has the table;
+  * keep `down_revision` pointing at the previous revision in this repo only —
+    downstream re-parents it, and a merge-shaped chain here multiplies that work.
+
+The graph/vector data migrations are a separate chain with its own rules; see
+`cognee/modules/migrations/README.md`.

--- a/cognee/tests/unit/test_alembic_revision_ids.py
+++ b/cognee/tests/unit/test_alembic_revision_ids.py
@@ -1,0 +1,123 @@
+"""Alembic revision ids must be generated, unique, and match their filenames.
+
+A revision id is the value stamped into every deployed database's
+``alembic_version`` table, so it can never be changed after a release ships.
+Hand-typed ids collide — ``b2c3d4e5f6a7`` already names two different migrations
+across this repo and the Cloud migration trees — and a collision means one id
+describes two schemas.
+
+The invariants below run in the normal unit-test job. The companion check for
+*newly added* ids that look hand-typed needs git, so it lives in
+``tools/check_alembic_revision_ids.py`` and runs from pre-commit.
+"""
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VERSIONS_DIR = REPO_ROOT / "cognee" / "alembic" / "versions"
+
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+from check_alembic_revision_ids import (  # noqa: E402
+    _REV_ID_RE,
+    _migration_files,
+    _revision_of,
+    looks_hand_typed,
+)
+
+
+class TestAlembicRevisionIds(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.files = _migration_files(VERSIONS_DIR)
+
+    def test_versions_directory_is_not_empty(self):
+        """A silently empty glob would make every assertion below vacuous."""
+        self.assertTrue(self.files, f"no migrations found in {VERSIONS_DIR}")
+
+    def test_revision_id_matches_filename_prefix(self):
+        """`alembic history` and the file listing must name a revision the same way."""
+        for path in self.files:
+            with self.subTest(migration=path.name):
+                revision = _revision_of(path)
+                self.assertIsNotNone(revision, f"{path.name}: no `revision = ...` found")
+                self.assertEqual(
+                    revision,
+                    path.name.split("_", 1)[0],
+                    f"{path.name}: revision id does not match the filename prefix",
+                )
+
+    def test_revision_ids_are_in_generated_format(self):
+        """12 lowercase hex characters — what alembic's rev_id() produces."""
+        for path in self.files:
+            with self.subTest(migration=path.name):
+                revision = _revision_of(path)
+                self.assertRegex(
+                    revision or "",
+                    _REV_ID_RE,
+                    f"{path.name}: {revision!r} is not 12 lowercase hex characters. "
+                    "Let `alembic revision -m ...` mint the id.",
+                )
+
+    def test_revision_ids_are_unique(self):
+        """Two migrations sharing an id makes `alembic_version` ambiguous."""
+        seen: dict[str, str] = {}
+        for path in self.files:
+            revision = _revision_of(path)
+            if revision is None:
+                continue
+            self.assertNotIn(
+                revision,
+                seen,
+                f"{path.name}: revision id {revision!r} is already used by {seen.get(revision)}",
+            )
+            seen[revision] = path.name
+
+    def test_down_revisions_resolve_and_form_one_chain(self):
+        """Every down_revision must exist, and the graph must have a single head.
+
+        A dangling parent makes `alembic upgrade head` fail at runtime, in the
+        deployment rather than in CI.
+        """
+        down_re = re.compile(r"^down_revision(?:\s*:\s*[^=]+)?\s*=\s*(.+)$", re.MULTILINE)
+        parents: dict[str, list[str]] = {}
+        for path in self.files:
+            revision = _revision_of(path)
+            if revision is None:
+                continue
+            match = down_re.search(path.read_text(encoding="utf-8"))
+            raw = match.group(1).split("#")[0] if match else ""
+            parents[revision] = re.findall(r"['\"]([^'\"]+)['\"]", raw)
+
+        for revision, downs in parents.items():
+            for down in downs:
+                self.assertIn(
+                    down,
+                    parents,
+                    f"{revision}: down_revision {down!r} does not exist in the versions directory",
+                )
+
+        referenced = {down for downs in parents.values() for down in downs}
+        heads = sorted(set(parents) - referenced)
+        self.assertEqual(len(heads), 1, f"expected exactly one head, found {len(heads)}: {heads}")
+
+    def test_hand_typed_detector_accepts_generated_ids(self):
+        """The detector must never reject an id alembic actually generated."""
+        from uuid import uuid4
+
+        generated = [uuid4().hex[-12:] for _ in range(5000)]
+        false_positives = [rev for rev in generated if looks_hand_typed(rev)]
+        self.assertEqual(false_positives, [], "detector rejected generated ids")
+
+    def test_hand_typed_detector_catches_keyboard_patterns(self):
+        """Regression pins for the id family that caused the Cloud collision."""
+        for revision in ("a1b2c3d4e5f6", "b2c3d4e5f6a7", "d4e5f6a7b8c9", "e5f6a7b8c9d0"):
+            with self.subTest(revision=revision):
+                self.assertTrue(looks_hand_typed(revision))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_alembic_revision_ids.py
+++ b/tools/check_alembic_revision_ids.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Enforce that Alembic revision ids are GENERATED, unique, and match their filename.
+
+Why this exists
+---------------
+A revision id is not a label — it is the value written into every deployed
+database's ``alembic_version`` table. It is the only thing that tells a database
+where it sits in the chain, and it can never be changed after a release ships.
+
+Historically these ids were typed by hand in this repo, producing keyboard
+patterns like ``a1b2c3d4e5f6`` / ``d4e5f6a7b8c9`` instead of the 12 hex chars
+``alembic revision`` generates. Hand-typed ids collide: two different migrations
+end up sharing one id, and from then on that id means two different schemas.
+That already happened once between this repo and the Cloud migration trees
+(``b2c3d4e5f6a7`` is ``add_search_history_indexes`` here and
+``add_renewal_amount_currency_to_user_subscription`` on Cloud), and the fix was
+to rename a shipped migration — something that is only survivable because no
+production database had yet stamped the losing id.
+
+So: always let Alembic mint the id.
+
+    uv run alembic revision -m "short description"
+
+Checks
+------
+Always, over every migration in the versions directory:
+
+  1. the module's ``revision`` equals its filename prefix;
+  2. the revision id is exactly 12 lowercase hex characters (``rev_id()`` format);
+  3. no two migrations share a revision id.
+
+Additionally, for migrations that are NEW relative to a git base ref (default
+``HEAD``, override with ``--base-ref``), the id must not look hand-typed.
+Existing ids are deliberately exempt: they are already stamped in real
+databases and renaming them is what this check exists to prevent.
+
+Usage
+-----
+    python tools/check_alembic_revision_ids.py                    # new-vs-HEAD
+    python tools/check_alembic_revision_ids.py --base-ref origin/dev
+    python tools/check_alembic_revision_ids.py --all              # shape-check everything
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VERSIONS_DIR = REPO_ROOT / "cognee" / "alembic" / "versions"
+
+# `revision = "abc"` and `revision: str = "abc"`.
+_REVISION_RE = re.compile(r'^revision(?:\s*:\s*[^=]+)?\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
+# What alembic's rev_id() produces: uuid4().hex[-12:]
+_REV_ID_RE = re.compile(r"^[0-9a-f]{12}$")
+
+
+def _is_run(chars: str) -> bool:
+    """True if ``chars`` steps by a constant amount through its own alphabet.
+
+    Hand-typed ids walk the digit alphabet (0-9) and the letter alphabet (a-f)
+    separately — ``d4e5f6a7b8c9`` is ``d,e,f,a,b,c`` interleaved with
+    ``4,5,6,7,8,9`` — so the modulus is the alphabet actually used, not 16.
+    """
+    if len(chars) < 4:
+        return False
+    if all(c.isdigit() for c in chars):
+        values, modulus = [int(c) for c in chars], 10
+    elif all(c.isalpha() for c in chars):
+        values, modulus = [ord(c) - ord("a") for c in chars], 6
+    else:
+        values, modulus = [int(c, 16) for c in chars], 16
+
+    step = (values[1] - values[0]) % modulus
+    if step == 0:
+        return False
+    return all((b - a) % modulus == step for a, b in zip(values, values[1:]))
+
+
+def looks_hand_typed(revision: str) -> bool:
+    """Detect the keyboard-pattern id family.
+
+    Flags an id whose characters form one arithmetic run, or whose even- and
+    odd-indexed characters each form one. Validated at 0 false positives over
+    200k generated ids, while catching every hand-typed id in this repo.
+    """
+    if not _REV_ID_RE.match(revision):
+        return False
+    return _is_run(revision) or (_is_run(revision[0::2]) and _is_run(revision[1::2]))
+
+
+def _revision_of(path: Path) -> str | None:
+    match = _REVISION_RE.search(path.read_text(encoding="utf-8"))
+    return match.group(1) if match else None
+
+
+def _migration_files(versions_dir: Path) -> list[Path]:
+    return sorted(p for p in versions_dir.glob("*.py") if p.name != "__init__.py")
+
+
+def _revisions_at(base_ref: str, versions_dir: Path) -> set[str]:
+    """Revision ids present in ``versions_dir`` at ``base_ref``, by filename prefix.
+
+    Returns an empty set when the ref cannot be read (shallow clone, fresh repo),
+    which makes every migration look new — the shape check then applies to all of
+    them. That is the safe direction to fail: noisy, never silent.
+    """
+    relative = versions_dir.relative_to(REPO_ROOT)
+    try:
+        listing = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "ls-tree", "--name-only", base_ref, f"{relative}/"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return set()
+    return {
+        Path(line).name.split("_", 1)[0]
+        for line in listing.splitlines()
+        if line.endswith(".py") and not line.endswith("__init__.py")
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-ref",
+        default="HEAD",
+        help="git ref whose migrations count as pre-existing (default: HEAD)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="apply the hand-typed check to every migration, not just new ones",
+    )
+    parser.add_argument(
+        "--versions-dir",
+        default=str(VERSIONS_DIR),
+        help=f"Alembic versions directory (default: {VERSIONS_DIR})",
+    )
+    args = parser.parse_args()
+
+    versions_dir = Path(args.versions_dir).resolve()
+    if not versions_dir.is_dir():
+        print(f"::error::versions directory not found: {versions_dir}")
+        return 1
+
+    files = _migration_files(versions_dir)
+    if not files:
+        print(f"::error::no migrations found in {versions_dir}")
+        return 1
+
+    errors: list[str] = []
+    seen: dict[str, str] = {}
+
+    for path in files:
+        prefix = path.name.split("_", 1)[0]
+        revision = _revision_of(path)
+
+        if revision is None:
+            errors.append(f'{path.name}: no `revision = "..."` assignment found')
+            continue
+
+        # 1. id must match the filename prefix — otherwise `alembic history` and
+        #    the file listing disagree about what a revision is called.
+        if revision != prefix:
+            errors.append(
+                f"{path.name}: revision id {revision!r} does not match filename prefix {prefix!r}"
+            )
+
+        # 2. id must be in the format alembic generates.
+        if not _REV_ID_RE.match(revision):
+            errors.append(
+                f"{path.name}: revision id {revision!r} is not 12 lowercase hex characters "
+                f"(the format `alembic revision` generates)"
+            )
+
+        # 3. ids must be unique.
+        if revision in seen:
+            errors.append(
+                f"{path.name}: revision id {revision!r} is already used by {seen[revision]}"
+            )
+        else:
+            seen[revision] = path.name
+
+    # 4. new ids must look generated.
+    if args.all:
+        new_revisions = set(seen)
+    else:
+        new_revisions = set(seen) - _revisions_at(args.base_ref, versions_dir)
+
+    for revision in sorted(new_revisions):
+        if looks_hand_typed(revision):
+            errors.append(
+                f"{seen[revision]}: revision id {revision!r} looks hand-typed (a keyboard "
+                f"pattern, not a generated id). Let alembic mint it:\n"
+                f'      uv run alembic revision -m "short description"\n'
+                f"    then move your upgrade()/downgrade() body into the generated file. "
+                f"Hand-typed ids collide, and a collided id can never be fixed once a "
+                f"database has stamped it."
+            )
+
+    if errors:
+        print("::error::Alembic revision id check failed:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    scope = "all" if args.all else f"{len(new_revisions)} new"
+    print(
+        f"OK: {len(files)} migrations — ids match filenames, are generated-format and unique "
+        f"({scope} checked for hand-typed patterns)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

A revision id is not a label — it is the value stamped into every deployed database's `alembic_version` table, and it **can never be changed once a release ships**. This repo types them by hand, producing keyboard patterns instead of the 12 hex characters `alembic revision` generates. **15 of the 41 ids currently in the tree are hand-typed** (`a1b2c3d4e5f6`, `d4e5f6a7b8c9`, `e5f6a7b8c9d0`, …).

Hand-typed ids collide, and one already has:

| id | here | in the Cloud migration trees |
|---|---|---|
| `b2c3d4e5f6a7` | `add_search_history_indexes` | `add_renewal_amount_currency_to_user_subscription` |

Cloud had to **rename a shipped migration** to `b2c3d4e5f6a8` and re-parent its child (`7c5d4e2f8a91`) to match. That was only survivable because no production database had stamped the losing id yet. The next one may not be.

## What this adds

`tools/check_alembic_revision_ids.py`, wired in two places:

- **pre-commit** (`.pre-commit-config.yaml`) — a bad id is rejected at commit time, which is the only moment it is still free to fix;
- **`cognee/tests/unit/test_alembic_revision_ids.py`** — runs in the existing unit-test job, so CI cannot regress it. No workflow file changes.

Checks:

1. `revision` equals the filename prefix
2. the id is 12 lowercase hex characters (`rev_id()` format)
3. ids are unique
4. every `down_revision` resolves, and the chain has exactly one head
5. **new** ids do not look hand-typed

## Existing ids are grandfathered — on purpose

Check 5 applies only to migrations added relative to a git base ref (default `HEAD`, `--base-ref` to override). Renaming a shipped id is exactly the damage this check exists to prevent, so it never asks for one. `--all` is available for reporting, and currently fails with the 15 known ids — that is expected, not a regression.

## The detector

Hand-typed ids walk the digit alphabet and the letter alphabet *separately* — `d4e5f6a7b8c9` is `d,e,f,a,b,c` interleaved with `4,5,6,7,8,9` — so a plain mod-16 arithmetic test misses them. The check tests each interleaved subsequence for a constant step within the alphabet it actually uses.

Measured: **0 false positives over 200k generated ids**, catches all 15 hand-typed ids in this tree.

## Verification

```
$ python tools/check_alembic_revision_ids.py
OK: 41 migrations — ids match filenames, are generated-format and unique (0 new checked for hand-typed patterns).

$ python cognee/tests/unit/test_alembic_revision_ids.py
Ran 7 tests in 0.068s — OK
```

Also verified by fixture: a new hand-typed id fails, a new generated id passes, a filename/id mismatch fails.

## Scope

No migration files are touched. No runtime behaviour changes. Docs for the rule (and the two habits that keep the downstream Cloud port cheap) go in `cognee/alembic/README`.

---

⚠️ **Needs a Linear key in the title before merge** — `require-linear-issue` is a required check and I did not have an issue to reference.

Part of a set of release-chain fixes; the counterpart lint (cloud-only ids must not collide with SDK ids) lands in `cloud-backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)