### PR TITLE
fix: Generate release notes from real diff (COG-6317)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,24 @@ jobs:
 
           echo "Tag to create: ${TAG}"
 
+          # Resolve the previous release tag BEFORE creating the new one, so the
+          # release notes describe prev-release..this-release instead of comparing
+          # the new tag against itself (issue #4661). Stable releases (main) are
+          # compared against the previous stable tag — dev canaries version-sort
+          # above their stable release, so they must be filtered out here.
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            PREV_TAG="$(git tag --sort=-version:refname --list 'v*' | grep -vE '\.(dev|rc|a|b|alpha|beta)[0-9]*$' | grep -vx "${TAG}" | head -n 1 || true)"
+          else
+            PREV_TAG="$(git tag --sort=-version:refname --list 'v*' | grep -vx "${TAG}" | head -n 1 || true)"
+          fi
+          echo "Previous release tag: ${PREV_TAG:-<none>}"
+
           git config user.name "Cognee Team"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
 
           git tag "${TAG}"
           git push origin "${TAG}"
@@ -68,10 +81,13 @@ jobs:
           # Set PYTHONPATH to include project root
           export PYTHONPATH="${GITHUB_WORKSPACE}:${PYTHONPATH}"
 
-          # Generate release notes
-          # Compares current branch against the latest release tag automatically
+          # Generate release notes comparing the previous release tag to the new
+          # one. --base may be empty on a first-ever release; the script then
+          # auto-detects a base (excluding the tag being released).
           uv run python tools/generate_release_notes.py \
             --version "${{ steps.create_tag.outputs.version }}" \
+            --base "${{ steps.create_tag.outputs.prev_tag }}" \
+            --target "${{ steps.create_tag.outputs.tag }}" \
             --github-output
 
       - name: Create GitHub Release with AI-generated notes

--- a/tools/generate_release_notes.py
+++ b/tools/generate_release_notes.py
@@ -36,14 +36,22 @@ def run_git_command(command: list[str]) -> str:
         sys.exit(1)
 
 
-def get_latest_release_tag() -> str | None:
-    """Get the latest release tag."""
+def get_latest_release_tag(exclude: str | None = None) -> str | None:
+    """Get the latest release tag.
+
+    ``exclude`` skips a tag by name — used to ignore the tag of the release
+    currently being cut, which the release workflow pushes before generating
+    notes. Without it the newest tag is the release itself and the notes
+    would compare the release against itself (issue #4661).
+    """
     try:
         # Get the latest tag that matches version pattern (vX.Y.Z)
         command = ["git", "tag", "--sort=-version:refname", "--list", "v*"]
         tags = run_git_command(command)
-        if tags:
-            return tags.split("\n")[0]
+        for tag in tags.split("\n"):
+            tag = tag.strip()
+            if tag and tag != exclude:
+                return tag
         return None
     except Exception:
         return None
@@ -520,8 +528,10 @@ async def main():
     # Determine base ref (what to compare against)
     base_ref = args.base
     if not base_ref:
-        # Use latest release tag as base
-        latest_tag = get_latest_release_tag()
+        # Use latest release tag as base, excluding the tag of the version being
+        # released — the release workflow pushes the new tag before this script
+        # runs, so the newest tag can be the release itself (issue #4661).
+        latest_tag = get_latest_release_tag(exclude=f"v{version}")
         if latest_tag:
             base_ref = latest_tag
             print(f"Using latest release tag as base: {base_ref}", file=sys.stderr)
@@ -546,12 +556,30 @@ async def main():
     dep_changes = get_dependency_changes(base_ref, target_ref)
     compat_info = get_compatibility_info(target_ref)
 
-    # Generate release notes with LLM, fall back to commit-based notes
-    notes = await generate_release_notes_with_llm(diff, commits, base_ref, target_ref, version)
+    changed_files = run_git_command(["git", "diff", "--name-only", f"{base_ref}...{target_ref}"])
 
-    if notes is None:
-        print("Falling back to commit-based release notes.", file=sys.stderr)
+    if not commits.strip() and not changed_files.strip():
+        # An empty comparison means the base is wrong (e.g. the release compared
+        # against its own tag, issue #4661). Never hand an empty diff to the
+        # LLM — it fabricates plausible-sounding notes for changes that are not
+        # in the release.
+        print(
+            f"Warning: no commits or file changes between {base_ref} and {target_ref}; "
+            "skipping LLM generation to avoid fabricated notes.",
+            file=sys.stderr,
+        )
         notes = generate_fallback_notes(commits, version)
+        notes.summary = (
+            f"No code changes detected between {base_ref} and {target_ref}. "
+            "If this is unexpected, the release notes comparison base is likely wrong."
+        )
+    else:
+        # Generate release notes with LLM, fall back to commit-based notes
+        notes = await generate_release_notes_with_llm(diff, commits, base_ref, target_ref, version)
+
+        if notes is None:
+            print("Falling back to commit-based release notes.", file=sys.stderr)
+            notes = generate_fallback_notes(commits, version)
 
     # Format as markdown
     title = get_release_title(notes, version)


### PR DESCRIPTION
## Description

Fixes #4661 (Linear: COG-6317).

The GitHub release notes have been describing work that is not in the release. In `release.yml` the new tag is created and pushed **before** `generate_release_notes.py` runs, and the script gets no `--base`, so it auto-detects the latest release tag — which is the tag pushed moments earlier, pointing at HEAD. The release is compared against itself, the LLM receives an empty diff, and it fabricates plausible-sounding notes. This is also why every release header reads `Changes: v1.5.3 -> main`.

## Changes

**`.github/workflows/release.yml`**
- Resolve the previous release tag *before* creating the new one and pass explicit `--base <prev-tag> --target <new-tag>` to the notes script.
- Stable releases (from `main`) compare against the previous **stable** tag: dev canaries version-sort above their stable release (`v1.5.0.dev5` > `v1.5.0`), so prerelease tags are filtered out. Dev canary releases compare against the latest tag of any kind.
- Headers now read `v1.5.2 → v1.5.3` instead of `v1.5.3 → main`.

**`tools/generate_release_notes.py`** (defense in depth)
- `get_latest_release_tag()` accepts an `exclude` and auto-detection skips `v{version}` — the tag of the release being cut — so even without `--base` the script can no longer compare a release against itself.
- If the comparison yields no commits and no changed files, the LLM is skipped entirely and honest fallback notes are emitted, so an empty diff can never again produce fabricated notes (the v1.5.0.dev1 notes shipped with "No detailed commit or diff information was provided for this snapshot").

## Verification

- Ran the script against the real `v1.5.2..v1.5.3` range: notes now list exactly what shipped (#4636 cryptography cap, #4623/#4622 MCP CI), matching `git log v1.5.2..v1.5.3`.
- Simulated the old failure (`--base` omitted with tag `v1.5.3` already existing, version 1.5.3): auto-detection now picks `v1.5.2`.
- Tested the shell prev-tag resolution under `pipefail` (GitHub Actions default) for main releases, dev canaries, self-exclusion, and the no-tags-yet edge case (empty `--base` falls through to script auto-detection).
- Self-compare guard (`--base v1.5.3 --target v1.5.3`) skips the LLM and states no changes were detected.
- `ruff check` / `ruff format --check` pass; workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)