### PR TITLE
docs: Sync router docstrings with handlers (RES-14)

### DIFF
--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -405,7 +405,11 @@ def get_activity_router() -> APIRouter:
 
     @router.get("/export/{dataset_id}")
     async def export_dataset_markdown(dataset_id: UUID, user=Depends(get_authenticated_user)):
-        """Export a dataset's knowledge graph as a Markdown memory report."""
+        """Export a dataset's knowledge graph as a Markdown memory report.
+
+        ## Path Parameters
+        - **dataset_id** (UUID): UUID of the dataset (from GET /api/v1/datasets).
+        """
         from fastapi.responses import Response
         from cognee.modules.data.models.Dataset import Dataset
         from cognee.modules.data.models.Data import Data

--- a/cognee/api/v1/agents/routers/get_agents_router.py
+++ b/cognee/api/v1/agents/routers/get_agents_router.py
@@ -76,7 +76,8 @@ def get_agents_router() -> APIRouter:
         """Create agent endpoint — POST /api/v1/agents/create.
 
         ## Query Parameters
-        - **name** (str): No description provided in code yet.
+        - **name** (str): Unique name for the new agent user; a conflict is returned if an
+          agent with this name exists.
         """
         try:
             agent_user, api_key = await create_agent(name, user)
@@ -117,10 +118,12 @@ def get_agents_router() -> APIRouter:
         """List agents connections — GET /api/v1/agents/connections.
 
         ## Query Parameters
-        - **active_only** (bool): No description provided in code yet. Defaults to True.
+        - **active_only** (bool): When true, restricts results to connections currently
+          considered active. Defaults to True.
         - **agent_id** (Optional[UUID]): Filter connections by agent user ID. Only returns
           connections belonging to this specific agent.
-        - **include_sources** (bool): No description provided in code yet. Defaults to True.
+        - **include_sources** (bool): When true, includes the source breakdown for each
+          returned connection. Defaults to True.
         - **limit** (int): Maximum number of rows to return. Defaults to 50.
         - **offset** (int): Number of rows to skip for pagination. Defaults to 0.
         - **range** (Literal['24h', '7d', '30d', 'all']): One of: '24h', '7d', '30d', 'all'.
@@ -202,17 +205,20 @@ def get_agents_router() -> APIRouter:
         - **agent_session_name** (str): A unique name for this agent connection. Combined with the
           authenticated user's ID to identify the connection.
         - **dataset_ids** (List[str]): UUIDs of the datasets (from GET /api/v1/datasets).
-        - **dataset_names** (List[str]): No description provided in code yet.
+        - **dataset_names** (List[str]): Names of the datasets this agent connection reads
+          from and writes to.
         - **memory_mode** (Literal['session', 'cognee', 'hybrid', 'none', 'unknown']): One of:
           'session', 'cognee', 'hybrid', 'none', 'unknown'. Defaults to 'unknown'.
         - **metadata** (Dict[str, Any]): Free-form metadata object.
-        - **origin_function** (Optional[str]): No description provided in code yet.
+        - **origin_function** (Optional[str]): Name of the calling function or tool that
+          triggered the registration, stored on the connection.
         - **session_id** (Optional[str]): Client-supplied session identifier — the same value passed
           as session_id to POST /api/v1/remember.
         - **source** (Literal['agent_memory', 'session_trace', 'serve', 'api_key', 'mcp', 'api']):
           One of: 'agent_memory', 'session_trace', 'serve', 'api_key', 'mcp', 'api'. Defaults to
           'api'.
-        - **type** (str): No description provided in code yet. Defaults to 'api'.
+        - **type** (str): Connection type label recorded for the registered agent. Defaults
+          to 'api'.
         """
         connection = await register_agent(user, request)
         return jsonable_encoder(connection)

--- a/cognee/api/v1/agents/routers/get_agents_router.py
+++ b/cognee/api/v1/agents/routers/get_agents_router.py
@@ -57,6 +57,7 @@ def get_agents_router() -> APIRouter:
     async def list_agents_endpoint(
         user: User = Depends(get_authenticated_user),
     ) -> list[AgentDTO]:
+        """List agents endpoint — GET /api/v1/agents/list."""
         agents = await list_agents(user.id)
         return [
             AgentDTO(
@@ -72,6 +73,11 @@ def get_agents_router() -> APIRouter:
         name: str,
         user: User = Depends(get_authenticated_user),
     ) -> AgentWithApiKeyDTO:
+        """Create agent endpoint — POST /api/v1/agents/create.
+
+        ## Query Parameters
+        - **name** (str): No description provided in code yet.
+        """
         try:
             agent_user, api_key = await create_agent(name, user)
         except UserAlreadyExists:
@@ -108,6 +114,20 @@ def get_agents_router() -> APIRouter:
         offset: int = Query(0, ge=0),
         user: User = Depends(get_authenticated_user),
     ):
+        """List agents connections — GET /api/v1/agents/connections.
+
+        ## Query Parameters
+        - **active_only** (bool): No description provided in code yet. Defaults to True.
+        - **agent_id** (Optional[UUID]): Filter connections by agent user ID. Only returns
+          connections belonging to this specific agent.
+        - **include_sources** (bool): No description provided in code yet. Defaults to True.
+        - **limit** (int): Maximum number of rows to return. Defaults to 50.
+        - **offset** (int): Number of rows to skip for pagination. Defaults to 0.
+        - **range** (Literal['24h', '7d', '30d', 'all']): One of: '24h', '7d', '30d', 'all'.
+          Defaults to '30d'.
+        - **status** (Optional[Literal['active', 'inactive', 'unknown']]): One of: 'active',
+          'inactive', 'unknown'.
+        """
         response = await list_agent_connections(
             user=user,
             agent_id=agent_id,
@@ -129,6 +149,12 @@ def get_agents_router() -> APIRouter:
         ),
         user: User = Depends(get_authenticated_user),
     ):
