### PR TITLE
feat: Add Linear agent integration (COG-6323)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -710,8 +710,9 @@ WEB_SCRAPER_MAX_DELAY=10.0
 ################################################################################
 #  Integrations
 #  Third-party OAuth integrations (cognee/modules/integrations/). Each
-#  provider registers itself only if its settings are configured — unset
-#  deployments simply don't offer that integration. See
+#  provider registers itself at startup; one whose secrets are left unset
+#  responds 503 "not configured" to connect attempts and rejects inbound
+#  webhooks, so unset deployments effectively cannot use it. See
 #  cognee/api/v1/integrations/routers/get_integrations_router.py for the
 #  generic install-flow endpoints every provider shares.
 ################################################################################
@@ -732,6 +733,7 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #SLACK_REDIRECT_URI="http://localhost:8000/api/v1/integrations/slack/callback"
 #SLACK_FRONTEND_BASE_URL="http://localhost:3000"
 
+# -- GitHub --------------------------------------------------------------------
 # Create a GitHub App at https://github.com/settings/apps to get these values.
 # Required app configuration: "Request user authorization (OAuth) during
 # installation" enabled; Callback URL pointing at this server's
@@ -750,6 +752,27 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #GITHUB_CLIENT_SECRET=""
 #GITHUB_WEBHOOK_SECRET=""
 #GITHUB_FRONTEND_BASE_URL="http://localhost:3000"
+
+# -- Linear --------------------------------------------------------------------
+# Create a Linear OAuth app at https://linear.app/settings/api/applications.
+# This is an *agent* app: the authorize URL uses actor=app, which installs an
+# app user into the workspace that members can @mention or delegate issues to
+# — the agent answers from cognee memory. Enable "Agent session events" on
+# the app and point its webhook URL at this server's
+# /api/v1/integrations/linear/events.
+# CLIENT_ID/CLIENT_SECRET: from the app's settings page.
+# WEBHOOK_SECRET: the app's webhook signing secret — verifies inbound
+# deliveries via the Linear-Signature header, and signs the OAuth state
+# parameter.
+# REDIRECT_URI: must match a callback URL registered on the app exactly, and
+# point at this server's /api/v1/integrations/linear/callback.
+# FRONTEND_BASE_URL: where the browser is redirected back to after
+# connect/cancel/error (appends ?linear=<outcome> to /integrations).
+#LINEAR_CLIENT_ID=""
+#LINEAR_CLIENT_SECRET=""
+#LINEAR_WEBHOOK_SECRET=""
+#LINEAR_REDIRECT_URI="http://localhost:8000/api/v1/integrations/linear/callback"
+#LINEAR_FRONTEND_BASE_URL="http://localhost:3000"
 
 
 ################################################################################

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -58,12 +58,13 @@ from cognee.api.v1.sessions import get_sessions_router
 from cognee.api.v1.slack.routers import get_slack_channels_router, get_slack_router
 from cognee.api.v1.integrations.routers import get_integrations_router
 
-# Registers the GitHub App integration with the integrations registry as an
-# import side effect. Slack registers via its router imports above; GitHub
-# mounts no routers of its own (webhooks arrive on the generic
-# /api/v1/integrations/github/events route), so the registration import is
-# explicit here.
+# Registers the GitHub and Linear integrations with the integrations registry
+# as import side effects. Slack registers via its router imports above; GitHub
+# and Linear mount no routers of their own (webhooks arrive on the generic
+# /api/v1/integrations/{provider}/events routes), so the registration imports
+# are explicit here.
 import cognee.modules.integrations.github  # noqa: F401,E402
+import cognee.modules.integrations.linear  # noqa: F401,E402
 from cognee.modules.users.methods.get_authenticated_user import REQUIRE_AUTHENTICATION
 
 # Ensure application logging is configured for container stdout/stderr

--- a/cognee/modules/integrations/linear/__init__.py
+++ b/cognee/modules/integrations/linear/__init__.py
@@ -1,0 +1,13 @@
+"""Linear agent integration package.
+
+Importing this package registers the Linear adapter with the integrations
+registry as a side effect — the same pattern as the GitHub package. Linear
+mounts no routers of its own (its webhooks, agent session events included,
+arrive on the generic ``POST /api/v1/integrations/linear/events`` route), so
+the API app imports this package explicitly to trigger registration.
+"""
+
+from cognee.modules.integrations.linear.adapter import LinearIntegration
+from cognee.modules.integrations.registry import use_integration
+
+use_integration(LinearIntegration())

--- a/cognee/modules/integrations/linear/adapter.py
+++ b/cognee/modules/integrations/linear/adapter.py
@@ -1,0 +1,225 @@
+"""Linear (agent app) as an ``OAuthIntegration`` adapter.
+
+Connects a Linear workspace through an *agent* install rather than a plain
+OAuth consent: the authorize URL carries ``actor=app``, which installs an
+app user — the agent's identity — into the workspace, and the
+``app:assignable``/``app:mentionable`` scopes let members delegate issues to
+it or @mention it. Those mentions/delegations arrive as agent session
+webhooks and are answered from cognee memory
+(:mod:`cognee.modules.integrations.linear.agent_session`).
+
+The token exchange differs from the plain-OAuth shape in one way, absorbed
+by ``exchange_callback``: Linear's token response says nothing about *which*
+workspace authorized the app, but every webhook delivery routes by its
+``organizationId`` envelope field — so the fresh token is immediately spent
+on one GraphQL query for ``viewer`` (the app user) and ``organization``, and
+the merged result is what ``parse_installation`` (which is sync, so it
+cannot make that call itself) turns into a credential keyed on the
+organization id.
+
+``revoke_remote`` is a real implementation here, unlike GitHub's deliberate
+no-op: Linear exposes a cheap token-revoke endpoint that kills only *our*
+token, whereas GitHub's remote equivalent would be uninstalling the app from
+the whole org — too destructive for a cognee-side disconnect. ``refresh``
+stays the base no-op for this first cut (the base contract blesses that);
+the refresh token is stored so a later cut can add rotation without a
+reconnect.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+from urllib.parse import urlencode
+
+import aiohttp
+
+from cognee.modules.integrations.base import (
+    OAuthInstallation,
+    OAuthIntegration,
+    WebhookVerifier,
+)
+from cognee.modules.integrations.credentials import decrypt_token_payload
+from cognee.modules.integrations.linear.client import graphql
+from cognee.modules.integrations.linear.handle_linear_event import handle_linear_event
+from cognee.modules.integrations.linear.linear_settings import LinearSettings, require
+from cognee.modules.integrations.linear.sync import sync_recent_issues
+from cognee.modules.integrations.linear.verify_linear_signature import LinearWebhookVerifier
+from cognee.modules.integrations.models.IntegrationCredential import IntegrationCredential
+
+logger = logging.getLogger(__name__)
+
+_AUTHORIZE_URL = "https://linear.app/oauth/authorize"
+_TOKEN_URL = "https://api.linear.app/oauth/token"
+_REVOKE_URL = "https://api.linear.app/oauth/revoke"
+
+# app:assignable lets members delegate issues to the agent; app:mentionable
+# lets them @mention it. Both require the actor=app install (and actor=app
+# cannot be combined with the admin scope).
+_SCOPES = "read,write,app:assignable,app:mentionable"
+
+_TIMEOUT = aiohttp.ClientTimeout(total=30)
+
+# viewer is the freshly installed app user (the agent identity in that
+# workspace); organization.id is what every webhook envelope routes by.
+_INSTALL_CONTEXT_QUERY = """
+query InstallContext {
+  viewer { id name }
+  organization { id name urlKey }
+}
+"""
+
+
+def access_token_for(credential: IntegrationCredential) -> str:
+    """The credential's decrypted access token — call only at Linear-API time.
+
+    The only sanctioned path from a stored credential to a usable bearer
+    token; raises rather than returning an empty string so a malformed
+    payload fails loudly at the call site instead of as a Linear 401.
+    """
+    token = decrypt_token_payload(credential).get("access_token")
+    if not token:
+        raise RuntimeError(
+            f"Linear credential for organization {credential.provider_account_id} "
+            f"holds no access token"
+        )
+    return token
+
+
+class LinearIntegration(OAuthIntegration):
+    provider = "linear"
+    settings_cls = LinearSettings
+
+    def authorize_url(self, state: str) -> str:
+        params = {
+            "client_id": require("client_id"),
+            "redirect_uri": require("redirect_uri"),
+            "response_type": "code",
+            "state": state,
+            # The agent install: puts an app user into the workspace instead
+            # of acting as the authorizing human.
+            "actor": "app",
+            "scope": _SCOPES,
+        }
+        return f"{_AUTHORIZE_URL}?{urlencode(params)}"
+
+    async def exchange_code(self, code: str) -> dict[str, Any]:
+        """Exchange the OAuth code for the workspace's agent token."""
+        async with aiohttp.ClientSession(timeout=_TIMEOUT) as session:
+            async with session.post(
+                _TOKEN_URL,
+                data={
+                    "code": code,
+                    "redirect_uri": require("redirect_uri"),
+                    "client_id": require("client_id"),
+                    "client_secret": require("client_secret"),
+                    "grant_type": "authorization_code",
+                },
+            ) as response:
+                if response.status != 200:
+                    raise RuntimeError(f"Linear code exchange failed: HTTP {response.status}")
+                payload: dict[str, Any] = await response.json()
+
+        if not payload.get("access_token"):
+            raise RuntimeError("Linear code exchange returned no access_token")
+        return payload
+
+    async def exchange_callback(self, code: str, params: dict[str, str]) -> dict[str, Any]:
+        """Exchange the code, then enrich the response with workspace identity.
+
+        The raw token response carries no workspace or app-user identity, but
+        ``parse_installation`` is sync and must derive ``provider_account_id``
+        from this response alone — and that id must be the organization id,
+        because webhooks route back by their ``organizationId`` envelope
+        field. So the fresh token is spent here, in the async leg, on one
+        GraphQL query and the result rides along.
+        """
+        token_response = await self.exchange_code(code)
+        install_context = await graphql(token_response["access_token"], _INSTALL_CONTEXT_QUERY)
+        return {
+            **token_response,
+            "viewer": install_context.get("viewer"),
+            "organization": install_context.get("organization"),
+        }
+
+    def parse_installation(self, token_response: dict[str, Any]) -> OAuthInstallation:
+        organization = token_response.get("organization") or {}
+        organization_id = organization.get("id")
+        if not organization_id:
+            raise ValueError("Linear token response carries no organization id")
+
+        # Secret material stays in token_payload (encrypted at rest); the
+        # refresh token is stored unused for now so a later cut can add
+        # rotation without forcing a reconnect.
+        token_payload = {"access_token": token_response["access_token"]}
+        if token_response.get("refresh_token"):
+            token_payload["refresh_token"] = token_response["refresh_token"]
+
+        token_expires_at = None
+        expires_in = token_response.get("expires_in")
+        if expires_in:
+            token_expires_at = datetime.now(timezone.utc) + timedelta(seconds=int(expires_in))
+
+        viewer = token_response.get("viewer") or {}
+        return OAuthInstallation(
+            provider_account_id=str(organization_id),
+            token_payload=token_payload,
+            provider_metadata={
+                "app_user_id": viewer.get("id"),
+                "app_user_name": viewer.get("name"),
+                "organization_name": organization.get("name"),
+                "organization_url_key": organization.get("urlKey"),
+                "scope": token_response.get("scope"),
+            },
+            account_label=organization.get("name"),
+            scopes=token_response.get("scope"),
+            token_expires_at=token_expires_at,
+            auth_type="oauth2",
+        )
+
+    def state_signing_secret(self) -> str:
+        return require("webhook_secret")
+
+    def frontend_base_url(self) -> str:
+        return require("frontend_base_url")
+
+    def webhook_verifier(self) -> Optional[WebhookVerifier]:
+        return LinearWebhookVerifier()
+
+    async def handle_webhook(self, raw_body: bytes, headers: dict[str, str]) -> None:
+        await handle_linear_event(raw_body, headers)
+
+    async def on_installed(self, credential: IntegrationCredential) -> None:
+        """Seed memory with the workspace's recently active issues.
+
+        Issue webhooks only cover changes from now on — and any delivery
+        racing ahead of the OAuth callback storing the credential is dropped
+        as unknown (same race as GitHub's ``installation.created``). This
+        hook, firing after the upsert, is what gives the agent something to
+        recall from on day one.
+        """
+        await sync_recent_issues(credential)
+
+    async def revoke_remote(self, credential: IntegrationCredential) -> None:
+        """Best-effort remote revoke of the workspace's agent token.
+
+        Cheap and non-destructive on Linear's side (it kills only this
+        token, not the app install), so worth doing — but still best-effort:
+        the local revoke is the actual access cut-off, and a network blip
+        here must never block a disconnect.
+        """
+        try:
+            token = access_token_for(credential)
+            async with aiohttp.ClientSession(timeout=_TIMEOUT) as session:
+                async with session.post(
+                    _REVOKE_URL, headers={"Authorization": f"Bearer {token}"}
+                ) as response:
+                    if response.status != 200:
+                        logger.warning(
+                            "Linear token revoke for organization %s failed: HTTP %s",
+                            credential.provider_account_id,
+                            response.status,
+                        )
+        except Exception:  # noqa: BLE001 - disconnect must proceed no matter what happens here
+            logger.exception(
+                "Linear token revoke for organization %s failed", credential.provider_account_id
+            )

