### PR TITLE
fix(ingestion): keep WHERE clause for schema-qualified SQL tables

### DIFF
--- a/cognee/tasks/ingestion/create_dlt_source.py
+++ b/cognee/tasks/ingestion/create_dlt_source.py
@@ -59,17 +59,23 @@ def create_dlt_source_from_connection_string(
 
     if query:
         table_name, where_clause = _parse_sql_query(query)
+        schema_name, bare_table_name = _split_schema_and_table(table_name)
 
         def query_adapter_callback(q, table):
-            if table.name == table_name:
+            # sqlalchemy Table.name is never schema-qualified
+            if table.name == bare_table_name:
                 return q.where(sqlalchemy.text(where_clause))
             return q
 
-        source = sql_database(
-            credentials=connection_string,
-            table_names=[table_name],
-            query_adapter_callback=query_adapter_callback,
-        )
+        source_kwargs = {
+            "credentials": connection_string,
+            "table_names": [bare_table_name],
+            "query_adapter_callback": query_adapter_callback,
+        }
+        if schema_name:
+            source_kwargs["schema"] = schema_name
+
+        source = sql_database(**source_kwargs)
     else:
         source = sql_database(credentials=connection_string)
 
@@ -102,11 +108,27 @@ def create_dlt_source_from_csv(csv_path: str, source_name: Optional[str] = None)
     return source.with_name(source_name or csv_source_name(filename))
 
 
+def _split_schema_and_table(qualified_name: str) -> tuple:
+    """Split a possibly schema-qualified table ref into (schema, table).
+
+    ``public.users`` -> (``public``, ``users``). A bare name has no schema.
+    """
+    if "." not in qualified_name:
+        return None, qualified_name
+    schema, table = qualified_name.rsplit(".", 1)
+    return schema, table
+
+
 def _parse_sql_query(query: str) -> tuple:
     """Extract table name and WHERE clause from a SELECT query.
-    Returns (table_name, where_clause) or raises ValueError."""
+    Returns (table_name, where_clause) or raises ValueError.
+
+    Table names may be schema-qualified (``public.users``). ``\\w+`` alone
+    stops at the first dot, which used to drop both the schema and the WHERE
+    clause.
+    """
     match = re.match(
-        r"SELECT\s+.+?\s+FROM\s+(\w+)(?:\s+WHERE\s+(.+))?",
+        r"SELECT\s+.+?\s+FROM\s+(\w+(?:\.\w+)*)(?:\s+WHERE\s+(.+))?",
         query.strip(),
         re.IGNORECASE | re.DOTALL,
     )

--- a/cognee/tests/unit/tasks/ingestion/test_parse_sql_query.py
+++ b/cognee/tests/unit/tasks/ingestion/test_parse_sql_query.py
@@ -1,0 +1,111 @@
+"""Unit tests for DLT SQL query parsing.
+
+``_parse_sql_query`` is a pure function used by
+``create_dlt_source_from_connection_string`` to pick a table and WHERE
+filter. Schema-qualified names (``public.users``) used to be truncated at
+the first dot, which also dropped the WHERE clause.
+"""
+
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognee.tasks.ingestion.create_dlt_source import (
+    _parse_sql_query,
+    _split_schema_and_table,
+    create_dlt_source_from_connection_string,
+)
+
+
+@pytest.mark.parametrize(
+    "query, expected",
+    [
+        ("SELECT * FROM users", ("users", "1=1")),
+        ("select id from users", ("users", "1=1")),
+        (
+            "SELECT * FROM public.users WHERE age > 18",
+            ("public.users", "age > 18"),
+        ),
+        ("SELECT id FROM analytics.events", ("analytics.events", "1=1")),
+        (
+            "SELECT id FROM analytics.events WHERE ts > 0",
+            ("analytics.events", "ts > 0"),
+        ),
+        (
+            "  SELECT * FROM users WHERE name = 'from town'  ",
+            ("users", "name = 'from town'"),
+        ),
+        (
+            "SELECT a, b FROM reporting.fact_orders WHERE status = 'open'",
+            ("reporting.fact_orders", "status = 'open'"),
+        ),
+    ],
+)
+def test_parse_sql_query(query, expected):
+    assert _parse_sql_query(query) == expected
+
+
+def test_parse_sql_query_rejects_non_select():
+    with pytest.raises(ValueError, match="Cannot parse SQL query"):
+        _parse_sql_query("DELETE FROM users")
+
+
+@pytest.mark.parametrize(
+    "qualified, expected",
+    [
+        ("users", (None, "users")),
+        ("public.users", ("public", "users")),
+        ("analytics.events", ("analytics", "events")),
+        ("catalog.schema.table", ("catalog.schema", "table")),
+    ],
+)
+def test_split_schema_and_table(qualified, expected):
+    assert _split_schema_and_table(qualified) == expected
+
+
+def _install_fake_sql_database(monkeypatch):
+    """Stub dlt so the connection-string helper can be tested without the extra."""
+    mock_sql = MagicMock(return_value=MagicMock(name="source"))
+    fake_sql_database = ModuleType("dlt.sources.sql_database")
+    fake_sql_database.sql_database = mock_sql
+    monkeypatch.setitem(sys.modules, "dlt", ModuleType("dlt"))
+    monkeypatch.setitem(sys.modules, "dlt.sources", ModuleType("dlt.sources"))
+    monkeypatch.setitem(sys.modules, "dlt.sources.sql_database", fake_sql_database)
+    return mock_sql
+
+
+def test_schema_qualified_query_passes_schema_and_bare_table_to_dlt(monkeypatch):
+    mock_sql = _install_fake_sql_database(monkeypatch)
+
+    create_dlt_source_from_connection_string(
+        "postgresql://user:pass@localhost/db",
+        query="SELECT * FROM public.users WHERE age > 18",
+    )
+
+    kwargs = mock_sql.call_args.kwargs
+    assert kwargs["table_names"] == ["users"]
+    assert kwargs["schema"] == "public"
+
+    query = MagicMock()
+    matching = SimpleNamespace(name="users")
+    other = SimpleNamespace(name="orders")
+    kwargs["query_adapter_callback"](query, matching)
+    query.where.assert_called_once()
+    query.reset_mock()
+    assert kwargs["query_adapter_callback"](query, other) is query
+    query.where.assert_not_called()
+
+
+def test_bare_table_query_does_not_set_schema(monkeypatch):
+    mock_sql = _install_fake_sql_database(monkeypatch)
+
+    create_dlt_source_from_connection_string(
+        "postgresql://user:pass@localhost/db",
+        query="SELECT * FROM users WHERE age > 18",
+    )
+
+    kwargs = mock_sql.call_args.kwargs
+    assert kwargs["table_names"] == ["users"]
+    assert "schema" not in kwargs


### PR DESCRIPTION
## What Problem This Solves

Fixes #3663.

`_parse_sql_query` extracted the table name with `(\w+)`, which stops at the first dot. For `SELECT * FROM public.users WHERE age > 18` it captured `public` and then dropped the WHERE clause (fallback `1=1`). The whole table was ingested instead of the filtered rows.

A previous PR (#3664) was closed after a DLT refactor, but the parser on current `dev` still has this regex.

## Why This Change Was Made

- Capture schema-qualified identifiers with `(\w+(?:\.\w+)*)` so the WHERE group matches again.
- Split `schema.table` before calling dlt: `sql_database(schema=..., table_names=[bare_name])`. dlt's `table_names` are not schema-qualified, and SQLAlchemy `Table.name` is the bare table name, so passing `public.users` would still fail to apply the filter.
- Bare table names and queries without WHERE keep the previous behavior.

## User Impact

Anyone filtering a DLT SQL source with a schema-qualified table now gets the requested rows instead of the whole table.

## Evidence

```text
uv run pytest cognee/tests/unit/tasks/ingestion/test_parse_sql_query.py -v
======================= 14 passed, 11 warnings in 0.03s ========================
```

Covers the issue repro cases, quoted `FROM` in a WHERE literal, case-insensitive keywords, the non-SELECT `ValueError` path, and that `sql_database` receives `schema="public"` + `table_names=["users"]` for a qualified query (and no `schema=` for a bare table).

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.