### PR TITLE
fix(security): close the six findings from the SDK-463 review

### DIFF
--- a/cognee/modules/integrations/slack/response_url.py
+++ b/cognee/modules/integrations/slack/response_url.py
@@ -23,13 +23,26 @@ _RESPONSE_URL_TIMEOUT = aiohttp.ClientTimeout(total=10)
 # POST (carrying the answer text) at an attacker-chosen server (SSRF).
 _ALLOWED_RESPONSE_URL_HOST = "hooks.slack.com"
 
+# Host alone is not enough. hooks.slack.com also serves Incoming Webhooks under
+# /services/..., which anyone can create in a free workspace and which accept the
+# exact {"text": ..., "blocks": [...]} body this module sends. Pinning the host but
+# not the path still lets a forged payload exfiltrate the answer text into an
+# attacker's Slack workspace. Genuine response_urls are only ever these two:
+#   slash commands   -> https://hooks.slack.com/commands/T…/…/…
+#   interactivity    -> https://hooks.slack.com/actions/T…/…/…
+_ALLOWED_RESPONSE_URL_PATH_PREFIXES = ("/commands/", "/actions/")
+
 
 def _is_slack_response_url(response_url: str) -> bool:
+    if not isinstance(response_url, str):
+        return False
     try:
         parts = urlsplit(response_url)
     except ValueError:
         return False
-    return parts.scheme == "https" and parts.hostname == _ALLOWED_RESPONSE_URL_HOST
+    if parts.scheme != "https" or parts.hostname != _ALLOWED_RESPONSE_URL_HOST:
+        return False
+    return parts.path.startswith(_ALLOWED_RESPONSE_URL_PATH_PREFIXES)
 
 
 async def post_to_response_url(response_url: str, payload: dict[str, Any]) -> None:
@@ -44,11 +57,20 @@ async def post_to_response_url(response_url: str, payload: dict[str, Any]) -> No
         logger.error("No response_url to deliver a Slack message to")
         return
     if not _is_slack_response_url(response_url):
-        logger.error("Refusing to deliver to a response_url outside %s", _ALLOWED_RESPONSE_URL_HOST)
+        logger.error(
+            "Refusing to deliver to a response_url outside https://%s%s",
+            _ALLOWED_RESPONSE_URL_HOST,
+            "|".join(_ALLOWED_RESPONSE_URL_PATH_PREFIXES),
+        )
         return
     try:
         async with aiohttp.ClientSession(timeout=_RESPONSE_URL_TIMEOUT) as session:
-            async with session.post(response_url, json=payload) as response:
+            # allow_redirects=False: aiohttp follows redirects by default, and the
+            # guard above only ever sees hop 0. A 3xx from hooks.slack.com would
+            # otherwise carry this request -- and on 307/308 the answer text itself,
+            # since those preserve method and body -- to whatever Location names,
+            # including an internal address. Slack never redirects a response_url.
+            async with session.post(response_url, json=payload, allow_redirects=False) as response:
                 if response.status != 200:
                     logger.warning("Slack response_url POST returned %s", response.status)
     except Exception:  # noqa: BLE001 - nothing left to report to if delivery itself fails

--- a/cognee/modules/migration/import_source.py
+++ b/cognee/modules/migration/import_source.py
@@ -83,6 +83,8 @@ async def _ensure_user(user_payload: Dict[str, Any]):
         record.is_superuser = user_payload.get("is_superuser", False)
         record.is_verified = user_payload.get("is_verified", False)
         await session.commit()
+    # CALLERS MUST GATE: this writes hashed_password and is_superuser straight from
+    # the archive. Both current callers go through _require_social_layer_superuser.
     # The payload carries credentials (hashed password, email) — log nothing from it.
     logger.info("Restored a user account from the archive social layer.")
     return created