--- a/cognee/modules/integrations/linear/agent_session.py
+++ b/cognee/modules/integrations/linear/agent_session.py
@@ -1,0 +1,214 @@
+"""Answer Linear agent sessions (@mentions / delegated issues) from cognee memory.
+
+An agent session opens when a workspace member @mentions the agent or
+delegates an issue to it (action ``created``) and continues when they reply
+inside the session (action ``prompted``). Linear enforces a hard timing
+contract: within **10 seconds** of a ``created`` event the agent must emit
+an activity or the session is marked unresponsive. ``HYBRID_COMPLETION``
+search calls an LLM and routinely takes longer than that, so the handler
+posts an acknowledgement "thought" activity FIRST — before any search or
+LLM work — and only then goes looking for an answer. (The generic events
+route already acked the HTTP delivery; the 10 seconds are Linear's own
+clock on the session, which only an activity satisfies.)
+
+Every turn must also *end* in a terminal activity: a "response" completes
+the turn, an "error" tells Linear (and the user) the agent gave up. Leaving
+a session with only the thought would show it as working forever, so every
+failure path here ends in a best-effort error activity instead of a raise —
+this runs detached, there is no caller left to catch anything anyway.
+
+The result-unwrapping and refusal-filtering helpers are deliberate local
+copies of the Slack adapter's (:mod:`...slack.handle_cognee_ask`) —
+provider-local by convention, so one integration's formatting tweaks never
+ripple into another's.
+"""
+
+import logging
+from typing import Any, Optional
+
+from cognee.api.v1.search.search import search as cognee_search
+from cognee.infrastructure.databases.exceptions import EntityNotFoundError
+from cognee.modules.integrations.linear.client import create_agent_activity
+from cognee.modules.integrations.models.IntegrationCredential import IntegrationCredential
+from cognee.modules.search.types import SearchType
+from cognee.modules.users.methods import get_user
+
+logger = logging.getLogger(__name__)
+
+_ACK_THOUGHT = "Searching cognee memory…"
+_NO_ANSWER = "No relevant information found in cognee memory."
+_ERROR_BODY = "Something went wrong while searching cognee memory. Please try again."
+
+
+async def handle_agent_session(credential: IntegrationCredential, payload: dict[str, Any]) -> None:
+    """Answer one agent session event. Never raises — see module docstring."""
+    agent_session_id = (payload.get("agentSession") or {}).get("id")
+    if not agent_session_id:
+        logger.warning("Linear agent session event without a session id; ignoring")
+        return
+
+    # Imported here, not at module top: the adapter imports this module to
+    # wire handle_webhook, so a top-level import back into it would be
+    # circular.
+    from cognee.modules.integrations.linear.adapter import access_token_for
+
+    try:
+        access_token = access_token_for(credential)
+    except Exception:  # noqa: BLE001 - a bad stored payload must not crash the detached handler
+        logger.exception(
+            "Linear agent session %s: no usable token for organization %s",
+            agent_session_id,
+            credential.provider_account_id,
+        )
+        return
+
+    # The 10-second rule: acknowledge before any search/LLM work, or Linear
+    # marks the session unresponsive.
+    try:
+        await create_agent_activity(
+            access_token, agent_session_id, {"type": "thought", "body": _ACK_THOUGHT}
+        )
+    except Exception:  # noqa: BLE001 - a failed ack degrades the display; a missing response would kill the turn
+        logger.exception("Linear agent session %s: acknowledgement failed", agent_session_id)
+
+    try:
+        answer = await _answer(credential, payload)
+        await create_agent_activity(
+            access_token, agent_session_id, {"type": "response", "body": answer}
+        )
+    except Exception:  # noqa: BLE001 - every failure must end the turn in an error activity, not a raise
+        logger.exception("Linear agent session %s: answering failed", agent_session_id)
+        try:
+            await create_agent_activity(
+                access_token, agent_session_id, {"type": "error", "body": _ERROR_BODY}
+            )
+        except Exception:  # noqa: BLE001 - best effort; nothing left to do but log
+            logger.exception(
+                "Linear agent session %s: error activity delivery failed", agent_session_id
+            )
+
+
+def _resolve_question(payload: dict[str, Any]) -> str:
+    """The user's actual ask, per event shape.
+
+    ``prompted`` carries the new user message at the payload's top level in
+    ``agentActivity.body``. ``created`` carries the triggering comment inside
+    ``agentSession`` — but a delegation (issue assigned to the agent) has no
+    comment, so the issue title + description stand in for the question.
+    """
+    if payload.get("action") == "prompted":
+        return ((payload.get("agentActivity") or {}).get("body") or "").strip()
+
+    session = payload.get("agentSession") or {}
+    comment_body = ((session.get("comment") or {}).get("body") or "").strip()
+    if comment_body:
+        return comment_body
+
+    issue = session.get("issue") or {}
+    title = (issue.get("title") or "").strip()
+    description = (issue.get("description") or "").strip()
+    return f"{title}\n{description}".strip()
+
+
+def _build_query(payload: dict[str, Any], question: str) -> str:
+    """Prepend Linear's own context to the search query.
+
+    ``promptContext`` is a formatted digest Linear assembles (issue details,
+    prior comments) and ``guidance`` is workspace-level steering for agents —
+    both ground retrieval in what the session is about, so they ride along
+    ahead of the question instead of being discarded.
+    """
+    parts = [part for part in (payload.get("promptContext"), payload.get("guidance")) if part]
+    parts.append(question)
+    return "\n\n".join(parts)
+
+
+async def _answer(credential: IntegrationCredential, payload: dict[str, Any]) -> str:
+    """Search cognee memory and return the response body for this turn.
+
+    "Nothing found" and "no question asked" are friendly responses, not
+    errors — only genuine failures (which raise out of here) become an
+    error activity.
+    """
+    question = _resolve_question(payload)
+    if not question:
+        return (
+            "I couldn't find a question in this session — mention me with one "
+            "and I'll search cognee memory."
+        )
+
+    try:
+        owner = await get_user(credential.user_id)
+    except EntityNotFoundError:
+        logger.error(
+            "Linear credential for organization %s points at a deleted user",
+            credential.provider_account_id,
+        )
+        return (
+            "This workspace's cognee connection is not fully configured. "
+            "Please disconnect and reconnect the integration."
+        )
+
+    results = await cognee_search(
+        query_text=_build_query(payload, question),
+        # Matches the frontend recall default (and the Slack adapter): graph
+        # traversal alone can come back empty on a thin/loosely connected
+        # graph, where the vector-search fallback still finds a relevant
+        # chunk.
+        query_type=SearchType.HYBRID_COMPLETION,
+        user=owner,
+        datasets=None,  # search across every dataset the owner can read
+    )
+
+    facts = [
+        fact
+        for fact in (_extract_fact(result) for result in results)
+        if fact and not _is_refusal(fact)
+    ][:3]
+    if not facts:
+        return _NO_ANSWER
+    return "\n\n".join(facts)
+
+
+def _extract_fact(result: Any) -> Optional[str]:
+    """Pull the answer text out of one ``cognee.search()`` result.
+
+    Despite the ``List[SearchResult]`` type hint, the public ``search()``
+    never returns raw ``SearchResult`` objects — it always runs them through
+    ``_backwards_compatible_search_results`` first, which yields a dict with
+    a ``"search_result"`` key when backend access control is enabled, or the
+    bare completion payload otherwise. Either way that payload can itself be
+    a single string or a list of strings (e.g. ``HYBRID_COMPLETION`` returns
+    ``["<answer>"]``) — the first non-empty string is used. Anything else is
+    skipped rather than raising, since a shape this code doesn't recognize
+    shouldn't crash the whole answer.
+    """
+    value = result.get("search_result") if isinstance(result, dict) else result
+    if isinstance(value, list):
+        value = next((item for item in value if isinstance(item, str) and item), None)
+    return value if isinstance(value, str) and value else None
+
+
+# Substrings that mark a fact as "I can't answer this from the given
+# context" rather than an actual answer. HYBRID_COMPLETION can return a
+# separate per-chunk completion for each matched chunk group, and a chunk
+# irrelevant to the question still produces its own such completion —
+# _extract_fact has no way to tell that apart from a real answer (it's just
+# as valid a non-empty string), so it's filtered out here instead.
+_REFUSAL_MARKERS = (
+    "i can't",
+    "i cannot",
+    "i'm unable to",
+    "can't answer",
+    "cannot answer",
+    "no information about",
+    "no relevant information",
+    "doesn't contain",
+    "does not contain",
+    "contains no information",
+)
+
+
+def _is_refusal(fact: str) -> bool:
+    lowered = fact.lower()
+    return any(marker in lowered for marker in _REFUSAL_MARKERS)

