### PR TITLE
fix(llm): Stop retrying LiteLLM budget exhaustion (COG-6329)

### DIFF
--- a/cognee/infrastructure/llm/LLMGateway.py
+++ b/cognee/infrastructure/llm/LLMGateway.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from cognee.infrastructure.llm import get_llm_config
 from cognee.infrastructure.llm.config import get_llm_context_config
+from cognee.infrastructure.llm.exceptions import raise_if_budget_exhausted
 from cognee.infrastructure.llm.retry_config import raise_if_quota_error
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.types import (
     TranscriptionReturnType,
@@ -80,14 +81,21 @@ async def _record_session_usage_after(
 
 
 async def _fail_fast_on_quota(coro: Coroutine) -> T:
-    """Convert provider quota/billing exhaustion into ``LLMQuotaExceededError``.
+    """Convert provider quota/billing exhaustion into an actionable error.
 
     Runs at the single choke point every structured-output call flows through,
     so it is provider- and framework-agnostic.
+
+    Budget exhaustion is checked first, and here rather than only in the
+    adapters: each instructor adapter catches ``InstructorRetryException`` in a
+    clause that precedes its own budget handler, and the plain-text path
+    (``response_model is str``) bypasses those handlers altogether. Classifying
+    at this choke point gives every adapter and both paths the same 402.
     """
     try:
         return await coro
     except Exception as error:
+        raise_if_budget_exhausted(error)
         raise_if_quota_error(error)
         raise
 

--- a/cognee/infrastructure/llm/exceptions.py
+++ b/cognee/infrastructure/llm/exceptions.py
@@ -1,3 +1,5 @@
+import re
+
 from cognee.exceptions.exceptions import CogneeValidationError
 
 
@@ -14,19 +16,55 @@ class LLMPaymentRequiredError(CogneeValidationError):
         super().__init__(message=message, name="LLMPaymentRequiredError", status_code=402)
 
 
-def is_budget_exhausted_error(e: Exception) -> bool:
-    """Return True if e signals LLM budget or payment exhaustion.
+# Message text is the only signal that reliably survives the wrapper exceptions
+# the instructor adapters raise: by the time a LiteLLM-proxy budget rejection
+# reaches us it is an ``InstructorRetryException`` whose deepest cause is a
+# client-side ``RateLimitError`` — a different class from
+# ``litellm.BudgetExceededError``, and one whose response body has already been
+# consumed, so the structured ``error.type`` check below cannot fire.
+#
+# LiteLLM raises ``BudgetExceededError`` with three distinct wordings, each
+# covering several scopes:
+#   1. "Budget has been exceeded! [Scope=...] Current cost: X, Max budget: Y"
+#      -- virtual key, team member, team, project, organization, tag
+#   2. "ExceededBudget: [End ]User=<id> over budget. Spend=X, Budget=Y"
+#      -- internal-user and end-user budgets
+#   3. "LiteLLM {Virtual Key|End User}: <id>, exceeded budget for model=<m>"
+#      -- per-model budget caps
+# In wordings 1 and 2 a variable scope segment sits mid-sentence, so no single
+# contiguous substring spans them; each signature is therefore a set of
+# fragments that must ALL be present.
+#
+# Conjunctive matching is what keeps this safe: ``str(InstructorRetryException)``
+# embeds the model's own partial completion, so a single natural-language phrase
+# would misclassify an ordinary validation-retry failure on any document that
+# happens to discuss an exceeded budget.
+_BUDGET_MESSAGE_SIGNATURES = (
+    ("budget has been exceeded!", "max budget:"),
+    ("exceededbudget:", "over budget."),
+    ("exceeded budget for model=",),
+)
 
-    Three cases are handled:
-    1. Any provider returning HTTP 402 Payment Required directly.
-    2. litellm's own budget manager raising BudgetExceededError (status_code 429,
-       rate_limit_type "budget") when litellm is used as a library with a configured budget.
-    3. LiteLLM proxy (≥v1.x) returning HTTP 429 with a JSON body whose "error.type" field
-       equals "budget_exceeded". This is LiteLLM-proxy-specific: the proxy enforces virtual-key
-       and per-user spend caps and uses this response shape to distinguish budget exhaustion from
-       ordinary rate limiting. If LiteLLM changes this response format this branch silently falls
-       through, so callers should monitor for unhandled 429s after proxy upgrades.
-    """
+# Isolates just the provider sentence, skipping the surrounding wrapper noise.
+# Bounded repetition keeps the detail short and the scan linear.
+_BUDGET_SENTENCE_RE = re.compile(
+    r"Budget has been exceeded!.{0,200}?Max budget:\s*[\d.]+"
+    r"|ExceededBudget:.{0,200}?Budget=[\d.]+"
+    r"|LiteLLM (?:Virtual Key|End User):.{0,200}?exceeded budget for model=\S+",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _has_budget_message(text: str) -> bool:
+    lowered = text.lower()
+    return any(
+        all(fragment in lowered for fragment in signature)
+        for signature in _BUDGET_MESSAGE_SIGNATURES
+    )
+
+
+def _is_budget_exhausted_link(e: BaseException) -> bool:
+    """Classify a single exception in a ``__cause__`` chain."""
     # Case 1: provider-level payment required
     if getattr(e, "status_code", None) == 402:
         return True
@@ -40,7 +78,8 @@ def is_budget_exhausted_error(e: Exception) -> bool:
     except ImportError:
         pass
 
-    # Case 3: LiteLLM proxy budget_exceeded encoded inside a 429
+    # Case 3: LiteLLM proxy budget_exceeded encoded inside a 429. Only reachable
+    # when the error is caught before the response body is consumed.
     if getattr(e, "status_code", None) == 429:
         response = getattr(e, "response", None)
         if response is not None:
@@ -52,7 +91,62 @@ def is_budget_exhausted_error(e: Exception) -> bool:
             except Exception:
                 pass
 
+    # Case 4: message text, the wrapper-proof fallback. ``str()`` is guarded
+    # because this runs inside tenacity's retry predicate, where an exception
+    # with a raising ``__str__`` would escape the retry machinery itself.
+    try:
+        text = str(e)
+    except Exception:
+        return False
+    return _has_budget_message(text)
+
+
+def is_budget_exhausted_error(e: BaseException) -> bool:
+    """Return True if e signals LLM budget or payment exhaustion.
+
+    Walks the ``__cause__`` chain, because adapters and instructor wrap the
+    provider error with ``raise ... from``. ``__context__`` is deliberately not
+    followed, so an unrelated error merely raised while handling a budget error
+    is not misclassified.
+
+    Four signals are checked per link: HTTP 402, ``litellm.BudgetExceededError``,
+    the LiteLLM proxy's ``error.type == "budget_exceeded"`` body, and finally the
+    message wording (see ``_BUDGET_MESSAGE_SIGNATURES``).
+    """
+    seen: set[int] = set()
+    current: BaseException | None = e
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if _is_budget_exhausted_link(current):
+            return True
+        current = current.__cause__
     return False
+
+
+def budget_exhaustion_detail(e: BaseException) -> str | None:
+    """Pull the provider's own budget sentence out of a wrapped exception.
+
+    ``str(e)`` on an ``InstructorRetryException`` is long and embeds the model's
+    partial completions, so the sentence is extracted rather than passed whole.
+    """
+    match = _BUDGET_SENTENCE_RE.search(str(e))
+    return match.group(0).strip() if match else None
+
+
+def raise_if_budget_exhausted(error: BaseException) -> None:
+    """Re-raise budget exhaustion as ``LLMPaymentRequiredError`` (HTTP 402).
+
+    Instructor reports provider failures as ``InstructorRetryException``, which
+    the adapters catch in an earlier ``except`` clause than their budget
+    handler. The check therefore has to happen at that re-raise site, or the
+    budget handler further down is never reached.
+    """
+    if not is_budget_exhausted_error(error):
+        return
+    detail = budget_exhaustion_detail(error)
+    if detail:
+        raise LLMPaymentRequiredError(f"LLM budget exhausted: {detail}") from error
+    raise LLMPaymentRequiredError() from error
 
 
 class LLMAPIKeyNotSetError(CogneeValidationError):

--- a/cognee/infrastructure/llm/exceptions.py
+++ b/cognee/infrastructure/llm/exceptions.py
@@ -23,44 +23,45 @@ class LLMPaymentRequiredError(CogneeValidationError):
 # ``litellm.BudgetExceededError``, and one whose response body has already been
 # consumed, so the structured ``error.type`` check below cannot fire.
 #
-# LiteLLM raises ``BudgetExceededError`` with three distinct wordings, each
-# covering several scopes:
+# LiteLLM raises ``BudgetExceededError`` with three distinct sentence shapes,
+# between them covering every budget scope:
 #   1. "Budget has been exceeded! [Scope=...] Current cost: X, Max budget: Y"
 #      -- virtual key, team member, team, project, organization, tag
 #   2. "ExceededBudget: [End ]User=<id> over budget. Spend=X, Budget=Y"
 #      -- internal-user and end-user budgets
 #   3. "LiteLLM {Virtual Key|End User}: <id>, exceeded budget for model=<m>"
 #      -- per-model budget caps
-# In wordings 1 and 2 a variable scope segment sits mid-sentence, so no single
-# contiguous substring spans them; each signature is therefore a set of
-# fragments that must ALL be present.
 #
-# Conjunctive matching is what keeps this safe: ``str(InstructorRetryException)``
-# embeds the model's own partial completion, so a single natural-language phrase
-# would misclassify an ordinary validation-retry failure on any document that
-# happens to discuss an exceeded budget.
-_BUDGET_MESSAGE_SIGNATURES = (
-    ("budget has been exceeded!", "max budget:"),
-    ("exceededbudget:", "over budget."),
-    ("exceeded budget for model=",),
-)
-
-# Isolates just the provider sentence, skipping the surrounding wrapper noise.
-# Bounded repetition keeps the detail short and the scan linear.
+# One regex both detects and extracts, so a positive match always yields a
+# detail. Matching the WHOLE sentence — rather than checking for fragments
+# anywhere in the text — is what keeps this safe: ``str(InstructorRetryException)``
+# concatenates the model's own partial completions, so loose fragment matching
+# fires on any document that merely mentions an exceeded budget and a maximum
+# somewhere in several KB of unrelated prose. The bounded ``.{0,200}?`` spans
+# only the variable scope segment, keeps the scan linear, and caps the detail.
 _BUDGET_SENTENCE_RE = re.compile(
     r"Budget has been exceeded!.{0,200}?Max budget:\s*[\d.]+"
     r"|ExceededBudget:.{0,200}?Budget=[\d.]+"
-    r"|LiteLLM (?:Virtual Key|End User):.{0,200}?exceeded budget for model=\S+",
+    r"|LiteLLM (?:Virtual Key|End User):.{0,200}?exceeded budget for model=\S{1,100}",
     re.IGNORECASE | re.DOTALL,
 )
 
+# The sentence can carry the virtual-key hash, key alias, and end-user / team /
+# organization IDs, and the detail is returned to API callers in the 402 body.
+# Spend and budget figures are kept — they are the caller's own, and are the
+# actionable part — but identifiers are masked.
+_BUDGET_IDENTIFIER_RE = re.compile(
+    r"\b(Virtual Key|End User|User|Team|Project|Organization|Tag|key_alias)(\s*[:=]\s*)([^\s,]+)",
+    re.IGNORECASE,
+)
+
+
+def _redact_budget_identifiers(sentence: str) -> str:
+    return _BUDGET_IDENTIFIER_RE.sub(r"\1\2<redacted>", sentence)
+
 
 def _has_budget_message(text: str) -> bool:
-    lowered = text.lower()
-    return any(
-        all(fragment in lowered for fragment in signature)
-        for signature in _BUDGET_MESSAGE_SIGNATURES
-    )
+    return _BUDGET_SENTENCE_RE.search(text) is not None
 
 
 def _is_budget_exhausted_link(e: BaseException) -> bool:
@@ -127,10 +128,25 @@ def budget_exhaustion_detail(e: BaseException) -> str | None:
     """Pull the provider's own budget sentence out of a wrapped exception.
 
     ``str(e)`` on an ``InstructorRetryException`` is long and embeds the model's
-    partial completions, so the sentence is extracted rather than passed whole.
+    partial completions, so the sentence is extracted rather than passed whole,
+    and identifiers within it are masked before it reaches an API response.
+
+    Walks the ``__cause__`` chain like ``is_budget_exhausted_error``, since a
+    positive classification may come from a link below the outermost exception.
     """
-    match = _BUDGET_SENTENCE_RE.search(str(e))
-    return match.group(0).strip() if match else None
+    seen: set[int] = set()
+    current: BaseException | None = e
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        try:
+            text = str(current)
+        except Exception:
+            text = ""
+        match = _BUDGET_SENTENCE_RE.search(text)
+        if match:
+            return _redact_budget_identifiers(match.group(0).strip())
+        current = current.__cause__
+    return None
 
 
 def raise_if_budget_exhausted(error: BaseException) -> None:

--- a/cognee/infrastructure/llm/exceptions.py
+++ b/cognee/infrastructure/llm/exceptions.py
@@ -112,7 +112,7 @@ def is_budget_exhausted_error(e: BaseException) -> bool:
 
     Four signals are checked per link: HTTP 402, ``litellm.BudgetExceededError``,
     the LiteLLM proxy's ``error.type == "budget_exceeded"`` body, and finally the
-    message wording (see ``_BUDGET_MESSAGE_SIGNATURES``).
+    message wording (see ``_BUDGET_SENTENCE_RE``).
     """
     seen: set[int] = set()
     current: BaseException | None = e

--- a/cognee/infrastructure/llm/retry_config.py
+++ b/cognee/infrastructure/llm/retry_config.py
@@ -24,6 +24,7 @@ from tenacity import retry_if_exception, stop_after_attempt, stop_after_delay
 from cognee.infrastructure.llm.exceptions import (
     LLMPaymentRequiredError,
     LLMQuotaExceededError,
+    is_budget_exhausted_error,
 )
 
 # Minimum number of attempts before the call is allowed to give up.
@@ -77,12 +78,23 @@ def should_retry_llm_exception(error: BaseException) -> bool:
     )
     if isinstance(error, non_retryable):
         return False
