### PR TITLE
SDK-471 docs: fix dead OpenRouter model id in .env.template, document embeddings

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -838,11 +838,32 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #EMBEDDING_DIMENSIONS=768
 #HUGGINGFACE_TOKENIZER="nomic-ai/nomic-embed-text-v1.5"
 
-########## OpenRouter (also free) #############################################
-#LLM_API_KEY="<<go-get-one-yourself"
+########## OpenRouter (has a free tier) #######################################
+# One API key, hundreds of models. Get a key at https://openrouter.ai/keys.
+# Model ids change over time — OpenRouter adds and retires models, and the
+# free (":free") tier rotates especially fast — so treat the id below as an
+# example and confirm a current one before using it:
+#   curl -s https://openrouter.ai/api/v1/models | jq -r '.data[].id'
+# Prefix the slug you pick with "openrouter/" so LiteLLM routes it.
+#LLM_API_KEY="sk-or-..."
 #LLM_PROVIDER="custom"
-#LLM_MODEL="openrouter/google/gemini-2.0-flash-lite-preview-02-05:free"
+#LLM_MODEL="openrouter/deepseek/deepseek-r1"
 #LLM_ENDPOINT="https://openrouter.ai/api/v1"
+# Embeddings must be configured too. Setting only the LLM_* vars above leaves
+# EMBEDDING_* on the OpenAI defaults, so the LLM connects fine and ingestion
+# then fails at embedding time on a missing or invalid OpenAI key.
+# OpenRouter does serve embedding models, but they are a separate catalogue —
+# the /models call above does NOT list them. List them with:
+#   curl -s https://openrouter.ai/api/v1/embeddings/models | jq -r '.data[].id'
+# Pointing EMBEDDING_* at OpenAI or a local provider instead works just as
+# well. EMBEDDING_DIMENSIONS must be set explicitly: "custom" models are not
+# in the auto-derive registry and otherwise fall back to 3072, which causes a
+# vector-store shape mismatch. Leave EMBEDDING_ENDPOINT unset — the
+# "openrouter/" prefix already tells LiteLLM the base URL.
+#EMBEDDING_PROVIDER="custom"
+#EMBEDDING_MODEL="openrouter/openai/text-embedding-3-small"
+#EMBEDDING_API_KEY="sk-or-..."
+#EMBEDDING_DIMENSIONS=1536
 
 ########## DeepInfra ##########################################################
 #LLM_API_KEY="<<>>"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,10 +462,14 @@ HUGGINGFACE_TOKENIZER="nomic-ai/nomic-embed-text-v1.5"
 #### Custom / OpenRouter / vLLM
 ```bash
 LLM_PROVIDER="custom"
-LLM_MODEL="openrouter/google/gemini-2.0-flash-lite-preview-02-05:free"
+LLM_MODEL="openrouter/deepseek/deepseek-r1"
 LLM_ENDPOINT="https://openrouter.ai/api/v1"
 LLM_API_KEY="your_api_key"
 ```
+OpenRouter model ids change over time (the `:free` tier especially) — check
+`https://openrouter.ai/api/v1/models` for a current slug. Embeddings are a
+separate catalogue at `https://openrouter.ai/api/v1/embeddings/models` and
+must be configured separately; see the OpenRouter block in `.env.template`.
 
 #### AWS Bedrock (requires aws extra)
 ```bash


### PR DESCRIPTION
Fixes #3661. Linear: [SDK-471](https://linear.app/cognee/issue/SDK-471/envtemplate-replace-dead-openrouter-model-id-and-document-the)

Documentation only — `.env.template` and `CLAUDE.md`. No code changes.

## Two defects in the OpenRouter recipe

**1. The example model id is dead.**

```
LLM_MODEL="openrouter/google/gemini-2.0-flash-lite-preview-02-05:free"
```

Checked against OpenRouter's live catalogue (`GET /api/v1/models`, 419 models): neither that id nor the base `google/gemini-2.0-flash-lite` is there. Copying the block verbatim fails on the first LLM call — which is what the issue reporter hit.

Pinning any `:free` id is the underlying mistake, not just this one slug: OpenRouter rotates that tier fast, so the same bug would reappear. The block now uses `openrouter/deepseek/deepseek-r1` (live today) and tells the reader to confirm a current slug against the catalogue rather than trust the example.

**2. The block configured only half of what cognee needs.**

It set `LLM_*` and stopped, leaving `EMBEDDING_*` on the OpenAI defaults. The resulting failure mode — reported in the issue and confirmed by two other commenters — is that the LLM connects, setup looks complete, and ingestion crashes much later at embedding init on a missing OpenAI key. The embedding variables exist in the template, but in separate sections far away.

The block now carries the embedding half too, with:
- `EMBEDDING_DIMENSIONS=1536` and why it must be explicit (`custom` models aren't in the auto-derive registry; the silent `3072` fallback causes a vector-store shape mismatch)
- a note that `EMBEDDING_ENDPOINT` stays unset, since the `openrouter/` prefix already supplies the base URL to LiteLLM

## On OpenRouter embeddings

Worth flagging, because the issue thread and my own first reading both got this wrong: **OpenRouter does serve embedding models.** They are a separate catalogue that `/api/v1/models` does not return.

```
GET https://openrouter.ai/api/v1/embeddings/models   →   33 models
```

including `openai/text-embedding-3-small` (used in the recipe), `text-embedding-3-large`, `baai/bge-*`, `qwen/qwen3-embedding-*`, `voyageai/voyage-4*`.

So the existing `EMBEDDING_PROVIDER="custom"` + `openrouter/` recipe in the docs is correct and stays. It's also consistent with #4195 (SDK-311, fixes #3660), the `encoding_format` fix — that guard exists precisely because OpenRouter embedding requests are a real, working path.

The template says the two catalogues are separate explicitly, otherwise a user who checks `/api/v1/models` for an embedding model finds nothing and reasonably concludes there are none.

## Left alone on purpose

Two other hits for the dead id string:

- `cognee/tests/unit/infrastructure/llm/test_llm_config.py` — uses `openrouter/google/gemini-2.0-flash-lite` as a prefix-routing fixture for `ProviderNotDeducibleError`. Never reaches the network, so a retired id is harmless.
- `cognee/modules/session_lifecycle/usage_tracking.py:108` — a `gemini-2.0-flash-lite` pricing-table entry, unrelated to OpenRouter.

## Verified

- `openrouter/deepseek/deepseek-r1` — present in `/api/v1/models`
- `openai/text-embedding-3-small` — present in `/api/v1/embeddings/models`
- `google/gemini-2.0-flash-lite-preview-02-05:free` — absent from both

Not verified: a live embedding call through OpenRouter (needs a funded key).

Companion cognee-docs PR updates the same dead id in `setup-configuration/llm-providers.mdx` and adds the separate-catalogue fact to `setup-configuration/embedding-providers.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)