--- a/cognee/modules/integrations/linear/client.py
+++ b/cognee/modules/integrations/linear/client.py
@@ -1,0 +1,108 @@
+"""Thin async client for Linear's GraphQL API.
+
+Linear exposes a single GraphQL endpoint rather than REST resources, so this
+module is one generic :func:`graphql` call plus a named wrapper for the one
+mutation the agent loop depends on (:func:`create_agent_activity`). Every
+call opens its own short-lived session — the same per-call
+``aiohttp.ClientSession`` idiom as the GitHub adapter's ``app_auth`` — since
+these fire from detached webhook handlers with no shared lifecycle to hook a
+pooled session onto.
+
+Error messages carry the operation name and HTTP status only — never the
+access token, the variables, or the response body, any of which could
+contain secret or user content that must not reach logs.
+"""
+
+import logging
+from typing import Any, Optional
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+GRAPHQL_URL = "https://api.linear.app/graphql"
+
+_TIMEOUT = aiohttp.ClientTimeout(total=30)
+
+_AGENT_ACTIVITY_CREATE_MUTATION = """
+mutation AgentActivityCreate($input: AgentActivityCreateInput!) {
+  agentActivityCreate(input: $input) {
+    success
+  }
+}
+"""
+
+
+def _operation_label(query: str) -> str:
+    """A safe, short label for error messages — the operation header only.
+
+    Deliberately not the full query (which could inline user content) and
+    never the variables (which routinely do).
+    """
+    head = query.strip().split("(", 1)[0].split("{", 1)[0].strip()
+    return head or "anonymous operation"
+
+
+async def graphql(
+    access_token: str, query: str, variables: Optional[dict[str, Any]] = None
+) -> dict[str, Any]:
+    """Run one GraphQL operation as the app user and return its ``data`` dict.
+
+    Raises ``RuntimeError`` naming the operation on a non-200 response or a
+    GraphQL-level ``errors`` array (Linear, like most GraphQL servers,
+    returns those as HTTP 200).
+    """
+    operation = _operation_label(query)
+    payload: dict[str, Any] = {"query": query}
+    if variables:
+        payload["variables"] = variables
+
+    async with aiohttp.ClientSession(timeout=_TIMEOUT) as session:
+        async with session.post(
+            GRAPHQL_URL,
+            json=payload,
+            headers={"Authorization": f"Bearer {access_token}"},
+        ) as response:
+            if response.status != 200:
+                raise RuntimeError(f"Linear {operation} failed: HTTP {response.status}")
+            body: dict[str, Any] = await response.json()
+
+    errors = body.get("errors")
+    if errors:
+        # Only stable machine codes, never ``errors[].message`` — GraphQL
+        # validation messages echo the offending variable value ("Variable
+        # '$input' got invalid value {...}"), which would put user/memory
+        # content into the exception and thence into server logs.
+        codes = sorted(
+            {
+                str(code)
+                for error in errors
+                if isinstance(error, dict)
+                for code in ((error.get("extensions") or {}).get("code"), error.get("code"))
+                if code
+            }
+        )
+        detail = f"codes: {', '.join(codes)}" if codes else f"{len(errors)} GraphQL error(s)"
+        raise RuntimeError(f"Linear {operation} failed: {detail}")
+
+    return body.get("data") or {}
+
+
+async def create_agent_activity(
+    access_token: str, agent_session_id: str, content: dict[str, Any]
+) -> None:
+    """Emit one agent activity into a session.
+
+    ``content`` is Linear's discriminated-union shape, e.g.
+    ``{"type": "thought", "body": ...}`` / ``{"type": "response", "body": ...}``
+    / ``{"type": "error", "body": ...}``. A "response" completes the turn;
+    Linear tracks session lifecycle from the last emitted activity, which is
+    why callers must always end a turn with a response or an error.
+    """
+    data = await graphql(
+        access_token,
+        _AGENT_ACTIVITY_CREATE_MUTATION,
+        {"input": {"agentSessionId": agent_session_id, "content": content}},
+    )
+    if not (data.get("agentActivityCreate") or {}).get("success"):
+        raise RuntimeError("Linear agentActivityCreate reported failure")