@@ -104,10 +106,35 @@ async def _resolve_import_user(source: MemorySource, user):
     the /v1/remember archive-upload endpoint.
     """
     social_layer = getattr(source, "social_layer", None)
-    owner_payload = (social_layer or {}).get("owner")
-    if owner_payload is None:
+    if not social_layer:
         return user
 
+    # Gate on the social layer EXISTING, not on it carrying an "owner". Both
+    # consumers of the layer create accounts through _ensure_user, and checking
+    # owner_payload first let an archive whose permissions.json carried "grants"
+    # but no "owner" return here before the check ever ran.
+    await _require_social_layer_superuser(user)
+
+    owner_payload = social_layer.get("owner")
+    if owner_payload is None:
+        # Nothing to reassign ownership to; the import runs as the caller, and the
+        # grants are replayed later by _apply_social_grants under the same gate.
+        return user
+    return await _ensure_user(owner_payload)
+
+
+async def _require_social_layer_superuser(user):
+    """Resolve the importing identity and require it to be a superuser.
+
+    The archive supplies emails, password hashes and account flags verbatim, and
+    every path that consumes a social layer mints accounts through ``_ensure_user``,
+    which writes ``hashed_password`` and ``is_superuser`` straight from the payload.
+    So this must gate the layer as a whole: gating only the owner-restore path left
+    the grant-replay path reachable by any caller, which is privilege escalation to
+    superuser with an attacker-chosen password hash.
+
+    Returns the resolved importer so callers do not resolve the default user twice.
+    """
     importer = user
     if importer is None:
         from cognee.modules.users.methods import get_default_user
@@ -120,7 +147,7 @@ async def _resolve_import_user(source: MemorySource, user):
             message="Importing an archive that carries a social layer (permissions.json) "
             "requires a superuser: it restores user accounts and credentials."
         )
-    return await _ensure_user(owner_payload)
+    return importer
 
 
 async def _apply_social_grants(source: MemorySource, dataset_name: str, owner, importer) -> None:
@@ -135,6 +162,11 @@ async def _apply_social_grants(source: MemorySource, dataset_name: str, owner, i
     social_layer = getattr(source, "social_layer", None)
     if not social_layer:
         return
+
+    # Re-asserted here rather than trusted from the caller: this function creates
+    # accounts through _ensure_user independently of the owner-restore path, and it
+    # is reached from import_source() on any truthy social layer.
+    importer = await _require_social_layer_superuser(importer)
 
     from cognee.modules.data.methods import get_authorized_existing_datasets
     from cognee.modules.users.permissions.methods import give_permission_on_dataset
@@ -152,10 +184,6 @@ async def _apply_social_grants(source: MemorySource, dataset_name: str, owner, i
         for permission_name in grant.get("permissions", []):
             await give_permission_on_dataset(principal, dataset_id, permission_name)
 
-    if importer is None:
-        from cognee.modules.users.methods import get_default_user
-
-        importer = await get_default_user()
     if importer.id != owner.id:
         await give_permission_on_dataset(importer, dataset_id, "read")
 

--- a/cognee/tasks/code_graph/code_repo.py
+++ b/cognee/tasks/code_graph/code_repo.py
@@ -166,6 +166,14 @@ def partition_repo_files(directory: Path) -> tuple[List[Path], List[Path], List[
     skipped: List[Path] = []
 
     for file_path in sorted(directory.rglob("*")):
+        # is_file() follows symlinks, and read_bytes() below would then pull the
+        # TARGET's contents into the manifest. A repo (cloned or local) containing
+        # 'creds.py -> ~/.aws/credentials' would otherwise be indexed verbatim.
+        # Clones are written with core.symlinks=false, so this covers local paths
+        # and any pre-existing clone made before that landed.
+        if file_path.is_symlink():
+            skipped.append(file_path)
+            continue
         if not file_path.is_file():
             continue
         relative = file_path.relative_to(directory)

--- a/cognee/tasks/code_graph/resolve_repo.py
+++ b/cognee/tasks/code_graph/resolve_repo.py
@@ -160,6 +160,32 @@ async def resolve_repo_source(
         )
 
     url = str(spec)
+
+    # SSRF: the URL is caller-supplied and git runs server-side, so an http(s)
+    # remote must clear the same outbound check add()'s http items already clear --
+    # resolve the host and refuse internal/reserved addresses. Without it,
+    # repositories=['http://169.254.169.254/...'] issues the request from inside the
+    # VPC and git's stderr (returned to the caller below) distinguishes open ports,
+    # live hosts and auth failures: an authenticated internal port scanner.
+    #
+    # ssh:// and git@host: are deliberately not routed through it: that helper only
+    # understands http/https, and internal git servers over SSH are a legitimate and
+    # common setup. Non-http, non-ssh transports (file://, ext::, which git would
+    # execute) never reach here -- they do not match _REMOTE_PREFIXES and are handled
+    # as local paths above.
+    if url.lower().startswith(("http://", "https://")):
+        from cognee.tasks.web_scraper.ssrf_protection import (
+            SSRFProtectionError,
+            validate_outbound_url,
+        )
+
+        try:
+            await validate_outbound_url(url)
+        except SSRFProtectionError as error:
+            raise CodeRepositoryError(
+                message=f"Refusing to clone '{redact_repo_spec(url)}': {error}"
+            ) from error
+
     # Slug, remote, logs, and errors all use the credential-free URL: tokens
     # in the userinfo are short-lived, so persisting one anywhere would both
     # leak it and (via the slug) mint a new clone dir per sync.
@@ -201,7 +227,16 @@ async def resolve_repo_source(
 
     target.parent.mkdir(parents=True, exist_ok=True)
     logger.info("Cloning %s into %s", clean_url, target)
-    returncode, stderr = await _run_git(["clone", "--depth", "1", url, str(target)], env=auth_env)
+    # core.symlinks=false: git otherwise materializes symlinks committed in the
+    # remote, and nothing re-validates paths under the clone afterwards -- a repo
+    # containing '.enola -> ~/.ssh' would have the enola snapshot written through it,
+    # and 'mod.py -> /proc/self/environ' would be read into the code graph. With this
+    # set, git writes each symlink as a regular file containing its target path.
+    # Passed via -c on clone so it is persisted into the new repo's config and the
+    # later 'git pull --ff-only' honours it too.
+    returncode, stderr = await _run_git(
+        ["clone", "-c", "core.symlinks=false", "--depth", "1", url, str(target)], env=auth_env
+    )
     if returncode != 0:
         raise CodeRepositoryError(
             message=f"Failed to clone '{clean_url}': {_scrub(stderr[-1000:])}"

--- a/cognee/tasks/ingestion/resolve_dlt_sources.py
+++ b/cognee/tasks/ingestion/resolve_dlt_sources.py
@@ -67,10 +67,27 @@ async def resolve_dlt_sources(
         from dlt.extract import DltResource, SourceFactory
         from dlt.extract.source import DltSource
     except ImportError:
-        # dlt not installed — nothing to resolve. Warn when inputs would have
-        # matched the auto-detection below: they silently degrade to plain
-        # (LLM-processed) document ingestion otherwise.
-        _log_structured_inputs_without_dlt(data if isinstance(data, list) else [data])
+        # dlt not installed — nothing to resolve. Inputs that would have matched the
+        # auto-detection below otherwise degrade to plain document ingestion.
+        #
+        # For a connection string that degradation is a credential leak, not just a
+        # loss of function: the DSN is returned unchanged, ingested as a text
+        # document, and written verbatim to disk by LocalFileStorage.store(). A DSN
+        # like postgresql://user:pw@host/db -- the form .env.template itself uses --
+        # lands in clear text on the filesystem, and the user does not get the table
+        # contents they asked for either. Refuse instead.
+        items = data if isinstance(data, list) else [data]
+        _log_structured_inputs_without_dlt(items)
+        if any(isinstance(item, str) and is_connection_string(item) for item in items):
+            from cognee.exceptions import CogneeValidationError
+
+            raise CogneeValidationError(
+                message="A database connection string was passed but the 'dlt' extra is "
+                "not installed, so it cannot be read. Install it with "
+                "`pip install cognee[dlt]`. Refusing to ingest the connection string "
+                "as a plain document: it would be stored on disk in clear text.",
+                name="DltExtraNotInstalled",
+            )
         return data, None
 
     primary_key = kwargs["primary_key"] if "primary_key" in kwargs else None

--- a/cognee/tests/unit/migration/test_social_layer_gate.py
+++ b/cognee/tests/unit/migration/test_social_layer_gate.py
@@ -1,0 +1,77 @@
+"""The social layer of a COGX archive is a privilege boundary.
+
+`permissions.json` supplies emails, password hashes and account flags verbatim,
+and every path that consumes it mints accounts through `_ensure_user`, which
+writes `hashed_password` and `is_superuser` straight from the payload. So the
+superuser check has to gate the LAYER, not one path through it.
+
+Regression: the check sat behind `owner_payload is None`, so an archive whose
+permissions.json carried `grants` but no `owner` returned before the check ever
+ran -- and `_apply_social_grants`, reached independently from `import_source`,
+then created accounts from attacker-controlled payloads. Any caller who could
+import an archive could mint a superuser with a password hash of their choosing.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.migration.import_source import (
+    _apply_social_grants,
+    _resolve_import_user,
+)
+from cognee.modules.users.exceptions.exceptions import PermissionDeniedError
+
+# A layer with grants and deliberately NO "owner" key -- the shape that used to
+# slip past the gate.
+_GRANTS_ONLY = {
+    "grants": [
+        {
+            "user": {
+                "email": "attacker@example.com",
+                "hashed_password": "$2b$12$attackerchosenhashvalue",
+                "is_superuser": True,
+                "is_active": True,
+                "is_verified": True,
+            },
+            "permissions": ["read", "write"],
+        }
+    ]
+}
+
+_WITH_OWNER = {"owner": {"email": "owner@example.com", "hashed_password": "x"}, **_GRANTS_ONLY}
+
+
+def _user(is_superuser: bool):
+    return SimpleNamespace(id=uuid4(), is_superuser=is_superuser, email="importer@example.com")
+
+
+@pytest.mark.parametrize("layer", [_GRANTS_ONLY, _WITH_OWNER], ids=["grants-only", "with-owner"])
+@pytest.mark.asyncio
+async def test_non_superuser_cannot_import_any_social_layer(layer):
+    with pytest.raises(PermissionDeniedError):
+        await _resolve_import_user(SimpleNamespace(social_layer=layer), _user(is_superuser=False))
+
+
+@pytest.mark.asyncio
+async def test_grant_replay_refuses_a_non_superuser_importer():
+    """The second entry point. `import_source` calls this directly on any truthy
+    social layer, so it cannot rely on the caller having passed the gate."""
+    importer = _user(is_superuser=False)
+    with pytest.raises(PermissionDeniedError):
+        await _apply_social_grants(
+            SimpleNamespace(social_layer=_GRANTS_ONLY),
+            "some-dataset",
+            owner=importer,
+            importer=importer,
+        )
+
+
+@pytest.mark.asyncio
+async def test_archives_without_a_social_layer_are_unaffected():
+    """The common case must not start demanding a superuser."""
+    caller = _user(is_superuser=False)
+    assert await _resolve_import_user(SimpleNamespace(social_layer=None), caller) is caller
+    assert await _resolve_import_user(SimpleNamespace(social_layer={}), caller) is caller
+    assert await _resolve_import_user(SimpleNamespace(), caller) is caller

