### PR TITLE
CLO-365 fix: mark cancelled pipeline runs as errored, not stuck

### DIFF
--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -275,7 +275,15 @@ async def run_tasks(
                     data_ingestion_info=results,
                 )
 
-            except Exception as error:
+            except (Exception, asyncio.CancelledError) as error:
+                # asyncio.CancelledError is a BaseException (not an Exception)
+                # since Python 3.8, so a bare `except Exception` misses it —
+                # a cancelled run (deploy/restart, or a future disconnect-
+                # triggered cancel) would otherwise never reach
+                # log_pipeline_run_error below and stay stuck at
+                # DATASET_PROCESSING_STARTED forever (CLO-365). Re-raised at
+                # the end of this block either way, so cooperative
+                # cancellation still propagates once cleanup is done.
                 if callable(rollback_handler):
                     try:
                         await rollback_handler(

--- a/cognee/tests/unit/modules/pipelines/test_run_tasks_rollback.py
+++ b/cognee/tests/unit/modules/pipelines/test_run_tasks_rollback.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 import importlib
 from types import SimpleNamespace
@@ -105,3 +106,63 @@ async def test_run_tasks_calls_custom_rollback_on_pipeline_failure(monkeypatch):
     assert rollback_payload["data"] == [data_item]
     assert isinstance(rollback_payload["error"], Exception)
     assert rollback_payload["data_ingestion_info"][0]["run_info"].status == "PipelineRunErrored"
+
+
+@pytest.mark.asyncio
+async def test_run_tasks_marks_cancelled_run_as_errored_instead_of_stuck(monkeypatch):
+    """CLO-365: asyncio.CancelledError is a BaseException, not an Exception, so
+    a bare `except Exception` in run_tasks.py misses it — a cancelled run
+    (deploy/restart, or a disconnect-triggered cancel) would never reach
+    log_pipeline_run_error and would stay stuck at DATASET_PROCESSING_STARTED
+    forever. This proves log_pipeline_run_error DOES fire for a cancelled
+    run, and that cancellation still propagates out of run_tasks afterward
+    (cooperative cancellation isn't swallowed)."""
+    dataset_id = uuid4()
+    user_id = uuid4()
+    owner_id = uuid4()
+    pipeline_run_id = uuid4()
+
+    dataset = SimpleNamespace(id=dataset_id, name="dataset-1", owner_id=owner_id)
+    user = SimpleNamespace(id=user_id, tenant_id=uuid4())
+    data_item = SimpleNamespace(id=uuid4())
+
+    async def _cancelled_item(*_args, **_kwargs):
+        raise asyncio.CancelledError()
+
+    error_calls = []
+
+    async def _log_error(*_args, **_kwargs):
+        error_calls.append(_args)
+
+    monkeypatch.setattr(run_tasks_module, "get_relational_engine", lambda: _FakeEngine(dataset))
+    monkeypatch.setattr(run_tasks_module, "generate_pipeline_id", lambda *_args: uuid4())
+
+    async def _log_start(*_args, **_kwargs):
+        return SimpleNamespace(pipeline_run_id=pipeline_run_id)
+
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_start", _log_start)
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_error", _log_error)
+    monkeypatch.setattr(run_tasks_module, "set_database_global_context_variables", _no_op_context)
+    monkeypatch.setattr(run_tasks_module, "run_tasks_data_item", _cancelled_item)
+
+    yielded = []
+    with pytest.raises(asyncio.CancelledError):
+        async for item in run_tasks_module.run_tasks(
+            tasks=[Task(lambda x: x)],
+            dataset_id=dataset_id,
+            data=[data_item],
+            user=user,
+            pipeline_name="cognify_pipeline",
+        ):
+            yielded.append(item)
+
+    # log_pipeline_run_error must have fired — the row is marked errored,
+    # never left stuck at DATASET_PROCESSING_STARTED.
+    assert len(error_calls) == 1
+    assert error_calls[0][0] == pipeline_run_id
+
+    # PipelineRunStarted, then PipelineRunErrored — cancellation didn't skip
+    # the terminal-event yield either.
+    assert len(yielded) == 2
+    assert isinstance(yielded[0], PipelineRunStarted)
+    assert isinstance(yielded[1], PipelineRunErrored)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
`asyncio.CancelledError` is a `BaseException` (not an `Exception`) since Python 3.8, so the bare `except Exception as error:` in `run_tasks.py`'s terminal handler silently missed it. If a pipeline run's task was ever cancelled — a server deploy/restart today, or a future disconnect-triggered cancel from the HTTP layer once the cloud-backend side of CLO-365 lands — `log_pipeline_run_error(...)` never ran, so the `PipelineRun` row stayed at `DATASET_PROCESSING_STARTED` forever. That stuck row holds the per-dataset lock, so every subsequent request to that dataset blocks indefinitely — this is the "stuck upload" symptom CLO-365 is named for.

This PR is the cognee-core piece only (item #3 of 5 in the CLO-365 root-cause list). The other 4 items — defaulting uploads to `run_in_background=True`, `request.is_disconnected()` handling, a lock-acquire timeout, and a stale-row reaper — live in `cognee-saas-pod`/cloud-backend and are tracked separately.

Fix: catch `asyncio.CancelledError` alongside `Exception`, so `log_pipeline_run_error` always fires and the run is marked errored before cancellation is re-raised. Cancellation still propagates normally afterward — this only inserts one cleanup step, it doesn't swallow or delay the cancel.

Closes CLO-365 (partial — cognee-core piece only, see above).

## Acceptance Criteria
- A cancelled pipeline run's `PipelineRun` row is marked `DATASET_PROCESSING_ERRORED`, never left stuck at `DATASET_PROCESSING_STARTED`.
- Cancellation still propagates out of `run_tasks()` after cleanup.
- No change to existing `Exception`-path behavior (rollback handler, `PipelineRunErrored` yield, non-cancellation error logging).

Proof: new test `test_run_tasks_marks_cancelled_run_as_errored_instead_of_stuck` in `test_run_tasks_rollback.py` — mocks a cancelled item, asserts `log_pipeline_run_error` fires with the right `pipeline_run_id`, asserts `PipelineRunStarted`/`PipelineRunErrored` are yielded in order, and asserts `CancelledError` still escapes the generator via `pytest.raises(asyncio.CancelledError)`.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
cognee/tests/unit/modules/pipelines/test_run_tasks_rollback.py::test_run_tasks_calls_custom_rollback_on_pipeline_failure PASSED
cognee/tests/unit/modules/pipelines/test_run_tasks_rollback.py::test_run_tasks_marks_cancelled_run_as_errored_instead_of_stuck PASSED
2 passed, 11 warnings in 0.04s

Full `cognee/tests/unit/modules/pipelines/` suite: 79 passed. `ruff check` clean.

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable) — internal-only change, no user-facing docs needed
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.