--- a/cognee/modules/integrations/linear/handle_linear_event.py
+++ b/cognee/modules/integrations/linear/handle_linear_event.py
@@ -1,0 +1,87 @@
+"""Handle one verified Linear webhook delivery.
+
+Runs detached from the request (the generic events route acks first, well
+inside Linear's 5-second response window), so handlers here may run searches
+and pipelines. Every delivery's envelope carries an ``organizationId`` that
+routes back to the connecting cognee user via the credential store — an
+unknown or revoked organization is logged and dropped, never an error:
+Linear retries deliveries and gives no ordering guarantee, so a delivery
+racing ahead of the OAuth callback's credential upsert is a normal,
+self-healing state (the post-install hook covers the initial sync).
+
+Deliberately narrow event coverage for the first cut:
+
+* ``AgentSessionEvent`` created/prompted -> answer the session from cognee
+  memory (the agent loop, the point of this integration).
+* ``Issue`` create/update -> remember the issue's text, so the workspace's
+  issue history flows into memory as it changes.
+* ``OAuthApp`` revoked -> revoke the stored credential; the workspace
+  removed the app on Linear's side, so the local token must stop being used.
+
+Everything else — issue deletions included — is logged and dropped:
+deleting indexed data on a webhook would be a silent, destructive surprise;
+``forget()`` stays a human decision (same stance as the GitHub handler).
+"""
+
+import json
+import logging
+
+from cognee.modules.integrations.credentials import (
+    STATUS_ACTIVE,
+    get_credential_by_account,
+    revoke_credential_by_account,
+)
+from cognee.modules.integrations.linear.agent_session import handle_agent_session
+from cognee.modules.integrations.linear.sync import sync_issue
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER = "linear"
+
+
+async def handle_linear_event(raw_body: bytes, headers: dict[str, str]) -> None:
+    try:
+        payload = json.loads(raw_body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        logger.warning("Linear delivery with unparseable body")
+        return
+
+    event_type = payload.get("type", "")
+    action = payload.get("action", "")
+
+    organization_id = str(payload.get("organizationId") or "")
+    if not organization_id:
+        logger.info("Linear %s delivery without organizationId; ignoring", event_type)
+        return
+
+    if event_type == "OAuthApp" and action == "revoked":
+        # The workspace revoked the app on Linear's side — the local
+        # credential must stop being used. Idempotent, so redelivery is
+        # harmless.
+        await revoke_credential_by_account(_PROVIDER, organization_id)
+        logger.info("Linear app revoked for organization %s; credential revoked", organization_id)
+        return
+
+    credential = await get_credential_by_account(_PROVIDER, organization_id)
+    if credential is None or credential.status != STATUS_ACTIVE:
+        logger.info(
+            "Linear %s delivery for unconnected organization %s; ignoring",
+            event_type,
+            organization_id,
+        )
+        return
+
+    if event_type == "AgentSessionEvent" and action in ("created", "prompted"):
+        # May be slow (search + LLM) — fine, we are already off the request
+        # path, and the session handler acks Linear's own 10-second window
+        # itself before doing that work.
+        await handle_agent_session(credential, payload)
+        return
+
+    if event_type == "Issue" and action in ("create", "update"):
+        await sync_issue(credential, payload.get("data") or {})
+        return
+
+    logger.debug(
+        "Linear %s/%s delivery for organization %s ignored", event_type, action, organization_id
+    )

--- a/cognee/modules/integrations/linear/linear_settings.py
+++ b/cognee/modules/integrations/linear/linear_settings.py
@@ -1,0 +1,44 @@
+from pydantic_settings import SettingsConfigDict
+
+from cognee.modules.integrations.base import IntegrationSettings
+
+
+class LinearSettings(IntegrationSettings):
+    """Configuration for the Linear agent integration.
+
+    One Linear OAuth app is installed into many workspaces; these values
+    identify that single app. Secrets default to empty strings rather than
+    failing at import so that deployments without Linear configured (and
+    unit tests) still boot — consumers call :func:`require` at use time
+    instead, which fails loudly per missing value.
+
+    ``client_id``/``client_secret``/``redirect_uri``/``frontend_base_url``
+    come from :class:`IntegrationSettings`; the field below is the one thing
+    a Linear agent app needs beyond that shape.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="LINEAR_", extra="ignore")
+
+    # Keys every inbound delivery's linear-signature HMAC. Also keys the
+    # OAuth state parameter — both are server-side-only uses of the same
+    # secret (same doubling-up as Slack's signing_secret and GitHub's
+    # webhook_secret). Env: LINEAR_WEBHOOK_SECRET
+    webhook_secret: str = ""
+
+
+linear_settings = LinearSettings()
+
+
+def require(field_name: str) -> str:
+    """Return a settings value, refusing to proceed when it is unset.
+
+    A missing Linear secret must never degrade into a signature check
+    against an empty key or a token exchange with empty app credentials —
+    both would fail in confusing, downstream ways instead of naming the
+    actual problem.
+    """
+    value = getattr(linear_settings, field_name)
+    if not value:
+        env_name = f"LINEAR_{field_name.upper()}"
+        raise RuntimeError(f"{env_name} is not configured")
+    return value

--- a/cognee/modules/integrations/linear/sync.py
+++ b/cognee/modules/integrations/linear/sync.py
@@ -1,0 +1,152 @@
+"""Sync a Linear workspace's issues into cognee memory as text.
+
+The textual mirror of the GitHub adapter's repository sync: where GitHub
+feeds clone URLs to the code-graph pipeline, Linear feeds a stable
+plain-text rendering of each issue to the ordinary ``remember()`` path, so
+issue history becomes searchable knowledge the agent (and any recall) can
+draw on. ``format_issue`` keeps that rendering deterministic — the same
+issue state always produces the same text, so re-syncs don't churn the
+graph with cosmetic differences.
+
+One dataset per workspace (``linear_<url_key>``), not per team or issue —
+same reasoning as GitHub's one-dataset-per-installation: per-item datasets
+would mean one isolated database per item under backend access control.
+
+Per-issue webhook syncs run with ``self_improvement=False``: ``improve()``
+is a whole-graph enrichment pass with LLM cost attached, far too heavy to
+fire on every issue edit — enrichment stays a human/scheduled decision, the
+webhook path just has to be cheap enough to run on every delivery.
+"""
+
+import logging
+import re
+from typing import Any
+
+from cognee.modules.integrations.linear.client import graphql
+from cognee.modules.integrations.models.IntegrationCredential import IntegrationCredential
+
+logger = logging.getLogger(__name__)
+
+LINEAR_DATASET_PREFIX = "linear"
+
+_RECENT_ISSUES_QUERY = """
+query RecentIssues($limit: Int!) {
+  issues(first: $limit, orderBy: updatedAt) {
+    nodes { id identifier title description url state { name } }
+  }
+}
+"""
+
+
+def dataset_name_for_org(url_key: str) -> str:
+    """The one dataset a workspace's issues land in."""
+    slug = re.sub(r"[^A-Za-z0-9_]+", "_", url_key).strip("_").lower()
+    return f"{LINEAR_DATASET_PREFIX}_{slug or 'workspace'}"
+
+
+def format_issue(issue: dict[str, Any]) -> str:
+    """A stable plain-text rendering of one issue.
+
+    Identifier, title, URL, state, description — nothing volatile (no
+    updated-at timestamps, no computed counts), so an unchanged issue always
+    renders to byte-identical text.
+    """
+    identifier = issue.get("identifier") or issue.get("id") or "unknown"
+    state_name = (issue.get("state") or {}).get("name") or "Unknown"
+
+    lines = [
+        f"Linear issue {identifier}: {issue.get('title') or ''}".rstrip(),
+        f"URL: {issue.get('url') or ''}",
+        f"State: {state_name}",
+    ]
+    description = issue.get("description")
+    if description:
+        lines.append(f"Description: {description}")
+    return "\n".join(lines)
+
+
+def _dataset_name(credential: IntegrationCredential) -> str:
+    url_key = (credential.provider_metadata or {}).get("organization_url_key") or str(
+        credential.provider_account_id
+    )
+    return dataset_name_for_org(url_key)
+
+
+async def sync_issue(credential: IntegrationCredential, issue: dict[str, Any]) -> None:
+    """Remember one issue's current text (webhook-driven create/update path).
+
+    Runs the ingestion to completion — callers are already off the request
+    path (webhook handling runs detached), so there is nothing to hand off
+    to.
+    """
+    # Imported here, not at module top: this module is imported at API
+    # startup (via the adapter registration), and cognee's package root is
+    # heavyweight.
+    from cognee.api.v1.remember.remember import remember as cognee_remember
+    from cognee.modules.users.methods import get_user
+
+    owner = await get_user(credential.user_id)
+    result = await cognee_remember(
+        format_issue(issue),
+        dataset_name=_dataset_name(credential),
+        user=owner,
+        # Per-issue webhook syncs must stay cheap; improve() is a
+        # human/scheduled decision (see module docstring).
+        self_improvement=False,
+    )
+    if getattr(result, "status", None) == "errored":
+        logger.warning(
+            "Linear issue sync for organization %s finished with errors: %s",
+            credential.provider_account_id,
+            getattr(result, "error", None),
+        )
+
+
+async def sync_recent_issues(credential: IntegrationCredential, limit: int = 50) -> None:
+    """Remember the workspace's most recently updated issues, one batch.
+
+    The post-install seed: gives the agent something to recall from on day
+    one, since webhooks only cover changes from now on. One ``remember()``
+    call for the whole batch, not one per issue — a single pipeline run over
+    the list is far cheaper than fifty.
+    """
+    # Imported here, not at module top: this module is imported at API
+    # startup (via the adapter registration), and cognee's package root is
+    # heavyweight.
+    from cognee.api.v1.remember.remember import remember as cognee_remember
+    from cognee.modules.users.methods import get_user
+
+    # Imported here, not at module top: the adapter imports this module to
+    # wire on_installed, so a top-level import back into it would be
+    # circular.
+    from cognee.modules.integrations.linear.adapter import access_token_for
+
+    data = await graphql(access_token_for(credential), _RECENT_ISSUES_QUERY, {"limit": limit})
+    issues = ((data.get("issues") or {}).get("nodes")) or []
+    if not issues:
+        logger.info("Linear organization %s has no issues to sync", credential.provider_account_id)
+        return
+
+    owner = await get_user(credential.user_id)
+    dataset_name = _dataset_name(credential)
+
+    logger.info(
+        "Syncing %d Linear issues for organization %s into dataset %s",
+        len(issues),
+        credential.provider_account_id,
+        dataset_name,
+    )
+    result = await cognee_remember(
+        [format_issue(issue) for issue in issues if issue],
+        dataset_name=dataset_name,
+        user=owner,
+        # Same stance as sync_issue: the initial seed should not silently
+        # spend an improve() pass either.
+        self_improvement=False,
+    )
+    if getattr(result, "status", None) == "errored":
+        logger.warning(
+            "Linear initial sync for organization %s finished with errors: %s",
+            credential.provider_account_id,
+            getattr(result, "error", None),
+        )

--- a/cognee/modules/integrations/linear/verify_linear_signature.py
+++ b/cognee/modules/integrations/linear/verify_linear_signature.py
@@ -1,0 +1,76 @@
+"""Linear webhook delivery verification.
+
+Every inbound delivery is authenticated by a hex HMAC-SHA256 over the raw
+body keyed with the app's webhook signing secret, compared against the
+``Linear-Signature`` header
+(https://linear.app/developers/webhooks#securing-webhooks).
+
+The check MUST run over the raw request bytes, before any parsing —
+re-serializing a parsed JSON body changes key order/escaping and breaks the
+HMAC (same rule as the Slack and GitHub verifiers). Unlike GitHub, Linear
+does carry replay protection: the payload's ``webhookTimestamp`` field (Unix
+milliseconds) is checked against a one-minute skew window, Linear's
+documented guidance. That field lives *inside* the body, so it is read only
+after the HMAC has authenticated the bytes — a timestamp from an unverified
+body proves nothing.
+"""
+
+import hashlib
+import hmac
+import json
+import time
+
+from fastapi import HTTPException, Request
+
+from cognee.modules.integrations.base import WebhookVerifier
+from cognee.modules.integrations.linear.linear_settings import require
+
+# Linear's documented replay-protection window: reject deliveries whose
+# webhookTimestamp differs from local time by more than a minute, so a
+# captured request cannot be replayed after the fact.
+_MAX_TIMESTAMP_SKEW_SECONDS = 60
+
+
+def is_valid_linear_signature(raw_body: bytes, signature: str) -> bool:
+    """Whether ``signature`` is an authentic Linear signature for ``raw_body``.
+
+    Pure function of its inputs — the verifier and the unit tests share it.
+    """
+    if not signature:
+        return False
+
+    expected = hmac.new(require("webhook_secret").encode(), raw_body, hashlib.sha256).hexdigest()
+    # compare_digest, not ==: a timing-safe comparison so the signature cannot
+    # be brute-forced byte by byte from response latencies.
+    return hmac.compare_digest(expected, signature)
+
+
+def has_fresh_webhook_timestamp(raw_body: bytes) -> bool:
+    """Whether ``raw_body`` carries a ``webhookTimestamp`` within the skew window.
+
+    Call only on a body whose HMAC already passed — parsing (and trusting a
+    timestamp from) unverified bytes would defeat the point of the guard.
+    A missing or malformed timestamp is rejected the same as a stale one.
+    """
+    try:
+        payload = json.loads(raw_body)
+        timestamp_ms = int(payload["webhookTimestamp"])
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return False
+
+    return abs(time.time() - timestamp_ms / 1000) <= _MAX_TIMESTAMP_SKEW_SECONDS
+
+
+class LinearWebhookVerifier(WebhookVerifier):
+    async def verify(self, request: Request) -> bytes:
+        raw_body = await request.body()
+        signature = request.headers.get("linear-signature", "")
+
+        if not is_valid_linear_signature(raw_body, signature):
+            raise HTTPException(status_code=401, detail="Invalid Linear signature")
+
+        # Only after the HMAC passed — see module docstring.
+        if not has_fresh_webhook_timestamp(raw_body):
+            raise HTTPException(status_code=401, detail="Stale Linear webhook timestamp")
+
+        return raw_body

--- a/cognee/modules/integrations/registry.py
+++ b/cognee/modules/integrations/registry.py
@@ -3,11 +3,12 @@
 Mirrors the ``supported_databases``/``use_vector_adapter`` seam already used
 by the graph and vector adapters: a plain module-level dict, populated by
 ``use_integration()`` at provider-package import time, never by this module
-importing providers itself. A provider that isn't installed (its ``pip``
-extra wasn't selected) simply never registers — callers get an unregistered
-``KeyError`` at lookup, not an import error at startup. See each provider's
-``__init__.py`` (e.g. Slack's) for the ``try/except ImportError`` guard that
-makes registration optional.
+importing providers itself. A provider package that is never imported simply
+never registers — callers get an unregistered ``KeyError`` at lookup, not an
+import error at startup. All in-tree providers (Slack, GitHub, Linear) use
+only core dependencies and register unconditionally from their
+``__init__.py``; an out-of-tree provider with optional dependencies would
+gate its own import instead.
 """
 
 from cognee.modules.integrations.base import OAuthIntegration

--- a/cognee/tests/unit/modules/integrations/test_app_registration.py
+++ b/cognee/tests/unit/modules/integrations/test_app_registration.py
@@ -1,20 +1,23 @@
-"""Confirms Slack actually self-registers when the real app is imported.
+"""Confirms real providers actually self-register when the real app is imported.
 
 Every other test in this package builds its own bare FastAPI app + a fake
 integration, which proves the router's generic logic works but never proves
 the wiring that gets a REAL provider registered at process startup — that
-only happens because something imports cognee.modules.integrations.slack
-(today, transitively, via cognee.api.v1.slack.routers -> handle_slack_command
--> ... -> the slack package's own __init__.py side effect). This test
-imports the real app object (not its lifespan — no DB/migrations run just
-from importing cognee.api.client) and checks the registry directly, so a
-future refactor that accidentally drops that import chain fails a test
-instead of only failing silently at runtime.
+only happens because something imports the provider package (Slack
+transitively via cognee.api.v1.slack.routers -> handle_slack_command -> ...
+-> the slack package's own __init__.py side effect; GitHub and Linear only
+via the bare ``import cognee.modules.integrations.<provider>  # noqa: F401``
+lines in cognee/api/client.py — exactly the kind of "unused" import a
+cleanup can silently drop). This test imports the real app object (not its
+lifespan — no DB/migrations run just from importing cognee.api.client) and
+checks the registry directly, so a future refactor that accidentally drops
+any of those import chains fails a test instead of only failing silently at
+runtime.
 """
 
 
-def test_slack_registers_itself_when_the_real_app_is_imported():
+def test_real_providers_register_themselves_when_the_real_app_is_imported():
     from cognee.api.client import app  # noqa: F401 - import side effect is the point
     from cognee.modules.integrations.registry import supported_integrations
 
-    assert "slack" in supported_integrations
+    assert {"slack", "github", "linear"} <= set(supported_integrations)

--- a/cognee/tests/unit/modules/integrations/test_handle_linear_event.py
+++ b/cognee/tests/unit/modules/integrations/test_handle_linear_event.py
@@ -1,0 +1,140 @@
+"""Unit tests for cognee.modules.integrations.linear.handle_linear_event.
+
+The credential store, the agent session handler, and the issue sync are
+mocked — what's under test is the routing: which deliveries revoke, which
+open an agent session, which sync an issue, and which are dropped (unknown
+or revoked organization, malformed body, unknown types) without raising,
+since the handler runs detached and Linear retries on errors.
+"""
+
+import importlib
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+handle_module = importlib.import_module("cognee.modules.integrations.linear.handle_linear_event")
+handle_linear_event = handle_module.handle_linear_event
+
+_ACTIVE_CREDENTIAL = SimpleNamespace(status="active", provider_account_id="org-1")
+
+
+@pytest.fixture
+def mocks(monkeypatch):
+    mocked = SimpleNamespace(
+        revoke=AsyncMock(return_value=True),
+        get_credential=AsyncMock(return_value=_ACTIVE_CREDENTIAL),
+        agent_session=AsyncMock(),
+        sync_issue=AsyncMock(),
+    )
+    monkeypatch.setattr(handle_module, "revoke_credential_by_account", mocked.revoke)
+    monkeypatch.setattr(handle_module, "get_credential_by_account", mocked.get_credential)
+    monkeypatch.setattr(handle_module, "handle_agent_session", mocked.agent_session)
+    monkeypatch.setattr(handle_module, "sync_issue", mocked.sync_issue)
+    return mocked
+
+
+def _body(payload: dict) -> bytes:
+    return json.dumps(payload).encode()
+
+
+@pytest.mark.asyncio
+async def test_unparseable_body_never_raises(mocks):
+    await handle_linear_event(b"not json", {"linear-event": "Issue"})
+
+    mocks.agent_session.assert_not_awaited()
+    mocks.sync_issue.assert_not_awaited()
+    mocks.revoke.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delivery_without_organization_id_is_dropped(mocks):
+    await handle_linear_event(_body({"type": "Issue", "action": "create"}), {})
+
+    mocks.get_credential.assert_not_awaited()
+    mocks.sync_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_organization_is_dropped(mocks):
+    mocks.get_credential.return_value = None
+
+    await handle_linear_event(
+        _body({"type": "Issue", "action": "create", "organizationId": "org-999", "data": {}}),
+        {},
+    )
+
+    mocks.sync_issue.assert_not_awaited()
+    mocks.agent_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_revoked_credential_is_dropped(mocks):
+    mocks.get_credential.return_value = SimpleNamespace(status="revoked")
+
+    await handle_linear_event(
+        _body({"type": "Issue", "action": "create", "organizationId": "org-1", "data": {}}),
+        {},
+    )
+
+    mocks.sync_issue.assert_not_awaited()
+    mocks.agent_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_oauth_app_revoked_revokes_the_credential(mocks):
+    await handle_linear_event(
+        _body({"type": "OAuthApp", "action": "revoked", "organizationId": "org-1"}),
+        {},
+    )
+
+    mocks.revoke.assert_awaited_once_with("linear", "org-1")
+    mocks.agent_session.assert_not_awaited()
+    mocks.sync_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["created", "prompted"])
+async def test_agent_session_events_dispatch_to_the_session_handler(mocks, action):
+    payload = {
+        "type": "AgentSessionEvent",
+        "action": action,
+        "organizationId": "org-1",
+        "agentSession": {"id": "sess-1"},
+    }
+
+    await handle_linear_event(_body(payload), {})
+
+    mocks.agent_session.assert_awaited_once_with(_ACTIVE_CREDENTIAL, payload)
+    mocks.sync_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["create", "update"])
+async def test_issue_events_dispatch_to_sync_issue(mocks, action):
+    issue = {"identifier": "COG-1", "title": "Fix login"}
+
+    await handle_linear_event(
+        _body({"type": "Issue", "action": action, "organizationId": "org-1", "data": issue}),
+        {},
+    )
+
+    mocks.sync_issue.assert_awaited_once_with(_ACTIVE_CREDENTIAL, issue)
+    mocks.agent_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_event_types_are_ignored(mocks):
+    # Issue deletions included: deleting indexed data on a webhook would be
+    # a silent destructive surprise — forget() stays a human decision.
+    for payload in (
+        {"type": "Issue", "action": "remove", "organizationId": "org-1", "data": {}},
+        {"type": "Comment", "action": "create", "organizationId": "org-1", "data": {}},
+        {"type": "AgentSessionEvent", "action": "closed", "organizationId": "org-1"},
+    ):
+        await handle_linear_event(_body(payload), {})
+
+    mocks.agent_session.assert_not_awaited()
+    mocks.sync_issue.assert_not_awaited()
+    mocks.revoke.assert_not_awaited()