+        """Get my connection detail — GET /api/v1/agents/connections/me.
+
+        ## Query Parameters
+        - **agent_session_name** (Optional[str]): Filter by connection name. Uses the authenticated
+          user's ID as the agent ID.
+        """
         response = await get_agent_connection_detail(
             user=user,
             agent_id=user.id,
@@ -147,6 +173,15 @@ def get_agents_router() -> APIRouter:
         ),
         user: User = Depends(get_authenticated_user),
     ):
+        """Get connection detail — GET /api/v1/agents/connections/{agent_id}.
+
+        ## Path Parameters
+        - **agent_id** (UUID): The agent's user ID (from GET /api/v1/agents/list).
+
+        ## Query Parameters
+        - **agent_session_name** (Optional[str]): Filter by connection name within the agent's
+          connections.
+        """
         response = await get_agent_connection_detail(
             user=user,
             agent_id=agent_id,
@@ -161,6 +196,24 @@ def get_agents_router() -> APIRouter:
         request: RegisterAgentRequest,
         user: User = Depends(get_authenticated_user),
     ):
+        """Register agent endpoint — POST /api/v1/agents/register.
+
+        ## Request Parameters
+        - **agent_session_name** (str): A unique name for this agent connection. Combined with the
+          authenticated user's ID to identify the connection.
+        - **dataset_ids** (List[str]): UUIDs of the datasets (from GET /api/v1/datasets).
+        - **dataset_names** (List[str]): No description provided in code yet.
+        - **memory_mode** (Literal['session', 'cognee', 'hybrid', 'none', 'unknown']): One of:
+          'session', 'cognee', 'hybrid', 'none', 'unknown'. Defaults to 'unknown'.
+        - **metadata** (Dict[str, Any]): Free-form metadata object.
+        - **origin_function** (Optional[str]): No description provided in code yet.
+        - **session_id** (Optional[str]): Client-supplied session identifier — the same value passed
+          as session_id to POST /api/v1/remember.
+        - **source** (Literal['agent_memory', 'session_trace', 'serve', 'api_key', 'mcp', 'api']):
+          One of: 'agent_memory', 'session_trace', 'serve', 'api_key', 'mcp', 'api'. Defaults to
+          'api'.
+        - **type** (str): No description provided in code yet. Defaults to 'api'.
+        """
         connection = await register_agent(user, request)
         return jsonable_encoder(connection)
 
@@ -169,6 +222,12 @@ def get_agents_router() -> APIRouter:
         request: UnregisterAgentRequest,
         user: User = Depends(get_authenticated_user),
     ) -> AgentModeDTO:
+        """Unregister agent endpoint — POST /api/v1/agents/unregister.
+
+        ## Request Parameters
+        - **agent_session_name** (str): The name used when registering the connection. Combined with
+          the authenticated user's ID to identify which connection to deactivate.
+        """
         count = await unregister_agent(user, request)
         return AgentModeDTO(active_agents=count)
 
@@ -181,6 +240,11 @@ def get_agents_router() -> APIRouter:
         agent_id: UUID,
         user: User = Depends(get_authenticated_user),
     ) -> AgentDTO:
+        """Get agent endpoint — GET /api/v1/agents/{agent_id}.
+
+        ## Path Parameters
+        - **agent_id** (UUID): The agent's user ID (from GET /api/v1/agents/list).
+        """
         try:
             agent_info = await get_agent(agent_id, user.id)
         except LookupError:
@@ -197,6 +261,11 @@ def get_agents_router() -> APIRouter:
     async def delete_agent_endpoint(
         agent_id: UUID, user: User = Depends(get_authenticated_user)
     ) -> None:
+        """Delete agent endpoint — DELETE /api/v1/agents/{agent_id}.
+
+        ## Path Parameters
+        - **agent_id** (UUID): The agent's user ID (from GET /api/v1/agents/list).
+        """
         try:
             await delete_agent(agent_id, user.id)
         except LookupError:

--- a/cognee/api/v1/api_keys/routers/get_api_key_management_router.py
+++ b/cognee/api/v1/api_keys/routers/get_api_key_management_router.py
@@ -65,7 +65,8 @@ def get_api_key_management_router():
         """Create api key for user — POST /api/v1/auth/api-keys.
 
         ## Request Parameters
-        - **name** (Optional[str]): No description provided in code yet.
+        - **name** (Optional[str]): Human-readable label to store with the generated API
+          key.
         """
         send_telemetry(
             "Api Key Management API Endpoint Invoked",

--- a/cognee/api/v1/api_keys/routers/get_api_key_management_router.py
+++ b/cognee/api/v1/api_keys/routers/get_api_key_management_router.py
@@ -24,6 +24,7 @@ def get_api_key_management_router():
 
     @api_key_management_router.get("/api-keys")
     async def get_api_keys_for_user(user: User = Depends(get_authenticated_user)):
+        """Get api keys for user — GET /api/v1/auth/api-keys."""
         send_telemetry(
             "Api Key Management API Endpoint Invoked",
             user,
@@ -61,6 +62,11 @@ def get_api_key_management_router():
         payload: ApiKeyCreationPayload,
         user: User = Depends(get_authenticated_user),
     ):
+        """Create api key for user — POST /api/v1/auth/api-keys.
+
+        ## Request Parameters
+        - **name** (Optional[str]): No description provided in code yet.
+        """
         send_telemetry(
             "Api Key Management API Endpoint Invoked",
             user,
@@ -87,6 +93,11 @@ def get_api_key_management_router():
         api_key_id: UUID,
         user: User = Depends(get_authenticated_user),
     ):
+        """Delete api key for user — DELETE /api/v1/auth/api-keys/{api_key_id}.
+
+        ## Path Parameters
+        - **api_key_id** (UUID): UUID of the API key (from GET /api/v1/auth/api-keys).
+        """
         send_telemetry(
             "Api Key Management API Endpoint Invoked",
             user,

--- a/cognee/api/v1/cloud/routers/get_checks_router.py
+++ b/cognee/api/v1/cloud/routers/get_checks_router.py
@@ -13,6 +13,7 @@ def get_checks_router():
     async def get_connection_check_endpoint(
         request: Request, user: User = Depends(get_authenticated_user)
     ):
+        """Get connection check endpoint — POST /api/v1/checks/connection."""
         api_token = request.headers.get("X-Api-Key")
 
         if api_token is None:

--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -551,6 +551,13 @@ def get_datasets_router() -> APIRouter:
         status — a dedicated endpoint rather than a flag on /status, so neither
         endpoint's response shape ever depends on how it was called.
 
+        ## Query Parameters
+        - **dataset** (List[UUID]): Dataset UUIDs to check (from GET /api/v1/datasets). Omit to get
+          status for all datasets you can read.
+        - **pipeline** (List[str]): Pipeline names to check: 'add_pipeline', 'cognify_pipeline', or
+          'code_graph_pipeline' (code ingestion via remember content_type='code'). Omit to default
+          to cognify_pipeline.
+
         ## Response
         - Single pipeline (default): {dataset_id: {status, progress}}
         - Multiple pipelines: {dataset_id: {pipeline_name: {status, progress}}}
@@ -800,7 +807,11 @@ def get_datasets_router() -> APIRouter:
 
     @router.get("/{dataset_id}/schema", response_model=dict)
     async def get_dataset_schema(dataset_id: UUID, user: User = Depends(get_authenticated_user)):
-        """Return the stored graph schema and custom prompt for a dataset."""
+        """Return the stored graph schema and custom prompt for a dataset.
+
+        ## Path Parameters
+        - **dataset_id** (UUID): UUID of the dataset (from GET /api/v1/datasets).
+        """
         from cognee.modules.data.models import DatasetConfiguration
         from sqlalchemy import select
 
@@ -826,7 +837,15 @@ def get_datasets_router() -> APIRouter:
         payload: DatasetSchemaPayloadDTO,
         user: User = Depends(get_authenticated_user),
     ):
-        """Store or update the graph schema and custom prompt for a dataset."""
+        """Store or update the graph schema and custom prompt for a dataset.
+
+        ## Path Parameters
+        - **dataset_id** (UUID): UUID of the dataset (from GET /api/v1/datasets).
+
+        ## Request Parameters
+        - **customPrompt** (Optional[str]): No description provided in code yet.
+        - **graphSchema** (Optional[Dict[str, Any]]): No description provided in code yet.
+        """
         from cognee.modules.data.models import DatasetConfiguration
         from sqlalchemy import select
 

--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -843,8 +843,10 @@ def get_datasets_router() -> APIRouter:
         - **dataset_id** (UUID): UUID of the dataset (from GET /api/v1/datasets).
 
         ## Request Parameters
-        - **customPrompt** (Optional[str]): No description provided in code yet.
-        - **graphSchema** (Optional[Dict[str, Any]]): No description provided in code yet.
+        - **customPrompt** (Optional[str]): Custom extraction prompt to store for the
+          dataset; omitting it leaves any existing prompt unchanged.
+        - **graphSchema** (Optional[Dict[str, Any]]): JSON graph schema to store for the
+          dataset; omitting it leaves any existing schema unchanged.
         """
         from cognee.modules.data.models import DatasetConfiguration
         from sqlalchemy import select

--- a/cognee/api/v1/improve/routers/get_improve_router.py
+++ b/cognee/api/v1/improve/routers/get_improve_router.py
@@ -59,6 +59,7 @@ def get_improve_router() -> APIRouter:
         - **build_global_context_index** (Optional[bool]): Build the global context index after enrichment (default: False).
 
         Either dataset_name or dataset_id must be provided.
+        - **sessionIds** (Optional[List[str]]): No description provided in code yet.
 
         ## Error Codes
         - **400 Bad Request**: Neither dataset_id nor dataset_name provided

--- a/cognee/api/v1/improve/routers/get_improve_router.py
+++ b/cognee/api/v1/improve/routers/get_improve_router.py
@@ -59,7 +59,8 @@ def get_improve_router() -> APIRouter:
         - **build_global_context_index** (Optional[bool]): Build the global context index after enrichment (default: False).
 
         Either dataset_name or dataset_id must be provided.
-        - **sessionIds** (Optional[List[str]]): No description provided in code yet.
+        - **sessionIds** (Optional[List[str]]): Session identifiers whose cached memory
+          entries are used as input for enrichment.
 
         ## Error Codes
         - **400 Bad Request**: Neither dataset_id nor dataset_name provided

--- a/cognee/api/v1/integrations/routers/get_integrations_router.py
+++ b/cognee/api/v1/integrations/routers/get_integrations_router.py
@@ -376,6 +376,9 @@ def get_integrations_router():
         returns the same agent but rotates the key (old keys are revoked —
         re-provision *is* the rotation flow). The returned key is shown once
         and never retrievable again.
+
+        ## Path Parameters
+        - **plugin_key** (str): Key of a known plugin (see GET /api/v1/integrations/status).
         """
         with new_span("cognee.integrations.plugins.provision") as span:
             span.set_attribute("cognee.integrations.plugin", plugin_key)
@@ -439,6 +442,9 @@ def get_integrations_router():
         disconnect would be surprising; full removal stays on
         ``DELETE /api/v1/agents/{agent_id}``. Re-provisioning later revives
         the same identity with a fresh key.
+
+        ## Path Parameters
+        - **plugin_key** (str): Key of a known plugin (see GET /api/v1/integrations/status).
         """
         with new_span("cognee.integrations.plugins.disconnect") as span:
             span.set_attribute("cognee.integrations.plugin", plugin_key)
@@ -462,7 +468,12 @@ def get_integrations_router():
     async def authorize(
         provider: str, user: User = Depends(get_authenticated_user)
     ) -> AuthorizeUrlDTO:
-        """Mint the provider's authorize URL for the requesting user."""
+        """Mint the provider's authorize URL for the requesting user.
+
+        ## Path Parameters
+        - **provider** (str): Key of a registered OAuth provider (see GET
+          /api/v1/integrations/status).
+        """
         with new_span("cognee.integrations.authorize") as span:
             span.set_attribute("cognee.integrations.provider", provider)
             integration = _integration_or_404(provider)
@@ -576,7 +587,12 @@ def get_integrations_router():
     async def connection_status(
         provider: str, user: User = Depends(get_authenticated_user)
     ) -> ConnectionStatusDTO:
-        """Connection state for the Integrations page."""
+        """Connection state for the Integrations page.
+
+        ## Path Parameters
+        - **provider** (str): Key of a registered OAuth provider (see GET
+          /api/v1/integrations/status).
+        """
         integration = _integration_or_404(provider)
         credential = await get_active_credential_for_user(user.id, integration.provider)
         if credential is None:
@@ -602,6 +618,10 @@ def get_integrations_router():
         of each adapter's own best-effort handling — a third-party
         integration that doesn't honor the "never raise" contract on
         ``revoke_remote`` still must not block the local disconnect.
+
+        ## Path Parameters
+        - **provider** (str): Key of a registered OAuth provider (see GET
+          /api/v1/integrations/status).
         """
         with new_span("cognee.integrations.disconnect") as span:
             span.set_attribute("cognee.integrations.provider", provider)

--- a/cognee/api/v1/llm/routers/get_llm_router.py
+++ b/cognee/api/v1/llm/routers/get_llm_router.py
@@ -212,6 +212,10 @@ def get_llm_router() -> APIRouter:
     ):
         """
         Generate a custom extraction prompt from a provided graph model schema JSON.
+
+        ## Request Parameters
+        - **graphModel** (Dict[str, Any]): Graph model schema as JSON object.
+        - **parameters** (Dict[str, Any]): Additional kwargs forwarded to LLMGateway.
         """
         send_telemetry(
             "LLM Custom Prompt Endpoint Invoked",
@@ -276,6 +280,12 @@ def get_llm_router() -> APIRouter:
         Analyze sample text and/or uploaded files, and propose a JSON Schema describing the entity types
         and relationships present. The returned schema can be passed directly to
         ``/v1/llm/custom-prompt`` or ``/v1/cognify``.
+
+        ## Request Parameters
+        - **data** (List[UploadFile]): No description provided in code yet.
+        - **parameters** (str): JSON string of additional kwargs forwarded to LLMGateway. Defaults
+          to '{}'.
+        - **text** (str): No description provided in code yet.
         """
         send_telemetry(
             "LLM Infer Schema Endpoint Invoked",

--- a/cognee/api/v1/llm/routers/get_llm_router.py
+++ b/cognee/api/v1/llm/routers/get_llm_router.py
@@ -282,10 +282,12 @@ def get_llm_router() -> APIRouter:
         ``/v1/llm/custom-prompt`` or ``/v1/cognify``.
 
         ## Request Parameters
-        - **data** (List[UploadFile]): No description provided in code yet.
+        - **data** (List[UploadFile]): Files to load and sample as input for schema
+          inference; at least one file or text is required.
         - **parameters** (str): JSON string of additional kwargs forwarded to LLMGateway. Defaults
           to '{}'.
-        - **text** (str): No description provided in code yet.
+        - **text** (str): Sample text to analyze for schema inference; at least one file or
+          text is required.
         """
         send_telemetry(
             "LLM Infer Schema Endpoint Invoked",

--- a/cognee/api/v1/proposals/routers/get_proposals_router.py
+++ b/cognee/api/v1/proposals/routers/get_proposals_router.py
@@ -83,7 +83,15 @@ def get_proposals_router() -> APIRouter:
         ),
         user: User = Depends(get_authenticated_user),
     ):
-        """Return one skill-improvement proposal with its before/after procedures."""
+        """Return one skill-improvement proposal with its before/after procedures.
+
+        ## Path Parameters
+        - **proposal_id** (str): ID of the skill-improvement proposal.
+
+        ## Query Parameters
+        - **dataset_id** (UUID): Dataset UUID the proposal is scoped to. List your datasets via GET
+          /api/v1/datasets to find it.
+        """
         send_telemetry(
             "Skill Proposal Get API Endpoint Invoked",
             user,

--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -210,6 +210,13 @@ def get_recall_router() -> APIRouter:
         - **response_schema** (Optional[dict]): JSON Schema for structured
           completion output; validated results land in each result's
           ``structured`` field. 422 on schemas outside the supported subset.
+        - **contextProfile** (str): Profile to render for the 'session_context' scope: 'qa'
+          (conversational) or 'agent' (tool/workflow). Ignored by other scopes. Defaults to 'qa'.
+        - **toolConnections** (Optional[List[str]]): Names of authorized external database
+          connections for the 'tools' scope. Omit to use every connection visible to the caller.
+        - **toolsTrigger** (str): When the 'tools' scope runs: 'always', or 'on_empty' to query the
+          external database only when every other requested source returned nothing. Defaults to
+          'always'.
 
         ## Error Codes
         - **402/403/404/409/422**: Cognee errors (payment required, permission

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -330,6 +330,14 @@ def get_remember_router() -> APIRouter:
           calls otherwise).
 
         Either datasetName or datasetId must be provided.
+        - **import_mode** (Optional[str]): COGX archive imports only: 'preserve' (default),
+          'hybrid', or 're-derive'.
+        - **skill_name** (Optional[str]): content_type='skills' + skills_text only: name/slug for
+          the inline skill (defaults to 'skill').
+        - **skills_text** (Optional[str]): content_type='skills' only: inline SKILL.md markdown to
+          ingest without a file upload (no-code path). When set and no files are uploaded, it is
+          written to a temporary SKILL.md and ingested via the normal skills pipeline. Pair with
+          skill_name to control the resulting skill name.
 
         ## Error Codes
         - **400 Bad Request**: Neither datasetId nor datasetName provided, unsupported
@@ -602,6 +610,16 @@ def get_remember_router() -> APIRouter:
         ``FeedbackEntry``, or ``SkillRunEntry`` and dispatches to the
         matching ``remember`` path. Session-backed entries require
         ``session_id``; ``SkillRunEntry`` can persist with or without one.
+
+        ## Request Parameters
+        - **dataset_id** (Optional[UUID]): UUID of an existing writable dataset. Takes precedence
+          over dataset_name and is required to target a shared dataset by ID.
+        - **dataset_name** (str): Name of the target dataset. Defaults to 'main_dataset'.
+        - **entry** (Union[QAEntry, TraceEntry, FeedbackEntry, SkillRunEntry]): No description
+          provided in code yet.
+        - **session_id** (Optional[str]): Required for qa/trace/feedback entries; optional for
+          skill_run entries.
+        - **skill_improvement** (Optional[dict]): No description provided in code yet.
 
         ## Response
         The returned ``RememberResult`` includes ``entry_type`` and

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -615,11 +615,12 @@ def get_remember_router() -> APIRouter:
         - **dataset_id** (Optional[UUID]): UUID of an existing writable dataset. Takes precedence
           over dataset_name and is required to target a shared dataset by ID.
         - **dataset_name** (str): Name of the target dataset. Defaults to 'main_dataset'.
-        - **entry** (Union[QAEntry, TraceEntry, FeedbackEntry, SkillRunEntry]): No description
-          provided in code yet.
+        - **entry** (Union[QAEntry, TraceEntry, FeedbackEntry, SkillRunEntry]): Typed memory
+          entry (qa, trace, feedback, or skill_run) to store, dispatched by its type field.
         - **session_id** (Optional[str]): Required for qa/trace/feedback entries; optional for
           skill_run entries.
-        - **skill_improvement** (Optional[dict]): No description provided in code yet.
+        - **skill_improvement** (Optional[dict]): Skill improvement details forwarded to
+          remember when recording a skill run.
 
         ## Response
         The returned ``RememberResult`` includes ``entry_type`` and

--- a/cognee/api/v1/responses/routers/get_responses_router.py
+++ b/cognee/api/v1/responses/routers/get_responses_router.py
@@ -87,8 +87,10 @@ def get_responses_router() -> APIRouter:
         - **tools** (Optional[List[Dict]]): Available tools for function calling
         - **tool_choice** (Any): Tool selection strategy (default: "auto")
         - **temperature** (float): Response randomness (default: 1.0)
-        - **maxCompletionTokens** (Optional[int]): No description provided in code yet.
-        - **user** (Optional[str]): No description provided in code yet.
+        - **maxCompletionTokens** (Optional[int]): Upper bound on tokens generated for the
+          completion.
+        - **user** (Optional[str]): OpenAI-compatible end-user identifier passed in the
+          request body.
 
         ## Response
         Returns an OpenAI-compatible response body with function call results.

--- a/cognee/api/v1/responses/routers/get_responses_router.py
+++ b/cognee/api/v1/responses/routers/get_responses_router.py
@@ -87,6 +87,8 @@ def get_responses_router() -> APIRouter:
         - **tools** (Optional[List[Dict]]): Available tools for function calling
         - **tool_choice** (Any): Tool selection strategy (default: "auto")
         - **temperature** (float): Response randomness (default: 1.0)
+        - **maxCompletionTokens** (Optional[int]): No description provided in code yet.
+        - **user** (Optional[str]): No description provided in code yet.
 
         ## Response
         Returns an OpenAI-compatible response body with function call results.

--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -341,6 +341,16 @@ def get_sessions_router() -> APIRouter:
         Response envelope mirrors ``GET /api/v1/sessions``, with each
         session additionally carrying ``agent_type``, ``agent_source``,
         ``agent_session_name``, and ``origin_function``.
+
+        ## Query Parameters
+        - **descending** (bool): Sort in descending order. Defaults to True.
+        - **limit** (int): Page size (max 500). Defaults to 50.
+        - **offset** (int): Rows to skip for pagination. Defaults to 0.
+        - **order_by** (str): Column to sort by. Defaults to 'last_activity_at'.
+        - **range** (Literal['24h', '7d', '30d', 'all']): Time window filtered on last_activity_at:
+          24h, 7d, 30d, or all. Defaults to '30d'.
+        - **status** (Optional[str]): Effective-status filter: running, completed, failed, or
+          abandoned.
         """
         since = _range_since(range)
         try:
@@ -382,6 +392,10 @@ def get_sessions_router() -> APIRouter:
         member's spend. A regular member — or anyone with no tenant,
         i.e. single-user/local mode — just keeps the base scope rather
         than being denied outright.
+
+        ## Query Parameters
+        - **range** (Literal['24h', '7d', '30d', 'all']): Time window filtered on last_activity_at:
+          24h, 7d, 30d, or all. Defaults to '30d'.
         """
         since = _range_since(range)
         try:
@@ -408,6 +422,12 @@ def get_sessions_router() -> APIRouter:
         ),
         user: User = Depends(get_authenticated_user),
     ):
+        """Get session detail — GET /api/v1/sessions/{session_id}.
+
+        ## Path Parameters
+        - **session_id** (str): Client-supplied session identifier; the same value passed as
+          session_id to POST /api/v1/remember.
+        """
         permitted = await get_permitted_dataset_ids(user.id)
         visible_ids = await get_visible_user_ids(user.id)
         row = await get_session_row(

--- a/cognee/api/v1/skills/routers/get_skills_router.py
+++ b/cognee/api/v1/skills/routers/get_skills_router.py
@@ -99,6 +99,13 @@ def get_skills_router() -> APIRouter:
 
         JSON-native companion to ``POST /api/v1/remember`` (content_type=skills),
         for no-code clients. Reuses the same skills ingestion pipeline.
+
+        ## Request Parameters
+        - **dataset_id** (Optional[UUID]): Target dataset UUID (alternative to dataset_name).
+        - **dataset_name** (Optional[str]): Target dataset name (created if needed). Required unless
+          dataset_id is given.
+        - **skill_name** (Optional[str]): Name/slug for the skill (defaults to 'skill').
+        - **skills_text** (str): Inline SKILL.md markdown to ingest as a Skill node.
         """
         if not payload.dataset_name and payload.dataset_id is None:
             return JSONResponse(
@@ -153,7 +160,16 @@ def get_skills_router() -> APIRouter:
         offset: int = Query(default=0, ge=0, description="Number of skills to skip."),
         user: User = Depends(get_authenticated_user),
     ) -> list[dict]:
-        """Return the skills available in an authorized dataset, with publisher metadata."""
+        """Return the skills available in an authorized dataset, with publisher metadata.
+
+        ## Query Parameters
+        - **dataset_id** (UUID): Dataset UUID to scope the skills to. List your datasets via GET
+          /api/v1/datasets to find it.
+        - **include_inactive** (bool): Include skills whose is_active flag is false. Defaults to
+          False.
+        - **limit** (int): Max skills to return. Defaults to 200.
+        - **offset** (int): Number of skills to skip. Defaults to 0.
+        """
         send_telemetry(
             "Skills List API Endpoint Invoked",
             user,
@@ -196,7 +212,14 @@ def get_skills_router() -> APIRouter:
         dataset_id: UUID = Query(..., description="Dataset UUID the skill belongs to."),
         user: User = Depends(get_authenticated_user),
     ):
-        """Return one skill, including its full procedure body."""
+        """Return one skill, including its full procedure body.
+
+        ## Path Parameters
+        - **skill_id** (str): ID of the skill (from GET /api/v1/skills/).
+
+        ## Query Parameters
+        - **dataset_id** (UUID): Dataset UUID the skill belongs to.
+        """
         from cognee.api.v1.skills.list_skills import get_skill
 
         try:
@@ -227,7 +250,14 @@ def get_skills_router() -> APIRouter:
         dataset_id: UUID = Query(..., description="Dataset UUID the skill belongs to."),
         user: User = Depends(get_authenticated_user),
     ):
-        """Delete one skill (graph node + embeddings) from an authorized dataset."""
+        """Delete one skill (graph node + embeddings) from an authorized dataset.
+
+        ## Path Parameters
+        - **skill_id** (str): ID of the skill (from GET /api/v1/skills/).
+
+        ## Query Parameters
+        - **dataset_id** (UUID): Dataset UUID the skill belongs to.
+        """
         from cognee.api.v1.skills.list_skills import delete_skill
 
         try:

--- a/cognee/api/v1/slack/routers/get_slack_channels_router.py
+++ b/cognee/api/v1/slack/routers/get_slack_channels_router.py
@@ -107,6 +107,9 @@ def get_slack_channels_router():
         An empty list means unrestricted (the default) — channel scoping is
         opt-in, so a workspace that never visits this settings screen keeps
         working everywhere, exactly as before this feature existed.
+
+        ## Request Parameters
+        - **channelIds** (List[str]): No description provided in code yet.
         """
         credential = _connected_credential_or_404(
             await get_active_credential_for_user(user.id, PROVIDER)
@@ -129,6 +132,9 @@ def get_slack_channels_router():
         Backs the ``/link-slack`` frontend page — the browser session here
         (not anything typed into Slack) is what proves which cognee account
         the invoking Slack member should be linked to.
+
+        ## Request Parameters
+        - **code** (str): No description provided in code yet.
         """
         linked = await confirm_link(payload.code, user.id)
         if not linked:

--- a/cognee/api/v1/slack/routers/get_slack_channels_router.py
+++ b/cognee/api/v1/slack/routers/get_slack_channels_router.py
@@ -109,7 +109,8 @@ def get_slack_channels_router():
         working everywhere, exactly as before this feature existed.
 
         ## Request Parameters
-        - **channelIds** (List[str]): No description provided in code yet.
+        - **channelIds** (List[str]): Slack channel IDs allowed to run slash commands; an
+          empty list removes all channel restrictions.
         """
         credential = _connected_credential_or_404(
             await get_active_credential_for_user(user.id, PROVIDER)
@@ -134,7 +135,8 @@ def get_slack_channels_router():
         the invoking Slack member should be linked to.
 
         ## Request Parameters
-        - **code** (str): No description provided in code yet.
+        - **code** (str): Magic-link code issued by /cognee-link, confirmed to bind the
+          Slack member to this account.
         """
         linked = await confirm_link(payload.code, user.id)
         if not linked:

--- a/cognee/api/v1/users/routers/get_auth_router.py
+++ b/cognee/api/v1/users/routers/get_auth_router.py
@@ -16,6 +16,7 @@ def get_auth_router():
         response: Response,
         credentials: OAuth2PasswordRequestForm = Depends(),
     ):
