### PR TITLE
feat: Add transparent graph roots and chunk_attachment (SDK-163)

### DIFF
--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -1,6 +1,6 @@
 import asyncio
 from pydantic import BaseModel
-from typing import Collection, Union, Optional
+from typing import Collection, Literal, Union, Optional
 from uuid import UUID
 
 from cognee.modules.cognify.config import get_cognify_config
@@ -9,6 +9,7 @@ from cognee.modules.cognify.routing import CognifyRoute, cognify_route_for
 from cognee.modules.ontology.ontology_env_config import get_ontology_env_config
 from cognee.shared.logging_utils import get_logger
 from cognee.shared.data_models import KnowledgeGraph
+from cognee.infrastructure.engine import DataPoint
 from cognee.infrastructure.llm import get_max_chunk_tokens
 
 from cognee.modules.pipelines import run_pipeline
@@ -71,6 +72,7 @@ async def cognify(
     embedding_config: Optional[EmbeddingConfig] = None,
     data_cache: bool = True,
     dry_run: bool = False,
+    chunk_attachment: Optional[Literal["direct", "all"]] = None,
     **kwargs,
 ):
     """
@@ -145,6 +147,22 @@ async def cognify(
         dry_run: If True, return a stage-level estimate of LLM token usage and rough cost
                  without making LLM calls or writing graph results. The estimate covers all
                  data in the selected dataset(s); an incremental run may process fewer items.
+        chunk_attachment: How widely each chunk links into the graph extracted from it.
+                 Accepts "direct", "all", or None; omitting it is the same as "direct".
+                 - "direct": the chunk links to the extracted root, or - if that root is a
+                   transparent container - to the children that replaced it. Today's behaviour.
+                 - "all": the chunk links once to every stored node reachable from that root,
+                   so any entity is one hop from its source chunk.
+                 Requires a custom DataPoint graph_model; passing it with KnowledgeGraph
+                 raises, since that path already attaches every extracted entity to its chunk.
+                 Applies to standard-routed items only, exactly like graph_model - DLT-source
+                 manifests and code files run their own task lists and ignore both.
+                 Orthogonal to metadata["transparent"], which is a property of the model.
+                 SDK-only: not exposed over the REST API. Raises with temporal_cognify=True
+                 or while connected to a remote instance; permitted with dry_run=True.
+                 Cost of "all": index_graph_edges embeds one EdgeType per distinct edge text,
+                 and contains edge text is "<chunk label> contains <node label>." - so a model
+                 yielding N nodes per chunk means roughly N extra embedded rows per chunk.
 
     Returns:
         Union[dict, list[PipelineRunInfo], DryRunEstimate]:
@@ -221,11 +239,34 @@ async def cognify(
         - LLM_RATE_LIMIT_ENABLED: Enable rate limiting (default: False)
         - LLM_RATE_LIMIT_REQUESTS: Max requests per interval (default: 60)
     """
+    if chunk_attachment is not None:
+        # cognify() forwards unknown kwargs into the LLM call, which also takes
+        # **kwargs, so an unusable value here has to raise rather than vanish.
+        if chunk_attachment not in ("direct", "all"):
+            raise ValueError(
+                f"Invalid chunk_attachment {chunk_attachment!r}; expected 'direct', 'all', or None."
+            )
+        if not (isinstance(graph_model, type) and issubclass(graph_model, DataPoint)):
+            raise ValueError(
+                "chunk_attachment requires a custom DataPoint graph_model; "
+                f"{getattr(graph_model, '__name__', graph_model)!r} is not a DataPoint subclass."
+            )
+        if temporal_cognify:
+            raise ValueError(
+                "chunk_attachment is not supported with temporal_cognify=True; the temporal "
+                "pipeline does not attach extracted graphs to chunks."
+            )
+
     # Route to remote instance if connected via serve()
     from cognee.api.v1.serve.state import get_remote_client
 
     client = get_remote_client()
     if client is not None:
+        if chunk_attachment is not None:
+            raise ValueError(
+                "chunk_attachment is not supported while connected to a remote Cognee "
+                "instance. Call cognee.disconnect() to use it locally."
+            )
         if dry_run:
             raise ValueError(
                 "dry_run is not supported while connected to a remote Cognee instance. "
@@ -288,6 +329,7 @@ async def cognify(
                 custom_prompt=custom_prompt,
                 chunks_per_batch=chunks_per_batch,
                 functional_relationships=functional_relationships,
+                chunk_attachment=chunk_attachment,
                 **kwargs,
             )
 
@@ -357,6 +399,7 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
     custom_prompt: Optional[str] = None,
     chunks_per_batch: int = None,
     functional_relationships: Optional[Collection[str]] = None,
+    chunk_attachment: Optional[Literal["direct", "all"]] = None,
     **kwargs,
 ) -> list[Task]:
     cognify_config = get_cognify_config()
@@ -385,6 +428,7 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
             graph_model=graph_model,
             config=config,
             custom_prompt=custom_prompt,
+            chunk_attachment=chunk_attachment,
             task_config={"batch_size": chunks_per_batch},
             **kwargs,
         ),

--- a/cognee/infrastructure/engine/models/DataPoint.py
+++ b/cognee/infrastructure/engine/models/DataPoint.py
@@ -21,6 +21,7 @@ class MetaData(TypedDict):
     type: NotRequired[str]
     index_fields: list[str]
     identity_fields: NotRequired[list[str]]
+    transparent: NotRequired[bool]
 
 
 # Updated DataPoint model with versioning and new fields

--- a/cognee/modules/graph/utils/__init__.py
+++ b/cognee/modules/graph/utils/__init__.py
@@ -2,7 +2,7 @@ from .expand_with_nodes_and_edges import (
     attach_new_edges_to_data_points,
     construct_data_points_and_edges,
 )
-from .get_graph_from_model import get_graph_from_model
+from .get_graph_from_model import collect_stored_data_points, get_graph_from_model
 from .prepare_edges_for_storage import ensure_default_edge_properties
 from .get_model_instance_from_graph import get_model_instance_from_graph
 from .retrieve_existing_edges import find_existing_edge_identities

--- a/cognee/modules/graph/utils/extract_field_relationships.py
+++ b/cognee/modules/graph/utils/extract_field_relationships.py
@@ -1,0 +1,60 @@
+"""Reading a DataPoint's fields: which of them declare relationships.
+
+A field either points at other DataPoints or holds a plain value. Every part of the
+graph walk asks that question, and this module is the only place it is answered.
+"""
+
+from typing import Any, Iterator, List, Optional, Tuple
+
+from cognee.infrastructure.engine import DataPoint, Edge
+
+# One relationship declaration: the edge metadata (if any) and everything it points at.
+EdgeTargets = Tuple[Optional[Edge], List[DataPoint]]
+
+
+def _as_edge_targets(value: Any) -> Optional[EdgeTargets]:
+    """Read one relationship declaration, or None when ``value`` is a plain property.
+
+    Accepts a bare DataPoint or an ``(Edge, DataPoint | list[DataPoint])`` tuple —
+    the two forms a field, or an item inside a list field, may take.
+    """
+    if isinstance(value, DataPoint):
+        return (None, [value])
+
+    if isinstance(value, tuple) and len(value) == 2 and isinstance(value[0], Edge):
+        edge_metadata, targets = value
+        if isinstance(targets, DataPoint):
+            return (edge_metadata, [targets])
+        if isinstance(targets, list) and targets and isinstance(targets[0], DataPoint):
+            return (edge_metadata, targets)
+
+    return None
+
+
+def extract_relationships(field_value: Any) -> List[EdgeTargets]:
+    """Every relationship declared by one field. Empty list means it is a property."""
+    items = field_value if isinstance(field_value, list) else [field_value]
+    return [pair for item in items if (pair := _as_edge_targets(item)) is not None]
+
+
+def iter_fields(
+    data_point: DataPoint,
+    skip: Tuple[str, ...] = (),
+) -> Iterator[Tuple[str, Any, List[EdgeTargets]]]:
+    """Every field of a node, paired with the relationships it declares.
+
+    An empty ``edge_targets`` means the field is a scalar property. Deciding that here
+    is what keeps the walk and the container resolution from drifting on what counts as
+    a relationship, and it is decided before any container is resolved: a field that
+    points at an empty container is still a relationship, not a property.
+    """
+    for field_name, field_value in data_point:
+        if field_name == "metadata" or field_name in skip:
+            continue
+        yield field_name, field_value, extract_relationships(field_value)
+
+
+def iter_targets(edge_targets: List[EdgeTargets]) -> Iterator[DataPoint]:
+    """Every target a field points at, dropping the edge metadata."""
+    for _edge_metadata, targets in edge_targets:
+        yield from targets

--- a/cognee/modules/graph/utils/get_graph_from_model.py
+++ b/cognee/modules/graph/utils/get_graph_from_model.py
@@ -1,13 +1,19 @@
 from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from threading import Lock
-from typing import Tuple, List, Any, Dict, Optional
+from typing import Tuple, List, Any, Dict, Iterator, Optional
 from cognee.infrastructure.engine import DataPoint, Edge
+from cognee.modules.graph.utils.extract_field_relationships import EdgeTargets, iter_fields
+from cognee.modules.graph.utils.unwrap_transparent_nodes import (
+    is_transparent,
+    unwrap_transparent,
+    unwrap_transparent_targets,
+)
 from cognee.modules.storage.utils import copy_model
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()
-
 
 # Memoized simple-node pydantic classes. Without this, every call to
 # ``get_graph_from_model`` — one per DataPoint added to the graph — re-ran
@@ -46,52 +52,6 @@ def _simple_model_for(data_point_type, excluded_fields):
     return model
 
 
-def _extract_field_data(field_value: Any) -> List[Tuple[Optional[Edge], List[DataPoint]]]:
-    """Extract edge metadata and datapoints from a field value."""
-    # Handle single DataPoint
-    if isinstance(field_value, DataPoint):
-        return [(None, [field_value])]
-
-    # Handle list - could contain DataPoints, edge tuples, or mixed
-    if isinstance(field_value, list) and len(field_value) > 0:
-        result = []
-        for item in field_value:
-            # Handle tuple[Edge, DataPoint or list[DataPoint]]
-            if isinstance(item, tuple) and len(item) == 2 and isinstance(item[0], Edge):
-                edge, data_value = item
-                if isinstance(data_value, DataPoint):
-                    result.append((edge, [data_value]))
-                elif (
-                    isinstance(data_value, list)
-                    and len(data_value) > 0
-                    and isinstance(data_value[0], DataPoint)
-                ):
-                    result.append((edge, data_value))
-            # Handle single DataPoint in list
-            elif isinstance(item, DataPoint):
-                result.append((None, [item]))
-        return result
-
-    # Handle tuple[Edge, DataPoint or list[DataPoint]]
-    if (
-        isinstance(field_value, tuple)
-        and len(field_value) == 2
-        and isinstance(field_value[0], Edge)
-    ):
-        edge_metadata, data_value = field_value
-        if isinstance(data_value, DataPoint):
-            return [(edge_metadata, [data_value])]
-        elif (
-            isinstance(data_value, list)
-            and len(data_value) > 0
-            and isinstance(data_value[0], DataPoint)
-        ):
-            return [(edge_metadata, data_value)]
-
-    # Regular property or empty list
-    return []
-
-
 def _create_edge_properties(
     source_id: str, target_id: str, relationship_name: str, edge_metadata: Optional[Edge]
 ) -> Dict[str, Any]:
@@ -118,11 +78,7 @@ def _create_edge_properties(
 
 def _get_relationship_key(field_name: str, edge_metadata: Optional[Edge]) -> str:
     """Extract relationship key from edge metadata or use field name as fallback."""
-    if (
-        edge_metadata
-        and hasattr(edge_metadata, "relationship_type")
-        and edge_metadata.relationship_type
-    ):
+    if edge_metadata and edge_metadata.relationship_type:
         return edge_metadata.relationship_type
     return field_name
 
@@ -132,188 +88,165 @@ def _generate_property_key(data_point_id: str, relationship_key: str, target_id:
     return f"{data_point_id}_{relationship_key}_{target_id}"
 
 
-def _process_datapoint_field(
+def _node_set_names(belongs_to_set: List[Any]) -> List[str]:
+    """Nodeset names as a scalar property, so the vector database can filter on them."""
+    return [
+        node_set if isinstance(node_set, str) else node_set.name
+        for node_set in belongs_to_set
+        if isinstance(node_set, str) or hasattr(node_set, "name")
+    ]
+
+
+def _has_unvisited_target(
     data_point_id: str,
     field_name: str,
-    edge_datapoint_pairs: List[Tuple[Optional[Edge], List[DataPoint]]],
+    edge_targets: List[EdgeTargets],
     visited_properties: Dict[str, bool],
-    properties_to_visit: set,
-    excluded_properties: set,
-) -> None:
-    """Process a field containing DataPoints, always working with lists."""
-    if field_name != "belongs_to_set":
-        excluded_properties.add(field_name)
+) -> bool:
+    """True while any target of this field is still unwalked from this node.
 
-    for edge_metadata, datapoints in edge_datapoint_pairs:
-        relationship_key = _get_relationship_key(field_name, edge_metadata)
-
-        for datapoint in datapoints:
-            property_key = _generate_property_key(
-                data_point_id, relationship_key, str(datapoint.id)
-            )
-            if property_key in visited_properties:
-                continue
-
-            # Always use field_name since we're working with lists
-            properties_to_visit.add(field_name)
-
-
-def _targets_generator(
-    data_point: DataPoint,
-    properties_to_visit: set,
-) -> Tuple[DataPoint, str, Optional[Edge]]:
-    """Generator that yields (target_datapoint, field_name, edge_metadata) tuples."""
-    for field_name in properties_to_visit:
-        field_value = getattr(data_point, field_name)
-        edge_datapoint_pairs = _extract_field_data(field_value)
-
-        if not edge_datapoint_pairs:
-            continue
-
-        for edge_metadata, datapoints in edge_datapoint_pairs:
-            for target_datapoint in datapoints:
-                yield target_datapoint, field_name, edge_metadata
-
-
-async def get_graph_from_model(
-    data_point: DataPoint,
-    added_nodes: Optional[Dict[str, bool]] = None,
-    added_edges: Optional[Dict[str, bool]] = None,
-    visited_properties: Optional[Dict[str, bool]] = None,
-    include_root: bool = True,
-) -> Tuple[List[DataPoint], List[Tuple[str, str, str, Dict[str, Any]]]]:
+    Once every one of them is visited the field is skipped entirely — that is what
+    stops a cycle from being walked a second time.
     """
-    Extract graph representation from a DataPoint model.
-
-    Args:
-        data_point: The DataPoint to extract graph from
-        added_nodes: Dictionary tracking already processed nodes
-        added_edges: Dictionary tracking already processed edges
-        visited_properties: Dictionary tracking visited properties to avoid cycles
-        include_root: Whether to include the root node in results
-
-    Returns:
-        Tuple of (nodes, edges) extracted from the model
-    """
-    if added_nodes is None:
-        added_nodes = {}
-
-    if added_edges is None:
-        added_edges = {}
-
-    if str(data_point.id) in added_nodes:
-        logger.debug(
-            "Skipping already processed DataPoint",
-            extra={"datapoint_id": str(data_point.id)},
+    return any(
+        _generate_property_key(
+            data_point_id, _get_relationship_key(field_name, edge_metadata), str(target.id)
         )
-        return [], []
-
-    nodes = []
-    edges = []
-    visited_properties = visited_properties or {}
-    data_point_id = str(data_point.id)
-
-    logger.debug(
-        "Starting graph extraction for DataPoint",
-        extra={
-            "datapoint_id": data_point_id,
-            "datapoint_type": type(data_point).__name__,
-            "processed_nodes_so_far": len(added_nodes),
-        },
+        not in visited_properties
+        for edge_metadata, targets in edge_targets
+        for target in targets
     )
 
-    data_point_properties = {"id": data_point.id, "type": type(data_point).__name__}
-    excluded_properties = set()
-    properties_to_visit = set()
 
-    # Analyze all fields to categorize them as properties or relationships
-    for field_name, field_value in data_point:
-        if field_name == "metadata":
+def _iter_targets_to_walk(
+    relationship_fields: Dict[str, List[EdgeTargets]],
+) -> Iterator[Tuple[DataPoint, str, Optional[Edge]]]:
+    """Flatten the per-field declarations into (target, field name, edge) triples."""
+    for field_name, edge_targets in relationship_fields.items():
+        for edge_metadata, targets in edge_targets:
+            for target in targets:
+                yield target, field_name, edge_metadata
+
+
+@dataclass
+class _WalkState:
+    """The accumulators every step of one walk shares."""
+
+    added_nodes: Dict[str, bool]
+    added_edges: Dict[str, bool]
+    visited_properties: Dict[str, bool]
+    # When present, collects the original DataPoint behind every node the walk stores.
+    # The returned nodes are ``copy_model`` copies with the relationship fields
+    # stripped, which a caller linking into the graph cannot use.
+    stored_originals: Optional[List[DataPoint]] = None
+
+
+def _split_fields(
+    data_point: DataPoint,
+    data_point_id: str,
+    visited_properties: Dict[str, bool],
+) -> Tuple[Dict[str, Any], set, Dict[str, List[EdgeTargets]]]:
+    """Split a node's fields into what is stored on it and what is walked from it.
+
+    Returns the scalar properties, the field names to strip from the stored copy, and
+    the relationships still worth walking. A relationship whose targets have all been
+    visited is left out of the third but still belongs in the second: it is a
+    relationship either way, and storing it as a property would store DataPoints.
+    """
+    properties: Dict[str, Any] = {"id": data_point.id, "type": type(data_point).__name__}
+    excluded: set = set()
+    relationships: Dict[str, List[EdgeTargets]] = {}
+
+    for field_name, field_value, declared in iter_fields(data_point):
+        if not declared:
+            properties[field_name] = field_value
             continue
 
-        edge_datapoint_pairs = _extract_field_data(field_value)
+        edge_targets = unwrap_transparent_targets(declared)
 
-        if not edge_datapoint_pairs:
-            # Regular property
-            data_point_properties[field_name] = field_value
+        if field_name == "belongs_to_set":
+            properties[field_name] = _node_set_names(field_value)
         else:
-            # DataPoint relationship
-            _process_datapoint_field(
-                data_point_id,
-                field_name,
-                edge_datapoint_pairs,
-                visited_properties,
-                properties_to_visit,
-                excluded_properties,
-            )
+            excluded.add(field_name)
 
-            # We want to enable nodeset filtering on the vector database side
-            if field_name == "belongs_to_set":
-                node_set_names = []
-                for node_set in field_value:
-                    if isinstance(node_set, str):
-                        node_set_names.append(node_set)
-                    elif hasattr(node_set, "name"):
-                        node_set_names.append(node_set.name)
-                data_point_properties[field_name] = node_set_names
+        if _has_unvisited_target(data_point_id, field_name, edge_targets, visited_properties):
+            relationships[field_name] = edge_targets
 
-    # Create node for current DataPoint if needed
-    if include_root and data_point_id not in added_nodes:
-        SimpleDataPointModel = _simple_model_for(type(data_point), excluded_properties)
-        nodes.append(SimpleDataPointModel(**data_point_properties))
-        added_nodes[data_point_id] = True
+    return properties, excluded, relationships
 
-        logger.debug(
-            "Added node to graph",
-            extra={
-                "datapoint_id": data_point_id,
-                "node_type": type(data_point).__name__,
-            },
-        )
 
-    # Process all relationships using generator
-    for target_datapoint, field_name, edge_metadata in _targets_generator(
-        data_point, properties_to_visit
-    ):
+def _walk_data_point(
+    data_point: DataPoint,
+    state: _WalkState,
+) -> Tuple[List[DataPoint], List[Tuple[str, str, str, Dict[str, Any]]]]:
+    """Walk ``data_point``, or each of its children when it is a transparent container.
+
+    Synchronous on purpose: nothing in the walk touches I/O, and the only thing this
+    function ever awaited was itself, so no step of it could ever suspend. The public
+    entry points stay ``async`` so callers do not change.
+
+    Recursion stays here and never re-enters ``get_graph_from_model``, so the resolution
+    below runs on the root only: every target reached from it came through
+    ``_unwrap_transparent_targets``, which already replaced any container it found.
+    """
+    nodes: List[DataPoint] = []
+    edges: List[Tuple[str, str, str, Dict[str, Any]]] = []
+
+    if is_transparent(data_point):
+        for root in unwrap_transparent(data_point):
+            root_nodes, root_edges = _walk_data_point(root, state)
+            nodes.extend(root_nodes)
+            edges.extend(root_edges)
+        return nodes, edges
+
+    data_point_id = str(data_point.id)
+    if data_point_id in state.added_nodes:
+        return nodes, edges
+
+    properties, excluded, relationships = _split_fields(
+        data_point, data_point_id, state.visited_properties
+    )
+
+    SimpleDataPointModel = _simple_model_for(type(data_point), excluded)
+    nodes.append(SimpleDataPointModel(**properties))
+    state.added_nodes[data_point_id] = True
+    if state.stored_originals is not None:
+        state.stored_originals.append(data_point)
+
+    for target, field_name, edge_metadata in _iter_targets_to_walk(relationships):
         relationship_name = _get_relationship_key(field_name, edge_metadata)
+        target_id = str(target.id)
 
-        # Create edge if not already added
-        edge_key = f"{data_point_id}_{target_datapoint.id}_{field_name}"
-        if edge_key not in added_edges:
-            edge_properties = _create_edge_properties(
-                data_point.id, target_datapoint.id, relationship_name, edge_metadata
+        edge_key = f"{data_point_id}_{target_id}_{field_name}"
+        if edge_key not in state.added_edges:
+            edges.append(
+                (
+                    data_point.id,
+                    target.id,
+                    relationship_name,
+                    _create_edge_properties(
+                        data_point.id, target.id, relationship_name, edge_metadata
+                    ),
+                )
             )
-            edges.append((data_point.id, target_datapoint.id, relationship_name, edge_properties))
-            logger.debug("Added edge to graph")
+            state.added_edges[edge_key] = True
 
-            added_edges[edge_key] = True
+        # Marking the property visited is CRITICAL for preventing infinite loops.
+        property_key = _generate_property_key(data_point_id, relationship_name, target_id)
+        state.visited_properties[property_key] = True
 
-        # Mark property as visited - CRITICAL for preventing infinite loops
-        property_key = _generate_property_key(
-            data_point_id, relationship_name, str(target_datapoint.id)
-        )
-        visited_properties[property_key] = True
-
-        # Recursively process target node if not already processed
-        if str(target_datapoint.id) in added_nodes:
+        if target_id in state.added_nodes:
             continue
 
-        logger.debug("Recursing into target DataPoint")
-
-        child_nodes, child_edges = await get_graph_from_model(
-            target_datapoint,
-            include_root=True,
-            added_nodes=added_nodes,
-            added_edges=added_edges,
-            visited_properties=visited_properties,
-        )
+        child_nodes, child_edges = _walk_data_point(target, state)
         nodes.extend(child_nodes)
         edges.extend(child_edges)
 
-    logger.info(
-        "Completed graph extraction for DataPoint",
+    logger.debug(
+        "Extracted graph for DataPoint",
         extra={
             "datapoint_id": data_point_id,
+            "datapoint_type": type(data_point).__name__,
             "nodes_extracted": len(nodes),
             "edges_extracted": len(edges),
         },
@@ -322,18 +255,49 @@ async def get_graph_from_model(
     return nodes, edges
 
 
-def get_own_property_nodes(
-    property_nodes: List[DataPoint], property_edges: List[Tuple[str, str, str, Dict[str, Any]]]
-) -> List[DataPoint]:
+async def get_graph_from_model(
+    data_point: DataPoint,
+    added_nodes: Optional[Dict[str, bool]] = None,
+    added_edges: Optional[Dict[str, bool]] = None,
+    visited_properties: Optional[Dict[str, bool]] = None,
+) -> Tuple[List[DataPoint], List[Tuple[str, str, str, Dict[str, Any]]]]:
     """
-    Filter nodes to return only those that are not destinations of any edges.
+    Extract graph representation from a DataPoint model.
+
+    A transparent ``data_point`` (``metadata["transparent"]``) is replaced by its
+    DataPoint children, so this may return several top-level nodes, or none.
 
     Args:
-        property_nodes: List of all nodes
-        property_edges: List of all edges
+        data_point: The DataPoint to extract graph from
+        added_nodes: Dictionary tracking already processed nodes
+        added_edges: Dictionary tracking already processed edges
+        visited_properties: Dictionary tracking visited properties to avoid cycles
 
     Returns:
-        List of nodes that are not edge destinations
+        Tuple of (nodes, edges) extracted from the model
     """
-    destination_node_ids = {str(edge[1]) for edge in property_edges}
-    return [node for node in property_nodes if str(node.id) not in destination_node_ids]
+    return _walk_data_point(
+        data_point,
+        _WalkState(
+            {} if added_nodes is None else added_nodes,
+            {} if added_edges is None else added_edges,
+            # ``or {}`` rather than ``is None``, and deliberately unlike the two above:
+            # ``add_data_points`` hands every root the same dict, but it is empty at that
+            # point, so each root is given a fresh one and only nodes and edges are shared.
+            visited_properties or {},
+        ),
+    )
+
+
+async def collect_stored_data_points(root: DataPoint) -> List[DataPoint]:
+    """The original DataPoints that storing ``root`` would persist.
+
+    Drives the real storage walk with throwaway accumulators, so this cannot drift from
+    what ``add_data_points`` writes. See ``_walk_data_point`` for why the walk's own
+    ``nodes`` output cannot be used in their place.
+
+    Order follows the walk; treat the result as a set.
+    """
+    stored: List[DataPoint] = []
+    _walk_data_point(root, _WalkState({}, {}, {}, stored))
+    return stored

--- a/cognee/modules/graph/utils/unwrap_transparent_nodes.py
+++ b/cognee/modules/graph/utils/unwrap_transparent_nodes.py
@@ -1,0 +1,116 @@
+"""Transparent containers: nodes the author marked as structure, not content.
+
+``metadata["transparent"]`` states that a DataPoint groups other DataPoints rather
+than being one. The rule is single: wherever such a node appears, it is replaced by
+its DataPoint children. Nothing here stores anything - resolution happens before the
+walk decides what to write.
+"""
+
+from typing import Any, List, Optional
+
+from cognee.infrastructure.engine import DataPoint
+from cognee.modules.graph.utils.extract_field_relationships import (
+    EdgeTargets,
+    iter_targets,
+    iter_fields,
+)
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
+
+# (class qualname, field name) pairs already warned about. Bounded by the number
+# of declared fields on transparent classes, so it cannot grow without limit.
+_WARNED_DROPPED_FIELDS: set = set()
+
+
+def is_transparent(data_point: DataPoint) -> bool:
+    """True when the author marked this node as a container rather than content."""
+    return bool((getattr(data_point, "metadata", None) or {}).get("transparent"))
+
+
+def _warn_dropped_field(data_point: DataPoint, field_name: str, value: Any) -> None:
+    """Warn once per (class, field) that a transparent node is dropping real data.
+
+    Silent for a field inherited from ``DataPoint`` (every node carries those) and for
+    an empty value — an optional relationship left ``None`` lost nothing. Array-likes
+    raise on truth testing; treat those as carrying.
+    """
+    if field_name in DataPoint.model_fields:
+        return
+
+    try:
+        carries = bool(value)
+    except Exception:
+        carries = True
+
+    key = (type(data_point).__qualname__, field_name)
+    if not carries or key in _WARNED_DROPPED_FIELDS:
+        return
+    _WARNED_DROPPED_FIELDS.add(key)
+
+    logger.warning(
+        "%s is marked transparent but carries data in %r; a transparent node is never "
+        "stored, so that value is dropped. If the field is worth searching for, the class "
+        "is not a container - remove metadata['transparent'].",
+        type(data_point).__qualname__,
+        field_name,
+    )
+
+
+def unwrap_transparent(
+    data_point: DataPoint,
+    _active: Optional[frozenset] = None,
+) -> List[DataPoint]:
+    """Replace a transparent node with its DataPoint children, recursively.
+
+    A non-transparent node resolves to ``[data_point]`` — the same object — so callers
+    may apply this unconditionally. Order is field-declaration order, then list order
+    within a field.
+    """
+    if not is_transparent(data_point):
+        return [data_point]
+
+    # Cycle guard keyed on OBJECT IDENTITY, not node id: identity_fields let two
+    # distinct wrapper instances share a node id, and treating the second as a cycle
+    # would silently drop its children. Every object on the active path is held alive
+    # by a caller frame, so id() cannot be reused mid-walk.
+    if _active and id(data_point) in _active:
+        return []
+    _active = (_active or frozenset()) | {id(data_point)}
+
+    resolved: List[DataPoint] = []
+    seen = set()
+
+    # ``belongs_to_set`` is a relationship, but a wrapper's NodeSets are not its
+    # children - inheriting them would mint ``Parent --field--> NodeSet`` edges.
+    for field_name, field_value, edge_targets in iter_fields(data_point, ("belongs_to_set",)):
+        if not edge_targets:
+            _warn_dropped_field(data_point, field_name, field_value)
+            continue
+
+        for target in iter_targets(edge_targets):
+            for node in unwrap_transparent(target, _active):
+                if str(node.id) not in seen:
+                    seen.add(str(node.id))
+                    resolved.append(node)
+
+    return resolved
+
+
+def unwrap_transparent_targets(edge_targets: List[EdgeTargets]) -> List[EdgeTargets]:
+    """Replace every transparent target with its children, in place of the container.
+
+    Returns the very same list object when nothing in the field is transparent, so a
+    graph using no containers behaves exactly as it does without this function.
+
+    A declaration whose targets all resolve away is kept as ``(edge, [])`` rather than
+    dropped, so the result stays one-for-one with what was declared.
+    """
+    if not any(is_transparent(target) for target in iter_targets(edge_targets)):
+        return edge_targets
+
+    return [
+        (edge_metadata, [node for t in targets for node in unwrap_transparent(t)])
+        for edge_metadata, targets in edge_targets
+    ]

--- a/cognee/tasks/graph/extract_graph_and_summarize.py
+++ b/cognee/tasks/graph/extract_graph_and_summarize.py
@@ -1,4 +1,4 @@
-from typing import List, Type, Optional
+from typing import List, Literal, Type, Optional
 from pydantic import BaseModel
 import asyncio
 
@@ -16,6 +16,7 @@ async def extract_graph_and_summarize(
     custom_prompt: Optional[str] = None,
     ctx=None,
     summarization_model: Type[BaseModel] = None,
+    chunk_attachment: Optional[Literal["direct", "all"]] = None,
     **kwargs,
 ) -> List[TextSummary]:
     result_chunks = await asyncio.gather(
@@ -25,6 +26,7 @@ async def extract_graph_and_summarize(
             config=config,
             custom_prompt=custom_prompt,
             ctx=ctx,
+            chunk_attachment=chunk_attachment,
             **kwargs,
         ),
         summarize_text(

--- a/cognee/tasks/graph/extract_graph_from_data.py
+++ b/cognee/tasks/graph/extract_graph_from_data.py
@@ -1,6 +1,6 @@
 import asyncio
 import inspect
-from typing import Type, List, Optional
+from typing import Type, List, Literal, Optional
 from pydantic import BaseModel
 
 from cognee.modules.pipelines.tasks.task import task_summary
@@ -13,6 +13,7 @@ from cognee.modules.ontology.construct_data_points_and_edges_with_ontology impor
 from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
 from cognee.modules.graph.utils import (
     attach_new_edges_to_data_points,
+    collect_stored_data_points,
     construct_data_points_and_edges,
     find_existing_edge_identities,
 )
@@ -83,6 +84,7 @@ async def integrate_chunk_graphs(
     chunk_graphs: list,
     graph_model: Type[BaseModel],
     ontology_resolver: Optional[BaseOntologyResolver],
+    chunk_attachment: Optional[Literal["direct", "all"]] = None,
     pipeline_name: str = None,
     task_name: str = None,
     **kwargs,
@@ -98,6 +100,9 @@ async def integrate_chunk_graphs(
         chunk_graphs: List of knowledge graphs corresponding to each chunk
         graph_model: Pydantic model class for graph data validation
         ontology_resolver: Optional resolver for ontology canonicalization and enrichment
+        chunk_attachment: How widely each chunk links into its extracted graph.
+            ``"all"`` links it to every stored node; omitted and ``"direct"``
+            keep the single-root linkage. Custom DataPoint models only.
 
     Returns:
         The input chunks, updated with their extracted entities
@@ -121,7 +126,12 @@ async def integrate_chunk_graphs(
 
     if not issubclass(graph_model, KnowledgeGraph):
         for chunk_index, chunk_graph in enumerate(chunk_graphs):
-            data_chunks[chunk_index].contains = chunk_graph
+            if chunk_attachment == "all" and isinstance(chunk_graph, DataPoint):
+                # The field name supplies the "contains" relationship, and the shared
+                # edge-text policy fills the label - no Edge wrapper needed here.
+                data_chunks[chunk_index].contains = await collect_stored_data_points(chunk_graph)
+            else:
+                data_chunks[chunk_index].contains = chunk_graph
 
         return data_chunks
 
@@ -168,6 +178,7 @@ async def extract_graph_from_data(
     config: Optional[Config] = None,
     custom_prompt: Optional[str] = None,
     ctx=None,
+    chunk_attachment: Optional[Literal["direct", "all"]] = None,
     **kwargs,
 ) -> List[DocumentChunk]:
     """
@@ -211,6 +222,7 @@ async def extract_graph_from_data(
         chunk_graphs,
         graph_model,
         ontology_resolver,
+        chunk_attachment=chunk_attachment,
         pipeline_name=pipeline_name,
         task_name=task_name,
         **kwargs,

--- a/cognee/tasks/provenance/record_provenance.py
+++ b/cognee/tasks/provenance/record_provenance.py
@@ -160,11 +160,16 @@ async def record_provenance(
                     visited_properties=generic_visited,
                 )
                 root_id = str(item.id)
+                # The walk may legitimately return a node set that does not include
+                # ``item``. Attribute to it only when it was actually stored.
+                root_source = (
+                    scoped(root_id) if any(str(node.id) == root_id for node in nodes) else ""
+                )
                 for node in nodes:
                     node_id = str(node.id)
                     batch.track_entity(
                         scoped(node_id),
-                        source="" if node_id == root_id else scoped(root_id),
+                        source="" if node_id == root_id else root_source,
                         entity_type="entity",
                         metadata={
                             "name": getattr(node, "name", None),
@@ -177,7 +182,7 @@ async def record_provenance(
                     target_id = scoped(str(edge_target_id))
                     batch.track_relationship(
                         f"rel:{source_id}:{relationship_name}:{target_id}",
-                        source=scoped(root_id),
+                        source=root_source,
                         used_entities=[source_id, target_id],
                         metadata={"relationship_name": relationship_name},
                         **common,

--- a/cognee/tests/integration/tasks/test_add_data_points.py
+++ b/cognee/tests/integration/tasks/test_add_data_points.py
@@ -1,4 +1,6 @@
 import pathlib
+import re
+import shutil
 from typing import Any
 
 import pytest
@@ -25,11 +27,29 @@ class Company(DataPoint):
 
 
 @pytest_asyncio.fixture
-async def clean_test_environment():
-    """Set up a clean test environment for add_data_points tests."""
+async def clean_test_environment(request):
+    """Set up a clean test environment for add_data_points tests.
+
+    Each test gets its own directories. Two tests cannot share one, because the
+    graph database is a file the engine locks exclusively and the previous test's
+    engine can still hold that lock: its close is deferred until the last handle
+    is released, which may not happen before the next test opens the same path.
+    """
     base_dir = pathlib.Path(__file__).parent.parent.parent.parent
-    system_directory_path = str(base_dir / ".cognee_system/test_add_data_points_integration")
-    data_directory_path = str(base_dir / ".data_storage/test_add_data_points_integration")
+    test_slug = re.sub(r"[^0-9A-Za-z]+", "_", request.node.name)
+    system_directory_path = str(
+        base_dir / ".cognee_system/test_add_data_points_integration" / test_slug
+    )
+    data_directory_path = str(
+        base_dir / ".data_storage/test_add_data_points_integration" / test_slug
+    )
+
+    # Start from nothing on disk: with access control on, ``prune_system`` prunes
+    # per-dataset databases only, so a graph written straight through
+    # ``add_data_points`` outlives it and the counts below would be read against
+    # a previous run's leftovers.
+    shutil.rmtree(system_directory_path, ignore_errors=True)
+    shutil.rmtree(data_directory_path, ignore_errors=True)
 
     cognee.config.system_root_directory(system_directory_path)
     cognee.config.data_root_directory(data_directory_path)

--- a/cognee/tests/integration/tasks/test_add_data_points.py
+++ b/cognee/tests/integration/tasks/test_add_data_points.py
@@ -1,4 +1,6 @@
 import pathlib
+from typing import Any
+
 import pytest
 import pytest_asyncio
 
@@ -142,3 +144,86 @@ async def test_add_data_points_comprehensive(clean_test_environment):
     final_nodes, final_edges = await graph_engine.get_graph_data()
     assert len(final_nodes) == 14
     assert len(final_edges) == 5
+
+
+class TeamWrapper(DataPoint):
+    """Container the LLM needs to return one object; not a fact about the domain."""
+
+    members: list[Person]
+    metadata: dict = {"index_fields": [], "transparent": True}
+
+
+@pytest.mark.asyncio
+async def test_add_data_points_resolves_transparent_wrapper(clean_test_environment):
+    """A transparent top-level wrapper stores its children as top-level nodes."""
+
+    alice = Person(name="Alice", age=30)
+    bob = Person(name="Bob", age=25)
+    wrapper = TeamWrapper(members=[alice, bob])
+
+    graph_engine = await get_graph_engine()
+    baseline_nodes, baseline_edges = await graph_engine.get_graph_data()
+    baseline_ids = {str(node[0]) for node in baseline_nodes}
+
+    result = await add_data_points([wrapper], graph_only=True)
+
+    assert result == [wrapper]
+
+    nodes, edges = await graph_engine.get_graph_data()
+    added_ids = {str(node[0]) for node in nodes} - baseline_ids
+
+    # Only the effective descendants are persisted; the container is not a node,
+    # and it cannot be an edge endpoint because it does not exist.
+    assert added_ids == {str(alice.id), str(bob.id)}
+    assert all(str(wrapper.id) not in (str(source), str(target)) for source, target, *_ in edges)
+
+    # The graph engine synthesizes a SELF edge per node, so compare real relationships.
+    def _relationships(graph_edges):
+        return [edge for edge in graph_edges if edge[2] != "SELF"]
+
+    assert _relationships(edges) == _relationships(baseline_edges)
+
+
+class AttachmentChunk(DataPoint):
+    """A DocumentChunk-shaped node, so the real walk mints the contains edges."""
+
+    text: str
+    contains: Any = None
+    metadata: dict = {"index_fields": ["text"]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chunk_attachment", [None, "all"])
+async def test_chunk_attachment_persists_expected_contains_edges(
+    clean_test_environment, chunk_attachment
+):
+    """Transparent wrapper + attachment, end to end through the graph store."""
+    from cognee.modules.graph.utils import collect_stored_data_points
+    from cognee.tasks.graph.extract_graph_from_data import integrate_chunk_graphs
+
+    alice = Person(name="Alice", age=30)
+    bob = Person(name="Bob", age=25)
+    wrapper = TeamWrapper(members=[alice, bob])
+    chunk = AttachmentChunk(text="Alice is 30. Bob is 25.")
+
+    await integrate_chunk_graphs(
+        [chunk], [wrapper], TeamWrapper, None, chunk_attachment=chunk_attachment
+    )
+    await add_data_points([chunk], graph_only=True)
+
+    graph_engine = await get_graph_engine()
+    nodes, edges = await graph_engine.get_graph_data()
+
+    stored_ids = {str(node[0]) for node in nodes}
+    assert str(wrapper.id) not in stored_ids
+
+    # Scope to this chunk: setup() seeds nodes that carry contains edges of their own.
+    contains = {
+        str(target)
+        for source, target, name, *_ in edges
+        if name == "contains" and str(source) == str(chunk.id)
+    }
+    if chunk_attachment == "all":
+        assert contains == {str(node.id) for node in await collect_stored_data_points(wrapper)}
+    else:
+        assert contains == {str(alice.id), str(bob.id)}

--- a/cognee/tests/integration/tasks/test_add_ingestion_regression.py
+++ b/cognee/tests/integration/tasks/test_add_ingestion_regression.py
@@ -44,7 +44,34 @@ def add_env():
 
     import cognee  # noqa: F401  (cognee's import runs load_dotenv(override=True))
 
-    os.environ.update(
+    def clear_config_caches():
+        import importlib
+
+        for module_name, factory_name in [
+            ("cognee.base_config", "get_base_config"),
+            ("cognee.infrastructure.databases.relational.config", "get_relational_config"),
+            (
+                "cognee.infrastructure.databases.relational.get_relational_engine",
+                "get_relational_engine",
+            ),
+            ("cognee.infrastructure.databases.graph.config", "get_graph_config"),
+            ("cognee.infrastructure.databases.vector.config", "get_vectordb_config"),
+            ("cognee.infrastructure.databases.cache.config", "get_cache_config"),
+            ("cognee.infrastructure.databases.cache.get_cache_engine", "create_cache_engine"),
+            ("cognee.infrastructure.databases.vector.embeddings.config", "get_embedding_config"),
+            (
+                "cognee.infrastructure.databases.vector.embeddings.get_embedding_engine",
+                "create_embedding_engine",
+            ),
+            ("cognee.infrastructure.llm.config", "get_llm_config"),
+        ]:
+            try:
+                getattr(importlib.import_module(module_name), factory_name).cache_clear()
+            except (ImportError, AttributeError):
+                pass
+
+    mp = pytest.MonkeyPatch()
+    for key, value in dict(
         DB_PROVIDER="sqlite",
         VECTOR_DB_PROVIDER="lancedb",
         GRAPH_DATABASE_PROVIDER="kuzu",
@@ -58,35 +85,14 @@ def add_env():
         # add-by-path tests read from source_dir; mkdtemp lives under the
         # default-allowed tempdir, this just makes the intent explicit.
         COGNEE_ALLOWED_LOCAL_FILE_ROOTS=os.pathsep.join([str(source_dir), tempfile.gettempdir()]),
-    )
-
-    import importlib
-
-    for module_name, factory_name in [
-        ("cognee.base_config", "get_base_config"),
-        ("cognee.infrastructure.databases.relational.config", "get_relational_config"),
-        (
-            "cognee.infrastructure.databases.relational.get_relational_engine",
-            "get_relational_engine",
-        ),
-        ("cognee.infrastructure.databases.graph.config", "get_graph_config"),
-        ("cognee.infrastructure.databases.vector.config", "get_vectordb_config"),
-        ("cognee.infrastructure.databases.cache.config", "get_cache_config"),
-        ("cognee.infrastructure.databases.cache.get_cache_engine", "create_cache_engine"),
-        ("cognee.infrastructure.databases.vector.embeddings.config", "get_embedding_config"),
-        (
-            "cognee.infrastructure.databases.vector.embeddings.get_embedding_engine",
-            "create_embedding_engine",
-        ),
-        ("cognee.infrastructure.llm.config", "get_llm_config"),
-    ]:
-        try:
-            getattr(importlib.import_module(module_name), factory_name).cache_clear()
-        except (ImportError, AttributeError):
-            pass
+    ).items():
+        mp.setenv(key, value)
+    clear_config_caches()
 
     yield source_dir
 
+    mp.undo()
+    clear_config_caches()
     shutil.rmtree(root, ignore_errors=True)
 
 

--- a/cognee/tests/integration/tasks/test_add_s3_call_counts.py
+++ b/cognee/tests/integration/tasks/test_add_s3_call_counts.py
@@ -49,8 +49,6 @@ def _free_port():
 
 @pytest.fixture(scope="module")
 def s3_env():
-    import os
-
     import boto3
 
     port = _free_port()
@@ -82,7 +80,28 @@ def s3_env():
 
     import cognee  # noqa: F401  (cognee's import runs load_dotenv(override=True))
 
-    os.environ.update(
+    def clear_config_caches():
+        import importlib
+
+        for module_name, factory_name in [
+            ("cognee.base_config", "get_base_config"),
+            ("cognee.infrastructure.files.storage.s3_config", "get_s3_config"),
+            ("cognee.infrastructure.databases.relational.config", "get_relational_config"),
+            (
+                "cognee.infrastructure.databases.relational.get_relational_engine",
+                "get_relational_engine",
+            ),
+            ("cognee.infrastructure.databases.cache.config", "get_cache_config"),
+            ("cognee.infrastructure.databases.cache.get_cache_engine", "create_cache_engine"),
+            ("cognee.infrastructure.llm.config", "get_llm_config"),
+        ]:
+            try:
+                getattr(importlib.import_module(module_name), factory_name).cache_clear()
+            except (ImportError, AttributeError):
+                pass
+
+    mp = pytest.MonkeyPatch()
+    for key, value in dict(
         DB_PROVIDER="sqlite",
         CACHE_BACKEND="sqlite",
         MOCK_EMBEDDING="true",
@@ -99,26 +118,9 @@ def s3_env():
         CACHE_ROOT_DIRECTORY=str(root / "cache"),
         ENABLE_BACKEND_ACCESS_CONTROL="false",
         COGNEE_SKIP_CONNECTION_TEST="true",
-    )
-
-    import importlib
-
-    for module_name, factory_name in [
-        ("cognee.base_config", "get_base_config"),
-        ("cognee.infrastructure.files.storage.s3_config", "get_s3_config"),
-        ("cognee.infrastructure.databases.relational.config", "get_relational_config"),
-        (
-            "cognee.infrastructure.databases.relational.get_relational_engine",
-            "get_relational_engine",
-        ),
-        ("cognee.infrastructure.databases.cache.config", "get_cache_config"),
-        ("cognee.infrastructure.databases.cache.get_cache_engine", "create_cache_engine"),
-        ("cognee.infrastructure.llm.config", "get_llm_config"),
-    ]:
-        try:
-            getattr(importlib.import_module(module_name), factory_name).cache_clear()
-        except (ImportError, AttributeError):
-            pass
+    ).items():
+        mp.setenv(key, value)
+    clear_config_caches()
 
     # Count every S3 API call, through both the async client and the sync bridge.
     counts = collections.Counter()
@@ -140,6 +142,8 @@ def s3_env():
 
     s3fs.S3FileSystem._call_s3 = original_async
     s3fs.S3FileSystem.call_s3 = original_sync
+    mp.undo()
+    clear_config_caches()
     moto_proc.terminate()
     shutil.rmtree(root, ignore_errors=True)
 

--- a/cognee/tests/integration/tasks/test_dataset_scoped_data.py
+++ b/cognee/tests/integration/tasks/test_dataset_scoped_data.py
@@ -36,13 +36,38 @@ MARKER = re.compile(r"ENT[A-Z0-9]+")
 
 @pytest.fixture(scope="module")
 def scoped_env():
-    import os
-
     root = Path(tempfile.mkdtemp(prefix="cognee_scoped_data_test_"))
 
     import cognee  # noqa: F401  (cognee's import runs load_dotenv(override=True))
 
-    os.environ.update(
+    def clear_config_caches():
+        import importlib
+
+        for module_name, factory_name in [
+            ("cognee.base_config", "get_base_config"),
+            ("cognee.infrastructure.databases.relational.config", "get_relational_config"),
+            (
+                "cognee.infrastructure.databases.relational.get_relational_engine",
+                "get_relational_engine",
+            ),
+            ("cognee.infrastructure.databases.graph.config", "get_graph_config"),
+            ("cognee.infrastructure.databases.vector.config", "get_vectordb_config"),
+            ("cognee.infrastructure.databases.cache.config", "get_cache_config"),
+            ("cognee.infrastructure.databases.cache.get_cache_engine", "create_cache_engine"),
+            ("cognee.infrastructure.databases.vector.embeddings.config", "get_embedding_config"),
+            (
+                "cognee.infrastructure.databases.vector.embeddings.get_embedding_engine",
+                "create_embedding_engine",
+            ),
+            ("cognee.infrastructure.llm.config", "get_llm_config"),
+        ]:
+            try:
+                getattr(importlib.import_module(module_name), factory_name).cache_clear()
+            except (ImportError, AttributeError):
+                pass
+
+    mp = pytest.MonkeyPatch()
+    for key, value in dict(
         DB_PROVIDER="sqlite",
         VECTOR_DB_PROVIDER="lancedb",
         GRAPH_DATABASE_PROVIDER="kuzu",
@@ -52,32 +77,9 @@ def scoped_env():
         DATA_ROOT_DIRECTORY=str(root / "data"),
         SYSTEM_ROOT_DIRECTORY=str(root / "system"),
         ENABLE_BACKEND_ACCESS_CONTROL="false",
-    )
-
-    import importlib
-
-    for module_name, factory_name in [
-        ("cognee.base_config", "get_base_config"),
-        ("cognee.infrastructure.databases.relational.config", "get_relational_config"),
-        (
-            "cognee.infrastructure.databases.relational.get_relational_engine",
-            "get_relational_engine",
-        ),
-        ("cognee.infrastructure.databases.graph.config", "get_graph_config"),
-        ("cognee.infrastructure.databases.vector.config", "get_vectordb_config"),
-        ("cognee.infrastructure.databases.cache.config", "get_cache_config"),
-        ("cognee.infrastructure.databases.cache.get_cache_engine", "create_cache_engine"),
-        ("cognee.infrastructure.databases.vector.embeddings.config", "get_embedding_config"),
-        (
-            "cognee.infrastructure.databases.vector.embeddings.get_embedding_engine",
-            "create_embedding_engine",
-        ),
-        ("cognee.infrastructure.llm.config", "get_llm_config"),
-    ]:
-        try:
-            getattr(importlib.import_module(module_name), factory_name).cache_clear()
-        except (ImportError, AttributeError):
-            pass
+    ).items():
+        mp.setenv(key, value)
+    clear_config_caches()
 
     from cognee.infrastructure.llm.LLMGateway import LLMGateway
     from cognee.shared.data_models import KnowledgeGraph, Node, SummarizedContent
@@ -101,6 +103,8 @@ def scoped_env():
     yield root
 
     LLMGateway.acreate_structured_output = original
+    mp.undo()
+    clear_config_caches()
     shutil.rmtree(root, ignore_errors=True)
 
 

--- a/cognee/tests/integration/tasks/test_update_id_stability.py
+++ b/cognee/tests/integration/tasks/test_update_id_stability.py
@@ -39,13 +39,38 @@ MARKER = re.compile(r"ENT[A-Z0-9]+")
 
 @pytest.fixture(scope="module")
 def update_env():
-    import os
-
     root = Path(tempfile.mkdtemp(prefix="cognee_update_id_test_"))
 
     import cognee  # noqa: F401  (cognee's import runs load_dotenv(override=True))
 
-    os.environ.update(
+    def clear_config_caches():
+        import importlib
+
+        for module_name, factory_name in [
+            ("cognee.base_config", "get_base_config"),
+            ("cognee.infrastructure.databases.relational.config", "get_relational_config"),
+            (
+                "cognee.infrastructure.databases.relational.get_relational_engine",
+                "get_relational_engine",
+            ),
+            ("cognee.infrastructure.databases.graph.config", "get_graph_config"),
+            ("cognee.infrastructure.databases.vector.config", "get_vectordb_config"),
+            ("cognee.infrastructure.databases.cache.config", "get_cache_config"),
+            ("cognee.infrastructure.databases.cache.get_cache_engine", "create_cache_engine"),
+            ("cognee.infrastructure.databases.vector.embeddings.config", "get_embedding_config"),
+            (
+                "cognee.infrastructure.databases.vector.embeddings.get_embedding_engine",
+                "create_embedding_engine",
+            ),
+            ("cognee.infrastructure.llm.config", "get_llm_config"),
+        ]:
+            try:
+                getattr(importlib.import_module(module_name), factory_name).cache_clear()
+            except (ImportError, AttributeError):
+                pass
+
+    mp = pytest.MonkeyPatch()
+    for key, value in dict(
         DB_PROVIDER="sqlite",
         VECTOR_DB_PROVIDER="lancedb",
         GRAPH_DATABASE_PROVIDER="kuzu",
@@ -55,32 +80,9 @@ def update_env():
         DATA_ROOT_DIRECTORY=str(root / "data"),
         SYSTEM_ROOT_DIRECTORY=str(root / "system"),
         ENABLE_BACKEND_ACCESS_CONTROL="false",
-    )
-
-    import importlib
-
-    for module_name, factory_name in [
-        ("cognee.base_config", "get_base_config"),
-        ("cognee.infrastructure.databases.relational.config", "get_relational_config"),
-        (
-            "cognee.infrastructure.databases.relational.get_relational_engine",
-            "get_relational_engine",
-        ),
-        ("cognee.infrastructure.databases.graph.config", "get_graph_config"),
-        ("cognee.infrastructure.databases.vector.config", "get_vectordb_config"),
-        ("cognee.infrastructure.databases.cache.config", "get_cache_config"),
-        ("cognee.infrastructure.databases.cache.get_cache_engine", "create_cache_engine"),
-        ("cognee.infrastructure.databases.vector.embeddings.config", "get_embedding_config"),
-        (
-            "cognee.infrastructure.databases.vector.embeddings.get_embedding_engine",
-            "create_embedding_engine",
-        ),
-        ("cognee.infrastructure.llm.config", "get_llm_config"),
-    ]:
-        try:
-            getattr(importlib.import_module(module_name), factory_name).cache_clear()
-        except (ImportError, AttributeError):
-            pass
+    ).items():
+        mp.setenv(key, value)
+    clear_config_caches()
 
     from cognee.infrastructure.llm.LLMGateway import LLMGateway
     from cognee.shared.data_models import KnowledgeGraph, Node, SummarizedContent
@@ -104,6 +106,8 @@ def update_env():
     yield root
 
     LLMGateway.acreate_structured_output = original
+    mp.undo()
+    clear_config_caches()
     shutil.rmtree(root, ignore_errors=True)
 
 

--- a/cognee/tests/unit/api/v1/cognify/test_chunk_attachment.py
+++ b/cognee/tests/unit/api/v1/cognify/test_chunk_attachment.py
@@ -1,0 +1,154 @@
+"""chunk_attachment validation and plumbing at the cognify() boundary (SDK-163).
+
+cognify() forwards unknown keyword arguments all the way into the LLM call, which
+also takes **kwargs, so anything unusable has to raise here rather than vanish.
+"""
+
+import importlib
+from typing import List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from cognee.infrastructure.engine import DataPoint
+from cognee.shared.data_models import KnowledgeGraph
+
+cognify_module = importlib.import_module("cognee.api.v1.cognify.cognify")
+serve_state_module = importlib.import_module("cognee.api.v1.serve.state")
+
+
+class _Person(DataPoint):
+    name: str
+    metadata: dict = {"index_fields": ["name"]}
+
+
+class _Directory(DataPoint):
+    people: List[_Person]
+    metadata: dict = {"index_fields": []}
+
+
+class _KnowledgeGraphSubclass(KnowledgeGraph):
+    pass
+
+
+class _PlainModel(BaseModel):
+    pass
+
+
+def _no_pipeline_work():
+    """Patch everything past validation, so a raise proves it came first."""
+    return [
+        patch.object(serve_state_module, "get_remote_client", return_value=None),
+        patch(
+            "cognee.modules.migrations.startup.run_migrations_and_block",
+            new_callable=AsyncMock,
+            side_effect=AssertionError("migrations ran before validation"),
+        ),
+        patch.object(
+            cognify_module,
+            "get_default_tasks",
+            new_callable=AsyncMock,
+            side_effect=AssertionError("tasks were built before validation"),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs,message",
+    [
+        ({"graph_model": _Directory, "chunk_attachment": "everything"}, "Invalid chunk_attachment"),
+        ({"graph_model": _Directory, "chunk_attachment": False}, "Invalid chunk_attachment"),
+        ({"graph_model": KnowledgeGraph, "chunk_attachment": "all"}, "requires a custom DataPoint"),
+        (
+            {"graph_model": _KnowledgeGraphSubclass, "chunk_attachment": "all"},
+            "requires a custom DataPoint",
+        ),
+        ({"graph_model": _PlainModel, "chunk_attachment": "all"}, "requires a custom DataPoint"),
+        (
+            {"graph_model": _Directory, "chunk_attachment": "all", "temporal_cognify": True},
+            "not supported with temporal_cognify",
+        ),
+    ],
+)
+async def test_invalid_combinations_raise_before_any_pipeline_work(kwargs, message):
+    patches = _no_pipeline_work()
+    for active in patches:
+        active.start()
+    try:
+        with pytest.raises(ValueError, match=message):
+            await cognify_module.cognify(**kwargs)
+    finally:
+        for active in reversed(patches):
+            active.stop()
+
+
+@pytest.mark.asyncio
+async def test_remote_client_raises():
+    with patch.object(serve_state_module, "get_remote_client", return_value=MagicMock()):
+        with pytest.raises(ValueError, match="remote Cognee instance"):
+            await cognify_module.cognify(graph_model=_Directory, chunk_attachment="all")
+
+
+@pytest.mark.asyncio
+@patch.object(serve_state_module, "get_remote_client", return_value=None)
+@patch("cognee.modules.migrations.startup.run_migrations_and_block", new_callable=AsyncMock)
+@patch.object(cognify_module, "get_configured_ontology_resolver", return_value=None)
+@patch(
+    "cognee.modules.cognify.estimator.estimate_cognify_dry_run",
+    new_callable=AsyncMock,
+    return_value={"estimate": "stub"},
+)
+async def test_dry_run_is_permitted(
+    mock_estimate,
+    mock_get_resolver,
+    mock_migrations,
+    mock_remote_client,
+):
+    # dry_run adds no LLM calls and the estimator already excludes embedding cost,
+    # so the estimate is correctly unchanged rather than wrongly ignored. Raising
+    # here would make cognify(..., chunk_attachment="all", dry_run=True) fail where
+    # cognify(..., dry_run=True) succeeds.
+    result = await cognify_module.cognify(
+        graph_model=_Directory, chunk_attachment="all", dry_run=True
+    )
+
+    assert result == {"estimate": "stub"}
+    mock_estimate.assert_awaited_once()
+    # The estimator covers the two LLM-heavy stages only; attachment is not its business.
+    assert "chunk_attachment" not in mock_estimate.await_args.kwargs
+
+
+@pytest.mark.asyncio
+@patch.object(serve_state_module, "get_remote_client", return_value=None)
+@patch.object(cognify_module, "get_pipeline_executor")
+@patch.object(cognify_module, "get_default_tasks", new_callable=AsyncMock)
+@patch("cognee.modules.migrations.startup.run_migrations_and_block", new_callable=AsyncMock)
+@patch.object(cognify_module, "get_configured_ontology_resolver", return_value=None)
+async def test_valid_value_reaches_get_default_tasks_by_name(
+    mock_get_resolver,
+    mock_migrations,
+    mock_get_default_tasks,
+    mock_get_pipeline_executor,
+    mock_remote_client,
+):
+    mock_get_default_tasks.return_value = []
+    mock_get_pipeline_executor.return_value = AsyncMock(return_value={})
+
+    await cognify_module.cognify(graph_model=_Directory, chunk_attachment="all")
+
+    assert mock_get_default_tasks.await_args.kwargs["chunk_attachment"] == "all"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("attachment", [None, "direct", "all"])
+async def test_get_default_tasks_binds_chunk_attachment_onto_the_extraction_task(attachment):
+    tasks = await cognify_module.get_default_tasks(
+        graph_model=_Directory, chunk_size=512, chunk_attachment=attachment
+    )
+
+    extraction = next(
+        task for task in tasks if task.executable.__name__ == "extract_graph_and_summarize"
+    )
+    assert extraction.default_params["kwargs"]["chunk_attachment"] == attachment

--- a/cognee/tests/unit/interfaces/graph/test_transparent_nodes.py
+++ b/cognee/tests/unit/interfaces/graph/test_transparent_nodes.py
@@ -1,0 +1,514 @@
+"""Transparency: wherever a transparent node appears, it is replaced by its children.
+
+Edges are compared as sets: the walk emits them in field-declaration order, which is
+not part of the contract.
+"""
+
+import logging
+from typing import Any, List, Optional
+
+import pytest
+
+from cognee.infrastructure.engine import DataPoint, Edge
+from cognee.modules.engine.models import NodeSet
+from cognee.modules.graph.utils import get_graph_from_model
+from cognee.modules.graph.utils.unwrap_transparent_nodes import _WARNED_DROPPED_FIELDS
+
+TRANSPARENT = {"index_fields": [], "transparent": True}
+
+
+class Activity(DataPoint):
+    name: str
+    metadata: dict = {"index_fields": ["name"], "identity_fields": ["name"]}
+
+
+class Company(DataPoint):
+    name: str
+    metadata: dict = {"index_fields": ["name"], "identity_fields": ["name"]}
+
+
+class Person(DataPoint):
+    name: str
+    likes: Optional[List[Activity]] = None
+    works_for: Optional[Company] = None
+    metadata: dict = {"index_fields": ["name"], "identity_fields": ["name"]}
+
+
+class Directory(DataPoint):
+    people: List[Person]
+    companies: List[Company]
+    metadata: dict = {"index_fields": []}
+
+
+class TransparentDirectory(DataPoint):
+    people: List[Person]
+    companies: List[Company]
+    metadata: dict = TRANSPARENT
+
+
+class MemberGroup(DataPoint):
+    members: List[Person]
+    metadata: dict = TRANSPARENT
+
+
+class NestedDirectory(DataPoint):
+    groups: List[MemberGroup]
+    companies: List[Company]
+    metadata: dict = TRANSPARENT
+
+
+class Department(DataPoint):
+    name: str
+    groups: List[Any]
+    metadata: dict = {"index_fields": ["name"], "identity_fields": ["name"]}
+
+
+class NamedGroup(DataPoint):
+    """A transparent wrapper that wrongly carries real data in ``name``."""
+
+    name: str
+    members: List[Person]
+    metadata: dict = {"index_fields": ["name"], "transparent": True}
+
+
+class EmptyGroup(DataPoint):
+    members: List[Person] = []
+    metadata: dict = TRANSPARENT
+
+
+class HolderOfEmpty(DataPoint):
+    name: str
+    groups: List[EmptyGroup]
+    metadata: dict = {"index_fields": ["name"]}
+
+
+class DiamondHolder(DataPoint):
+    name: str
+    left: List[Any]
+    right: List[Any]
+    metadata: dict = {"index_fields": ["name"]}
+
+
+class OptionalGroup(DataPoint):
+    """Relationship-only wrapper whose optional fields are legitimately empty."""
+
+    members: List[Person] = []
+    lead: Optional[Person] = None
+    metadata: dict = TRANSPARENT
+
+
+class Chunk(DataPoint):
+    text: str
+    contains: Any = None
+    metadata: dict = {"index_fields": ["text"]}
+
+
+def _people():
+    acme = Company(name="Acme")
+    return (
+        Person(name="Alice", likes=[Activity(name="Biking")], works_for=acme),
+        Person(name="Bob", likes=[Activity(name="Basketball")], works_for=acme),
+        acme,
+    )
+
+
+def _edge_set(edges):
+    return {(str(source), str(target), name) for source, target, name, _ in edges}
+
+
+def _ids(nodes):
+    return {str(node.id) for node in nodes}
+
+
+@pytest.mark.asyncio
+async def test_plain_wrapper_is_stored_as_a_node():
+    """Case 1 (A1): a wrapper with no flag keeps today's graph exactly."""
+    alice, bob, acme = _people()
+    directory = Directory(people=[alice, bob], companies=[acme])
+
+    nodes, edges = await get_graph_from_model(directory)
+
+    assert str(directory.id) in _ids(nodes)
+    assert _edge_set(edges) == {
+        (str(directory.id), str(alice.id), "people"),
+        (str(directory.id), str(bob.id), "people"),
+        (str(directory.id), str(acme.id), "companies"),
+        (str(alice.id), str(alice.likes[0].id), "likes"),
+        (str(alice.id), str(acme.id), "works_for"),
+        (str(bob.id), str(bob.likes[0].id), "likes"),
+        (str(bob.id), str(acme.id), "works_for"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_transparent_root_stores_children_as_top_level():
+    """Case 2 (A2): the wrapper is absent from nodes and from both edge endpoints."""
+    alice, bob, acme = _people()
+    directory = TransparentDirectory(people=[alice, bob], companies=[acme])
+
+    nodes, edges = await get_graph_from_model(directory)
+
+    wrapper_id = str(directory.id)
+    assert wrapper_id not in _ids(nodes)
+    assert _ids(nodes) == {
+        str(alice.id),
+        str(bob.id),
+        str(acme.id),
+        str(alice.likes[0].id),
+        str(bob.likes[0].id),
+    }
+    assert _edge_set(edges) == {
+        (str(alice.id), str(alice.likes[0].id), "likes"),
+        (str(alice.id), str(acme.id), "works_for"),
+        (str(bob.id), str(bob.likes[0].id), "likes"),
+        (str(bob.id), str(acme.id), "works_for"),
+    }
+    assert all(wrapper_id not in (str(source), str(target)) for source, target, _, _ in edges)
+
+
+@pytest.mark.asyncio
+async def test_nested_transparent_wrappers_resolve_recursively():
+    """Case 3 (A3): identical to A2 after applying the rule twice."""
+    alice, bob, acme = _people()
+    flat = TransparentDirectory(people=[alice, bob], companies=[acme])
+    nested = NestedDirectory(groups=[MemberGroup(members=[alice, bob])], companies=[acme])
+
+    flat_nodes, flat_edges = await get_graph_from_model(flat)
+    nested_nodes, nested_edges = await get_graph_from_model(nested)
+
+    assert _ids(nested_nodes) == _ids(flat_nodes)
+    assert _edge_set(nested_edges) == _edge_set(flat_edges)
+
+
+@pytest.mark.asyncio
+async def test_mid_graph_wrapper_keeps_parent_field_name():
+    """Case 4 (A4): the ``groups`` edge lands on each child."""
+    alice, bob, acme = _people()
+    department = Department(name="Engineering", groups=[MemberGroup(members=[alice, bob])])
+
+    nodes, edges = await get_graph_from_model(department)
+
+    assert str(department.id) in _ids(nodes)
+    assert (str(department.id), str(alice.id), "groups") in _edge_set(edges)
+    assert (str(department.id), str(bob.id), "groups") in _edge_set(edges)
+    assert not any(str(node.id) == str(department.groups[0].id) for node in nodes)
+
+
+@pytest.mark.asyncio
+async def test_edge_metadata_is_applied_to_each_child():
+    """Case 13: an ``(Edge, wrapper)`` tuple re-points with its metadata intact."""
+    alice, bob, _ = _people()
+    edge = Edge(relationship_type="staffed_by", weights={"strength": 0.5})
+    department = Department(name="Engineering", groups=[(edge, MemberGroup(members=[alice, bob]))])
+
+    _, edges = await get_graph_from_model(department)
+
+    repointed = [
+        properties
+        for _, target, _, properties in edges
+        if str(target) in (str(alice.id), str(bob.id))
+    ]
+    assert len(repointed) == 2
+    for properties in repointed:
+        assert properties["relationship_name"] == "staffed_by"
+        assert properties["weight_strength"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_wrapper_carrying_scalar_data_warns_once_and_drops_it(caplog):
+    """Case 5 (A5): the value is dropped, no node is minted, one warning is logged."""
+    _WARNED_DROPPED_FIELDS.clear()
+    alice, bob, _ = _people()
+    department = Department(
+        name="Engineering", groups=[NamedGroup(name="Core team", members=[alice, bob])]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        nodes, edges = await get_graph_from_model(department)
+
+    assert str(department.groups[0].id) not in _ids(nodes)
+    assert not any("Core team" in str(getattr(node, "name", "")) for node in nodes)
+    assert (str(department.id), str(alice.id), "groups") in _edge_set(edges)
+
+    warnings = [record for record in caplog.records if "marked transparent" in record.getMessage()]
+    assert len(warnings) == 1
+    assert "'name'" in warnings[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_dropped_field_warning_fires_at_most_once(caplog):
+    _WARNED_DROPPED_FIELDS.clear()
+    alice, bob, _ = _people()
+
+    with caplog.at_level(logging.WARNING):
+        for label in ("Core team", "Platform team"):
+            await get_graph_from_model(
+                Department(name=label, groups=[NamedGroup(name=label, members=[alice, bob])])
+            )
+
+    warnings = [record for record in caplog.records if "marked transparent" in record.getMessage()]
+    assert len(warnings) == 1
+
+
+@pytest.mark.asyncio
+async def test_relationship_only_wrapper_never_warns(caplog):
+    """An optional relationship left ``None`` and an empty list lose nothing."""
+    _WARNED_DROPPED_FIELDS.clear()
+    alice, _, _ = _people()
+
+    with caplog.at_level(logging.WARNING):
+        await get_graph_from_model(
+            Department(name="Engineering", groups=[OptionalGroup(members=[alice], lead=None)])
+        )
+        await get_graph_from_model(
+            Department(name="Support", groups=[OptionalGroup(members=[], lead=None)])
+        )
+
+    assert not [record for record in caplog.records if "marked transparent" in record.getMessage()]
+
+
+@pytest.mark.asyncio
+async def test_empty_wrapper_as_root_returns_nothing():
+    """Case 6."""
+    assert await get_graph_from_model(EmptyGroup(members=[])) == ([], [])
+
+
+@pytest.mark.asyncio
+async def test_field_holding_only_empty_wrappers_is_not_a_property():
+    """Case 7: no edge is minted and the field never becomes a scalar property."""
+    holder = HolderOfEmpty(name="Holder", groups=[EmptyGroup(members=[])])
+
+    nodes, edges = await get_graph_from_model(holder)
+
+    assert _ids(nodes) == {str(holder.id)}
+    assert edges == []
+    assert not hasattr(nodes[0], "groups")
+
+
+@pytest.mark.asyncio
+async def test_transparent_via_constructor_kwarg_is_honoured():
+    """Case 8: the MetaData TypedDict must declare ``transparent`` for this to survive."""
+    alice, bob, acme = _people()
+    directory = Directory(
+        people=[alice, bob],
+        companies=[acme],
+        metadata={"index_fields": [], "transparent": True},
+    )
+
+    assert directory.metadata.get("transparent") is True
+
+    nodes, _ = await get_graph_from_model(directory)
+
+    assert str(directory.id) not in _ids(nodes)
+
+
+@pytest.mark.asyncio
+async def test_children_across_several_fields_appear_exactly_once():
+    """Case 9."""
+    alice, bob, acme = _people()
+    directory = TransparentDirectory(people=[alice, bob, alice], companies=[acme])
+
+    nodes, _ = await get_graph_from_model(directory)
+
+    ids = [str(node.id) for node in nodes]
+    assert len(ids) == len(set(ids))
+
+
+@pytest.mark.asyncio
+async def test_diamond_wrapper_reached_from_two_fields_keeps_its_children():
+    """Case 10: regression guard for a shared mutable ``_active`` set."""
+    alice, bob, _ = _people()
+    group = MemberGroup(members=[alice, bob])
+    holder = DiamondHolder(name="Holder", left=[group], right=[group])
+
+    _, edges = await get_graph_from_model(holder)
+
+    assert (str(holder.id), str(alice.id), "left") in _edge_set(edges)
+    assert (str(holder.id), str(alice.id), "right") in _edge_set(edges)
+    assert (str(holder.id), str(bob.id), "right") in _edge_set(edges)
+
+
+@pytest.mark.asyncio
+async def test_distinct_instances_sharing_a_node_id_both_resolve():
+    """Case 11: identity_fields collision must not read as a cycle."""
+
+    class IdentityGroup(DataPoint):
+        name: str
+        members: List[Person]
+        metadata: dict = {
+            "index_fields": ["name"],
+            "identity_fields": ["name"],
+            "transparent": True,
+        }
+
+    alice, bob, _ = _people()
+    first = IdentityGroup(name="Team", members=[alice])
+    second = IdentityGroup(name="Team", members=[bob])
+    assert first.id == second.id
+
+    holder = DiamondHolder(name="Holder", left=[first], right=[second])
+
+    _, edges = await get_graph_from_model(holder)
+
+    assert (str(holder.id), str(alice.id), "left") in _edge_set(edges)
+    assert (str(holder.id), str(bob.id), "right") in _edge_set(edges)
+
+
+@pytest.mark.asyncio
+async def test_shared_child_of_two_parents_is_stored_once():
+    """Case 12."""
+    alice, bob, acme = _people()
+    directory = TransparentDirectory(people=[alice, bob], companies=[acme])
+
+    nodes, edges = await get_graph_from_model(directory)
+
+    assert [str(node.id) for node in nodes].count(str(acme.id)) == 1
+    assert (str(alice.id), str(acme.id), "works_for") in _edge_set(edges)
+    assert (str(bob.id), str(acme.id), "works_for") in _edge_set(edges)
+
+
+@pytest.mark.asyncio
+async def test_belongs_to_set_is_not_a_wrapper_child():
+    """Case 14: a wrapper's NodeSets must not be inherited by its parent."""
+    alice, _, _ = _people()
+    node_set = NodeSet(name="team")
+    group = MemberGroup(members=[alice])
+    group.belongs_to_set = [node_set]
+    department = Department(name="Engineering", groups=[group])
+
+    nodes, edges = await get_graph_from_model(department)
+
+    assert str(node_set.id) not in _ids(nodes)
+    assert all(str(target) != str(node_set.id) for _, target, _, _ in edges)
+
+
+@pytest.mark.asyncio
+async def test_transparent_only_cycle_terminates():
+    """Case 15."""
+
+    class CyclicGroup(DataPoint):
+        peers: List[Any] = []
+        metadata: dict = TRANSPARENT
+
+    first = CyclicGroup()
+    second = CyclicGroup(peers=[first])
+    first.peers = [second]
+
+    assert await get_graph_from_model(first) == ([], [])
+
+
+@pytest.mark.asyncio
+async def test_mixed_cycle_terminates_with_a_self_edge():
+    """Case 16: transparent -> plain -> transparent collapses onto the plain node."""
+
+    class Mixed(DataPoint):
+        name: str
+        groups: List[Any] = []
+        metadata: dict = {"index_fields": ["name"], "identity_fields": ["name"]}
+
+    class Wrapper(DataPoint):
+        members: List[Any] = []
+        metadata: dict = TRANSPARENT
+
+    person = Mixed(name="Alice")
+    wrapper = Wrapper(members=[person])
+    person.groups = [wrapper]
+
+    nodes, edges = await get_graph_from_model(wrapper)
+
+    assert _ids(nodes) == {str(person.id)}
+    assert _edge_set(edges) == {(str(person.id), str(person.id), "groups")}
+
+
+@pytest.mark.asyncio
+async def test_chunk_contains_a_transparent_wrapper():
+    """Case 18 (B3): the cognify chunk boundary, assigned after construction."""
+    alice, bob, acme = _people()
+    chunk = Chunk(text="Alice works for Acme. Bob works for Acme.")
+    chunk.contains = TransparentDirectory(people=[alice, bob], companies=[acme])
+    wrapper_id = str(chunk.contains.id)
+
+    nodes, edges = await get_graph_from_model(chunk)
+
+    assert wrapper_id not in _ids(nodes)
+    contains = {str(target) for source, target, name, _ in edges if name == "contains"}
+    assert contains == {str(alice.id), str(bob.id), str(acme.id)}
+    assert all(str(source) == str(chunk.id) for source, _, name, _ in edges if name == "contains")
+
+
+def test_transparent_survives_every_metadata_form():
+    """All three rows of the plan's metadata table keep the flag."""
+    alice, bob, acme = _people()
+
+    class Flagged(DataPoint):
+        people: List[Person]
+        metadata: dict = {"index_fields": [], "transparent": True}
+
+    assert Flagged(people=[alice]).metadata.get("transparent") is True
+
+    from_kwarg = Directory(
+        people=[alice, bob],
+        companies=[acme],
+        metadata={"index_fields": [], "transparent": True},
+    )
+    assert from_kwarg.metadata.get("transparent") is True
+
+    assigned = Directory(people=[alice], companies=[acme])
+    assigned.metadata = {"index_fields": [], "transparent": True}
+    assert assigned.metadata.get("transparent") is True
+
+    revalidated = Directory.model_validate(from_kwarg.model_dump())
+    assert revalidated.metadata.get("transparent") is True
+
+
+class CyclicPerson(DataPoint):
+    name: str
+    works_for: Any = None
+    metadata: dict = {"index_fields": ["name"], "identity_fields": ["name"]}
+
+
+class CyclicCompany(DataPoint):
+    name: str
+    employees: List[Any] = []
+    metadata: dict = {"index_fields": ["name"], "identity_fields": ["name"]}
+
+
+def _parity_fixtures():
+    """One root per storage shape the collector has to agree with."""
+    plain_a, plain_b, plain_acme = _people()
+    transparent_a, transparent_b, transparent_acme = _people()
+    nested_a, nested_b, nested_acme = _people()
+    node_set_a, _, _ = _people()
+
+    with_node_set = Department(name="Engineering", groups=[MemberGroup(members=[node_set_a])])
+    with_node_set.belongs_to_set = [NodeSet(name="team")]
+
+    person = CyclicPerson(name="Cyclic Alice")
+    company = CyclicCompany(name="Cyclic Acme", employees=[person])
+    person.works_for = company
+
+    return [
+        Directory(people=[plain_a, plain_b], companies=[plain_acme]),
+        TransparentDirectory(people=[transparent_a, transparent_b], companies=[transparent_acme]),
+        NestedDirectory(
+            groups=[MemberGroup(members=[nested_a, nested_b])], companies=[nested_acme]
+        ),
+        with_node_set,
+        company,
+    ]
+
+
+@pytest.mark.parametrize("root", _parity_fixtures())
+@pytest.mark.asyncio
+async def test_collector_returns_the_originals_that_storage_writes(root):
+    """Same node set as the walk, but the original objects rather than the copies."""
+    from cognee.modules.graph.utils import collect_stored_data_points
+
+    stored_nodes, _ = await get_graph_from_model(root)
+    collected = await collect_stored_data_points(root)
+
+    assert {str(node.id) for node in collected} == _ids(stored_nodes)
+    # The walk's own output is unusable for linking: copy_model strips the
+    # relationship fields, so edges out of those nodes would never be minted.
+    assert all(isinstance(node, DataPoint) for node in collected)
+    assert all(type(node) is not type(copy) for node, copy in zip(collected, stored_nodes))

--- a/cognee/tests/unit/modules/provenance/test_record_provenance_task.py
+++ b/cognee/tests/unit/modules/provenance/test_record_provenance_task.py
@@ -232,6 +232,41 @@ class TestRecordProvenanceTask:
         assert (await manager.verify_chain())["valid"] is True
 
     @pytest.mark.asyncio
+    async def test_generic_walk_without_the_input_attributes_to_nothing(self, manager):
+        # get_graph_from_model may return a node set that does not include the item
+        # it was given. Attributing those entries to the absent item would forge a
+        # provenance chain pointing at something that was never written.
+        class CustomTail(DataPoint):
+            name: str
+
+        class CustomLeaf(DataPoint):
+            name: str
+            points_to: CustomTail
+
+        class CustomContainer(DataPoint):
+            name: str
+            holds: CustomLeaf
+            metadata: dict = {"index_fields": [], "transparent": True}
+
+        tail = CustomTail(name="tail")
+        leaf = CustomLeaf(name="leaf", points_to=tail)
+        container = CustomContainer(name="container", holds=leaf)
+
+        result = await record_provenance([container], ctx=None)
+
+        assert result == [container]
+        entries = await storage.retrieve_all()
+        entity_ids = {entry.entity_id for entry in entries}
+        assert str(container.id) not in entity_ids
+        # The leaf, the tail, and the one relationship between them.
+        assert {str(leaf.id), str(tail.id)} <= entity_ids
+        assert any(entry.entity_type == "relationship" for entry in entries)
+        # Nothing may be attributed to an entity that was never written.
+        assert all(entry.source_document == "" for entry in entries)
+        assert all(entry.parent_entity_id is None for entry in entries)
+        assert (await manager.verify_chain())["valid"] is True
+
+    @pytest.mark.asyncio
     async def test_raw_item_without_document_still_tracked(self, manager):
         raw_item = SimpleNamespace(id=uuid4())  # no made_from, no is_part_of
         result = await record_provenance([raw_item], ctx=None)

--- a/cognee/tests/unit/tasks/graph/test_extract_graph_from_data.py
+++ b/cognee/tests/unit/tasks/graph/test_extract_graph_from_data.py
@@ -349,3 +349,193 @@ async def test_stub_resolver_reaches_graph_construction_via_task(mock_find_exist
     _, entity = chunk.contains[0]
     assert entity.name == "alice"
     assert entity.ontology_valid is True
+
+
+# --- chunk_attachment (SDK-163) -------------------------------------------------
+
+from typing import Any, List, Optional  # noqa: E402
+
+from cognee.infrastructure.engine import DataPoint  # noqa: E402
+from cognee.modules.graph.utils import (  # noqa: E402
+    ensure_default_edge_properties,
+    get_graph_from_model,
+)
+
+
+class _Activity(DataPoint):
+    name: str
+    metadata: dict = {"index_fields": ["name"], "identity_fields": ["name"]}
+
+
+class _Person(DataPoint):
+    name: str
+    likes: Optional[List[_Activity]] = None
+    metadata: dict = {"index_fields": ["name"], "identity_fields": ["name"]}
+
+
+class _Directory(DataPoint):
+    people: List[_Person]
+    metadata: dict = {"index_fields": []}
+
+
+class _TransparentDirectory(DataPoint):
+    people: List[_Person]
+    metadata: dict = {"index_fields": [], "transparent": True}
+
+
+class _AttachmentChunk(DataPoint):
+    """A DocumentChunk-shaped node, so the real walk can mint the contains edges."""
+
+    text: str
+    contains: Any = None
+    metadata: dict = {"index_fields": ["text"]}
+
+
+def _directory_fixture(wrapper_class):
+    biking = _Activity(name="Biking")
+    basketball = _Activity(name="Basketball")
+    alice = _Person(name="Alice", likes=[biking])
+    bob = _Person(name="Bob", likes=[basketball])
+    return wrapper_class(people=[alice, bob]), (alice, bob, biking, basketball)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("attachment", [None, "direct"])
+async def test_direct_attachment_leaves_the_root_assignment_untouched(attachment):
+    graph, _ = _directory_fixture(_Directory)
+    chunk = _make_chunk()
+
+    await integrate_chunk_graphs(
+        [chunk], [graph], _Directory, _mock_resolver(), chunk_attachment=attachment
+    )
+
+    assert chunk.contains is graph
+
+
+@pytest.mark.asyncio
+async def test_all_attachment_lists_every_stored_node_in_order():
+    graph, (alice, bob, biking, basketball) = _directory_fixture(_Directory)
+    chunk = _make_chunk()
+
+    await integrate_chunk_graphs(
+        [chunk], [graph], _Directory, _mock_resolver(), chunk_attachment="all"
+    )
+
+    # A set: the walk's traversal order is not part of the contract.
+    assert {str(node.id) for node in chunk.contains} == {
+        str(graph.id),
+        str(alice.id),
+        str(bob.id),
+        str(biking.id),
+        str(basketball.id),
+    }
+
+
+@pytest.mark.asyncio
+async def test_all_attachment_excludes_a_transparent_wrapper():
+    graph, (alice, bob, biking, basketball) = _directory_fixture(_TransparentDirectory)
+    chunk = _make_chunk()
+
+    await integrate_chunk_graphs(
+        [chunk], [graph], _TransparentDirectory, _mock_resolver(), chunk_attachment="all"
+    )
+
+    assert {str(node.id) for node in chunk.contains} == {
+        str(alice.id),
+        str(bob.id),
+        str(biking.id),
+        str(basketball.id),
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "wrapper_class,attachment,expected_targets",
+    [
+        (_Directory, None, {"root"}),
+        (_Directory, "direct", {"root"}),
+        (_Directory, "all", {"root", "alice", "bob", "biking", "basketball"}),
+        (_TransparentDirectory, None, {"alice", "bob"}),
+        (_TransparentDirectory, "all", {"alice", "bob", "biking", "basketball"}),
+    ],
+)
+async def test_attachment_matrix_over_the_real_walk(wrapper_class, attachment, expected_targets):
+    graph, (alice, bob, biking, basketball) = _directory_fixture(wrapper_class)
+    by_name = {
+        "root": graph,
+        "alice": alice,
+        "bob": bob,
+        "biking": biking,
+        "basketball": basketball,
+    }
+    chunk = _AttachmentChunk(text="Alice likes biking. Bob likes basketball.")
+
+    await integrate_chunk_graphs(
+        [chunk], [graph], wrapper_class, _mock_resolver(), chunk_attachment=attachment
+    )
+    nodes, edges = await get_graph_from_model(chunk)
+    edges = ensure_default_edge_properties(edges, nodes=nodes)
+
+    contains = [edge for edge in edges if edge[2] == "contains"]
+    assert {str(edge[1]) for edge in contains} == {
+        str(by_name[name].id) for name in expected_targets
+    }
+    # One edge per target, and the shared policy supplied the label.
+    assert len(contains) == len(expected_targets)
+    assert all(edge[3].get("edge_text") for edge in contains)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wrapper_class", [_Directory, _TransparentDirectory])
+async def test_attachment_never_changes_a_non_contains_edge(wrapper_class):
+    # One extraction, two chunks: chunk_attachment must only decide which nodes the
+    # chunk links to, never touch the graph the model itself describes.
+    graph, _ = _directory_fixture(wrapper_class)
+
+    results = []
+    for chunk_attachment in (None, "all"):
+        chunk = _AttachmentChunk(text="Alice likes biking. Bob likes basketball.")
+        await integrate_chunk_graphs(
+            [chunk], [graph], wrapper_class, _mock_resolver(), chunk_attachment=chunk_attachment
+        )
+        _, edges = await get_graph_from_model(chunk)
+        results.append({(str(s), str(t), name) for s, t, name, _ in edges if name != "contains"})
+
+    assert results[0] == results[1]
+    assert results[0]  # the model's own edges are actually present
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chunk_graph", [None, "not-a-datapoint"])
+async def test_all_attachment_falls_back_for_a_non_datapoint_extraction(chunk_graph):
+    from pydantic import BaseModel
+
+    class CustomModel(BaseModel):
+        pass
+
+    chunk = _make_chunk()
+
+    await integrate_chunk_graphs(
+        [chunk], [chunk_graph], CustomModel, _mock_resolver(), chunk_attachment="all"
+    )
+
+    assert chunk.contains is chunk_graph
+
+
+@pytest.mark.asyncio
+@patch.object(egd_module, "get_configured_ontology_resolver")
+@patch.object(egd_module, "integrate_chunk_graphs", new_callable=AsyncMock)
+@patch.object(egd_module, "extract_content_graph", new_callable=AsyncMock)
+async def test_chunk_attachment_reaches_integration_by_keyword_only(
+    mock_extract, mock_integrate, mock_get_resolver
+):
+    mock_get_resolver.return_value = None
+    mock_integrate.side_effect = lambda *a, **kw: a[0]
+    mock_extract.return_value = _two_node_graph()
+    chunk = _make_chunk()
+
+    await extract_graph_from_data([chunk], KnowledgeGraph, chunk_attachment="all")
+
+    assert mock_integrate.await_args.kwargs["chunk_attachment"] == "all"
+    # It must never reach the LLM call, which swallows unknown kwargs silently.
+    assert "chunk_attachment" not in mock_extract.await_args.kwargs


### PR DESCRIPTION
## Description

Lets a custom `graph_model` use a wrapper class that never reaches the graph, and lets a chunk link to every entity extracted from it instead of only the extraction root (SDK-163).

- A DataPoint class with `metadata["transparent"] = True` is skipped by the graph walk and its DataPoint children are promoted to roots, so one extraction can produce several top-level nodes, or none. The wrapper is never stored and never an edge endpoint.
- Non-DataPoint fields declared on a transparent class have nowhere to go once the wrapper is dropped. They are ignored, and each one warns once per class field rather than disappearing silently.
- New `cognify(chunk_attachment=...)`: `"all"` links each chunk once to every stored node reachable from the extracted root, so any entity is one hop from its source chunk. `"direct"` and omitting it keep the current single-root linkage, so existing runs are unaffected.
- `chunk_attachment` is rejected up front for an invalid value, a non-DataPoint `graph_model`, `temporal_cognify=True`, or a remote connection — `cognify()` forwards unknown keywords into the LLM call, where a bad value would be swallowed. It is allowed with `dry_run=True`, whose estimate is genuinely unchanged.
- The provenance task no longer attributes nodes to a root the walk did not store, which a transparent root now makes possible.
- The graph walk was reorganised to support the above: fields are classified once per node instead of twice, container resolution and field reading each moved into their own module, the recursion is synchronous (nothing in it touches I/O), and the unused `include_root` parameter is gone. `get_graph_from_model`'s public signature is otherwise unchanged.

## Acceptance Criteria

- A transparent wrapper class contributes no node and no edge to the stored graph.
- Its DataPoint children are stored as top-level nodes, including when a field points at one.
- `chunk_attachment="all"` puts every node reachable from a chunk's extracted root in that chunk's `contains`.
- Graphs with no transparent node and no `chunk_attachment` produce the same nodes and edges as before.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
