### PR TITLE
SDK-476: Add hybrid retrieval example script to examples/guides

### DIFF
--- a/examples/guides/hybrid_retrieval_recall.py
+++ b/examples/guides/hybrid_retrieval_recall.py
@@ -1,0 +1,87 @@
+import asyncio
+
+import cognee
+from cognee import SearchType
+
+QUERY = "What did Alice and Bob work on together?"
+
+
+async def main():
+    await cognee.remember(
+        [
+            "Alice and Bob were PhD students in Berlin from 2021 to 2024.",
+            "Alice and Bob worked on a paper together in 2023.",
+            "Alice joined Cognee as a backend engineer in 2025.",
+            "Bob joined Cognee as a data scientist in 2026.",
+            "Alice and Bob worked together on some sections of the documentation of Cognee in 2026.",
+            "New sections of the documentation are available since July 2026.",
+        ],
+        self_improvement=False,
+    )
+
+    context_passage_focused = await cognee.recall(
+        query_text=QUERY,
+        query_type=SearchType.HYBRID_COMPLETION,
+        only_context=True,
+        retriever_specific_config={
+            "chunks_top_k": 5,
+            "entities_top_k": 0,
+            "facts_top_k": 0,
+        },
+    )
+    print(context_passage_focused)
+
+    context_entity_focused = await cognee.recall(
+        query_text=QUERY,
+        query_type=SearchType.HYBRID_COMPLETION,
+        only_context=True,
+        retriever_specific_config={
+            "chunks_top_k": 0,
+            "entities_top_k": 5,
+            "max_edges_per_entity": 5,
+            "facts_top_k": 0,
+        },
+    )
+    print(context_entity_focused)
+
+    context_fact_focused = await cognee.recall(
+        query_text=QUERY,
+        query_type=SearchType.HYBRID_COMPLETION,
+        only_context=True,
+        retriever_specific_config={
+            "chunks_top_k": 0,
+            "entities_top_k": 5,
+            "max_edges_per_entity": 0,
+            "facts_top_k": 5,
+        },
+    )
+    print(context_fact_focused)
+
+    context_balanced = await cognee.recall(
+        query_text=QUERY,
+        query_type=SearchType.HYBRID_COMPLETION,
+        only_context=True,
+        retriever_specific_config={
+            "chunks_top_k": 2,
+            "entities_top_k": 2,
+            "max_edges_per_entity": 3,
+            "facts_top_k": 2,
+        },
+    )
+    print(context_balanced)
+
+    answer = await cognee.recall(
+        query_text=QUERY,
+        query_type=SearchType.HYBRID_COMPLETION,
+        retriever_specific_config={
+            "chunks_top_k": 2,
+            "entities_top_k": 2,
+            "max_edges_per_entity": 3,
+            "facts_top_k": 2,
+        },
+    )
+    print(answer)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds `examples/guides/hybrid_retrieval_recall.py`, a runnable example demonstrating `SearchType.HYBRID_COMPLETION` context shaping via `retriever_specific_config`: passage-focused, entity-focused, fact-focused, and balanced contexts (`chunks_top_k` / `entities_top_k` / `max_edges_per_entity` / `facts_top_k`), plus a final full-completion call.

No core-repo script demonstrated `HYBRID_COMPLETION` until now — the cognee-docs guide [Inspecting Hybrid Retrieval Context](https://docs.cognee.ai/guides/hybrid-retrieval-recall) carried its own docs-repo-authored copy and tracked `cognee/modules/retrieval/hybrid_retriever.py` as its sync source. This script is a verbatim copy of that guide's tested `tests/guides/hybrid_retrieval_recall.py` (blob `7d1f39b`), already exercised by the docs guide-tests workflow against current `dev` behavior (the fact lane's budget coupling to the entity lane from the HybridRetriever refactor). The docs `examples-registry.yaml` is being repointed to track this path as the sync source once it lands on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)