### PR TITLE
feat(retrieval): scope lexical chunk search to node sets

### DIFF
--- a/cognee/modules/retrieval/bm25_retriever.py
+++ b/cognee/modules/retrieval/bm25_retriever.py
@@ -22,6 +22,8 @@ class BM25ChunksRetriever(LexicalRetriever):
         stop_words: Optional[list[str]] = None,
         k1: float = 1.5,
         b: float = 0.75,
+        node_name: Optional[list[str]] = None,
+        node_name_filter_operator: str = "OR",
     ):
         """
         Parameters
@@ -37,6 +39,12 @@ class BM25ChunksRetriever(LexicalRetriever):
             BM25 term-frequency saturation parameter.
         b : float
             BM25 length-normalization parameter.
+        node_name : list[str], optional
+            Node set names to scope the corpus to. Defaults to None, which searches
+            every chunk.
+        node_name_filter_operator : str
+            "OR" keeps a chunk tagged with any of the requested node sets, "AND"
+            only one tagged with all of them.
         """
         if stop_words is None:
             self.stop_words = set(DEFAULT_STOP_WORDS)
@@ -51,7 +59,12 @@ class BM25ChunksRetriever(LexicalRetriever):
         self._stats_built = False
 
         super().__init__(
-            tokenizer=self._tokenizer, scorer=self._scorer, top_k=top_k, with_scores=with_scores
+            tokenizer=self._tokenizer,
+            scorer=self._scorer,
+            top_k=top_k,
+            with_scores=with_scores,
+            node_name=node_name,
+            node_name_filter_operator=node_name_filter_operator,
         )
 
     def _tokenizer(self, text: str) -> list[str]:
@@ -71,7 +84,12 @@ class BM25ChunksRetriever(LexicalRetriever):
         self._stats_built = True
 
     def _build_corpus_stats(self):
-        """Compute average chunk length and per-token IDF from the tokenized chunks."""
+        """Compute average chunk length and per-token IDF from the tokenized chunks.
+
+        When the retriever is scoped to node sets, only those chunks are loaded, so
+        IDF and average length describe the corpus actually being ranked rather than
+        the whole graph.
+        """
         total_chunks = len(self.chunks)
         document_frequency: Counter = Counter()
         total_length = 0

--- a/cognee/modules/retrieval/jaccard_retrival.py
+++ b/cognee/modules/retrieval/jaccard_retrival.py
@@ -14,6 +14,8 @@ class JaccardChunksRetriever(LexicalRetriever):
         with_scores: bool = False,
         stop_words: Optional[list[str]] = None,
         multiset_jaccard: bool = False,
+        node_name: Optional[list[str]] = None,
+        node_name_filter_operator: str = "OR",
     ):
         """
         Parameters
@@ -26,12 +28,23 @@ class JaccardChunksRetriever(LexicalRetriever):
             List of tokens to filter out.
         multiset_jaccard : bool
             If True, use multiset Jaccard (frequency aware).
+        node_name : list[str], optional
+            Node set names to scope the corpus to. Defaults to None, which searches
+            every chunk.
+        node_name_filter_operator : str
+            "OR" keeps a chunk tagged with any of the requested node sets, "AND"
+            only one tagged with all of them.
         """
         self.stop_words = {t.lower() for t in stop_words} if stop_words else set()
         self.multiset_jaccard = multiset_jaccard
 
         super().__init__(
-            tokenizer=self._tokenizer, scorer=self._scorer, top_k=top_k, with_scores=with_scores
+            tokenizer=self._tokenizer,
+            scorer=self._scorer,
+            top_k=top_k,
+            with_scores=with_scores,
+            node_name=node_name,
+            node_name_filter_operator=node_name_filter_operator,
         )
 
     def _tokenizer(self, text: str) -> list[str]:

--- a/cognee/modules/retrieval/lexical_retriever.py
+++ b/cognee/modules/retrieval/lexical_retriever.py
@@ -12,6 +12,58 @@ from cognee.shared.logging_utils import get_logger
 logger = get_logger("LexicalRetriever")
 
 