+        """Login — POST /api/v1/auth/login."""
         user = await authenticate_user(credentials.username, credentials.password)
 
         if user is None:
@@ -40,6 +41,7 @@ def get_auth_router():
 
     @router.post("/logout")
     async def logout(response: Response, user: User = Depends(get_authenticated_user)):
+        """Logout — POST /api/v1/auth/logout."""
         response.delete_cookie(
             key=default_transport.cookie_name,
             domain=default_transport.cookie_domain,
@@ -49,6 +51,7 @@ def get_auth_router():
 
     @router.get("/me")
     async def get_me(user: User = Depends(get_authenticated_user)):
+        """Get me — GET /api/v1/auth/me."""
         return {
             "email": user.email,
         }

--- a/cognee/api/v1/users/routers/get_user_id_by_email_router.py
+++ b/cognee/api/v1/users/routers/get_user_id_by_email_router.py
@@ -16,6 +16,11 @@ def get_user_id_by_email_router() -> APIRouter:
 
     @router.post("/get-user-id")
     async def get_user_id(body: UserEmailRequest, user: User = Depends(get_authenticated_user)):
+        """Get user id — POST /api/v1/users/get-user-id.
+
+        ## Request Parameters
+        - **email** (EmailStr): Email address of the user.
+        """
         user_id = await get_user_id_by_email(str(body.email))
 
         if user_id is None:

--- a/cognee/api/v1/users/routers/get_visualize_router.py
+++ b/cognee/api/v1/users/routers/get_visualize_router.py
@@ -309,6 +309,17 @@ def get_visualize_router() -> APIRouter:
 
         ## Query Parameters
         Same as `GET /visualize/json`.
+        - **dataset_id** (UUID): UUID of the dataset to visualize. List your datasets via GET
+          /api/v1/datasets to find it.
+        - **full** (bool): Include the entire graph instead of a bounded subgraph. Defaults to
+          False.
+        - **max_nodes** (int): Hard cap on rendered nodes after expansion. Defaults to 500.
+        - **neighborhood_depth** (int): k-hop neighborhood depth for subgraph expansion. Defaults to
+          2.
+        - **neighborhood_seed_top_k** (int): Maximum number of seed nodes. Defaults to 10.
+        - **query** (Optional[str]): Query string whose nearest vector hits seed the subgraph.
+        - **seed_node_ids** (Optional[List[str]]): Explicit seed node ids for subgraph neighborhood
+          expansion.
 
         ## Response
         A JSON object with `semantic_positions` and `semantic_clusters`,

--- a/cognee/api/v1/validate/routers/get_validate_router.py
+++ b/cognee/api/v1/validate/routers/get_validate_router.py
@@ -33,6 +33,10 @@ def get_validate_router() -> APIRouter:
         longer matches cognee's own dedup contract, and nodes present in the
         graph but missing from the vector index (unreachable by semantic
         search). Read-only — never modifies any store.
+
+        ## Query Parameters
+        - **dataset** (List[str]): Dataset name(s) to validate. Omit to validate the default
+          dataset.
         """
         try:
             report = await validate(dataset=dataset, user=user)


### PR DESCRIPTION
Automated router docstring sync.

The docstring checker found handlers whose documented parameters
no longer match their signatures. The fixes below were generated
from the handlers' own FastAPI/Pydantic metadata; a follow-up
commit fills the remaining descriptions with Claude. Review the
wording before merging.

```
GET /api/v1/activity/export/{dataset_id}  (cognee.api.v1.activity.routers.get_activity_router.get_activity_router.<locals>.export_dataset_markdown)
    parameter not documented:            dataset_id

GET /api/v1/agents/connections  (cognee.api.v1.agents.routers.get_agents_router.get_agents_router.<locals>.list_agents_connections)
    docstring: MISSING

GET /api/v1/agents/connections/me  (cognee.api.v1.agents.routers.get_agents_router.get_agents_router.<locals>.get_my_connection_detail)
    docstring: MISSING

GET /api/v1/agents/connections/{agent_id}  (cognee.api.v1.agents.routers.get_agents_router.get_agents_router.<locals>.get_connection_detail)
    docstring: MISSING

POST /api/v1/agents/create  (cognee.api.v1.agents.routers.get_agents_router.get_agents_router.<locals>.create_agent_endpoint)
    docstring: MISSING

GET /api/v1/agents/list  (cognee.api.v1.agents.routers.get_agents_router.get_agents_router.<locals>.list_agents_endpoint)
    docstring: MISSING

POST /api/v1/agents/register  (cognee.api.v1.agents.routers.get_agents_router.get_agents_router.<locals>.register_agent_endpoint)
    docstring: MISSING

POST /api/v1/agents/unregister  (cognee.api.v1.agents.routers.get_agents_router.get_agents_router.<locals>.unregister_agent_endpoint)
    docstring: MISSING

DELETE /api/v1/agents/{agent_id}  (cognee.api.v1.agents.routers.get_agents_router.get_agents_router.<locals>.delete_agent_endpoint)
    docstring: MISSING

GET /api/v1/agents/{agent_id}  (cognee.api.v1.agents.routers.get_agents_router.get_agents_router.<locals>.get_agent_endpoint)
    docstring: MISSING

GET /api/v1/auth/api-keys  (cognee.api.v1.api_keys.routers.get_api_key_management_router.get_api_key_management_router.<locals>.get_api_keys_for_user)
    docstring: MISSING

POST /api/v1/auth/api-keys  (cognee.api.v1.api_keys.routers.get_api_key_management_router.get_api_key_management_router.<locals>.create_api_key_for_user)
    docstring: MISSING

DELETE /api/v1/auth/api-keys/{api_key_id}  (cognee.api.v1.api_keys.routers.get_api_key_management_router.get_api_key_management_router.<locals>.delete_api_key_for_user)
    docstring: MISSING

POST /api/v1/auth/login  (cognee.api.v1.users.routers.get_auth_router.get_auth_router.<locals>.login)
    docstring: MISSING

POST /api/v1/auth/logout  (cognee.api.v1.users.routers.get_auth_router.get_auth_router.<locals>.logout)
    docstring: MISSING

GET /api/v1/auth/me  (cognee.api.v1.users.routers.get_auth_router.get_auth_router.<locals>.get_me)
    docstring: MISSING

POST /api/v1/checks/connection  (cognee.api.v1.cloud.routers.get_checks_router.get_checks_router.<locals>.get_connection_check_endpoint)
    docstring: MISSING

GET /api/v1/datasets/status/progress  (cognee.api.v1.datasets.routers.get_datasets_router.get_datasets_router.<locals>.get_dataset_progress)
    parameter not documented:            dataset
    parameter not documented:            pipeline

GET /api/v1/datasets/{dataset_id}/schema  (cognee.api.v1.datasets.routers.get_datasets_router.get_datasets_router.<locals>.get_dataset_schema)
    parameter not documented:            dataset_id

PUT /api/v1/datasets/{dataset_id}/schema  (cognee.api.v1.datasets.routers.get_datasets_router.get_datasets_router.<locals>.update_dataset_schema)
    parameter not documented:            customPrompt
    parameter not documented:            dataset_id
    parameter not documented:            graphSchema

POST /api/v1/improve  (cognee.api.v1.improve.routers.get_improve_router.get_improve_router.<locals>.improve)
    parameter not documented:            sessionIds

DELETE /api/v1/integrations/plugins/{plugin_key}  (cognee.api.v1.integrations.routers.get_integrations_router.get_integrations_router.<locals>.disconnect_plugin)
    parameter not documented:            plugin_key

POST /api/v1/integrations/plugins/{plugin_key}/provision  (cognee.api.v1.integrations.routers.get_integrations_router.get_integrations_router.<locals>.provision_plugin)
    parameter not documented:            plugin_key

POST /api/v1/integrations/{provider}/authorize  (cognee.api.v1.integrations.routers.get_integrations_router.get_integrations_router.<locals>.authorize)
    parameter not documented:            provider

DELETE /api/v1/integrations/{provider}/connection  (cognee.api.v1.integrations.routers.get_integrations_router.get_integrations_router.<locals>.disconnect)
    parameter not documented:            provider

GET /api/v1/integrations/{provider}/connection  (cognee.api.v1.integrations.routers.get_integrations_router.get_integrations_router.<locals>.connection_status)
    parameter not documented:            provider

POST /api/v1/llm/custom-prompt  (cognee.api.v1.llm.routers.get_llm_router.get_llm_router.<locals>.generate_custom_prompt)
    parameter not documented:            graphModel
    parameter not documented:            parameters

POST /api/v1/llm/infer-schema  (cognee.api.v1.llm.routers.get_llm_router.get_llm_router.<locals>.infer_schema)
    parameter not documented:            data
    parameter not documented:            parameters
    parameter not documented:            text

GET /api/v1/proposals/{proposal_id}  (cognee.api.v1.proposals.routers.get_proposals_router.get_proposals_router.<locals>.get_skill_proposal)
    parameter not documented:            dataset_id
    parameter not documented:            proposal_id

POST /api/v1/recall  (cognee.api.v1.recall.routers.get_recall_router.get_recall_router.<locals>.recall)
    parameter not documented:            contextProfile
    parameter not documented:            toolConnections
    parameter not documented:            toolsTrigger

POST /api/v1/remember  (cognee.api.v1.remember.routers.get_remember_router.get_remember_router.<locals>.remember)
    parameter not documented:            import_mode
    parameter not documented:            skill_name
    parameter not documented:            skills_text

POST /api/v1/remember/entry  (cognee.api.v1.remember.routers.get_remember_router.get_remember_router.<locals>.remember_entry)
    parameter not documented:            dataset_id
    parameter not documented:            dataset_name
    parameter not documented:            entry
    parameter not documented:            session_id
    parameter not documented:            skill_improvement

POST /api/v1/responses/  (cognee.api.v1.responses.routers.get_responses_router.get_responses_router.<locals>.create_response)
    parameter not documented:            maxCompletionTokens
    parameter not documented:            user

GET /api/v1/sessions/cost-by-user-agent  (cognee.api.v1.sessions.routers.get_sessions_router.get_sessions_router.<locals>.cost_by_user_agent)
    parameter not documented:            range

GET /api/v1/sessions/with-agent-info  (cognee.api.v1.sessions.routers.get_sessions_router.get_sessions_router.<locals>.list_sessions_with_agent_info)
    parameter not documented:            descending
    parameter not documented:            limit
    parameter not documented:            offset
    parameter not documented:            order_by
    parameter not documented:            range
    parameter not documented:            status

GET /api/v1/sessions/{session_id}  (cognee.api.v1.sessions.routers.get_sessions_router.get_sessions_router.<locals>.get_session_detail)
    docstring: MISSING

POST /api/v1/skills  (cognee.api.v1.skills.routers.get_skills_router.get_skills_router.<locals>.ingest_skill)
    parameter not documented:            dataset_id
    parameter not documented:            dataset_name
    parameter not documented:            skill_name
    parameter not documented:            skills_text

GET /api/v1/skills/  (cognee.api.v1.skills.routers.get_skills_router.get_skills_router.<locals>.list_dataset_skills)
    parameter not documented:            dataset_id
    parameter not documented:            include_inactive
    parameter not documented:            limit
    parameter not documented:            offset

DELETE /api/v1/skills/{skill_id}  (cognee.api.v1.skills.routers.get_skills_router.get_skills_router.<locals>.delete_dataset_skill)
    parameter not documented:            dataset_id
    parameter not documented:            skill_id

GET /api/v1/skills/{skill_id}  (cognee.api.v1.skills.routers.get_skills_router.get_skills_router.<locals>.get_dataset_skill)
    parameter not documented:            dataset_id
    parameter not documented:            skill_id

PUT /api/v1/slack/channels  (cognee.api.v1.slack.routers.get_slack_channels_router.get_slack_channels_router.<locals>.set_allowed_channels)
    parameter not documented:            channelIds

POST /api/v1/slack/link  (cognee.api.v1.slack.routers.get_slack_channels_router.get_slack_channels_router.<locals>.link)
    parameter not documented:            code

POST /api/v1/users/get-user-id  (cognee.api.v1.users.routers.get_user_id_by_email_router.get_user_id_by_email_router.<locals>.get_user_id)
    docstring: MISSING

GET /api/v1/validate  (cognee.api.v1.validate.routers.get_validate_router.get_validate_router.<locals>.run_validate)
    parameter not documented:            dataset

GET /api/v1/visualize/semantic  (cognee.api.v1.users.routers.get_visualize_router.get_visualize_router.<locals>.visualize_semantic)
    parameter not documented:            dataset_id
    parameter not documented:            full
    parameter not documented:            max_nodes
    parameter not documented:            neighborhood_depth
    parameter not documented:            neighborhood_seed_top_k
    parameter not documented:            query
    parameter not documented:            seed_node_ids

Checked 111 route handlers: 66 clean, 45 flagged, 80 issues.
```