### PR TITLE
fix(retrieval): thread live node schemas into NL Cypher-generation prompt

### DIFF
--- a/cognee/infrastructure/llm/prompts/natural_language_retriever_system.txt
+++ b/cognee/infrastructure/llm/prompts/natural_language_retriever_system.txt
@@ -33,26 +33,8 @@ ERROR PREVENTION:
 4. Use pattern variables consistently throughout the query
 5. If previous attempts failed, analyze the failures and adjust your approach
 
-Node schemas:
-- EntityType
-Properties: description, ontology_valid, name, created_at, type, version, topological_rank, updated_at, metadata, id
-Purpose: Represents the categories or classifications for entities in the database.
-
-- Entity
-Properties: description, ontology_valid, name, created_at, type, version, topological_rank, updated_at, metadata, id
-Purpose: Represents individual entities that belong to a specific type or classification.
-
-- TextDocument
-Properties: raw_data_location, name, mime_type, external_metadata, created_at, type, version, topological_rank, updated_at, metadata, id
-Purpose: Represents documents containing text data, along with metadata about their storage and format.
-
-- DocumentChunk
-Properties: version, created_at, type, topological_rank, cut_type, text, metadata, chunk_index, chunk_size, updated_at, id
-Purpose: Represents segmented portions of larger documents, useful for processing or analysis at a more granular level.
-
-- TextSummary
-Properties: topological_rank, metadata, id, type, updated_at, created_at, text, version
-Purpose: Represents summarized content generated from larger text documents, retaining essential information and metadata.
+Node schemas (node labels and their properties):
+`{{node_schemas}}`
 
 Edge schema (relationship properties):
 `{{edge_schemas}}`

--- a/cognee/modules/retrieval/natural_language_retriever.py
+++ b/cognee/modules/retrieval/natural_language_retriever.py
@@ -101,11 +101,14 @@ class NaturalLanguageRetriever(BaseRetriever):
         node_schemas = [row for row in node_schemas or [] if not _is_internal_schema_row(row)]
         return node_schemas, edge_schemas
 
-    async def _generate_cypher_query(self, query: str, edge_schemas, previous_attempts=None) -> str:
+    async def _generate_cypher_query(
+        self, query: str, node_schemas, edge_schemas, previous_attempts=None
+    ) -> str:
         """Generate a Cypher query using LLM based on natural language query and schema information."""
         system_prompt = render_prompt(
             self.system_prompt_path,
             context={
+                "node_schemas": node_schemas,
                 "edge_schemas": edge_schemas,
                 "previous_attempts": previous_attempts or "No attempts yet",
             },
@@ -127,7 +130,7 @@ class NaturalLanguageRetriever(BaseRetriever):
             logger.info(f"Starting attempt {attempt + 1}/{self.max_attempts} for query generation")
             try:
                 cypher_query = await self._generate_cypher_query(
-                    query, edge_schemas, previous_attempts
+                    query, node_schemas, edge_schemas, previous_attempts
                 )
 
                 logger.info(

--- a/cognee/tests/unit/modules/retrieval/test_natural_language_node_schemas.py
+++ b/cognee/tests/unit/modules/retrieval/test_natural_language_node_schemas.py
@@ -1,0 +1,44 @@
+"""The live node-label schema must reach the Cypher-generation prompt.
+
+Regression for the case where ``_execute_cypher_query`` computed ``node_schemas``
+but dropped them before calling ``_generate_cypher_query`` (only ``edge_schemas``
+was threaded through), while the prompt template hardcoded a static node-schema
+block. The effect was that the LLM never saw the store's real node labels, so
+every generated Cypher query targeted guessed labels and bound nothing.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.modules.retrieval.natural_language_retriever import NaturalLanguageRetriever
+
+
+@pytest.mark.asyncio
+async def test_live_node_labels_reach_generation_prompt():
+    # A label that is NOT part of the template's old static block, so it can only
+    # appear in the rendered prompt if the live node schema is actually threaded in.
+    node_schema = [{"NodeLabels": ["WidgetGizmo"], "Properties": ["sku", "name"]}]
+    edge_schema = [{"key": "USED_IN"}]
+    raw_result = [{"n": {"id": "w-1", "name": "Sprocket"}}]
+
+    mock_engine = AsyncMock()
+    mock_engine.query = AsyncMock(side_effect=[node_schema, edge_schema, raw_result])
+
+    captured = {}
+
+    async def _capture(text_input, system_prompt, response_model):
+        captured["system_prompt"] = system_prompt
+        return "MATCH (n:WidgetGizmo) RETURN n"
+
+    retriever = NaturalLanguageRetriever(max_attempts=1)
+    with patch(
+        "cognee.modules.retrieval.natural_language_retriever.LLMGateway.acreate_structured_output",
+        AsyncMock(side_effect=_capture),
+    ):
+        await retriever._execute_cypher_query("find widgets", mock_engine)
+
+    # The real template + render_prompt ran; the live label must be present.
+    assert "WidgetGizmo" in captured["system_prompt"], (
+        "live node labels were not threaded into the Cypher-generation prompt"
+    )


### PR DESCRIPTION
## Description

`NaturalLanguageRetriever` translates a natural-language question into Cypher using an LLM, and to do that it shows the LLM the graph's schema. It fetches **both** the node schema and the edge schema, but only the edge schema actually reached the model:

- `_execute_cypher_query` computes `node_schemas, edge_schemas = await self._get_graph_schema(...)`, then calls `_generate_cypher_query(query, edge_schemas, previous_attempts)` — `node_schemas` is dropped on the floor.
- `_generate_cypher_query` only put `edge_schemas` into the prompt context.
- The prompt template compounded this: it rendered edges live via `{{edge_schemas}}`, but the node section was a **hardcoded static block** listing five fixed labels (`EntityType`, `Entity`, `TextDocument`, `DocumentChunk`, `TextSummary`) with fixed properties.

So the LLM never saw the store's *real* node labels. On any graph whose labels differ from that static set, it generated Cypher against guessed labels that bind nothing, and `NATURAL_LANGUAGE` search silently returned empty results for every query — no error, just nothing. (The issue reporter measured 0/29 answered for `NATURAL_LANGUAGE` versus 20–28/29 for the other search types on the same store.)

The fix threads the already-computed `node_schemas` through to the prompt using the exact same mechanism `edge_schemas` already uses, and replaces the static block with `{{node_schemas}}`. No new graph query is issued — `node_schemas` was already being fetched and simply discarded. Internal schema rows are still filtered upstream in `_get_graph_schema` (`_is_internal_schema_row`), so nothing internal is newly exposed.

## Acceptance Criteria

- The live node labels of the store appear in the Cypher-generation system prompt (they did not before).
- Existing internal-node filtering behaviour is unchanged (internal schema rows stay out of the prompt).
- No regression in the retriever test suite.

Proof: a new regression test renders the **real** template through `render_prompt` and asserts a distinctive live node label reaches the generation prompt. It fails on the pre-fix code (`AssertionError: live node labels were not threaded into the Cypher-generation prompt`) and passes with the fix. Retriever tests: 16 passed, 1 skipped.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Non-UI change. Test evidence (local): the regression test passes with the fix and fails without it (`AssertionError: live node labels were not threaded into the Cypher-generation prompt`).

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines (ruff format + check clean)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable) — n/a
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin

Fixes #4655
