### PR TITLE
SDK-473: accept the RES team prefix in the Linear issue check

### DIFF
--- a/.github/workflows/require-linear-issue.yml
+++ b/.github/workflows/require-linear-issue.yml
@@ -31,10 +31,12 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
         run: |
           # List ALL your Linear team prefixes — verify against Linear ▸ Settings ▸ Teams.
-          KEYS='COG|SDK|CLO|COM|ENG'
+          # Teams that do not ship code to this repo are omitted on purpose (Sales,
+          # Growth, Growth-Seo-Geo, Admin&Finance); add their prefix here if that changes.
+          KEYS='COG|SDK|CLO|COM|ENG|RES'
           if echo "$PR_TITLE $HEAD_REF" | grep -Eiq "\b(${KEYS})-[0-9]+\b"; then
             echo "Linear issue reference found."
           else
-            echo "::error::PR title or branch must reference a Linear issue, e.g. COG-123."
+            echo "::error::PR title or branch must reference a Linear issue, e.g. COG-123. Accepted prefixes: ${KEYS//|/, }."
             exit 1
           fi


### PR DESCRIPTION
Closes SDK-473.

## What was wrong

`linear-issue-check` in `.github/workflows/require-linear-issue.yml` matches a PR's Linear reference against one hardcoded prefix list:

```
KEYS='COG|SDK|CLO|COM|ENG'
```

The Research team's prefix, `RES`, is not in it. The team was created on 2026-08-21, after this check landed, so a correctly-referenced Research PR fails a **required** status check and cannot merge.

This is live, not hypothetical: PR #4669 is titled `RES-20: fix/correct is_embeddable docstring to match its behavior`, and the [failing run](https://github.com/topoteretes/cognee/actions/runs/32859706450/job/97840361037) shows the job receiving `PR_TITLE: RES-20: ...` and matching nothing. The only workarounds are to relabel the PR with an unrelated team's ticket or to open it from a fork, which the job deliberately skips.

## The change

Two lines:

- Add `RES` to `KEYS`.
- Print the accepted prefixes in the failure message. The old message (`e.g. COG-123.`) gave an author no way to tell that their prefix was simply unsupported, which is why this took a failing required check to surface. New output:

```
::error::PR title or branch must reference a Linear issue, e.g. COG-123. Accepted prefixes: COG, SDK, CLO, COM, ENG, RES.
```

A comment now also records that the non-code teams are omitted deliberately, so the omission reads as a decision rather than an oversight.

## Verification

The matcher was run locally against the real inputs. Case-insensitivity means both the `RES-20:` title form and the `feature/res-20-...` branch form pass, and both negative cases still fail:

| Title | Branch | Result |
|---|---|---|
| `RES-20: fix/correct is_embeddable...` | `fix/3438-is-embeddable-docstring` | PASS |
| `fix: correct is_embeddable docstring` | `feature/res-20-correct-the-is_embeddable-docstring` | PASS |
| `COG-123 something` | `whatever` | PASS |
| `SDK-473: add RES prefix` | `feature/sdk-473-...` | PASS |
| `fix: correct is_embeddable docstring` | `fix/3438-is-embeddable-docstring` | FAIL (correct) |
| `no ticket here` | `chore/cleanup` | FAIL (correct) |

This PR's own branch and title both carry `SDK-473`, so the check passes here regardless of the change.

## Deliberately not in scope

- **Four more missing prefixes.** Five of the ten Linear team prefixes are absent from `KEYS`: `RES` (Research), `SAL` (Sales), `GRO` (Growth-Seo-Geo), `GRO2` (Growth), `ADM` (Admin&Finance). Only `RES` demonstrably blocks work, and the other four teams do not ship code to this repo — worth a maintainer decision rather than a silent addition.
- **`main`/`dev` divergence.** `main` carries an `elif` exempting automated release PRs (`[release]` in the title plus a `release/` branch), added in `499d4a217`; `dev` does not have it. This PR targets `dev` and leaves that alone, but a future dev-to-main merge would drop the release exemption. Flagging it as a separate fix.
- **No existence check.** The job matches the *shape* of a reference, so `RES-99999` passes. Validating against Linear needs an API token.
- **PR description is not scanned**, only the title and branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)