+def nodeset_tags(payload: dict) -> list[str]:
+    """Return a node payload's ``belongs_to_set`` tags as NodeSet names.
+
+    Graph serialization already reduces the field to names, and keeps it as a node
+    property rather than only as edges precisely so node sets can be filtered on
+    (see ``get_graph_from_model``). A tag can still reach the graph as a mapping or
+    a DataPoint from another writer, so each shape is reduced to the same string
+    key the vector payloads carry.
+    """
+    value = payload.get("belongs_to_set")
+    if value is None:
+        return []
+    if not isinstance(value, (list, tuple, set)):
+        value = [value]
+
+    tags: list[str] = []
+    for item in value:
+        if item is None:
+            continue
+        if isinstance(item, str):
+            tag: Any = item
+        elif isinstance(item, dict):
+            tag = item.get("name") or item.get("id")
+        else:
+            tag = getattr(item, "name", None) or getattr(item, "id", None)
+        if tag is not None:
+            tags.append(str(tag))
+    return tags
+
+
+def matches_node_set(
+    payload: dict,
+    node_name: Optional[List[str]],
+    node_name_filter_operator: str = "OR",
+) -> bool:
+    """Whether a chunk payload belongs to the requested node sets.
+
+    Mirrors what the vector adapters apply to the same field: "OR" keeps a chunk
+    tagged with any of the requested sets, "AND" only one tagged with all of them.
+    An empty ``node_name`` applies no filter, exactly as it does on the vector path.
+    """
+    if not node_name:
+        return True
+
+    tags = set(nodeset_tags(payload))
+    wanted = {str(name) for name in node_name}
+
+    if node_name_filter_operator == "AND":
+        return wanted.issubset(tags)
+    return bool(tags & wanted)
+
+
 def tokenize_words(text: str, stop_words: Optional[set[str]] = None) -> list[str]:
     """Lowercase, split on word characters, and drop any stop words.
 
@@ -25,17 +77,27 @@ def tokenize_words(text: str, stop_words: Optional[set[str]] = None) -> list[str
 
 class LexicalRetriever(BaseRetriever):
     def __init__(
-        self, tokenizer: Callable, scorer: Callable, top_k: int = 15, with_scores: bool = False
+        self,
+        tokenizer: Callable,
+        scorer: Callable,
+        top_k: int = 15,
+        with_scores: bool = False,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: str = "OR",
     ):
         if not callable(tokenizer) or not callable(scorer):
             raise TypeError("tokenizer and scorer must be callables")
         if not isinstance(top_k, int) or top_k <= 0:
             raise ValueError("top_k must be a positive integer")
+        if node_name is not None and not isinstance(node_name, (list, tuple)):
+            raise TypeError("node_name must be a list of node set names")
 
         self.tokenizer = tokenizer
         self.scorer = scorer
         self.top_k = top_k
         self.with_scores = bool(with_scores)
+        self.node_name = list(node_name) if node_name else None
+        self.node_name_filter_operator = node_name_filter_operator
 
         # Cache keyed by dataset context
         self.chunks: dict[str, Any] = {}  # {chunk_id: tokens}
@@ -59,6 +121,7 @@ class LexicalRetriever(BaseRetriever):
                 raise NoDataError("Graph engine initialization failed") from e
 
             chunk_count = 0
+            document_chunk_count = 0
             for node in nodes:
                 try:
                     chunk_id, document = node
@@ -67,6 +130,14 @@ class LexicalRetriever(BaseRetriever):
                     continue
 
                 if document.get("type") == "DocumentChunk" and document.get("text"):
+                    document_chunk_count += 1
+                    # Filter before tokenizing so a scoped search neither pays to
+                    # tokenize chunks it will not rank, nor lets them influence
+                    # corpus statistics a subclass derives from what was loaded.
+                    if not matches_node_set(
+                        document, self.node_name, self.node_name_filter_operator
+                    ):
+                        continue
                     try:
                         tokens = self.tokenizer(document["text"])
                         if not tokens:
@@ -82,6 +153,17 @@ class LexicalRetriever(BaseRetriever):
                         logger.error("Tokenizer failed for chunk %s: %s", chunk_id, str(e))
 
             if chunk_count == 0:
+                if self.node_name and document_chunk_count:
+                    # There is data, the requested node sets are simply empty. The
+                    # vector chunk search returns nothing in that case rather than
+                    # reporting that the system holds no data, so this does too.
+                    logger.info(
+                        "No chunks matched node sets %s out of %d document chunks",
+                        self.node_name,
+                        document_chunk_count,
+                    )
+                    self._initialized = True
+                    return
                 logger.error("Initialization completed but no valid chunks were loaded.")
                 raise NoDataError("No valid chunks loaded during initialization.")
 

--- a/cognee/modules/search/methods/get_search_type_retriever_instance.py
+++ b/cognee/modules/search/methods/get_search_type_retriever_instance.py
@@ -331,7 +331,14 @@ async def get_search_type_retriever_instance(
                 "include_references": include_references,
             },
         ),
-        SearchType.CHUNKS_LEXICAL: (BM25ChunksRetriever, {"top_k": top_k}),
+        SearchType.CHUNKS_LEXICAL: (
+            BM25ChunksRetriever,
+            {
+                "top_k": top_k,
+                "node_name": node_name,
+                "node_name_filter_operator": node_name_filter_operator,
+            },
+        ),
         SearchType.GRAPH_REPORT: (GraphReportRetriever, {"top_n": top_k}),
         SearchType.CODING_RULES: (
             CodingRulesRetriever,

--- a/cognee/tests/unit/modules/retrieval/test_bm25_retriever.py
+++ b/cognee/tests/unit/modules/retrieval/test_bm25_retriever.py
@@ -119,3 +119,133 @@ async def test_no_match_query_returns_zero_scored_chunks():
     # LexicalRetriever still returns top_k payloads for a no-match query; all score 0.0.
     assert len(results) == 2
     assert all(score == 0.0 for _, score in results)
+
+
+def _patch_graph_nodes(nodes: list[tuple[str, dict]]):
+    """Patch the graph engine with fully formed node payloads.
+
+    Node sets are carried on the chunk payload itself: graph serialization keeps
+    ``belongs_to_set`` as a property, reduced to NodeSet names, so it can be
+    filtered on the same way the vector payloads are.
+    """
+    engine = AsyncMock()
+    engine.get_filtered_graph_data = AsyncMock(return_value=(nodes, {}))
+    return patch(
+        "cognee.modules.retrieval.lexical_retriever.get_graph_engine",
+        AsyncMock(return_value=engine),
+    )
+
+
+def _chunk(chunk_id: str, text: str, node_sets=None) -> tuple[str, dict]:
+    payload = {"id": chunk_id, "type": "DocumentChunk", "text": text}
+    if node_sets is not None:
+        payload["belongs_to_set"] = node_sets
+    return (chunk_id, payload)
+
+
+TAGGED_CORPUS = [
+    _chunk("chunk_a", "alpha project", ["set_a"]),
+    _chunk("chunk_b", "alpha project", ["set_b"]),
+    _chunk("chunk_ab", "alpha project", ["set_a", "set_b"]),
+    _chunk("chunk_untagged", "alpha project"),
+]
+
+
+@pytest.mark.asyncio
+async def test_node_name_scopes_the_corpus_with_or():
+    retriever = BM25ChunksRetriever(top_k=10, node_name=["set_a"])
+
+    with _patch_graph_nodes(TAGGED_CORPUS):
+        results = await retriever.get_retrieved_objects("project")
+
+    assert {payload["id"] for payload in results} == {"chunk_a", "chunk_ab"}
+
+
+@pytest.mark.asyncio
+async def test_node_name_or_matches_any_requested_set():
+    retriever = BM25ChunksRetriever(top_k=10, node_name=["set_a", "set_b"])
+
+    with _patch_graph_nodes(TAGGED_CORPUS):
+        results = await retriever.get_retrieved_objects("project")
+
+    assert {payload["id"] for payload in results} == {"chunk_a", "chunk_b", "chunk_ab"}
+
+
+@pytest.mark.asyncio
+async def test_node_name_and_requires_every_requested_set():
+    retriever = BM25ChunksRetriever(
+        top_k=10, node_name=["set_a", "set_b"], node_name_filter_operator="AND"
+    )
+
+    with _patch_graph_nodes(TAGGED_CORPUS):
+        results = await retriever.get_retrieved_objects("project")
+
+    # Only the chunk carrying both tags qualifies; a chunk in one of the two does not.
+    assert {payload["id"] for payload in results} == {"chunk_ab"}
+
+
+@pytest.mark.asyncio
+async def test_no_node_name_searches_every_chunk():
+    retriever = BM25ChunksRetriever(top_k=10)
+
+    with _patch_graph_nodes(TAGGED_CORPUS):
+        results = await retriever.get_retrieved_objects("project")
+
+    assert len(results) == len(TAGGED_CORPUS)
+
+
+@pytest.mark.asyncio
+async def test_node_set_tags_stored_as_objects_are_matched_by_name():
+    class _NodeSet:
+        name = "set_a"
+
+    corpus = [
+        _chunk("chunk_mapping", "alpha project", [{"name": "set_a"}]),
+        _chunk("chunk_object", "alpha project", [_NodeSet()]),
+        _chunk("chunk_other", "alpha project", ["set_b"]),
+    ]
+    retriever = BM25ChunksRetriever(top_k=10, node_name=["set_a"])
+
+    with _patch_graph_nodes(corpus):
+        results = await retriever.get_retrieved_objects("project")
+
+    assert {payload["id"] for payload in results} == {"chunk_mapping", "chunk_object"}
+
+
+@pytest.mark.asyncio
+async def test_corpus_statistics_are_built_from_the_scoped_chunks_only():
+    corpus = [
+        _chunk("chunk_a", "alpha shared", ["set_a"]),
+        _chunk("chunk_b", "beta shared outsideterm", ["set_b"]),
+    ]
+    retriever = BM25ChunksRetriever(top_k=10, node_name=["set_a"])
+
+    with _patch_graph_nodes(corpus):
+        await retriever.get_retrieved_objects("shared")
+
+    # A term that only exists outside the scope must not reach the corpus stats,
+    # otherwise IDF would describe a corpus the search cannot return.
+    assert "outsideterm" not in retriever.idf
+    assert set(retriever.chunks) == {"chunk_a"}
+
+
+@pytest.mark.asyncio
+async def test_empty_node_set_returns_no_results_instead_of_reporting_no_data():
+    retriever = BM25ChunksRetriever(top_k=10, node_name=["set_missing"])
+
+    with _patch_graph_nodes(TAGGED_CORPUS):
+        results = await retriever.get_retrieved_objects("project")
+
+    # The system holds data, the requested node set is simply empty. The vector
+    # chunk search returns nothing here rather than raising, so this does too.
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_genuinely_empty_corpus_still_raises_no_data():
+    from cognee.modules.retrieval.exceptions.exceptions import NoDataError
+
+    retriever = BM25ChunksRetriever(top_k=10, node_name=["set_a"])
+
+    with _patch_graph_nodes([]), pytest.raises(NoDataError):
+        await retriever.get_retrieved_objects("project")

--- a/cognee/tests/unit/modules/search/test_get_search_type_retriever_instance.py
+++ b/cognee/tests/unit/modules/search/test_get_search_type_retriever_instance.py
@@ -372,6 +372,23 @@ async def test_chunks_lexical_returns_bm25_retriever():
 
 
 @pytest.mark.asyncio
+async def test_chunks_lexical_forwards_node_set_filtering():
+    import cognee.modules.search.methods.get_search_type_retriever_instance as mod
+    from cognee.modules.retrieval.bm25_retriever import BM25ChunksRetriever
+
+    retriever_instance = await mod.get_search_type_retriever_instance(
+        SearchType.CHUNKS_LEXICAL,
+        query_text="q",
+        top_k=3,
+        node_name=["set_a"],
+        node_name_filter_operator="AND",
+    )
+    assert isinstance(retriever_instance, BM25ChunksRetriever)
+    assert retriever_instance.node_name == ["set_a"]
+    assert retriever_instance.node_name_filter_operator == "AND"
+
+
+@pytest.mark.asyncio
 async def test_coding_rules_uses_node_name_as_rules_nodeset_name():
     import cognee.modules.search.methods.get_search_type_retriever_instance as mod
     from cognee.modules.retrieval.coding_rules_retriever import CodingRulesRetriever


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

`SearchType.CHUNKS` takes `node_name` and `node_name_filter_operator` and hands them to the vector search, which filters on the `belongs_to_set` tags carried in each chunk payload. `SearchType.CHUNKS_LEXICAL` takes neither. The factory builds `BM25ChunksRetriever` with `top_k` alone, and `LexicalRetriever.initialize()` loads every `DocumentChunk` in the graph:

```python
SearchType.CHUNKS_LEXICAL: (BM25ChunksRetriever, {"top_k": top_k}),
```

So a caller who scopes `CHUNKS` to one node set and then switches to `CHUNKS_LEXICAL` gets the whole corpus back. The scope is not rejected and not warned about, it is just dropped, which is the failure mode you notice last.

I went looking for where the tags live before deciding how to filter, and they turn out to be on the node already. `get_graph_from_model` treats `belongs_to_set` as the one DataPoint-valued field that is *not* excluded from node properties, and reduces it to a list of NodeSet names, with a comment saying it does this so node sets can be filtered on. That is what the vector adapters read (`payload -> 'belongs_to_set' ?| ARRAY[...]` in PGVector). Since `LexicalRetriever` is reading those same node payloads out of `get_filtered_graph_data`, the filter is a local check on data already in hand: no adapter support to add, no second graph query, and it works on every adapter where lexical search works today rather than only on those implementing `get_nodeset_subgraph`.

Three decisions worth flagging, since none of them are forced by the code:

**The filter runs while the corpus is loading, not while it is being scored.** That is not only about skipping tokenization. `BM25ChunksRetriever` derives IDF and average chunk length from whatever the parent loaded, so filtering later would leave BM25 ranking a scoped result set against statistics computed over the entire graph. A term that is common inside the requested node set but rare outside it would keep an IDF that describes a corpus the search cannot return. Filtering first makes the statistics describe the corpus actually being ranked.

**An empty node set returns nothing instead of raising.** `initialize()` raises `NoDataError("No valid chunks loaded during initialization.")` when it loads zero chunks. With scoping added, the same path is reached when the system is full of data and the requested node set is simply empty, and telling that caller there is no data in the system would be wrong. The vector chunk search returns an empty result there, so this now does too. A genuinely empty corpus, with no node-set filter or with no `DocumentChunk` nodes at all, still raises exactly as before, and there is a test pinning each half.

**The tag normalizer tolerates more than the serializer emits.** Serialization always produces plain names, but `consolidate_entities` also writes this property and reads it back through shapes that include mappings and DataPoints, so `nodeset_tags` reduces all three to the same string key rather than assuming the happy path. I deliberately did not move that module's private `_belongs_to_set_tags` into shared code as part of this PR: it is a task-layer helper, importing it into retrieval would be the wrong direction, and unifying them properly is a refactor that does not belong in a feature change. Happy to do it as a follow-up if you would rather have one implementation.

`JaccardChunksRetriever` gets the same two parameters, since it is the other `LexicalRetriever` subclass and would otherwise be the next thing to silently ignore a scope.

## Acceptance Criteria

* `SearchType.CHUNKS_LEXICAL` accepts `node_name` and `node_name_filter_operator` and applies them with the same meaning `SearchType.CHUNKS` gives them: `OR` keeps a chunk tagged with any requested set, `AND` only one tagged with all of them.
* Unscoped lexical search is unchanged.
* BM25 corpus statistics reflect only the scoped chunks.
* An empty node set returns no results; a genuinely empty corpus still raises `NoDataError`.

9 new tests, in the existing `test_bm25_retriever.py` and `test_get_search_type_retriever_instance.py` rather than in new files:

```
cognee/tests/unit/modules/retrieval/  and  cognee/tests/unit/modules/search/
578 passed, 10 failed, 1 skipped
```

The 10 failures are identical, by name, on `upstream/dev` with these files reverted (569 passed there, so all 9 new tests are additive and nothing regressed). 8 of the 9 fail against `dev`; the 9th is `test_no_node_name_searches_every_chunk`, which passes both before and after on purpose, because its job is to pin that unscoped search did not change.

`ruff format --check` is clean on all six files. `ruff check` reports no new rule violations against the base beyond the pre-existing `Optional[...]` / `List[...]` style already used throughout these files, which I matched rather than modernized so the new parameters read like their neighbours. `ty check` is unaffected: `cognee/modules/retrieval` and `cognee/modules/search` are not in `[tool.ty.src] include`, and the 9 diagnostics it reports are the same ones as on `dev`, none in these files.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

`gh` cannot attach images, so the run is pasted above rather than shown. Happy to add a screenshot if you want it on the PR.

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

Note on the existing-PR check: #3894 also touches `lexical_retriever.py`, but only `get_context_from_objects`, and it adds `test_lexical_retriever.py`. This PR touches `__init__` and `initialize()` and puts its tests in the existing `test_bm25_retriever.py`, so the two do not overlap textually. No open PR references node-set filtering for lexical search, and there is no issue open for it that I could find.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