--- a/cognee/tests/unit/modules/integrations/test_response_url.py
+++ b/cognee/tests/unit/modules/integrations/test_response_url.py
@@ -8,7 +8,14 @@ from unittest.mock import patch
 
 import pytest
 
-from cognee.modules.integrations.slack.response_url import post_to_response_url
+from cognee.modules.integrations.slack.response_url import (
+    _is_slack_response_url,
+    post_to_response_url,
+)
+
+# A well-formed response_url. Slack only ever issues /commands/ (slash commands)
+# and /actions/ (interactivity); anything else is not a response_url.
+_VALID = "https://hooks.slack.com/commands/T00000000/1111111111/abcdefghijklmnop"
 
 
 @pytest.mark.asyncio
@@ -20,4 +27,51 @@ async def test_noop_without_a_url():
 @pytest.mark.asyncio
 async def test_never_raises_on_network_failure():
     with patch("aiohttp.ClientSession", side_effect=RuntimeError("network is down")):
-        await post_to_response_url("https://hooks.slack.com/x", {"text": "hi"})  # must not raise
+        await post_to_response_url(_VALID, {"text": "hi"})  # must not raise
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        _VALID,
+        "https://hooks.slack.com/actions/T00000000/1111111111/abcdefghijklmnop",
+        "https://HOOKS.SLACK.COM/commands/T0/1/a",
+    ],
+)
+def test_accepts_real_slack_response_urls(url):
+    assert _is_slack_response_url(url) is True
+
+
+@pytest.mark.parametrize(
+    ("url", "why"),
+    [
+        ("https://hooks.slack.com/services/T0/B0/tok", "Incoming Webhook: same host, and it "
+         "accepts the exact body this module sends, so a forged payload would exfiltrate "
+         "the answer into an attacker's workspace"),
+        ("https://hooks.slack.com.evil.com/commands/x", "suffix host"),
+        ("https://hooks.slack.com@evil.com/commands/x", "userinfo host"),
+        ("http://hooks.slack.com/commands/T0/1/a", "scheme downgrade"),
+        ("https://hooks.slack.com/../services/T0/B0/t", "traversal toward /services/"),
+        ("https://evil.com/commands/T0/1/a", "right path, wrong host"),
+        ("", "empty"),
+        (None, "non-string"),
+    ],
+)
+def test_rejects_everything_that_is_not_a_response_url(url, why):
+    assert _is_slack_response_url(url) is False, why
+
+
+@pytest.mark.asyncio
+async def test_delivery_does_not_follow_redirects():
+    """aiohttp follows redirects by default and the host/path guard only sees hop 0,
+    so a 3xx from hooks.slack.com would carry the answer text onward -- and 307/308
+    preserve method and body."""
+    from unittest.mock import MagicMock
+
+    session = MagicMock()
+    post = session.__aenter__.return_value.post
+    with patch("aiohttp.ClientSession", return_value=session):
+        await post_to_response_url(_VALID, {"text": "hi"})
+
+    assert post.call_args is not None, "delivery never reached session.post"
+    assert post.call_args.kwargs.get("allow_redirects") is False