--- a/cognee/tests/unit/modules/integrations/test_linear_adapter.py
+++ b/cognee/tests/unit/modules/integrations/test_linear_adapter.py
@@ -1,0 +1,217 @@
+"""Unit tests for cognee.modules.integrations.linear.adapter.
+
+Network calls (code exchange, install-context GraphQL query, token revoke)
+are mocked at the aiohttp/client seam — what's under test is the install
+flow: the agent-install authorize URL, the identity-enriching callback, the
+secret/metadata split in parse_installation, and revoke_remote's never-raise
+contract.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from cognee.modules.integrations.linear import adapter as adapter_module
+from cognee.modules.integrations.linear.adapter import LinearIntegration
+from cognee.modules.integrations.linear.verify_linear_signature import LinearWebhookVerifier
+
+_TOKEN_RESPONSE = {
+    "access_token": "lin_oauth_tok",
+    "refresh_token": "lin_refresh_tok",
+    "token_type": "Bearer",
+    "expires_in": 86400,
+    "scope": "read,write,app:assignable,app:mentionable",
+}
+
+_INSTALL_CONTEXT = {
+    "viewer": {"id": "app-user-1", "name": "cognee-agent"},
+    "organization": {"id": "org-1", "name": "Acme Co", "urlKey": "acme-co"},
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings(monkeypatch):
+    settings = "cognee.modules.integrations.linear.linear_settings.linear_settings"
+    monkeypatch.setattr(f"{settings}.client_id", "lin_client")
+    monkeypatch.setattr(f"{settings}.client_secret", "shhh")
+    monkeypatch.setattr(
+        f"{settings}.redirect_uri", "http://localhost:8000/api/v1/integrations/linear/callback"
+    )
+    monkeypatch.setattr(f"{settings}.webhook_secret", "hook-secret")
+    monkeypatch.setattr(f"{settings}.frontend_base_url", "http://localhost:3000")
+
+
+class _FakeResponse:
+    def __init__(self, status=200, payload=None):
+        self.status = status
+        self._payload = payload if payload is not None else {}
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, response=None, post_error=None):
+        self._response = response
+        self._post_error = post_error
+        self.post_calls = []
+
+    def post(self, url, **kwargs):
+        if self._post_error is not None:
+            raise self._post_error
+        self.post_calls.append((url, kwargs))
+        return self._response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+def _fake_aiohttp(monkeypatch, session):
+    fake = SimpleNamespace(
+        ClientSession=lambda **_kwargs: session,
+        ClientTimeout=lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(adapter_module, "aiohttp", fake)
+    return session
+
+
+def test_authorize_url_is_the_agent_install_flow():
+    url = LinearIntegration().authorize_url("the-state")
+    scheme_host_path, query = url.split("?", 1)
+
+    assert scheme_host_path == "https://linear.app/oauth/authorize"
+    params = parse_qs(urlsplit(url).query)
+    assert params["client_id"] == ["lin_client"]
+    assert params["response_type"] == ["code"]
+    assert params["state"] == ["the-state"]
+    # actor=app is what makes this an agent install (an app user in the
+    # workspace) rather than acting as the authorizing human.
+    assert params["actor"] == ["app"]
+    assert params["scope"] == ["read,write,app:assignable,app:mentionable"]
+
+
+def test_state_signing_secret_is_the_webhook_secret():
+    assert LinearIntegration().state_signing_secret() == "hook-secret"
+
+
+def test_webhook_verifier_is_registered():
+    assert isinstance(LinearIntegration().webhook_verifier(), LinearWebhookVerifier)
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_rejects_a_response_without_access_token(monkeypatch):
+    _fake_aiohttp(monkeypatch, _FakeSession(_FakeResponse(200, {"token_type": "Bearer"})))
+
+    with pytest.raises(RuntimeError, match="no access_token"):
+        await LinearIntegration().exchange_code("the-code")
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_rejects_a_non_200_response(monkeypatch):
+    _fake_aiohttp(monkeypatch, _FakeSession(_FakeResponse(500)))
+
+    with pytest.raises(RuntimeError, match="HTTP 500"):
+        await LinearIntegration().exchange_code("the-code")
+
+
+@pytest.mark.asyncio
+async def test_exchange_callback_merges_workspace_identity_into_the_token_response():
+    integration = LinearIntegration()
+    with (
+        patch.object(
+            integration, "exchange_code", new=AsyncMock(return_value=dict(_TOKEN_RESPONSE))
+        ),
+        patch.object(
+            adapter_module, "graphql", new=AsyncMock(return_value=_INSTALL_CONTEXT)
+        ) as graphql,
+    ):
+        result = await integration.exchange_callback("the-code", {})
+
+    # The fresh token is spent on the install-context query so the sync
+    # parse_installation can key the credential on the organization id.
+    assert graphql.await_args.args[0] == "lin_oauth_tok"
+    assert result["access_token"] == "lin_oauth_tok"
+    assert result["viewer"] == _INSTALL_CONTEXT["viewer"]
+    assert result["organization"] == _INSTALL_CONTEXT["organization"]
+
+
+def test_parse_installation_splits_secrets_from_metadata():
+    installation = LinearIntegration().parse_installation({**_TOKEN_RESPONSE, **_INSTALL_CONTEXT})
+
+    assert installation.provider_account_id == "org-1"
+    # Token material lives ONLY in the encrypted payload; the queryable
+    # metadata carries identity, never secrets.
+    assert installation.token_payload == {
+        "access_token": "lin_oauth_tok",
+        "refresh_token": "lin_refresh_tok",
+    }
+    assert installation.provider_metadata == {
+        "app_user_id": "app-user-1",
+        "app_user_name": "cognee-agent",
+        "organization_name": "Acme Co",
+        "organization_url_key": "acme-co",
+        "scope": "read,write,app:assignable,app:mentionable",
+    }
+    assert installation.account_label == "Acme Co"
+    assert installation.auth_type == "oauth2"
+    assert installation.token_expires_at is not None
+
+
+def test_parse_installation_without_refresh_token_stores_only_the_access_token():
+    token_response = {**_TOKEN_RESPONSE, **_INSTALL_CONTEXT}
+    del token_response["refresh_token"]
+
+    installation = LinearIntegration().parse_installation(token_response)
+
+    assert installation.token_payload == {"access_token": "lin_oauth_tok"}
+
+
+def test_parse_installation_without_organization_id_raises():
+    with pytest.raises(ValueError, match="organization"):
+        LinearIntegration().parse_installation(dict(_TOKEN_RESPONSE))
+    with pytest.raises(ValueError, match="organization"):
+        LinearIntegration().parse_installation(
+            {**_TOKEN_RESPONSE, "organization": {"name": "Acme Co"}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_revoke_remote_never_raises_on_network_failure(monkeypatch):
+    monkeypatch.setattr(adapter_module, "access_token_for", lambda _credential: "lin_oauth_tok")
+    _fake_aiohttp(monkeypatch, _FakeSession(post_error=ConnectionError("network down")))
+
+    # Best-effort by contract: a network blip must never block a disconnect.
+    await LinearIntegration().revoke_remote(SimpleNamespace(provider_account_id="org-1"))
+
+
+@pytest.mark.asyncio
+async def test_revoke_remote_never_raises_on_a_non_200_response(monkeypatch):
+    monkeypatch.setattr(adapter_module, "access_token_for", lambda _credential: "lin_oauth_tok")
+    session = _fake_aiohttp(monkeypatch, _FakeSession(_FakeResponse(401)))
+
+    await LinearIntegration().revoke_remote(SimpleNamespace(provider_account_id="org-1"))
+
+    (url, kwargs) = session.post_calls[0]
+    assert url == "https://api.linear.app/oauth/revoke"
+    assert kwargs["headers"] == {"Authorization": "Bearer lin_oauth_tok"}
+
+
+@pytest.mark.asyncio
+async def test_revoke_remote_never_raises_on_an_unusable_credential(monkeypatch):
+    def _boom(_credential):
+        raise RuntimeError("holds no access token")
+
+    monkeypatch.setattr(adapter_module, "access_token_for", _boom)
+
+    await LinearIntegration().revoke_remote(SimpleNamespace(provider_account_id="org-1"))

--- a/cognee/tests/unit/modules/integrations/test_linear_agent_session.py
+++ b/cognee/tests/unit/modules/integrations/test_linear_agent_session.py
@@ -1,0 +1,138 @@
+"""Unit tests for cognee.modules.integrations.linear.agent_session.
+
+The Linear activity client, cognee search, and the user lookup are mocked —
+what's under test is the turn protocol: the acknowledgement thought is
+posted BEFORE any search work (Linear's 10-second responsiveness contract),
+every turn ends in a response or error activity, the question is resolved
+per event shape, and refusal-only results degrade to the friendly
+no-information response instead of parroting a refusal.
+"""
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+session_module = importlib.import_module("cognee.modules.integrations.linear.agent_session")
+adapter_module = importlib.import_module("cognee.modules.integrations.linear.adapter")
+
+handle_agent_session = session_module.handle_agent_session
+
+_USER_ID = uuid4()
+
+
+def _credential(**overrides):
+    defaults = {
+        "status": "active",
+        "provider_account_id": "org-1",
+        "provider_metadata": {"organization_url_key": "acme-co"},
+        "user_id": _USER_ID,
+    }
+    return SimpleNamespace(**{**defaults, **overrides})
+
+
+def _created_payload(question="Where is auth handled?"):
+    return {
+        "type": "AgentSessionEvent",
+        "action": "created",
+        "organizationId": "org-1",
+        "agentSession": {"id": "sess-1", "comment": {"body": question}},
+    }
+
+
+def _prompted_payload(question="What changed in the API?"):
+    return {
+        "type": "AgentSessionEvent",
+        "action": "prompted",
+        "organizationId": "org-1",
+        "agentSession": {"id": "sess-1"},
+        "agentActivity": {"body": question},
+    }
+
+
+@pytest.fixture
+def mocks(monkeypatch):
+    owner = SimpleNamespace(id=_USER_ID)
+    calls = []
+    mocked = SimpleNamespace(
+        owner=owner,
+        calls=calls,
+        search_results=[{"search_result": ["The answer."]}],
+    )
+
+    async def _record_activity(access_token, agent_session_id, content):
+        calls.append(("activity", content["type"], content["body"]))
+
+    async def _record_search(**_kwargs):
+        calls.append(("search",))
+        return mocked.search_results
+
+    mocked.activity = AsyncMock(side_effect=_record_activity)
+    mocked.search = AsyncMock(side_effect=_record_search)
+    mocked.get_user = AsyncMock(return_value=owner)
+
+    monkeypatch.setattr(session_module, "create_agent_activity", mocked.activity)
+    monkeypatch.setattr(session_module, "cognee_search", mocked.search)
+    monkeypatch.setattr(session_module, "get_user", mocked.get_user)
+    # Imported lazily inside handle_agent_session, so patched at its home.
+    monkeypatch.setattr(adapter_module, "access_token_for", lambda _credential: "lin_tok")
+    return mocked
+
+
+@pytest.mark.asyncio
+async def test_created_acks_with_a_thought_before_any_search_runs(mocks):
+    await handle_agent_session(_credential(), _created_payload())
+
+    # The 10-second contract: the thought MUST precede the search, and the
+    # turn must end in a response.
+    assert [call[:2] for call in mocks.calls] == [
+        ("activity", "thought"),
+        ("search",),
+        ("activity", "response"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_created_answers_with_the_search_result(mocks):
+    await handle_agent_session(_credential(), _created_payload())
+
+    kind, activity_type, body = mocks.calls[-1]
+    assert (kind, activity_type) == ("activity", "response")
+    assert body == "The answer."
+    assert mocks.search.await_args.kwargs["query_text"] == "Where is auth handled?"
+    assert mocks.search.await_args.kwargs["user"] is mocks.owner
+    assert mocks.search.await_args.kwargs["datasets"] is None
+
+
+@pytest.mark.asyncio
+async def test_prompted_takes_the_question_from_the_agent_activity_body(mocks):
+    await handle_agent_session(_credential(), _prompted_payload("What changed in the API?"))
+
+    assert mocks.search.await_args.kwargs["query_text"] == "What changed in the API?"
+    assert mocks.calls[-1][:2] == ("activity", "response")
+
+
+@pytest.mark.asyncio
+async def test_search_failure_ends_the_turn_in_an_error_activity_without_raising(mocks):
+    mocks.search.side_effect = RuntimeError("search exploded")
+
+    await handle_agent_session(_credential(), _created_payload())
+
+    kind, activity_type, _body = mocks.calls[-1]
+    assert (kind, activity_type) == ("activity", "error")
+
+
+@pytest.mark.asyncio
+async def test_refusal_only_results_produce_the_no_information_response(mocks):
+    mocks.search_results = [
+        {"search_result": ["I cannot answer this from the given context."]},
+        {"search_result": ["The text does not contain information about auth."]},
+    ]
+
+    await handle_agent_session(_credential(), _created_payload())
+
+    kind, activity_type, body = mocks.calls[-1]
+    assert (kind, activity_type) == ("activity", "response")
+    assert body == "No relevant information found in cognee memory."

--- a/cognee/tests/unit/modules/integrations/test_linear_sync.py
+++ b/cognee/tests/unit/modules/integrations/test_linear_sync.py
@@ -1,0 +1,134 @@
+"""Unit tests for cognee.modules.integrations.linear.sync.
+
+The GraphQL client and remember()/get_user() are mocked — what's under test
+is the orchestration: one dataset per workspace, deterministic issue text,
+webhook syncs kept cheap with self_improvement=False, and the post-install
+seed batching every issue into ONE remember() call.
+"""
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+sync_module = importlib.import_module("cognee.modules.integrations.linear.sync")
+adapter_module = importlib.import_module("cognee.modules.integrations.linear.adapter")
+
+# The remember package's __init__ rebinds `remember` to the function,
+# shadowing the submodule — string-target monkeypatching resolves the
+# function and fails. Importing the submodule explicitly sidesteps it (same
+# workaround as test_github_sync.py).
+_remember_module = importlib.import_module("cognee.api.v1.remember.remember")
+_users_methods = importlib.import_module("cognee.modules.users.methods")
+
+_USER_ID = uuid4()
+
+_ISSUE = {
+    "id": "issue-uuid-1",
+    "identifier": "COG-1",
+    "title": "Fix login",
+    "description": "Users cannot log in.",
+    "url": "https://linear.app/acme-co/issue/COG-1",
+    "state": {"name": "In Progress"},
+}
+
+
+def _credential(**overrides):
+    defaults = {
+        "status": "active",
+        "provider_account_id": "org-1",
+        "provider_metadata": {"organization_url_key": "Acme-Co"},
+        "user_id": _USER_ID,
+    }
+    return SimpleNamespace(**{**defaults, **overrides})
+
+
+@pytest.fixture
+def mocks(monkeypatch):
+    owner = SimpleNamespace(id=_USER_ID)
+    mocked = SimpleNamespace(
+        graphql=AsyncMock(return_value={"issues": {"nodes": [_ISSUE]}}),
+        remember=AsyncMock(return_value=SimpleNamespace(status="completed", error=None)),
+        get_user=AsyncMock(return_value=owner),
+        owner=owner,
+    )
+    monkeypatch.setattr(sync_module, "graphql", mocked.graphql)
+    # Patched at their home modules: sync imports both lazily.
+    monkeypatch.setattr(_remember_module, "remember", mocked.remember)
+    monkeypatch.setattr(_users_methods, "get_user", mocked.get_user)
+    # Imported lazily inside sync_recent_issues (circular-import seam).
+    monkeypatch.setattr(adapter_module, "access_token_for", lambda _credential: "lin_tok")
+    return mocked
+
+
+def test_dataset_name_is_one_per_workspace_and_identifier_safe():
+    assert sync_module.dataset_name_for_org("Acme-Co") == "linear_acme_co"
+    assert sync_module.dataset_name_for_org("my.workspace") == "linear_my_workspace"
+    assert sync_module.dataset_name_for_org("---") == "linear_workspace"
+
+
+def test_format_issue_renders_stable_plain_text():
+    assert sync_module.format_issue(_ISSUE) == (
+        "Linear issue COG-1: Fix login\n"
+        "URL: https://linear.app/acme-co/issue/COG-1\n"
+        "State: In Progress\n"
+        "Description: Users cannot log in."
+    )
+
+
+def test_format_issue_omits_an_absent_description_and_tolerates_gaps():
+    assert sync_module.format_issue({"identifier": "COG-2", "title": "Add SSO"}) == (
+        "Linear issue COG-2: Add SSO\nURL: \nState: Unknown"
+    )
+    # Identifier falls back to the id, then to a placeholder.
+    assert sync_module.format_issue({}).startswith("Linear issue unknown")
+
+
+@pytest.mark.asyncio
+async def test_sync_issue_remembers_into_the_workspace_dataset(mocks):
+    await sync_module.sync_issue(_credential(), _ISSUE)
+
+    mocks.remember.assert_awaited_once_with(
+        sync_module.format_issue(_ISSUE),
+        dataset_name="linear_acme_co",
+        user=mocks.owner,
+        # Webhook syncs must stay cheap: no improve() pass per issue edit.
+        self_improvement=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_issue_falls_back_to_the_organization_id_dataset(mocks):
+    await sync_module.sync_issue(_credential(provider_metadata=None), _ISSUE)
+
+    assert mocks.remember.await_args.kwargs["dataset_name"] == "linear_org_1"
+
+
+@pytest.mark.asyncio
+async def test_sync_recent_issues_batches_one_remember_call(mocks):
+    second_issue = {**_ISSUE, "id": "issue-uuid-2", "identifier": "COG-2", "title": "Add SSO"}
+    mocks.graphql.return_value = {"issues": {"nodes": [_ISSUE, second_issue]}}
+
+    await sync_module.sync_recent_issues(_credential())
+
+    mocks.graphql.assert_awaited_once()
+    assert mocks.graphql.await_args.args[0] == "lin_tok"
+    assert mocks.graphql.await_args.args[2] == {"limit": 50}
+    # One pipeline run over the whole batch, not one per issue.
+    mocks.remember.assert_awaited_once_with(
+        [sync_module.format_issue(_ISSUE), sync_module.format_issue(second_issue)],
+        dataset_name="linear_acme_co",
+        user=mocks.owner,
+        self_improvement=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_recent_issues_with_no_issues_remembers_nothing(mocks):
+    mocks.graphql.return_value = {"issues": {"nodes": []}}
+
+    await sync_module.sync_recent_issues(_credential())
+
+    mocks.remember.assert_not_awaited()

--- a/cognee/tests/unit/modules/integrations/test_verify_linear_signature.py
+++ b/cognee/tests/unit/modules/integrations/test_verify_linear_signature.py
@@ -1,0 +1,128 @@
+"""Unit tests for cognee.modules.integrations.linear.verify_linear_signature.
+
+No DB, no network — the request is a stub with raw bytes and headers. The
+invariants that matter: only a hex HMAC-SHA256 keyed with the webhook secret
+over the exact raw bytes passes; the body's ``webhookTimestamp`` replay
+guard runs strictly AFTER the HMAC (a timestamp from unverified bytes proves
+nothing); and a stale/missing timestamp is a 401 even with a valid HMAC.
+"""
+
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+from fastapi import HTTPException
+
+from cognee.modules.integrations.linear.verify_linear_signature import (
+    LinearWebhookVerifier,
+    has_fresh_webhook_timestamp,
+    is_valid_linear_signature,
+)
+
+_SECRET = "It's a Secret to Everybody"
+
+
+@pytest.fixture(autouse=True)
+def _webhook_secret(monkeypatch):
+    monkeypatch.setattr(
+        "cognee.modules.integrations.linear.linear_settings.linear_settings.webhook_secret",
+        _SECRET,
+    )
+
+
+def _sign(body: bytes, secret: str = _SECRET) -> str:
+    # Linear signs the raw body as bare hex — no sha256= prefix.
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _body(timestamp_ms=...) -> bytes:
+    payload = {"type": "Issue", "action": "create", "organizationId": "org-1"}
+    if timestamp_ms is ...:
+        timestamp_ms = int(time.time() * 1000)
+    if timestamp_ms is not None:
+        payload["webhookTimestamp"] = timestamp_ms
+    return json.dumps(payload).encode()
+
+
+class _FakeRequest:
+    def __init__(self, raw_body: bytes, headers: dict):
+        self._raw_body = raw_body
+        self.headers = headers
+
+    async def body(self) -> bytes:
+        return self._raw_body
+
+
+def test_valid_signature_passes():
+    body = _body()
+    assert is_valid_linear_signature(body, _sign(body))
+
+
+def test_tampered_body_fails():
+    signature = _sign(b'{"action":"create"}')
+    assert not is_valid_linear_signature(b'{"action":"remove"}', signature)
+
+
+def test_wrong_secret_fails():
+    body = _body()
+    assert not is_valid_linear_signature(body, _sign(body, secret="other-secret"))
+
+
+def test_missing_signature_fails():
+    assert not is_valid_linear_signature(_body(), "")
+    assert not is_valid_linear_signature(_body(), None)
+
+
+def test_stale_timestamp_is_not_fresh():
+    two_minutes_ago = int((time.time() - 120) * 1000)
+    assert not has_fresh_webhook_timestamp(_body(two_minutes_ago))
+
+
+def test_missing_or_malformed_timestamp_is_not_fresh():
+    # A delivery without replay protection is unverifiable, same as stale.
+    assert not has_fresh_webhook_timestamp(_body(None))
+    assert not has_fresh_webhook_timestamp(b"not json")
+
+
+@pytest.mark.asyncio
+async def test_verify_returns_the_raw_body_on_a_valid_delivery():
+    body = _body()
+    request = _FakeRequest(body, {"linear-signature": _sign(body)})
+
+    assert await LinearWebhookVerifier().verify(request) == body
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_a_missing_signature_header():
+    request = _FakeRequest(_body(), {})
+
+    with pytest.raises(HTTPException) as excinfo:
+        await LinearWebhookVerifier().verify(request)
+    assert excinfo.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_a_stale_timestamp_even_with_a_valid_hmac():
+    body = _body(int((time.time() - 120) * 1000))
+    request = _FakeRequest(body, {"linear-signature": _sign(body)})
+
+    with pytest.raises(HTTPException) as excinfo:
+        await LinearWebhookVerifier().verify(request)
+    assert excinfo.value.status_code == 401
+    assert "timestamp" in excinfo.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_verify_checks_the_hmac_before_reading_the_timestamp():
+    # A bad signature with a stale timestamp must report the SIGNATURE
+    # failure: the timestamp lives inside the body, and parsing (let alone
+    # trusting) unverified bytes would defeat the guard.
+    body = _body(int((time.time() - 120) * 1000))
+    request = _FakeRequest(body, {"linear-signature": _sign(body, secret="other-secret")})
+
+    with pytest.raises(HTTPException) as excinfo:
+        await LinearWebhookVerifier().verify(request)
+    assert excinfo.value.status_code == 401
+    assert "signature" in excinfo.value.detail.lower()


### PR DESCRIPTION
## Description

Adds a **Linear integration** to cognee core, built on the same `OAuthIntegration` seam as the Slack and GitHub providers, using Linear's agentic setup — cognee installs as an **agent (app user)** in the workspace rather than a plain OAuth app.

Closes COG-6323 (related: CLO-498).

### What it does

- **OAuth install as an agent** — `actor=app` with `read,write,app:assignable,app:mentionable` scopes, so the cognee agent can be @mentioned and delegated issues. The workspace (organization) id becomes the credential's `provider_account_id`, which is how webhook deliveries route back (every Linear envelope carries `organizationId`). The callback enriches the token exchange with a `viewer`/`organization` GraphQL query so `parse_installation` stays sync.
- **Agent sessions (the centerpiece)** — on `AgentSessionEvent` (`created` from a mention/delegation, `prompted` from a follow-up), the handler posts a `thought` activity **first** to satisfy Linear's 10-second acknowledgement rule, then runs `HYBRID_COMPLETION` search across the owner's cognee memory and replies with a `response` activity via `agentActivityCreate`. Any failure posts an `error` activity so a session never hangs.
- **Webhook security** — HMAC-SHA256 over the raw body against the `linear-signature` header (constant-time compare), plus a 60-second `webhookTimestamp` replay guard checked only after the HMAC passes.
- **Issue sync** — issue create/update webhooks and an install-time backfill flow issues into a `linear_<org>` dataset via `remember()` (`self_improvement=False` so webhook-driven syncs stay cheap); app-revoked events revoke the local credential. Unlike GitHub, `revoke_remote` is actually implemented — Linear's revoke endpoint is cheap and non-destructive.

### Structure

New package `cognee/modules/integrations/linear/` (~920 lines), mirroring `github/` file-for-file: `linear_settings.py`, `verify_linear_signature.py`, `client.py` (GraphQL helper), `adapter.py`, `handle_linear_event.py`, `agent_session.py`, `sync.py`. No router changes — the generic `/{provider}/authorize|callback|events` routes cover it. Wiring: registration import in `cognee/api/client.py` and a `LINEAR_*` section in `.env.template`.

Also aligns surrounding docs with reality: the registry docstring and `.env.template` banner no longer describe a conditional registration guard that never existed, and the app-registration test now covers all three providers.

### Testing

- 44 new unit tests in `cognee/tests/unit/modules/integrations/` (`test_linear_adapter`, `test_verify_linear_signature`, `test_handle_linear_event`, `test_linear_agent_session`, `test_linear_sync`), mirroring the github/slack test conventions — all network and cognee-search calls mocked.
- Full integrations suite green: **276 passed** (slack, github, linear).
- `ruff format` / `ruff check` clean.

### Setup (for reviewers who want to try it)

Create a Linear OAuth app with agent capabilities and "Agent session events" webhooks enabled, point the webhook URL at `POST /api/v1/integrations/linear/events`, set `LINEAR_CLIENT_ID/CLIENT_SECRET/WEBHOOK_SECRET/REDIRECT_URI/FRONTEND_BASE_URL`, and connect from the integrations page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)