### PR TITLE
perf(storage): skip re-embedding data points whose indexed field is unchanged

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/config.py
+++ b/cognee/infrastructure/databases/vector/embeddings/config.py
@@ -83,6 +83,13 @@ class EmbeddingConfig(BaseSettings):
     # Total data points allowed in flight to the embedding engine during indexing.
     # Concurrent embedding requests = max(1, this // embedding_batch_size).
     embedding_max_concurrent_data_points: int = 150
+    #: Skip re-embedding a data point whose indexed field already matches what the
+    #: vector store holds. A redundant write costs an embedding call and produces
+    #: a byte-identical row; on stores that version on write (LanceDB upserts via
+    #: merge_insert) it also creates a table version and data fragment that
+    #: accumulate until something compacts them. Set to False to restore the
+    #: previous unconditional behaviour.
+    skip_unchanged_vector_writes: bool = True
     huggingface_tokenizer: Optional[str] = None
     # Some providers (e.g. NVIDIA NIM's nv-embed family) require an
     # "input_type" field in the embedding request body (typically "query" or
@@ -142,6 +149,7 @@ class EmbeddingConfig(BaseSettings):
             "embedding_input_type": self.embedding_input_type,
             "embedding_batch_size": self.embedding_batch_size,
             "embedding_max_concurrent_data_points": self.embedding_max_concurrent_data_points,
+            "skip_unchanged_vector_writes": self.skip_unchanged_vector_writes,
             "embedding_rate_limit_enabled": self.embedding_rate_limit_enabled,
             "embedding_rate_limit_requests": self.embedding_rate_limit_requests,
             "embedding_rate_limit_interval": self.embedding_rate_limit_interval,

--- a/cognee/tasks/storage/index_data_points.py
+++ b/cognee/tasks/storage/index_data_points.py
@@ -8,6 +8,56 @@ from cognee.shared.logging_utils import get_logger
 logger = get_logger("index_data_points")
 
 