--- a/cognee/tests/unit/tasks/code_graph/test_code_repo.py
+++ b/cognee/tests/unit/tasks/code_graph/test_code_repo.py
@@ -150,3 +150,26 @@ async def test_documents_kept_with_llm_api_key(tmp_path, monkeypatch):
 
     assert {path.name for path in documents} == {"README.md", "notes.txt"}
     assert skip_count == 4
+
+
+@pytest.mark.asyncio
+async def test_symlinks_are_not_followed_into_the_manifest(tmp_path):
+    """rglob + is_file() both follow symlinks, and read_bytes() would then hash and
+    index the TARGET. A repo containing 'creds.py -> ~/.aws/credentials' must not
+    pull that file's contents into the code graph."""
+    from cognee.tasks.code_graph.code_repo import partition_repo_files
+
+    secret = tmp_path / "outside_secret.py"
+    secret.write_text("AWS_SECRET_ACCESS_KEY = 'leaked'")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text("[project]\nname='x'")
+    (repo / "real.py").write_text("x = 1")
+    (repo / "creds.py").symlink_to(secret)
+
+    covered, documents, skipped = partition_repo_files(repo)
+
+    indexed = {p.name for p in covered} | {p.name for p in documents}
+    assert "real.py" in indexed
+    assert "creds.py" not in indexed, "symlink was followed into the manifest"

