### PR TITLE
docs: remove stray colon in README translations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Cognee is the open-source AI memory platform that gives AI agents persistent lon
 
   <p align="center">
   🌐 This README is also available in:
-  :
   <!-- Keep these links. Translations will automatically update with the README. -->
   <a href="https://www.readme-i18n.com/topoteretes/cognee?lang=de">Deutsch</a> |
   <a href="https://www.readme-i18n.com/topoteretes/cognee?lang=es">Español</a> |


### PR DESCRIPTION
## What
Removed a lone `:` line in the "This README is also available in:" block that
rendered as a stray colon above the language links.

## Why
Leftover from editing — the sentence already ends with a colon on the previous
line.

## How verified
Confirmed the surrounding block renders cleanly with no duplicate punctuation.