+def _embeddable_value(data_point, field_name: str):
+    """The exact value that would be embedded for ``field_name``."""
+    return getattr(data_point, field_name, None)
+
+
+async def _drop_unchanged(vector_engine, type_name: str, field_name: str, points: list):
+    """Return only the points whose indexed field differs from what is stored.
+
+    Re-embedding and upserting a point whose indexed text has not changed costs
+    an embedding call and a write, and produces a byte-identical row. On stores
+    that version on write (LanceDB upserts via ``merge_insert``) each redundant
+    write also creates a new table version and data fragment, which accumulate
+    until something compacts them.
+
+    Fails OPEN in the direction of doing the work: any error, any point the
+    store does not know, and any payload that does not carry the field is
+    indexed as before. Skipping is only ever chosen on positive evidence that
+    the stored value is identical, so this can never leave a vector stale.
+    """
+    ids = [str(point.id) for point in points if getattr(point, "id", None) is not None]
+    if not ids:
+        return points
+    try:
+        stored_rows = await vector_engine.retrieve(type_name, ids)
+
+        stored_by_id: dict[str, dict] = {}
+        for row in stored_rows or []:
+            row_id = getattr(row, "id", None)
+            payload = getattr(row, "payload", None)
+            if row_id is None and isinstance(row, dict):
+                row_id, payload = row.get("id"), row.get("payload")
+            if row_id is not None and isinstance(payload, dict):
+                stored_by_id[str(row_id)] = payload
+
+        changed = []
+        for point in points:
+            payload = stored_by_id.get(str(getattr(point, "id", "")))
+            if payload is None or field_name not in payload:
+                changed.append(point)
+                continue
+            if payload[field_name] != _embeddable_value(point, field_name):
+                changed.append(point)
+        return changed
+    except Exception:  # noqa: BLE001
+        # ANY failure means index as before. A store that cannot answer, an
+        # adapter without retrieve, a mocked engine returning something
+        # unexpected: all of them must index, never skip.
+        return points
+
+
 async def index_data_points(data_points: list[DataPoint], vector_engine=None):
     """Index data points in the vector engine by creating embeddings for specified fields.
 
@@ -62,9 +112,24 @@ async def index_data_points(data_points: list[DataPoint], vector_engine=None):
         async with semaphore:
             await vector_engine.index_data_points(type_name, field_name, batch)
 
+    skip_unchanged = getattr(
+        get_embedding_context_config(), "skip_unchanged_vector_writes", True
+    )
+
     tasks = []
     for type_name, fields in data_points_by_type.items():
         for field_name, points in fields.items():
+            if skip_unchanged:
+                before = len(points)
+                points = await _drop_unchanged(vector_engine, type_name, field_name, points)
+                if len(points) != before:
+                    logger.debug(
+                        "index_data_points: %s.%s skipped %d unchanged of %d",
+                        type_name,
+                        field_name,
+                        before - len(points),
+                        before,
+                    )
             for i in range(0, len(points), batch_size):
                 batch = points[i : i + batch_size]
                 tasks.append(asyncio.create_task(_index_batch(type_name, field_name, batch)))

--- a/cognee/tests/unit/infrastructure/databases/test_index_data_points.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_data_points.py
@@ -112,3 +112,120 @@ async def test_index_data_points_does_not_mutate_metadata():
         await index_data_points([data_point])
 
     assert data_point.metadata["index_fields"] == original_index_fields
+
+
+# --- skipping re-indexing of unchanged data points ---------------------------
+
+
+def _engine_with_stored(stored_rows, *, retrieve_raises=False):
+    """A vector engine whose store already holds ``stored_rows``."""
+    engine = AsyncMock()
+    engine.embedding_engine.get_batch_size = MagicMock(return_value=100)
+    if retrieve_raises:
+        engine.retrieve = AsyncMock(side_effect=RuntimeError("store unavailable"))
+    else:
+        engine.retrieve = AsyncMock(return_value=stored_rows)
+    return engine
+
+
+def _indexed_names(engine):
+    """Names the engine was actually asked to index."""
+    names = []
+    for call in engine.index_data_points.await_args_list:
+        for point in call.args[2]:
+            names.append(point.name)
+    return names
+
+
+async def _run(points, engine, *, skip=True):
+    for point in points:
+        point.metadata["index_fields"] = ["name"]
+
+    async def _get_vector_engine():
+        return engine
+
+    with patch.dict(
+        index_data_points.__globals__,
+        {
+            "get_vector_engine_async": _get_vector_engine,
+            "get_embedding_context_config": lambda: SimpleNamespace(
+                embedding_max_concurrent_data_points=150,
+                skip_unchanged_vector_writes=skip,
+            ),
+        },
+    ):
+        await index_data_points(points, vector_engine=engine)
+
+
+@pytest.mark.asyncio
+async def test_unchanged_point_is_not_reindexed():
+    """The whole point: an identical value must not be re-embedded or rewritten."""
+    point = TestDataPoint(name="unchanged")
+    engine = _engine_with_stored(
+        [SimpleNamespace(id=point.id, payload={"name": "unchanged"})]
+    )
+    await _run([point], engine)
+    assert engine.index_data_points.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_changed_point_is_reindexed():
+    point = TestDataPoint(name="new value")
+    engine = _engine_with_stored(
+        [SimpleNamespace(id=point.id, payload={"name": "old value"})]
+    )
+    await _run([point], engine)
+    assert _indexed_names(engine) == ["new value"]
+
+
+@pytest.mark.asyncio
+async def test_point_the_store_does_not_know_is_indexed():
+    point = TestDataPoint(name="brand new")
+    engine = _engine_with_stored([])
+    await _run([point], engine)
+    assert _indexed_names(engine) == ["brand new"]
+
+
+@pytest.mark.asyncio
+async def test_payload_without_the_indexed_field_is_indexed():
+    """Absent evidence is not evidence of sameness."""
+    point = TestDataPoint(name="value")
+    engine = _engine_with_stored(
+        [SimpleNamespace(id=point.id, payload={"something_else": "value"})]
+    )
+    await _run([point], engine)
+    assert _indexed_names(engine) == ["value"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_failure_indexes_everything():
+    """Fail open. A store that cannot answer must never cause a skip."""
+    point = TestDataPoint(name="value")
+    engine = _engine_with_stored(None, retrieve_raises=True)
+    await _run([point], engine)
+    assert _indexed_names(engine) == ["value"]
+
+
+@pytest.mark.asyncio
+async def test_mixed_batch_indexes_only_the_changed_ones():
+    same = TestDataPoint(name="same")
+    different = TestDataPoint(name="different now")
+    engine = _engine_with_stored(
+        [
+            SimpleNamespace(id=same.id, payload={"name": "same"}),
+            SimpleNamespace(id=different.id, payload={"name": "different before"}),
+        ]
+    )
+    await _run([same, different], engine)
+    assert _indexed_names(engine) == ["different now"]
+
+
+@pytest.mark.asyncio
+async def test_disabling_the_flag_restores_unconditional_indexing():
+    point = TestDataPoint(name="unchanged")
+    engine = _engine_with_stored(
+        [SimpleNamespace(id=point.id, payload={"name": "unchanged"})]
+    )
+    await _run([point], engine, skip=False)
+    assert _indexed_names(engine) == ["unchanged"]
+    assert engine.retrieve.await_count == 0, "the flag must skip the lookup entirely"


### PR DESCRIPTION
Fixes the write amplification reported in #4684.

## The problem

`index_data_points` re-embeds and upserts **every** point it is handed, with no check against what the store already holds:

https://github.com/topoteretes/cognee/blob/main/cognee/tasks/storage/index_data_points.py

`add_data_points` calls it on every extracted node, so any pipeline that re-processes the same content pays a full re-embed and re-write that produces byte-identical rows.

On stores that version on write, that is not free. LanceDB upserts through `merge_insert`, so each redundant write creates a new table version **and a new data fragment** — and nothing in cognee compacts them (the only `optimize()` call in the tree is inside a one-off migration).

## Measured on a self-hosted deployment

```
120 seconds:  11 pipeline runs
              +21 LanceDB fragments
              + 0 rows
```

~630 fragments/hour of pure amplification. Left alone it reached:

| | |
|---|---|
| version files | 6,592 |
| data fragments | 6,557 across 20 tables |
| storage | 937 MB for a 2,461-node graph |
| worst single table | `EdgeType_relationship_name`, 1,451 fragments, 269 MB |

Offline compaction cut that to 48 versions / 27 fragments / 411 MB with **identical row counts** — which is what established the writes were redundant rather than useful.

The trigger in our case was `POST /api/v1/improve`: one call distilled a long agent session into **344 documents** and ran an ingest pipeline per document, re-ingesting all of them each time. The cost grows with session length, so it gets worse the longer an agent runs.

## The change

Compare each point's indexed field against the stored payload, and index only what differs. One `retrieve` by id per batch replaces an embedding call plus a write per point.

**It fails open, in the direction of doing the work.** Skipping happens *only* on positive evidence that the stored value is identical. Every other case indexes exactly as before:

- point the store does not know → index
- payload without the indexed field → index
- adapter that raises, or has no `retrieve` → index
- unexpected return shape → index

So a wrong guess can never leave a vector stale; the worst case is the current behaviour.

`retrieve` is on the shared `VectorDBInterface`, so this works across adapters rather than special-casing LanceDB.

## Config

`skip_unchanged_vector_writes` (default `True`) restores the previous unconditional behaviour when set to `False` — and disables the lookup entirely rather than performing it and ignoring the result.

Happy to flip the default to `False` if you would rather ship it opt-in first.

## Tests

Seven new, alongside the four existing ones in that file (**11 passed**):

- unchanged point is not re-indexed
- changed point is re-indexed
- point the store does not know is indexed
- payload missing the indexed field is indexed
- `retrieve` failure indexes everything
- mixed batch indexes only the changed member
- flag off performs no lookup at all

Wider suite: `4577 passed`. Twelve failures exist, and all twelve are **identical on clean `main`** — verified by running the same selections with the change stashed. Two directories (`eval_framework`, `databases/graph`) fail at collection on `main` for missing optional deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