--- a/cognee/tests/unit/tasks/code_graph/test_resolve_repo.py
+++ b/cognee/tests/unit/tasks/code_graph/test_resolve_repo.py
@@ -64,7 +64,9 @@ async def test_remote_is_shallow_cloned(monkeypatch, tmp_path):
     assert resolved == tmp_path / "github.com-org-repo"
     assert len(git_calls) == 1
     args, _cwd = git_calls[0]
-    assert args[:3] == ["clone", "--depth", "1"]
+    # core.symlinks=false is a security requirement, not incidental: without it a
+    # symlink committed in the remote is materialized and later written through.
+    assert args[:5] == ["clone", "-c", "core.symlinks=false", "--depth", "1"]
     assert "https://github.com/org/repo" in args
 
 

--- a/cognee/tests/unit/tasks/code_graph/test_resolve_repo_credentials.py
+++ b/cognee/tests/unit/tasks/code_graph/test_resolve_repo_credentials.py
@@ -48,7 +48,9 @@ async def test_clone_slug_and_remote_never_carry_the_token(monkeypatch, tmp_path
     assert resolved == tmp_path / "github.com-org-repo"
 
     clone_args, _ = git_calls[0]
-    assert clone_args[:3] == ["clone", "--depth", "1"]
+    # core.symlinks=false is a security requirement, not incidental: without it a
+    # symlink committed in the remote is materialized and later written through.
+    assert clone_args[:5] == ["clone", "-c", "core.symlinks=false", "--depth", "1"]
     assert _TOKEN_URL in clone_args
 
     # The persisted remote is rewritten to the credential-free URL.
@@ -114,7 +116,15 @@ async def test_out_of_band_credentials_ride_the_environment(monkeypatch, tmp_pat
     assert resolved == tmp_path / "github.com-org-repo"
     ((clone_args, _cwd, clone_env),) = git_calls
     # argv carries only the clean URL; the token is nowhere in it.
-    assert clone_args == ["clone", "--depth", "1", _CLEAN_URL, str(resolved)]
+    assert clone_args == [
+        "clone",
+        "-c",
+        "core.symlinks=false",
+        "--depth",
+        "1",
+        _CLEAN_URL,
+        str(resolved),
+    ]
     assert "tok-SECRET" not in " ".join(clone_args)
     # ...and rides GIT_CONFIG_* as a basic-auth header instead.
     assert clone_env["GIT_CONFIG_KEY_0"] == "http.extraHeader"


### PR DESCRIPTION
Closes findings 1-6 from the review of #4657. Stacked on `Vasilije1990/security_issues`, so this diff is exactly the fixes: 5 source files, 5 test files, +295/-19.

> **Disclosure note, please read before merging.** Finding 1 is a critical privilege escalation, and `topoteretes/cognee` is a public repository — this branch describes it in the open. If you would rather handle it as a GitHub Security Advisory with a coordinated release, say so and I will reduce the commit message and test docstring to something neutral. I pushed the fix rather than sitting on it because the vulnerability is already public in the code; the tradeoff is yours to make.

## 1. Privilege escalation via a COGX archive social layer — critical

`_resolve_import_user` read `(social_layer or {}).get("owner")` and returned **before** the superuser check whenever that key was absent:

```python
owner_payload = (social_layer or {}).get("owner")
if owner_payload is None:
    return user          # <- gate never runs
...
if not importer.is_superuser:
    raise PermissionDeniedError(...)
```

But `_apply_social_grants` is reached independently from `import_source()` on any truthy social layer, and it creates accounts through `_ensure_user`, which writes straight from the payload:

```python
record.hashed_password = user_payload["hashed_password"]
record.is_superuser   = user_payload.get("is_superuser", False)
```

So an archive whose `permissions.json` carried `grants` but **no `owner`** skipped the gate entirely. Any caller able to import an archive — SDK or `/v1/remember` — could mint a superuser with a password hash of their choosing.

The gate now keys off the layer **existing**, and the grant path re-asserts it rather than trusting its caller.

Worth noting where this sat: #4657 edits this exact function, and its own added comment — *"The payload carries credentials (hashed password, email) — log nothing from it"* — is two lines below the `is_superuser` write. The sweep correctly identified that the payload carries credentials, redacted the log line, and walked past the escalation.

Related, not fixed here: `cogx_archive.py` is a fifth migration source that reads `manifest.json` / `permissions.json` with no allowlist, and was not among the four #4657 covered.

## 2-3. SSRF — the host pin closed one half of two

The host check itself is sound (it uses `parts.hostname`, so userinfo cannot fool it). Two gaps remained:

**Path was unconstrained.** `hooks.slack.com` also serves Incoming Webhooks under `/services/...`, which anyone can create in a free workspace and which accept the exact `{"text", "blocks"}` body this module sends — so a forged payload still exfiltrated the answer text, just into an attacker's Slack rather than an arbitrary host. Now pinned to `/commands/` and `/actions/`, the only paths Slack issues response_urls on.

**Redirects were followed.** `session.post` kept aiohttp's `allow_redirects=True`, so the guard only ever saw hop 0; 307/308 preserve method and body. Now `allow_redirects=False`.

Nine adversarial cases are covered by tests, including `hooks.slack.com.evil.com`, `hooks.slack.com@evil.com`, scheme downgrade, and `/../services/`.

## 4. Clone URLs had no outbound validation

`validate_outbound_url` already exists in-repo and already guards `add()`'s http items; the clone path never called it. Since git's stderr is returned to the caller, `repositories=['http://169.254.169.254/...']` worked as an authenticated internal port scanner — refused / 401 / unresolved are all distinguishable.

http(s) remotes now clear the same check. `ssh://` and `git@` are deliberately exempt (internal git servers over SSH are a legitimate, common setup, and the helper only understands http/https). `file://` and `ext::` — the latter executes arbitrary commands — never reach here; they fail `_REMOTE_PREFIXES` and are handled as local paths.

## 5. Symlink escape

Nothing re-validated paths under a clone, so a repo containing `.enola -> ~/.ssh` had the enola snapshot written through it, and `mod.py -> /proc/self/environ` was read into the code graph.

Clones now set `core.symlinks=false` — passed via `-c` so it persists into the new repo's config and later `git pull --ff-only` honours it too. Separately `partition_repo_files` skips symlinks: `is_file()` follows them and `read_bytes()` would pull the target's contents into the manifest. That covers local paths and any clone made before this landed.

## 6. The dismissed clear-text-storage alerts are not false positives

With the `dlt` extra absent, `resolve_dlt_sources` returned the connection string unchanged; it was ingested as a plain document and written verbatim by `LocalFileStorage.store()`. #4657's own added comment says these inputs *"may embed credentials (connection strings)"*, which is the opposite of the dismissal rationale.

A DSN now raises `CogneeValidationError` naming the missing extra. The user was not getting their table contents either way — the only outcome was a credential on disk.

## Tests

13 added, and the important ones are mutation-checked rather than merely green.

Restoring the original owner-first ordering in `_resolve_import_user` and dropping the grant-path assertion turns **both** escalation tests red, while the three "no social layer" cases stay green:

```
FAILED test_non_superuser_cannot_import_any_social_layer[grants-only]
FAILED test_grant_replay_refuses_a_non_superuser_importer
2 failed, 2 passed
```

Two existing tests needed updating, one of which matters: `test_never_raises_on_network_failure` posted to `https://hooks.slack.com/x`, which the new path check rejects — the test would have kept passing while silently no longer reaching the network path at all. It now uses a valid `/commands/` URL. The clone-argv assertions were tightened to *require* `core.symlinks=false` rather than tolerate it.

## Suite state

`cognee/tests/unit/{tasks,modules}`: **11 failed / 2461 passed** with these changes, and **11 failed / 2448 passed** on the unmodified branch — the same 11, all pre-existing.

One is worth flagging separately: `test_directory_with_project_resolves_to_repo_item_plus_documents` is already red on #4657's head. I confirmed it fails identically with my changes stashed, so it is not from this work, but #4657 should probably not merge with it red.