+    # A configured spend cap cannot clear within a retry window, so budget
+    # exhaustion is terminal for this call even when the budget resets on a
+    # later period. Checked separately from ``_TERMINAL_QUOTA_PATTERNS`` so that
+    # ``raise_if_quota_error`` keeps mapping budget errors to the 402
+    # ``LLMPaymentRequiredError`` rather than the 422 quota error.
+    if is_budget_exhausted_error(error):
+        return False
     return not is_quota_or_billing_error(error)
 
 
 def raise_if_quota_error(error: BaseException) -> None:
     """Re-raise quota/billing exhaustion as the actionable ``LLMQuotaExceededError``."""
     if isinstance(error, LLMQuotaExceededError):
+        raise error
+    # Budget exhaustion is already the more specific 402; do not downgrade it to
+    # the 422 quota error just because it also reads as a spend problem.
+    if isinstance(error, LLMPaymentRequiredError):
         raise error
     if is_quota_or_billing_error(error):
         raise LLMQuotaExceededError(str(error)) from error

--- a/cognee/infrastructure/llm/retry_config.py
+++ b/cognee/infrastructure/llm/retry_config.py
@@ -89,7 +89,15 @@ def should_retry_llm_exception(error: BaseException) -> bool:
 
 
 def raise_if_quota_error(error: BaseException) -> None:
-    """Re-raise quota/billing exhaustion as the actionable ``LLMQuotaExceededError``."""
+    """Re-raise quota/billing exhaustion as the actionable ``LLMQuotaExceededError``.
+
+    Returns normally when *error* is not a quota problem, leaving the caller to
+    re-raise it. Already-typed errors pass through unchanged: an
+    ``LLMQuotaExceededError`` is re-raised as-is, and so is an
+    ``LLMPaymentRequiredError`` — budget exhaustion is the more specific 402 and
+    must not be downgraded to the 422 quota error just because it also reads as
+    a spend problem.
+    """
     if isinstance(error, LLMQuotaExceededError):
         raise error
     # Budget exhaustion is already the more specific 402; do not downgrade it to

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -33,6 +33,7 @@ from cognee.infrastructure.llm.exceptions import (
     ContentPolicyFilterError,
     LLMPaymentRequiredError,
     is_budget_exhausted_error,
+    raise_if_budget_exhausted,
 )
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
     LLMInterface,
@@ -223,6 +224,13 @@ class GenericAPIAdapter(LLMInterface):
             ContentPolicyViolationError,
             InstructorRetryException,
         ) as error:
+            # Budget exhaustion arrives wrapped in InstructorRetryException, so it has to
+            # be classified here: the handler further down is unreachable once this clause
+            # matches. Checked before the content-policy branch because the model's partial
+            # completion is rendered into str(error), so a budget rejection whose completion
+            # happens to mention a content policy would otherwise be misrouted to fallback.
+            raise_if_budget_exhausted(error)
+
             if (
                 isinstance(error, InstructorRetryException)
                 and "content management policy" not in str(error).lower()
@@ -262,6 +270,8 @@ class GenericAPIAdapter(LLMInterface):
                 ContentPolicyViolationError,
                 InstructorRetryException,
             ) as error:
+                raise_if_budget_exhausted(error)
+
                 if (
                     isinstance(error, InstructorRetryException)
                     and "content management policy" not in str(error).lower()
@@ -272,8 +282,8 @@ class GenericAPIAdapter(LLMInterface):
                         f"The provided input contains content that is not aligned with our content policy: {text_input}"
                     ) from error
         except Exception as e:
-            if is_budget_exhausted_error(e):
-                raise LLMPaymentRequiredError() from e
+            # Same detail-carrying message as the wrapped-error path above.
+            raise_if_budget_exhausted(e)
             raise
 
     @observe(as_type="transcription")

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -31,8 +31,6 @@ from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.ll
 )
 from cognee.infrastructure.llm.exceptions import (
     ContentPolicyFilterError,
-    LLMPaymentRequiredError,
-    is_budget_exhausted_error,
     raise_if_budget_exhausted,
 )
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (

--- a/cognee/tests/unit/infrastructure/llm/test_budget_exhaustion.py
+++ b/cognee/tests/unit/infrastructure/llm/test_budget_exhaustion.py
@@ -35,8 +35,10 @@ from tenacity import Future as TenacityFuture
 from cognee.infrastructure.llm.exceptions import (
     LLMPaymentRequiredError,
     LLMQuotaExceededError,
+    _redact_budget_identifiers,
     budget_exhaustion_detail,
     is_budget_exhausted_error,
+    raise_if_budget_exhausted,
 )
 from cognee.infrastructure.llm.retry_config import (
     is_quota_or_billing_error,
@@ -202,6 +204,33 @@ class TestNoFalsePositives:
         assert is_budget_exhausted_error(exc) is False, f"false positive: {prose}"
         assert should_retry_llm_exception(exc) is True
 
+    def test_fragments_far_apart_are_not_budget_exhaustion(self):
+        """Detection matches a whole sentence, not fragments anywhere in the text.
+
+        ``str(InstructorRetryException)`` concatenates every failed attempt's
+        partial completion, so a document mentioning an exceeded budget in one
+        paragraph and a maximum several KB later must not be classified.
+        """
+        doc = "the marketing budget has been exceeded! " + "x" * 4000 + " Our max budget: 40000 EUR"
+        exc = Exception("validation failed, completion=" + doc)
+        assert is_budget_exhausted_error(exc) is False
+        assert should_retry_llm_exception(exc) is True
+
+    def test_per_model_wording_requires_the_litellm_prefix(self):
+        """Shape 3's distinguishing fragment is short enough to occur in prose,
+        so the ``LiteLLM Virtual Key:`` / ``End User:`` prefix is required."""
+        exc = Exception("the CI job exceeded budget for model=trained last sprint")
+        assert is_budget_exhausted_error(exc) is False
+        assert should_retry_llm_exception(exc) is True
+
+    def test_detection_and_extraction_agree(self):
+        """A positive classification must always yield a detail. Disagreement
+        would mean the two used different rules again."""
+        for message in LITELLM_BUDGET_MESSAGES:
+            exc = _wrapped_budget_error(message)
+            assert is_budget_exhausted_error(exc) is True
+            assert budget_exhaustion_detail(exc) is not None
+
     def test_known_limitation_verbatim_provider_message_in_a_document(self):
         """Documents the one residual false positive, deliberately accepted.
 
@@ -316,10 +345,68 @@ class TestDetailExtraction:
     def test_detail_is_none_when_absent(self):
         assert budget_exhaustion_detail(Exception("something else")) is None
 
+    def test_detail_is_bounded_against_an_unbroken_token(self):
+        """The per-model shape ends in a bare token; without a length bound a
+        100 KB model name would land verbatim in the 402 response body."""
+        exc = Exception("LiteLLM Virtual Key: k, exceeded budget for model=" + "A" * 100_000)
+        detail = budget_exhaustion_detail(exc)
+        assert detail is None or len(detail) < 300
+
+    def test_identifiers_are_redacted(self):
+        """The sentence can carry the virtual-key hash, key alias and tenant
+        IDs, and the detail is returned to API callers in the 402 body."""
+        exc = Exception(
+            "LiteLLM Virtual Key: sk-abc123secret, key_alias: prod-key, "
+            "exceeded budget for model=gpt-4o"
+        )
+        detail = budget_exhaustion_detail(exc)
+        assert detail is not None
+        assert "sk-abc123secret" not in detail
+        assert "prod-key" not in detail
+        assert "<redacted>" in detail
+        # The model is not an identifier and stays: it is the actionable part.
+        assert "gpt-4o" in detail
+
+    def test_scope_ids_are_redacted_but_figures_kept(self):
+        detail = budget_exhaustion_detail(
+            Exception(
+                "Budget has been exceeded! Team=acme-corp Current cost: 70.0, Max budget: 70.0"
+            )
+        )
+        assert detail is not None
+        assert "acme-corp" not in detail
+        assert "70.0" in detail
+
+    def test_detail_walks_the_cause_chain(self):
+        """Classification can succeed on a link below the outermost exception,
+        so extraction has to walk too or the 402 loses its detail."""
+        inner = Exception(LITELLM_BUDGET_MESSAGES[0])
+        outer = Exception("wrapper with no budget wording")
+        outer.__cause__ = inner
+        assert is_budget_exhausted_error(outer) is True
+        assert budget_exhaustion_detail(outer) is not None
+
+    def test_detail_survives_a_raising_str(self):
+        """``budget_exhaustion_detail`` runs inside ``raise_if_budget_exhausted``;
+        a raising ``__str__`` must not replace the 402 with an unrelated error."""
+
+        class Hostile(Exception):
+            status_code = 402
+
+            def __str__(self):
+                raise RuntimeError("boom")
+
+        exc = Hostile()
+        assert is_budget_exhausted_error(exc) is True
+        assert budget_exhaustion_detail(exc) is None
+        with pytest.raises(LLMPaymentRequiredError):
+            raise_if_budget_exhausted(exc)
+
     @pytest.mark.parametrize("message", LITELLM_BUDGET_MESSAGES)
     def test_detail_extracted_for_every_scope(self, message):
         detail = budget_exhaustion_detail(_wrapped_budget_error(message))
         assert detail is not None, f"no detail extracted for: {message}"
         assert len(detail) < 300
-        # The extracted sentence must come from the provider message itself.
-        assert detail.lower() in message.lower()
+        # The detail is the provider sentence with identifiers masked -- nothing
+        # invented, nothing pulled in from the surrounding wrapper noise.
+        assert detail.lower() in _redact_budget_identifiers(message).lower()

--- a/cognee/tests/unit/infrastructure/llm/test_budget_exhaustion.py
+++ b/cognee/tests/unit/infrastructure/llm/test_budget_exhaustion.py
@@ -1,0 +1,325 @@
+"""LiteLLM-proxy budget exhaustion must be terminal, and nothing else may be.
+
+A proxy spend-cap rejection cannot clear by retrying, but cognee used to treat
+it as a transient rate limit: one logical LLM call fanned out to ~36 HTTP
+requests over ~270s before failing.
+
+The classification is unavoidably message-text based, because every structured
+signal is destroyed on the way up:
+
+* the error surfaces as ``InstructorRetryException``, whose ``__cause__`` chain
+  is ``InstructorRetryException -> RetryError -> RateLimitError``;
+* the outermost exception carries no ``status_code`` and no ``response``;
+* the client-side ``RateLimitError`` is a *different class* from
+  ``litellm.BudgetExceededError``, so an ``isinstance`` check cannot fire;
+* that ``RateLimitError``'s ``.response.json()`` raises ``JSONDecodeError``
+  because the body has already been consumed, so the proxy's structured
+  ``error.type == "budget_exceeded"`` field is unreadable.
+
+Text matching is therefore load-bearing and fragile across litellm upgrades,
+which is what these tests pin. Two failure directions matter equally:
+
+* a FALSE NEGATIVE resurrects the retry storm;
+* a FALSE POSITIVE is worse — ``str(InstructorRetryException)`` embeds the
+  model's own partial completion, so an over-eager match would turn a routine,
+  retryable extraction failure into a hard 402 for any document that merely
+  discusses an exceeded budget.
+"""
+
+import litellm
+import pytest
+from instructor.core.exceptions import FailedAttempt, InstructorRetryException
+from tenacity import RetryError
+from tenacity import Future as TenacityFuture
+
+from cognee.infrastructure.llm.exceptions import (
+    LLMPaymentRequiredError,
+    LLMQuotaExceededError,
+    budget_exhaustion_detail,
+    is_budget_exhausted_error,
+)
+from cognee.infrastructure.llm.retry_config import (
+    is_quota_or_billing_error,
+    raise_if_quota_error,
+    should_retry_llm_exception,
+)
+
+# The exact wordings litellm raises ``BudgetExceededError`` with. Sourced from
+# litellm/exceptions.py, litellm/proxy/auth/auth_checks.py and
+# litellm/proxy/hooks/model_max_budget_limiter.py. There are three sentence
+# shapes, and in two of them a variable scope segment sits mid-sentence, so no
+# single contiguous substring spans them all.
+#
+# Keep this list in sync with litellm on upgrade: a wording added upstream and
+# missed here silently resurrects the retry storm for that budget scope.
+LITELLM_BUDGET_MESSAGES = [
+    # Shape 1 -- virtual key / team member / team / project / organization / tag
+    "Budget has been exceeded! Current cost: 20.014285, Max budget: 20.0",
+    "Budget has been exceeded! User=u1 in Team=t1 Current cost: 5.504, Max budget: 5.5",
+    "Budget has been exceeded! Team=t1 Current cost: 70.004, Max budget: 70.0",
+    "Budget has been exceeded! Project=p1 Current cost: 2.503, Max budget: 2.5",
+    "Budget has been exceeded! Organization=o1 Current cost: 9.1, Max budget: 9.0",
+    "Budget has been exceeded! Tag=prod Current cost: 1.2, Max budget: 1.0",
+    # Shape 2 -- internal-user and end-user budgets (auth_checks.py:557,581,894)
+    "ExceededBudget: User=u1 over budget. Spend=12.0, Budget=10.0",
+    "ExceededBudget: End User=e1 over budget. Spend=3.0, Budget=2.0",
+    # Shape 3 -- per-model budget caps (model_max_budget_limiter.py:80,135)
+    "LiteLLM Virtual Key: tok, key_alias: ka, exceeded budget for model=gpt-4o",
+    "LiteLLM End User: e1, exceeded budget for model=gpt-4o",
+]
+
+# Prose that a cognified document could plausibly contain. None of it may be
+# mistaken for a proxy rejection.
+INNOCENT_PROSE = [
+    "Q3 report: the marketing budget has been exceeded by 12%.",
+    "If the budget has been exceeded, escalate to finance.",
+    "Our max budget: 40000 EUR for the fiscal year.",
+    "The travel budget has been exceeded again this quarter.",
+    "The team is over budget. Spend=high, morale=low.",
+    "We exceeded budget for the model rollout last year.",
+    # Exclamation form, but no "Max budget:" label -- the conjunction is what
+    # keeps this from matching.
+    "The marketing budget has been exceeded! Please review before Friday.",
+    "ExceededBudget was the title of the Q3 retrospective.",
+]
+
+
+def _rate_limit_error(message: str) -> litellm.RateLimitError:
+    """The client-side error litellm raises for a proxy 429."""
+    return litellm.RateLimitError(
+        message=f"litellm.RateLimitError: RateLimitError: Litellm_proxyException - {message}",
+        llm_provider="openai",
+        model="litellm_proxy/litellm",
+    )
+
+
+def _wrapped_budget_error(
+    message: str = LITELLM_BUDGET_MESSAGES[0],
+    completion: str = "",
+) -> InstructorRetryException:
+    """Rebuild the exact chain prod produces: Instructor -> RetryError -> RateLimitError.
+
+    ``completion`` populates the ``FailedAttempt`` so the model's own output is
+    rendered into ``str()``, exactly as instructor does in production.
+    """
+    inner = _rate_limit_error(message)
+    future = TenacityFuture(attempt_number=2)
+    future.set_exception(inner)
+    retry_error = RetryError(future)
+    retry_error.__cause__ = inner
+
+    exc = InstructorRetryException(
+        str(inner),
+        n_attempts=2,
+        total_usage=0,
+        failed_attempts=[
+            FailedAttempt(attempt_number=1, exception=inner, completion=completion),
+        ],
+    )
+    exc.__cause__ = retry_error
+    return exc
+
+
+class TestRealExceptionShape:
+    """Pins the wrapper chain itself, so an instructor/litellm upgrade that
+    changes it fails loudly here rather than silently in production."""
+
+    def test_chain_is_what_we_think_it_is(self):
+        exc = _wrapped_budget_error()
+        chain = []
+        current = exc
+        while current is not None:
+            chain.append(type(current).__name__)
+            current = current.__cause__
+        assert chain == ["InstructorRetryException", "RetryError", "RateLimitError"]
+
+    def test_structured_signals_are_genuinely_unavailable(self):
+        """Guards the rationale for text matching. If this ever fails, a
+        structured check became possible and should be preferred."""
+        exc = _wrapped_budget_error()
+        assert getattr(exc, "status_code", None) is None
+        assert not isinstance(exc, litellm.BudgetExceededError)
+
+        deepest = exc.__cause__.__cause__
+        assert deepest.status_code == 429
+        # A different class from the server-side error, so isinstance cannot work.
+        assert not isinstance(deepest, litellm.BudgetExceededError)
+
+    def test_model_output_is_embedded_in_str(self):
+        """The reason false positives are a live risk, not a theoretical one."""
+        exc = _wrapped_budget_error(completion="the marketing budget has been exceeded by 12%")
+        assert "marketing budget has been exceeded" in str(exc)
+
+    def test_wrapped_error_is_classified_and_not_retried(self):
+        exc = _wrapped_budget_error()
+        assert is_budget_exhausted_error(exc) is True
+        assert should_retry_llm_exception(exc) is False
+
+
+class TestNoFalseNegatives:
+    @pytest.mark.parametrize("message", LITELLM_BUDGET_MESSAGES)
+    def test_every_litellm_budget_scope_is_terminal(self, message):
+        exc = _wrapped_budget_error(message)
+        assert is_budget_exhausted_error(exc) is True, f"not detected: {message}"
+        assert should_retry_llm_exception(exc) is False, f"still retried: {message}"
+
+    def test_bare_provider_error_is_terminal(self):
+        """Unwrapped, as the non-instructor paths raise it."""
+        exc = _rate_limit_error(LITELLM_BUDGET_MESSAGES[0])
+        assert is_budget_exhausted_error(exc) is True
+        assert should_retry_llm_exception(exc) is False
+
+    def test_http_402_is_terminal_without_any_message_match(self):
+        """Case 1 must keep working for direct-provider payment errors."""
+
+        class PaymentRequired(Exception):
+            status_code = 402
+
+        assert is_budget_exhausted_error(PaymentRequired("payment required")) is True
+
+
+class TestNoFalsePositives:
+    @pytest.mark.parametrize("prose", INNOCENT_PROSE)
+    def test_document_prose_is_not_budget_exhaustion(self, prose):
+        exc = Exception(prose)
+        assert is_budget_exhausted_error(exc) is False, f"false positive: {prose}"
+        assert should_retry_llm_exception(exc) is True, f"wrongly terminal: {prose}"
+
+    @pytest.mark.parametrize("prose", INNOCENT_PROSE)
+    def test_prose_inside_a_failed_completion_is_not_budget_exhaustion(self, prose):
+        """The dangerous case: a real validation-retry exhaustion whose partial
+        completion quotes budget language must stay retryable."""
+        inner = ValueError("validation failed: 3 attempts")
+        exc = InstructorRetryException(
+            str(inner),
+            n_attempts=3,
+            total_usage=0,
+            failed_attempts=[
+                FailedAttempt(attempt_number=1, exception=inner, completion=prose),
+            ],
+        )
+        exc.__cause__ = inner
+        assert is_budget_exhausted_error(exc) is False, f"false positive: {prose}"
+        assert should_retry_llm_exception(exc) is True
+
+    def test_known_limitation_verbatim_provider_message_in_a_document(self):
+        """Documents the one residual false positive, deliberately accepted.
+
+        Text matching cannot distinguish a real rejection from a document that
+        quotes one verbatim (a runbook, a pasted log, a GitHub issue). The
+        trade-off is intentional and asymmetric: a false negative resurrects the
+        production retry storm, whereas this costs one already-failing call a
+        wrong 402 instead of a few more doomed retries. Pinned so the behaviour
+        is a known quantity rather than a surprise.
+        """
+        quoted = (
+            "Runbook: if the gateway logs "
+            "'Budget has been exceeded! Current cost: 20.0, Max budget: 20.0', "
+            "raise the tenant's cap."
+        )
+        assert is_budget_exhausted_error(Exception(quoted)) is True
+
+    def test_ordinary_rate_limit_still_retries(self):
+        """A real per-minute 429 has no budget wording and must stay retryable."""
+        exc = _rate_limit_error("Rate limit reached for gpt-4o. Please try again in 20s.")
+        assert is_budget_exhausted_error(exc) is False
+        assert should_retry_llm_exception(exc) is True
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            TimeoutError("read timeout"),
+            ConnectionError("connection reset"),
+            Exception("Internal server error"),
+        ],
+    )
+    def test_transient_failures_still_retry(self, exc):
+        assert is_budget_exhausted_error(exc) is False
+        assert should_retry_llm_exception(exc) is True
+
+
+class TestCauseChainWalk:
+    def test_context_is_not_followed(self):
+        """An unrelated error raised *while handling* a budget error must not be
+        misclassified. ``__context__`` is set implicitly by nested raises;
+        following it would produce false positives."""
+        try:
+            try:
+                raise _rate_limit_error(LITELLM_BUDGET_MESSAGES[0])
+            except Exception:
+                raise ValueError("secondary failure during cleanup")
+        except ValueError as e:
+            unrelated = e
+
+        assert unrelated.__context__ is not None  # the chain exists...
+        assert unrelated.__cause__ is None  # ...but only via __context__
+        assert is_budget_exhausted_error(unrelated) is False
+
+    def test_cycle_in_cause_chain_terminates(self):
+        a = Exception("a")
+        b = Exception("b")
+        a.__cause__ = b
+        b.__cause__ = a
+        assert is_budget_exhausted_error(a) is False  # must not hang
+
+    def test_deep_chain_is_walked(self):
+        exc = _rate_limit_error(LITELLM_BUDGET_MESSAGES[0])
+        for i in range(50):
+            outer = Exception(f"layer {i}")
+            outer.__cause__ = exc
+            exc = outer
+        assert is_budget_exhausted_error(exc) is True
+
+
+class TestErrorMapping:
+    """Budget exhaustion is a 402, and must not be downgraded to the 422 quota
+    error on its way through the gateway."""
+
+    def test_payment_required_is_not_converted_to_quota_error(self):
+        inner = _wrapped_budget_error()
+        try:
+            raise LLMPaymentRequiredError("LLM budget exhausted") from inner
+        except LLMPaymentRequiredError as e:
+            payment_error = e
+
+        with pytest.raises(LLMPaymentRequiredError) as caught:
+            raise_if_quota_error(payment_error)
+        assert caught.value.status_code == 402
+
+    def test_budget_wording_does_not_trip_the_quota_classifier(self):
+        """``_TERMINAL_QUOTA_PATTERNS`` must stay free of budget wording, or
+        ``raise_if_quota_error`` would rewrite the 402 into a 422."""
+        assert is_quota_or_billing_error(_wrapped_budget_error()) is False
+
+    def test_genuine_quota_errors_still_map_to_422(self):
+        exc = Exception("You exceeded your current quota: insufficient_quota")
+        assert is_quota_or_billing_error(exc) is True
+        with pytest.raises(LLMQuotaExceededError):
+            raise_if_quota_error(exc)
+
+
+class TestDetailExtraction:
+    def test_detail_is_the_provider_sentence_only(self):
+        exc = _wrapped_budget_error(completion="x" * 5000)
+        detail = budget_exhaustion_detail(exc)
+        assert detail is not None
+        assert detail.startswith("Budget has been exceeded!")
+        assert detail.endswith("20.0")
+        assert "xxxx" not in detail, "model output leaked into the user-facing detail"
+
+    def test_detail_stays_short(self):
+        """Bounded so a hostile completion cannot bloat the 402 response body."""
+        exc = _wrapped_budget_error(completion="budget " * 2000)
+        detail = budget_exhaustion_detail(exc)
+        assert detail is not None and len(detail) < 300
+
+    def test_detail_is_none_when_absent(self):
+        assert budget_exhaustion_detail(Exception("something else")) is None
+
+    @pytest.mark.parametrize("message", LITELLM_BUDGET_MESSAGES)
+    def test_detail_extracted_for_every_scope(self, message):
+        detail = budget_exhaustion_detail(_wrapped_budget_error(message))
+        assert detail is not None, f"no detail extracted for: {message}"
+        assert len(detail) < 300
+        # The extracted sentence must come from the provider message itself.
+        assert detail.lower() in message.lower()


### PR DESCRIPTION
## Problem

A LiteLLM-proxy spend-cap rejection cannot clear by retrying, but cognee classified it as a transient rate limit.

Measured on the production gateway:

| | |
|---|---|
| HTTP requests per doomed logical LLM call | **~36** over ~270s |
| Share of all gateway traffic that was budget rejections | **93%** (2,904 of 2,969 in 15 min) |
| Tenants responsible | **6**, all with zero successful requests |

The amplification is three nested retry layers, only the outermost of which backs off:

| Layer | Attempts | Backoff |
|---|---|---|
| cognee tenacity (`retry_config`) | ~6 | 8→17→33→64→128s ✅ |
| instructor `MAX_RETRIES=2` | 2 | none (`wait_none`) |
| litellm/openai client | 3 | ~0.5s, ~0.8s |

Side effects: doomed calls held pipeline concurrency slots for ~4.5 minutes each, and the ~15-line traceback logged per rejection rotated the gateway's own logs down from 24h of history to ~4h.

## Why the classifier missed it

The rejection arrives as:

```
InstructorRetryException  →  RetryError  →  RateLimitError (status_code=429)
```

Every structured signal is destroyed on the way up, so all three existing branches of `is_budget_exhausted_error` are unreachable for this path:

- the outermost exception has no `status_code` and no `.response`;
- the client-side `RateLimitError` is a **different class** from `litellm.BudgetExceededError`;
- that `RateLimitError`'s `.response.json()` raises `JSONDecodeError` — the body is already consumed, so the proxy's `error.type == "budget_exceeded"` cannot be read.

Message text is the only signal that survives.

## Changes

**`exceptions.py`** — `is_budget_exhausted_error` walks the `__cause__` chain (deliberately not `__context__`, so an unrelated error raised while handling a budget error isn't misclassified) and adds message wording as a fourth, wrapper-proof case. Matching is **conjunctive** because `str(InstructorRetryException)` embeds the model's own partial completion — a single natural-language phrase would turn an ordinary validation-retry failure into a hard 402 for any document discussing an exceeded budget. All three LiteLLM sentence shapes are covered:

```
Budget has been exceeded! [Scope=...] Current cost: X, Max budget: Y   key/team/project/org/tag
ExceededBudget: [End ]User=<id> over budget. Spend=X, Budget=Y         internal-user, end-user
LiteLLM {Virtual Key|End User}: <id>, exceeded budget for model=<m>    per-model caps
```

Also adds `budget_exhaustion_detail()` (extracts just the provider sentence, bounded, so a hostile completion can't bloat the 402 body) and `raise_if_budget_exhausted()`.

**`retry_config.py`** — the check goes in `should_retry_llm_exception`, **not** `_TERMINAL_QUOTA_PATTERNS`. Putting it in the patterns tuple would also feed `is_quota_or_billing_error`, causing `raise_if_quota_error` to rewrite the 402 into a 422. A defensive `LLMPaymentRequiredError` short-circuit was added there too.

**`generic_llm_api/adapter.py`** — the budget check must run at the re-raise site: the `except` clause catching `InstructorRetryException` shadows the budget handler further down in the same `try`. It runs *before* the content-policy branch, so a rejection whose completion happens to mention a content policy isn't misrouted to the fallback path.

**`LLMGateway._fail_fast_on_quota`** — classification also happens at the single choke point every structured-output call passes through. Each instructor adapter has the same shadowing pattern, and the plain-text path (`response_model is str`) bypasses adapter budget handlers entirely, so `openai` / `azure_openai` / `gemini` / `bedrock` and `POST /api/v1/llm` were still surfacing a raw `InstructorRetryException` as HTTP 500. This gives every adapter and both paths the same 402.

**Matching is whole-sentence.** Detection and extraction share one regex, so fragments scattered across several KB of model output cannot trigger a match, and a positive classification always yields a detail. Identifiers in that detail (virtual-key hash, key alias, tenant IDs) are masked before it reaches the 402 body; spend and budget figures are kept, since they are the caller's own and are the actionable part.

## Verification

Against a local proxy returning the production 429 body:

| | before | after |
|---|---|---|
| HTTP requests | ~36 | **6** |
| Wall clock | ~270 s | **2.8 s** |
| Exception surfaced | `InstructorRetryException` | `LLMPaymentRequiredError` (402) |

Through the gateway choke point, the paths that previously returned HTTP 500:

| Path | after |
|---|---|
| `openai` adapter (unpatched, default provider) | 402, 6 requests, 2.76s |
| plain-text `response_model=str` | 402, 3 requests, 1.26s |

A control run with the new checks stubbed out reproduces 36 requests / 266s exactly, confirming this is the load-bearing change.

`cognee/tests/unit/infrastructure/llm/test_budget_exhaustion.py` adds 64 cases (0.11s, no network). It rebuilds the real exception chain with a populated `FailedAttempt` so the model's completion is embedded exactly as in production, and covers: the chain shape itself, all ten message variants, prose false-positives (bare and inside a completion), `__context__` not being followed, cycle and deep-chain handling, 402-not-downgraded-to-422, and bounded detail extraction.

Each assertion was mutation-tested — reverting any part of the fix is caught by at least one test.

Full suite: **255 passed, 7 skipped**. `ruff check` and `ruff format --check` clean.

## Scope / follow-ups

- The remaining 6 requests come from instructor (`MAX_RETRIES=2`) × the litellm client (3 tries). Closing that is a separate change.
- `openai`, `azure_openai`, `gemini` and `bedrock` still contain the same shadowing pattern in their own `except` clauses. It is no longer user-visible now that classification happens in `_fail_fast_on_quota`, but cleaning it up locally would be a reasonable follow-up.
- One residual false positive is accepted and pinned as a test: a document quoting a LiteLLM error verbatim is classified as budget exhaustion. The trade-off is deliberately asymmetric — a false negative resurrects the production storm, whereas this costs one already-failing call a wrong 402.
