### PR TITLE
COG-6335 fix: Harden memory-only forget's code-graph reset

### DIFF
--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -322,6 +322,15 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user: Any) -> di
         # that safe); otherwise just report honestly what is known to remain.
         graph_memory_status = await ensure_graph_memory_cleared(dataset_id, user)
 
+        # Fold in anything a fallback reset removed (real graph/vector content
+        # with no deletion provenance) so both the reported counts below and
+        # the session-invalidation call right after this see it too —
+        # otherwise a fallback reset stays invisible in nodes_deleted/
+        # edges_deleted, and dataset-unattributed sessions referencing that
+        # wiped content never get cleaned up.
+        if graph_memory_status.deleted_elements is not None:
+            deleted_elements.merge(graph_memory_status.deleted_elements)
+
         # 1c. Drop sessions attributed to this dataset, then remove tagged
         # QAs from dataset-unattributed sessions (non-fatal).
         try:
@@ -367,11 +376,16 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user: Any) -> di
 
             await session.commit()
 
-        # 3. Reset dataset-level pipeline run status so cached cognify runs can execute again.
+        # 3. Reset dataset-level pipeline run status so cached cognify runs can
+        # execute again. code_graph_pipeline is included unconditionally —
+        # reset_dataset_pipeline_run_status no-ops safely for a pipeline name
+        # with no matching rows, and a dataset that ever ran
+        # remember(content_type="code") must not keep showing that pipeline
+        # as "completed" in the dataset-status API after this call wiped it.
         await reset_dataset_pipeline_run_status(
             dataset_id=dataset_id,
             user=user,
-            pipeline_names=["cognify_pipeline"],
+            pipeline_names=["cognify_pipeline", "code_graph_pipeline"],
         )
 
     logger.info(
@@ -409,6 +423,17 @@ async def _forget_data_memory(data_id: UUID, dataset_ref: Union[str, UUID], user
     - Pipeline status (for this data item): reset for cognify only
     - Relational DB (data record): preserved
     - Raw file: preserved
+
+    Returns a dict with ``nodes_deleted``/``edges_deleted`` (from
+    ``delete_data_nodes_and_edges``), for consistency with
+    ``_forget_dataset_memory``. Unlike the dataset-level path, this response
+    has no ``graph_memory_cleared`` field: that flag exists to warn about
+    unprovenanced content (e.g. ``remember(content_type="code")``) a
+    provenance-driven delete cannot see, and that content is never reachable
+    from this per-item path in the first place — it carries no persisted
+    ``data_id`` to key a single-item delete on. A ``graph_memory_cleared=True``
+    here would always be true and would carry no information, so it is
+    omitted rather than added as noise.
     """
     from sqlalchemy import select
     from sqlalchemy.orm import attributes as orm_attributes
@@ -479,6 +504,8 @@ async def _forget_data_memory(data_id: UUID, dataset_ref: Union[str, UUID], user
     return {
         "data_id": str(data_id),
         "dataset_id": str(dataset_id),
+        "nodes_deleted": len(deleted_elements.node_ids),
+        "edges_deleted": len(deleted_elements.edge_ids),
         "status": "success",
     }
 

--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -268,14 +268,27 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user: Any) -> di
     (e.g. a new custom prompt or graph model).
 
     Cleanup scope:
-    - Graph DB (nodes, edges): yes
-    - Vector DB (embeddings): yes
+    - Graph DB (nodes, edges): content tracked by deletion provenance, yes.
+      Content with none (e.g. ``remember(content_type="code")``) is also
+      cleared when this dataset owns an isolated graph+vector store on a
+      backend that supports resetting it safely; see ``graph_memory_cleared``/
+      ``graph_memory_note`` in the return value for what actually happened.
+    - Vector DB (embeddings): same scope as the graph DB above.
     - Session cache: yes — attributed sessions are deleted; QAs in
       dataset-unattributed sessions that used the removed graph ids are
       removed (non-fatal, best-effort)
     - Pipeline status: reset (so cognify re-processes all data)
     - Relational DB (dataset, data records): preserved
     - Raw files: preserved
+
+    Returns a dict with ``nodes_deleted``/``edges_deleted`` (from deletion-
+    provenance tracking) and ``graph_memory_cleared`` (bool, ``True`` only when
+    this call is confident nothing memory-relevant remains). ``status`` stays
+    ``"success"`` whenever the call itself completes without error — including
+    when there was nothing to delete, or when ``graph_memory_cleared`` is
+    ``False`` — so repeated calls on an already-forgotten or never-populated
+    dataset stay safe; a caller that needs to know whether memory was actually
+    cleared reads ``graph_memory_cleared``, not ``status``.
     """
     from sqlalchemy import select
     from sqlalchemy.orm import attributes as orm_attributes
@@ -284,6 +297,9 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user: Any) -> di
     from cognee.modules.data.models import Data
     from cognee.modules.graph.methods.delete_dataset_nodes_and_edges import (
         delete_dataset_nodes_and_edges,
+    )
+    from cognee.modules.graph.methods.ensure_graph_memory_cleared import (
+        ensure_graph_memory_cleared,
     )
     from cognee.modules.pipelines.layers.reset_dataset_pipeline_run_status import (
         reset_dataset_pipeline_run_status,
@@ -294,10 +310,19 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user: Any) -> di
     # Same per-dataset lock as pipeline runs: wait for any in-flight pipeline
     # on this dataset and exclude concurrent deletes.
     async with dataset_lock(dataset_id):
-        # 1. Delete graph nodes/edges and vector embeddings
+        # 1. Delete graph nodes/edges and vector embeddings tracked by deletion
+        # provenance.
         deleted_elements = await delete_dataset_nodes_and_edges(dataset_id, user.id)
 
-        # 1b. Drop sessions attributed to this dataset, then remove tagged
+        # 1b. Content with no deletion provenance (e.g. code graphs) is invisible
+        # to step 1. When this dataset owns an isolated graph+vector store on a
+        # backend that supports it, finish the job with a full store reset (safe
+        # even if step 1 also found and removed provenance-tracked content — see
+        # ensure_graph_memory_cleared's module docstring for why isolation makes
+        # that safe); otherwise just report honestly what is known to remain.
+        graph_memory_status = await ensure_graph_memory_cleared(dataset_id, user)
+
+        # 1c. Drop sessions attributed to this dataset, then remove tagged
         # QAs from dataset-unattributed sessions (non-fatal).
         try:
             from cognee.modules.session_lifecycle.invalidate_sessions import (
@@ -350,14 +375,22 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user: Any) -> di
         )
 
     logger.info(
-        "forget: cleared memory for dataset=%s, user=%s (%d data records reset)",
+        "forget: cleared memory for dataset=%s, user=%s (%d data records reset, "
+        "%d nodes / %d edges deleted, graph_memory_cleared=%s)",
         dataset_id,
         user.id,
         len(data_records),
+        len(deleted_elements.node_ids),
+        len(deleted_elements.edge_ids),
+        graph_memory_status.cleared,
     )
     return {
         "dataset_id": str(dataset_id),
         "data_records_reset": len(data_records),
+        "nodes_deleted": len(deleted_elements.node_ids),
+        "edges_deleted": len(deleted_elements.edge_ids),
+        "graph_memory_cleared": graph_memory_status.cleared,
+        "graph_memory_note": graph_memory_status.note,
         "status": "success",
     }
 

--- a/cognee/cli/api_dispatch.py
+++ b/cognee/cli/api_dispatch.py
@@ -377,18 +377,26 @@ def _dispatch_improve(client: CogneeApiClient, args: argparse.Namespace) -> None
 
 def _dispatch_forget(client: CogneeApiClient, args: argparse.Namespace) -> None:
     everything = getattr(args, "everything", False)
-    dataset = getattr(args, "dataset_name", None)
+    # ForgetCommand's own flag is --dataset (-> args.dataset), not --dataset-name;
+    # reading dataset_name here always returned None, silently dropping --dataset
+    # in --api-url mode.
+    dataset = getattr(args, "dataset", None)
     dataset_id = getattr(args, "dataset_id", None)
     data_id = getattr(args, "data_id", None)
+    memory_only = getattr(args, "memory_only", False)
     if not everything and not dataset and not dataset_id and not data_id:
-        fmt.error(
-            "Specify --dataset-name or --dataset-id, --data-id with dataset, or --everything."
-        )
+        fmt.error("Specify --dataset or --dataset-id, --data-id with dataset, or --everything.")
         return
     result = client.forget(
         dataset=dataset,
         dataset_id=dataset_id,
         data_id=data_id,
         everything=everything,
+        memory_only=memory_only,
     )
     fmt.success(f"Done: {result}")
+
+    if memory_only and isinstance(result, dict) and result.get("graph_memory_cleared") is False:
+        fmt.warning(
+            result.get("graph_memory_note") or "Memory was not fully cleared for this dataset."
+        )

--- a/cognee/cli/commands/forget_command.py
+++ b/cognee/cli/commands/forget_command.py
@@ -17,7 +17,9 @@ class ForgetCommand(SupportsCliCommand):
 Remove data from the knowledge graph.
 
 Use --everything (alias --all) to delete all user data, --dataset/--dataset-id
-to delete a dataset, or dataset + --data-id to delete a single item.
+to delete a dataset, or dataset + --data-id to delete a single item. Add
+--memory-only to clear graph/vector memory while keeping raw files and data
+records, so the dataset (or item) can be re-cognified later.
     """
 
     def configure_parser(self, parser: argparse.ArgumentParser) -> None:
@@ -36,6 +38,16 @@ to delete a dataset, or dataset + --data-id to delete a single item.
             action="store_true",
             default=False,
             help="Delete all datasets and data",
+        )
+        parser.add_argument(
+            "--memory-only",
+            action="store_true",
+            default=False,
+            help=(
+                "Delete only graph/vector memory (requires --dataset or --dataset-id); "
+                "raw files and data records are preserved so the dataset can be "
+                "re-cognified with different settings"
+            ),
         )
 
     def execute(self, args: argparse.Namespace) -> None:
@@ -63,12 +75,26 @@ to delete a dataset, or dataset + --data-id to delete a single item.
                         dataset=dataset,
                         dataset_id=dataset_id,
                         everything=args.everything,
+                        memory_only=args.memory_only,
                     )
                 except Exception as e:
                     raise CliCommandInnerException(f"Failed to forget: {str(e)}") from e
 
             result = asyncio.run(run_forget())
             fmt.success(f"Done: {result}")
+
+            # memory_only's response carries graph_memory_cleared/graph_memory_note
+            # (see cognee.forget()'s docstring) -- surface a False clear as a
+            # readable warning instead of leaving it buried in the printed dict.
+            if (
+                args.memory_only
+                and isinstance(result, dict)
+                and result.get("graph_memory_cleared") is False
+            ):
+                fmt.warning(
+                    result.get("graph_memory_note")
+                    or "Memory was not fully cleared for this dataset."
+                )
 
             # After a successful forget the natural next step is to seed the
             # graph again with remember; a placeholder is used when the user

--- a/cognee/infrastructure/databases/graph/ladybug/LadybugDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/ladybug/LadybugDatasetDatabaseHandler.py
@@ -1,7 +1,9 @@
+import asyncio
 import os
-from uuid import UUID
+from uuid import UUID, NAMESPACE_OID, uuid5
 from typing import Optional
 
+from cognee.infrastructure.databases.cache.config import get_cache_config
 from cognee.infrastructure.databases.graph.get_graph_engine import (
     graph_engine_cache,
 )
@@ -64,25 +66,64 @@ class LadybugDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
         )
         graph_db_name = dataset_database.graph_database_name
 
-        # Never open the database to drop it: opening spawns a fresh engine
-        # (in subprocess mode, a worker that must take the on-disk file lock)
-        # which races the just-torn-down one. Evict every cached engine for
-        # this database — the same DB can sit under multiple cache keys —
-        # wait for their in-flight closes to finish (a close deferred behind
-        # an idle holder is not waited on; see graph_engine_cache.aevict_for_database),
-        # then remove the files directly. Server-backed handlers (e.g.
-        # Postgres) are different on purpose: they drop the per-dataset
-        # database over a connection, so no file handling applies there.
-        await graph_engine_cache.aevict_for_database(graph_db_name)
+        # In SHARED_LADYBUG_LOCK mode the Redis lock is the cross-process
+        # mutex LadybugAdapter.query() takes before opening the native
+        # ladybug.Database on this exact file — and LadybugAdapter.delete_graph()
+        # already takes the same lock before removing files, for the same
+        # reason. This handler evicts the cache and removes files directly
+        # (see below), so it must hold that same lock too, or a concurrent
+        # query()/search() in another process could be mid-query (holding the
+        # on-disk file lock) when we delete its files, or could open the file
+        # right between our drop and a later recreate. The lock key is
+        # rebuilt from this dataset's own db path — identical to the path
+        # get_graph_engine() resolves for this dataset (see
+        # context_global_variables.apply_database_context_variables) — so it
+        # is the exact same lock a concurrent query on this dataset would take.
+        # Deployments that have NOT opted into SHARED_LADYBUG_LOCK get no
+        # locking here (cache_config.shared_ladybug_lock is False and
+        # redis_lock stays None) — that race is pre-existing for full dataset
+        # deletion (datasets.delete_dataset() calls this same handler) and out
+        # of scope for this fix.
+        cache_config = get_cache_config()
+        redis_lock = None
+        held_redis_lock = None
+        if cache_config.shared_ladybug_lock:
+            from cognee.infrastructure.databases.cache.get_cache_engine import get_cache_engine
 
-        file_storage = get_file_storage(databases_directory_path)
-        if await file_storage.is_file(graph_db_name):
-            await file_storage.remove(graph_db_name)
-            # A clean close checkpoints and removes the WAL; the lock file and
-            # a leftover WAL from a crashed worker must not survive the drop,
-            # or a same-name recreate would replay stale data.
-            for companion_file in (f"{graph_db_name}.lock", f"{graph_db_name}.wal"):
-                if await file_storage.is_file(companion_file):
-                    await file_storage.remove(companion_file)
-        else:
-            await file_storage.remove_all(graph_db_name)
+            db_path = os.path.join(databases_directory_path, graph_db_name)
+            redis_lock = get_cache_engine(
+                lock_key="ladybug-lock-" + str(uuid5(NAMESPACE_OID, db_path))
+            )
+            # get_cache_engine() is typed Optional; shared_ladybug_lock=True means a
+            # cache config was resolved, so a lock instance always comes back here
+            # (same assumption LadybugAdapter.query()/delete_graph() make with this
+            # exact assert before calling redis_lock.acquire_lock).
+            assert redis_lock is not None
+            held_redis_lock = await asyncio.to_thread(redis_lock.acquire_lock)
+
+        try:
+            # Never open the database to drop it: opening spawns a fresh engine
+            # (in subprocess mode, a worker that must take the on-disk file lock)
+            # which races the just-torn-down one. Evict every cached engine for
+            # this database — the same DB can sit under multiple cache keys —
+            # wait for their in-flight closes to finish (a close deferred behind
+            # an idle holder is not waited on; see graph_engine_cache.aevict_for_database),
+            # then remove the files directly. Server-backed handlers (e.g.
+            # Postgres) are different on purpose: they drop the per-dataset
+            # database over a connection, so no file handling applies there.
+            await graph_engine_cache.aevict_for_database(graph_db_name)
+
+            file_storage = get_file_storage(databases_directory_path)
+            if await file_storage.is_file(graph_db_name):
+                await file_storage.remove(graph_db_name)
+                # A clean close checkpoints and removes the WAL; the lock file and
+                # a leftover WAL from a crashed worker must not survive the drop,
+                # or a same-name recreate would replay stale data.
+                for companion_file in (f"{graph_db_name}.lock", f"{graph_db_name}.wal"):
+                    if await file_storage.is_file(companion_file):
+                        await file_storage.remove(companion_file)
+            else:
+                await file_storage.remove_all(graph_db_name)
+        finally:
+            if redis_lock is not None:
+                await asyncio.to_thread(redis_lock.release_lock, held_redis_lock)

--- a/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
@@ -63,14 +63,29 @@ class TursoGraphDatasetDatabaseHandler:
     @classmethod
     async def delete_dataset(cls, dataset_database: DatasetDatabase) -> None:
         dataset_url = str(dataset_database.graph_database_url or "")
+        graph_db_name = dataset_database.graph_database_name
 
-        graph_engine_cache.evict(
-            graph_database_provider="turso",
-            graph_file_path="",
-            graph_database_url=dataset_url,
-            graph_database_key="",
-        )
+        # The engine cache key ensure_graph_memory_cleared's get_graph_engine()
+        # resolves (built generically from graph_file_path/graph_database_name/
+        # handler name by apply_database_context_variables) differs from the
+        # narrower key an exact-match evict() here would target (graph_file_path=
+        # "", no graph_database_name, default handler name) -- an exact-key evict
+        # would miss the live cache entry and leave a stale engine with an open
+        # connection to the file this method is about to remove. Evict by
+        # database name instead, same pattern LadybugDatasetDatabaseHandler.
+        # delete_dataset uses, and wait for any in-flight close (this adapter is
+        # file-based, same reasoning as Ladybug's) before touching the file below.
+        if graph_db_name:
+            await graph_engine_cache.aevict_for_database(graph_db_name)
 
-        # Remove the dataset's libSQL file.
+        # Remove the dataset's libSQL file and its WAL-mode companions. This
+        # adapter runs PRAGMA journal_mode=WAL, so SQLite keeps write-ahead-log
+        # state in "<file>-wal"/"<file>-shm" until a clean close checkpoints
+        # them into the main file -- leaving them behind risks stale data
+        # surviving under a same-name recreate.
         if dataset_url.startswith("/") and os.path.exists(dataset_url):
             os.remove(dataset_url)
+            for suffix in ("-wal", "-shm"):
+                companion_path = dataset_url + suffix
+                if os.path.exists(companion_path):
+                    os.remove(companion_path)

--- a/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
@@ -83,7 +83,7 @@ class TursoGraphDatasetDatabaseHandler:
         # state in "<file>-wal"/"<file>-shm" until a clean close checkpoints
         # them into the main file -- leaving them behind risks stale data
         # surviving under a same-name recreate.
-        if dataset_url.startswith("/") and os.path.exists(dataset_url):
+        if dataset_url and os.path.isabs(dataset_url) and os.path.exists(dataset_url):
             os.remove(dataset_url)
             for suffix in ("-wal", "-shm"):
                 companion_path = dataset_url + suffix

--- a/cognee/infrastructure/databases/unified/graph_vector_store_interface.py
+++ b/cognee/infrastructure/databases/unified/graph_vector_store_interface.py
@@ -24,9 +24,12 @@ class GraphVectorStoreInterface:
         """
         raise UnsupportedProvenanceCapability()
 
-    async def delete_by_dataset_id(self, dataset_id: str) -> None:
+    async def delete_by_dataset_id(self, dataset_id: str):
         """
         Delete artifacts owned only by the given dataset.
+
+        Returns a ``SourceRefRemovalResult`` carrying the hard-deleted node/edge
+        identities, mirroring ``delete_by_source_ref``.
 
         Parameters:
         -----------

--- a/cognee/infrastructure/databases/unified/graph_vector_store_interface.py
+++ b/cognee/infrastructure/databases/unified/graph_vector_store_interface.py
@@ -1,4 +1,5 @@
 from cognee.infrastructure.databases.exceptions import UnsupportedProvenanceCapability
+from .provenance_delete_planner import SourceRefRemovalResult
 
 
 class GraphVectorStoreInterface:
@@ -24,7 +25,7 @@ class GraphVectorStoreInterface:
         """
         raise UnsupportedProvenanceCapability()
 
-    async def delete_by_dataset_id(self, dataset_id: str):
+    async def delete_by_dataset_id(self, dataset_id: str) -> "SourceRefRemovalResult":
         """
         Delete artifacts owned only by the given dataset.
 

--- a/cognee/infrastructure/databases/unified/unified_store_engine.py
+++ b/cognee/infrastructure/databases/unified/unified_store_engine.py
@@ -111,8 +111,14 @@ class UnifiedStoreEngine(GraphVectorStoreInterface):
             refs_by_edge=refs_by_edge,
         )
 
-    async def delete_by_dataset_id(self, dataset_id: str) -> None:
-        """Remove the dataset's source refs; delete artifacts left unowned."""
+    async def delete_by_dataset_id(self, dataset_id: str) -> "SourceRefRemovalResult":
+        """Remove the dataset's source refs; delete artifacts left unowned.
+
+        Returns the hard-deleted node/edge identities, same as
+        ``delete_by_source_ref`` — callers that need to know whether this
+        dataset's graph held anything (e.g. to decide whether a fallback is
+        needed) read them off the result instead of re-deriving them.
+        """
         if not self.supports_graph_provenance_delete():
             raise UnsupportedProvenanceCapability()
         graph = self.graph
@@ -124,7 +130,7 @@ class UnifiedStoreEngine(GraphVectorStoreInterface):
         node_data = await graph.get_node_delete_data(list(refs_by_node.keys()))
         edge_data = await graph.get_edge_delete_data(list(refs_by_edge.keys()))
 
-        await execute_source_ref_removal(
+        return await execute_source_ref_removal(
             graph,
             vector,
             node_data=node_data,

--- a/cognee/infrastructure/databases/utils/__init__.py
+++ b/cognee/infrastructure/databases/utils/__init__.py
@@ -1,4 +1,8 @@
-from .get_or_create_dataset_database import get_or_create_dataset_database
+from .get_or_create_dataset_database import (
+    get_or_create_dataset_database,
+    get_existing_dataset_database,
+)
 from .resolve_dataset_database_connection_info import resolve_dataset_database_connection_info
 from .get_graph_dataset_database_handler import get_graph_dataset_database_handler
 from .get_vector_dataset_database_handler import get_vector_dataset_database_handler
+from .delete_isolated_dataset_storage import delete_isolated_dataset_storage

--- a/cognee/infrastructure/databases/utils/delete_isolated_dataset_storage.py
+++ b/cognee/infrastructure/databases/utils/delete_isolated_dataset_storage.py
@@ -20,8 +20,15 @@ async def delete_isolated_dataset_storage(dataset_database: DatasetDatabase) -> 
     per-dataset graph/vector database pair — this function does not check;
     callers resolve ``dataset_database`` via
     ``get_existing_dataset_database`` first.
+
+    Order matters: vector is dropped first, graph last. A memory-only forget's
+    retry-safety net is ``graph_engine.is_empty()`` (see
+    ``ensure_graph_memory_cleared``) — as long as the graph delete is the LAST
+    step, any failure here (in either delete) leaves the graph non-empty, so a
+    retried forget() correctly re-triggers a full reset instead of finding an
+    already-empty graph and falsely reporting the vector store cleared too.
     """
     graph_handler = get_graph_dataset_database_handler(dataset_database)
     vector_handler = get_vector_dataset_database_handler(dataset_database)
-    await graph_handler["handler_instance"].delete_dataset(dataset_database)
     await vector_handler["handler_instance"].delete_dataset(dataset_database)
+    await graph_handler["handler_instance"].delete_dataset(dataset_database)

--- a/cognee/infrastructure/databases/utils/delete_isolated_dataset_storage.py
+++ b/cognee/infrastructure/databases/utils/delete_isolated_dataset_storage.py
@@ -1,0 +1,27 @@
+from cognee.infrastructure.databases.utils.get_graph_dataset_database_handler import (
+    get_graph_dataset_database_handler,
+)
+from cognee.infrastructure.databases.utils.get_vector_dataset_database_handler import (
+    get_vector_dataset_database_handler,
+)
+from cognee.modules.users.models.DatasetDatabase import DatasetDatabase
+
+
+async def delete_isolated_dataset_storage(dataset_database: DatasetDatabase) -> None:
+    """Drop the physical graph and vector databases for one dataset.
+
+    Same two handler calls ``cognee.modules.data.methods.delete_dataset`` makes
+    before it removes the ``Dataset`` row, factored out so a caller that must
+    keep the ``Dataset`` row, its ``Data`` rows, and this ``DatasetDatabase``
+    registry row (e.g. a memory-only reset) can reuse the exact primitive
+    without any of that relational cleanup.
+
+    Only call this for a dataset that is confirmed to own an isolated
+    per-dataset graph/vector database pair — this function does not check;
+    callers resolve ``dataset_database`` via
+    ``get_existing_dataset_database`` first.
+    """
+    graph_handler = get_graph_dataset_database_handler(dataset_database)
+    vector_handler = get_vector_dataset_database_handler(dataset_database)
+    await graph_handler["handler_instance"].delete_dataset(dataset_database)
+    await vector_handler["handler_instance"].delete_dataset(dataset_database)

--- a/cognee/infrastructure/databases/utils/get_or_create_dataset_database.py
+++ b/cognee/infrastructure/databases/utils/get_or_create_dataset_database.py
@@ -39,13 +39,16 @@ async def _get_graph_db_info(dataset_id: UUID, user: User) -> dict:
     return await handler["handler_instance"].create_dataset(dataset_id, user)
 
 
-async def _existing_dataset_database(
+async def get_existing_dataset_database(
     dataset_id: UUID,
     user: User,
 ) -> Optional[DatasetDatabase]:
     """
     Check if a DatasetDatabase row already exists for the given owner + dataset.
-    Return None if it doesn't exist, return the row if it does.
+    Return None if it doesn't exist, return the row if it does. Never creates one —
+    callers that need "create if missing" use ``get_or_create_dataset_database``
+    instead. A row existing is the ground-truth signal that this dataset owns an
+    isolated graph+vector database pair.
     Args:
         dataset_id:
         user:
@@ -99,7 +102,7 @@ async def get_or_create_dataset_database(
         dataset = await create_authorized_dataset(dataset, user)
 
     # If dataset database already exists return it
-    existing_dataset_database = await _existing_dataset_database(dataset_id, user)
+    existing_dataset_database = await get_existing_dataset_database(dataset_id, user)
     if existing_dataset_database:
         return existing_dataset_database
 

--- a/cognee/modules/data/methods/delete_dataset.py
+++ b/cognee/modules/data/methods/delete_dataset.py
@@ -2,11 +2,8 @@ from cognee.modules.users.models import DatasetDatabase
 from sqlalchemy import select, text
 
 from cognee.modules.data.models import Dataset, Data
-from cognee.infrastructure.databases.utils.get_vector_dataset_database_handler import (
-    get_vector_dataset_database_handler,
-)
-from cognee.infrastructure.databases.utils.get_graph_dataset_database_handler import (
-    get_graph_dataset_database_handler,
+from cognee.infrastructure.databases.utils.delete_isolated_dataset_storage import (
+    delete_isolated_dataset_storage,
 )
 from cognee.infrastructure.databases.relational import get_relational_engine
 
@@ -25,14 +22,7 @@ async def delete_dataset(dataset: Dataset):
         )
         dataset_database: DatasetDatabase = await session.scalar(stmt)
         if dataset_database:
-            graph_dataset_database_handler = get_graph_dataset_database_handler(dataset_database)
-            vector_dataset_database_handler = get_vector_dataset_database_handler(dataset_database)
-            await graph_dataset_database_handler["handler_instance"].delete_dataset(
-                dataset_database
-            )
-            await vector_dataset_database_handler["handler_instance"].delete_dataset(
-                dataset_database
-            )
+            await delete_isolated_dataset_storage(dataset_database)
 
         # Rows are dataset-scoped: deleting the dataset deletes its documents.
         # (Stale pipeline_status can't survive because the rows themselves go.)

--- a/cognee/modules/graph/methods/__init__.py
+++ b/cognee/modules/graph/methods/__init__.py
@@ -24,5 +24,6 @@ from .get_dataset_related_edges import get_dataset_related_edges, get_global_dat
 from .delete_dataset_related_nodes import delete_dataset_related_nodes
 from .delete_dataset_related_edges import delete_dataset_related_edges
 from .delete_dataset_nodes_and_edges import delete_dataset_nodes_and_edges
+from .ensure_graph_memory_cleared import ensure_graph_memory_cleared, GraphMemoryStatus
 
 from .legacy_delete import legacy_delete

--- a/cognee/modules/graph/methods/delete_dataset_nodes_and_edges.py
+++ b/cognee/modules/graph/methods/delete_dataset_nodes_and_edges.py
@@ -34,8 +34,8 @@ async def delete_dataset_nodes_and_edges(dataset_id: UUID, user_id: UUID) -> Del
     if unified.supports_graph_provenance_delete():
         graph_engine = unified.graph
         if await stores_provenance_in_graph(graph_engine):
-            await unified.delete_by_dataset_id(str(dataset_id))
-            return DeletedGraphElements()
+            result = await unified.delete_by_dataset_id(str(dataset_id))
+            return DeletedGraphElements.from_source_ref_removal(result)
 
     if backend_access_control_enabled():
         affected_nodes = await get_dataset_related_nodes(dataset_id)

--- a/cognee/modules/graph/methods/ensure_graph_memory_cleared.py
+++ b/cognee/modules/graph/methods/ensure_graph_memory_cleared.py
@@ -37,7 +37,20 @@ control it.
 Databases that are NOT isolated (``ENABLE_BACKEND_ACCESS_CONTROL=false``) get
 no reset — nothing here is safe to wipe when other datasets could share the
 same store — but they still get one narrow, cheap, read-only honesty check:
-see ``_UNPROVENANCED_PIPELINE_NAME`` below.
+see ``_UNPROVENANCED_PIPELINE_NAMES`` below.
+
+An empty graph is not proof the isolated store is fully clear, either:
+``remember(content_type="code", index_vectors=True)`` writes real vector
+embeddings alongside the graph nodes, and the code-graph pipeline's own
+stale-content sweep (``_sweep_stale_code_graph``) only removes graph nodes
+and edges — it never touches the vector side. So a dataset can end up with an
+empty graph and a non-empty vector store (most plausibly after an earlier
+reset that reached the graph but not the vector store, or any other path that
+empties the graph without the vector store also emptying). The same
+``_UNPROVENANCED_PIPELINE_NAMES`` signal used for the non-isolated honesty
+check doubles as the cheap, read-only trigger for that case below: an
+otherwise-empty isolated graph with a code-graph run on record still routes
+into the same reset path, so the vector store gets wiped too.
 """
 
 from dataclasses import dataclass
@@ -52,6 +65,8 @@ from cognee.infrastructure.databases.utils.delete_isolated_dataset_storage impor
 from cognee.infrastructure.databases.utils.get_or_create_dataset_database import (
     get_existing_dataset_database,
 )
+from cognee.modules.engine.utils import generate_edge_object_id
+from cognee.modules.graph.methods.deleted_graph_elements import DeletedGraphElements
 from cognee.modules.pipelines.methods import get_pipeline_run_by_dataset
 from cognee.shared.logging_utils import get_logger
 
@@ -66,9 +81,14 @@ _SELF_HEALING_DATASET_DATABASE_HANDLERS = frozenset(
     {"ladybug", "kuzu", "lancedb", "turso_graph", "turso"}
 )
 
-# The one pipeline that writes graph content with no deletion provenance today
-# (see cognee/tasks/code_graph/extract_code_graph.py, which every
-# remember(content_type="code") call runs under this pipeline_name).
+# Pipelines that write graph content with no deletion provenance today (see
+# cognee/tasks/code_graph/extract_code_graph.py, which every
+# remember(content_type="code") call runs under pipeline_name
+# "code_graph_pipeline"). A frozenset (not a single constant) so a future
+# unprovenanced pipeline is a one-line addition here — otherwise it would
+# silently miss detection on non-isolated deployments and skip the
+# empty-graph-but-maybe-not-vector-empty check on isolated ones.
+#
 # run_tasks calls log_pipeline_run_start unconditionally at the top of every
 # run — use_pipeline_cache (always False for this pipeline; see
 # run_pipeline_per_dataset) only gates whether an existing PipelineRun row is
@@ -77,7 +97,16 @@ _SELF_HEALING_DATASET_DATABASE_HANDLERS = frozenset(
 # (dataset_id, pipeline_name is a covered index) that such content was
 # written at some point. It is not a certainty: an errored run could exist
 # with no content ever having been written.
-_UNPROVENANCED_PIPELINE_NAME = "code_graph_pipeline"
+_UNPROVENANCED_PIPELINE_NAMES = frozenset({"code_graph_pipeline"})
+
+
+async def _unprovenanced_pipeline_run(dataset_id: UUID):
+    """First on-record PipelineRun for a pipeline in ``_UNPROVENANCED_PIPELINE_NAMES``, or None."""
+    for pipeline_name in _UNPROVENANCED_PIPELINE_NAMES:
+        run = await get_pipeline_run_by_dataset(dataset_id, pipeline_name)
+        if run is not None:
+            return run
+    return None
 
 
 @dataclass
@@ -86,11 +115,17 @@ class GraphMemoryStatus:
 
     ``cleared`` is only ``True`` when this call is confident nothing
     memory-relevant remains. ``note`` explains why when it is not, or how the
-    dataset ended up cleared when a fallback reset was needed.
+    dataset ended up cleared when a fallback reset was needed. ``deleted_elements``
+    carries the node/edge identities a fallback reset physically removed (read
+    from the graph immediately before the reset, since nothing survives the
+    reset to read them from afterward) — ``None`` when no reset ran. Callers
+    fold this into their own provenance-driven delete result so reported
+    counts and session invalidation both see what the reset removed.
     """
 
     cleared: bool
     note: Optional[str] = None
+    deleted_elements: Optional[DeletedGraphElements] = None
 
 
 async def ensure_graph_memory_cleared(dataset_id: UUID, user: Any) -> GraphMemoryStatus:
@@ -104,7 +139,7 @@ async def ensure_graph_memory_cleared(dataset_id: UUID, user: Any) -> GraphMemor
     """
     try:
         if not backend_access_control_enabled():
-            code_run = await get_pipeline_run_by_dataset(dataset_id, _UNPROVENANCED_PIPELINE_NAME)
+            code_run = await _unprovenanced_pipeline_run(dataset_id)
             if code_run is not None:
                 return GraphMemoryStatus(
                     cleared=False,
@@ -133,12 +168,29 @@ async def ensure_graph_memory_cleared(dataset_id: UUID, user: Any) -> GraphMemor
         # process-wide default. get_graph_context_config() is what reads that
         # ContextVar; get_graph_engine() builds its cache key from it.
         graph_engine = await get_graph_engine()
-        if await graph_engine.is_empty():
-            return GraphMemoryStatus(cleared=True)
+        graph_empty = await graph_engine.is_empty()
 
-        # Non-empty. See the module docstring: in an isolated store, nothing
-        # left after the provenance-driven step ran can belong to any other
-        # dataset, so it is safe to remove regardless of what that step found.
+        if graph_empty:
+            # See the module docstring: an empty graph alone does not prove
+            # the vector store is empty too. Only route into a reset here
+            # when the cheap unprovenanced-pipeline signal says content that
+            # bypasses deletion provenance was ever written for this dataset.
+            code_run = await _unprovenanced_pipeline_run(dataset_id)
+            if code_run is None:
+                return GraphMemoryStatus(cleared=True)
+            reset_reason = (
+                "its graph reads empty, but a remember(content_type='code') run "
+                "is on record and any vector embeddings it wrote "
+                "(index_vectors=True) are never swept by the code-graph "
+                "pipeline's own stale-content sweep"
+            )
+        else:
+            reset_reason = "its graph is not empty"
+
+        # Non-empty (or empty-but-unprovenanced, see above). See the module
+        # docstring: in an isolated store, nothing left after the
+        # provenance-driven step ran can belong to any other dataset, so it
+        # is safe to remove regardless of what that step found.
         graph_handler_name = dataset_database.graph_dataset_database_handler
         vector_handler_name = dataset_database.vector_dataset_database_handler
         if (
@@ -148,14 +200,42 @@ async def ensure_graph_memory_cleared(dataset_id: UUID, user: Any) -> GraphMemor
             return GraphMemoryStatus(
                 cleared=False,
                 note=(
-                    "This dataset's graph is not empty, but a full per-dataset "
-                    f"store reset is not yet supported for the '{graph_handler_name}'/"
-                    f"'{vector_handler_name}' backend, so its remaining content "
-                    "(e.g. from remember(content_type='code')) was left in place."
+                    f"This dataset needs a full per-dataset store reset ({reset_reason}), "
+                    "but that is not yet supported for the "
+                    f"'{graph_handler_name}'/'{vector_handler_name}' backend, so its "
+                    "remaining content (e.g. from remember(content_type='code')) was "
+                    "left in place."
                 ),
             )
 
+        # Capture what the reset is about to remove BEFORE wiping the store —
+        # nothing survives the reset to read this from afterward. Callers use
+        # this to report accurate nodes_deleted/edges_deleted and to widen
+        # session invalidation to dataset-unattributed sessions that used this
+        # content (see forget.py's _forget_dataset_memory).
+        nodes, edges = await graph_engine.get_graph_data()
+        deleted_elements = DeletedGraphElements(
+            node_ids={str(node_id) for node_id, _properties in nodes},
+            edge_ids={
+                str(generate_edge_object_id(str(source_id), str(target_id), relationship_name))
+                for source_id, target_id, relationship_name, _properties in edges
+            },
+        )
+
         await delete_isolated_dataset_storage(dataset_database)
+
+        # The reset just wiped whatever the CODE search snapshot cache may
+        # have parsed from this dataset's graph — drop it too, or a
+        # SearchType.CODE query inside the cache's TTL can still return
+        # results from the store that was just reset. Local import mirrors
+        # extract_code_graph.py's own invalidation call (avoids importing the
+        # retrieval layer at module load time).
+        from cognee.modules.retrieval.code_retriever import (
+            invalidate_code_graph_snapshot_cache,
+        )
+
+        invalidate_code_graph_snapshot_cache(dataset_id=dataset_id)
+
         logger.info(
             "forget: reset isolated graph+vector store for dataset=%s "
             "(content had no deletion provenance)",
@@ -165,16 +245,18 @@ async def ensure_graph_memory_cleared(dataset_id: UUID, user: Any) -> GraphMemor
             cleared=True,
             note=(
                 "Cleared by resetting this dataset's isolated graph and vector "
-                "store: its remaining content had no deletion provenance to "
-                "remove it by (e.g. it was ingested via remember(content_type="
-                "'code'))."
+                f"store ({reset_reason}): remaining content had no deletion "
+                "provenance to remove it by (e.g. it was ingested via "
+                "remember(content_type='code'))."
             ),
+            deleted_elements=deleted_elements,
         )
     except Exception as error:
         logger.warning(
             "forget: could not verify graph memory was cleared for dataset=%s (non-fatal): %s",
             dataset_id,
             error,
+            exc_info=True,
         )
         return GraphMemoryStatus(
             cleared=False,

--- a/cognee/modules/graph/methods/ensure_graph_memory_cleared.py
+++ b/cognee/modules/graph/methods/ensure_graph_memory_cleared.py
@@ -1,0 +1,182 @@
+"""Fallback for graph content that a memory-only forget cannot see via provenance.
+
+``remember(content_type="code")`` writes its graph nodes and edges through a
+payload that carries no persisted data-item id (the payload is a repository
+path string — see ``add_data_points``), so neither the relational rollback
+ledger nor graph-provenance marking ever covers them.
+``delete_dataset_nodes_and_edges`` (whichever branch it takes) can then find
+nothing to remove for a dataset that is entirely code, or clear the document
+half of a dataset that mixes cognified documents with code and leave the code
+half behind — which matters because both ``remember(text)`` and
+``remember(content_type="code")`` default to ``dataset_name="main_dataset"``,
+so a mixed dataset is a likely default, not an edge case.
+
+This module runs after that provenance-driven step and answers two questions:
+is the dataset's graph actually empty now, and — if not — can the rest be
+cleared safely. "Safely" means the dataset owns its own isolated graph and
+vector database on a backend whose per-dataset store is a plain file that the
+next connection recreates on its own — not a server-managed database/schema
+that a DROP leaves gone until something re-issues CREATE, which nothing does
+today (see ``get_or_create_dataset_database``, which reuses an existing
+registry row without ever calling the handler's ``create_dataset`` again).
+
+Isolation is what makes a reset safe even for a mixed dataset: each dataset's
+store is one physical database, named after the dataset id (e.g.
+``f"{dataset_id}.lbug"``), so nothing belonging to another dataset could ever
+have been written into it. The provenance-driven step already removed (or,
+for content shared across two datasets, correctly detached) everything it
+could attribute to THIS dataset — cross-dataset sharing cannot exist in an
+isolated store, so there is nothing it could have "kept" that isn't this
+dataset's own. Whatever is still in the store afterward is this dataset's own
+unprovenanced content, and clearing it is exactly what ``memory_only``
+promises — regardless of whether the provenance step found anything for this
+dataset or not. That is why the decision below no longer looks at what the
+provenance step found; only the isolation and self-healing-backend gates
+control it.
+
+Databases that are NOT isolated (``ENABLE_BACKEND_ACCESS_CONTROL=false``) get
+no reset — nothing here is safe to wipe when other datasets could share the
+same store — but they still get one narrow, cheap, read-only honesty check:
+see ``_UNPROVENANCED_PIPELINE_NAME`` below.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Optional
+from uuid import UUID
+
+from cognee.context_global_variables import backend_access_control_enabled
+from cognee.infrastructure.databases.graph.get_graph_engine import get_graph_engine
+from cognee.infrastructure.databases.utils.delete_isolated_dataset_storage import (
+    delete_isolated_dataset_storage,
+)
+from cognee.infrastructure.databases.utils.get_or_create_dataset_database import (
+    get_existing_dataset_database,
+)
+from cognee.modules.pipelines.methods import get_pipeline_run_by_dataset
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("ensure_graph_memory_cleared")
+
+# Embedded, file-based per-dataset stores: dropping the file is self-healing,
+# because the next connection recreates it. Server-managed per-dataset
+# databases/schemas (Neo4j, the postgres_demo graph, PGVector) are
+# deliberately excluded — their handlers issue DROP DATABASE / DROP SCHEMA,
+# and nothing re-issues CREATE before the next write.
+_SELF_HEALING_DATASET_DATABASE_HANDLERS = frozenset(
+    {"ladybug", "kuzu", "lancedb", "turso_graph", "turso"}
+)
+
+# The one pipeline that writes graph content with no deletion provenance today
+# (see cognee/tasks/code_graph/extract_code_graph.py, which every
+# remember(content_type="code") call runs under this pipeline_name).
+# run_tasks calls log_pipeline_run_start unconditionally at the top of every
+# run — use_pipeline_cache (always False for this pipeline; see
+# run_pipeline_per_dataset) only gates whether an existing PipelineRun row is
+# later *read* to skip re-processing, never whether one is *written* — so a
+# row existing for this dataset is a reliable, cheap, index-backed signal
+# (dataset_id, pipeline_name is a covered index) that such content was
+# written at some point. It is not a certainty: an errored run could exist
+# with no content ever having been written.
+_UNPROVENANCED_PIPELINE_NAME = "code_graph_pipeline"
+
+
+@dataclass
+class GraphMemoryStatus:
+    """Whether a dataset's graph is confirmed free of memory-relevant content.
+
+    ``cleared`` is only ``True`` when this call is confident nothing
+    memory-relevant remains. ``note`` explains why when it is not, or how the
+    dataset ended up cleared when a fallback reset was needed.
+    """
+
+    cleared: bool
+    note: Optional[str] = None
+
+
+async def ensure_graph_memory_cleared(dataset_id: UUID, user: Any) -> GraphMemoryStatus:
+    """Confirm a dataset's graph is empty; reset it as a last resort if safe.
+
+    Call this after the provenance-driven delete (``delete_dataset_nodes_and_edges``)
+    already ran — it never widens or pre-empts that step, only inspects (and, when
+    safe, finishes clearing) the graph afterward. On any unexpected error this
+    returns ``cleared=False`` rather than raising, so a forget() call stays safe
+    to retry.
+    """
+    try:
+        if not backend_access_control_enabled():
+            code_run = await get_pipeline_run_by_dataset(dataset_id, _UNPROVENANCED_PIPELINE_NAME)
+            if code_run is not None:
+                return GraphMemoryStatus(
+                    cleared=False,
+                    note=(
+                        "This dataset has a remember(content_type='code') run on "
+                        "record, so unprovenanced content may remain — this "
+                        "deployment shares graph/vector databases across datasets "
+                        "(ENABLE_BACKEND_ACCESS_CONTROL=false), so completeness "
+                        "could not be verified."
+                    ),
+                )
+            return GraphMemoryStatus(cleared=True)
+
+        dataset_database = await get_existing_dataset_database(dataset_id, user)
+        if dataset_database is None:
+            # No isolated store was ever provisioned for this dataset.
+            return GraphMemoryStatus(cleared=True)
+
+        # _forget_dataset_memory always calls this from inside
+        # set_database_global_context_variables(resolved_dataset_id, user.id),
+        # which sets the graph_db_config ContextVar to THIS dataset's own
+        # connection info before get_graph_engine() is ever reached here (see
+        # DatabaseContextManager.apply_database_context_variables). So this
+        # resolves — and, via the process-wide engine cache, is keyed on —
+        # this dataset's own isolated engine, never another dataset's or the
+        # process-wide default. get_graph_context_config() is what reads that
+        # ContextVar; get_graph_engine() builds its cache key from it.
+        graph_engine = await get_graph_engine()
+        if await graph_engine.is_empty():
+            return GraphMemoryStatus(cleared=True)
+
+        # Non-empty. See the module docstring: in an isolated store, nothing
+        # left after the provenance-driven step ran can belong to any other
+        # dataset, so it is safe to remove regardless of what that step found.
+        graph_handler_name = dataset_database.graph_dataset_database_handler
+        vector_handler_name = dataset_database.vector_dataset_database_handler
+        if (
+            graph_handler_name not in _SELF_HEALING_DATASET_DATABASE_HANDLERS
+            or vector_handler_name not in _SELF_HEALING_DATASET_DATABASE_HANDLERS
+        ):
+            return GraphMemoryStatus(
+                cleared=False,
+                note=(
+                    "This dataset's graph is not empty, but a full per-dataset "
+                    f"store reset is not yet supported for the '{graph_handler_name}'/"
+                    f"'{vector_handler_name}' backend, so its remaining content "
+                    "(e.g. from remember(content_type='code')) was left in place."
+                ),
+            )
+
+        await delete_isolated_dataset_storage(dataset_database)
+        logger.info(
+            "forget: reset isolated graph+vector store for dataset=%s "
+            "(content had no deletion provenance)",
+            dataset_id,
+        )
+        return GraphMemoryStatus(
+            cleared=True,
+            note=(
+                "Cleared by resetting this dataset's isolated graph and vector "
+                "store: its remaining content had no deletion provenance to "
+                "remove it by (e.g. it was ingested via remember(content_type="
+                "'code'))."
+            ),
+        )
+    except Exception as error:
+        logger.warning(
+            "forget: could not verify graph memory was cleared for dataset=%s (non-fatal): %s",
+            dataset_id,
+            error,
+        )
+        return GraphMemoryStatus(
+            cleared=False,
+            note="Could not verify whether this dataset's graph memory was fully cleared.",
+        )

--- a/cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py
@@ -177,3 +177,87 @@ class TestUserIdHeader:
         call_kwargs = MockClient.call_args
         headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
         assert "X-User-Id" not in headers
+
+
+class TestForgetDispatch:
+    """Finding 8 (COG-6335 review): --memory-only must reach the API client,
+    and a --dataset value must reach it too (args.dataset, not the
+    never-set args.dataset_name the dispatcher used to read)."""
+
+    @patch("cognee.cli.api_dispatch.CogneeApiClient")
+    def test_memory_only_and_dataset_forwarded_to_client(self, MockClient):
+        mock_instance = MagicMock()
+        mock_instance.forget.return_value = {
+            "status": "success",
+            "dataset_id": "ds-id",
+            "graph_memory_cleared": True,
+        }
+        MockClient.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+        args = argparse.Namespace(
+            api_url="http://localhost:8000",
+            command="forget",
+            user_id=None,
+            dataset="my_dataset",
+            dataset_id=None,
+            data_id=None,
+            everything=False,
+            memory_only=True,
+        )
+        dispatch(args)
+
+        mock_instance.forget.assert_called_once_with(
+            dataset="my_dataset",
+            dataset_id=None,
+            data_id=None,
+            everything=False,
+            memory_only=True,
+        )
+
+    @patch("cognee.cli.api_dispatch.fmt.warning")
+    @patch("cognee.cli.api_dispatch.CogneeApiClient")
+    def test_incomplete_memory_only_clear_prints_warning(self, MockClient, mock_warning):
+        mock_instance = MagicMock()
+        mock_instance.forget.return_value = {
+            "status": "success",
+            "dataset_id": "ds-id",
+            "graph_memory_cleared": False,
+            "graph_memory_note": "content had no deletion provenance",
+        }
+        MockClient.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+        args = argparse.Namespace(
+            api_url="http://localhost:8000",
+            command="forget",
+            user_id=None,
+            dataset=None,
+            dataset_id="11111111-1111-1111-1111-111111111111",
+            data_id=None,
+            everything=False,
+            memory_only=True,
+        )
+        dispatch(args)
+
+        mock_warning.assert_called_once_with("content had no deletion provenance")
+
+    @patch("cognee.cli.api_dispatch.CogneeApiClient")
+    def test_missing_forget_target_does_not_call_client(self, MockClient):
+        mock_instance = MagicMock()
+        MockClient.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+        args = argparse.Namespace(
+            api_url="http://localhost:8000",
+            command="forget",
+            user_id=None,
+            dataset=None,
+            dataset_id=None,
+            data_id=None,
+            everything=False,
+            memory_only=False,
+        )
+        dispatch(args)
+
+        mock_instance.forget.assert_not_called()

--- a/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
@@ -15,6 +15,7 @@ from cognee.cli.commands.search_command import SearchCommand
 from cognee.cli.commands.recall_command import RecallCommand
 from cognee.cli.commands.cognify_command import CognifyCommand
 from cognee.cli.commands.delete_command import DeleteCommand
+from cognee.cli.commands.forget_command import ForgetCommand
 from cognee.cli.commands.config_command import ConfigCommand
 from cognee.cli.exceptions import CliCommandException
 from cognee.modules.data.methods.get_deletion_counts import DeletionCountsPreview
@@ -611,6 +612,140 @@ class TestDeleteCommand:
         args = argparse.Namespace(dataset_name="test_dataset", user_id=None, all=False, force=True)
 
         mock_asyncio_run.side_effect = Exception("Delete error")
+
+        with pytest.raises(CliCommandException):
+            command.execute(args)
+
+
+class TestForgetCommand:
+    """Test the ForgetCommand class"""
+
+    def test_command_properties(self):
+        command = ForgetCommand()
+        assert command.command_string == "forget"
+        assert "Remove data" in command.help_string
+        assert command.docs_url is not None
+
+    def test_configure_parser(self):
+        command = ForgetCommand()
+        parser = argparse.ArgumentParser()
+
+        command.configure_parser(parser)
+
+        actions = {action.dest: action for action in parser._actions}
+        assert "dataset" in actions
+        assert "dataset_id" in actions
+        assert "data_id" in actions
+        assert "everything" in actions
+        assert "memory_only" in actions
+        assert actions["memory_only"].default is False
+
+    @patch("cognee.cli.commands.forget_command.asyncio.run", side_effect=_mock_run)
+    def test_execute_threads_memory_only_flag(self, mock_asyncio_run):
+        """--memory-only must reach cognee.forget(memory_only=True)."""
+        mock_cognee = MagicMock()
+        mock_cognee.forget = AsyncMock(
+            return_value={
+                "status": "success",
+                "dataset_id": "ds",
+                "graph_memory_cleared": True,
+                "graph_memory_note": None,
+            }
+        )
+
+        with patch.dict(sys.modules, {"cognee": mock_cognee}):
+            command = ForgetCommand()
+            args = argparse.Namespace(
+                dataset="my_dataset",
+                dataset_id=None,
+                data_id=None,
+                everything=False,
+                memory_only=True,
+            )
+            command.execute(args)
+
+        mock_cognee.forget.assert_awaited_once_with(
+            data_id=None,
+            dataset="my_dataset",
+            dataset_id=None,
+            everything=False,
+            memory_only=True,
+        )
+
+    @patch("cognee.cli.commands.forget_command.asyncio.run", side_effect=_mock_run)
+    def test_execute_memory_only_incomplete_clear_prints_warning(self, mock_asyncio_run):
+        """graph_memory_cleared=False must surface graph_memory_note as a
+        readable warning, not just a buried dict key."""
+        mock_cognee = MagicMock()
+        mock_cognee.forget = AsyncMock(
+            return_value={
+                "status": "success",
+                "dataset_id": "ds",
+                "graph_memory_cleared": False,
+                "graph_memory_note": "content had no deletion provenance",
+            }
+        )
+
+        with (
+            patch.dict(sys.modules, {"cognee": mock_cognee}),
+            patch("cognee.cli.commands.forget_command.fmt.warning") as mock_warning,
+        ):
+            command = ForgetCommand()
+            args = argparse.Namespace(
+                dataset="my_dataset",
+                dataset_id=None,
+                data_id=None,
+                everything=False,
+                memory_only=True,
+            )
+            command.execute(args)
+
+        mock_warning.assert_called_once_with("content had no deletion provenance")
+
+    @patch("cognee.cli.commands.forget_command.asyncio.run", side_effect=_mock_run)
+    def test_execute_memory_only_cleared_skips_warning(self, mock_asyncio_run):
+        mock_cognee = MagicMock()
+        mock_cognee.forget = AsyncMock(
+            return_value={"status": "success", "dataset_id": "ds", "graph_memory_cleared": True}
+        )
+
+        with (
+            patch.dict(sys.modules, {"cognee": mock_cognee}),
+            patch("cognee.cli.commands.forget_command.fmt.warning") as mock_warning,
+        ):
+            command = ForgetCommand()
+            args = argparse.Namespace(
+                dataset="my_dataset",
+                dataset_id=None,
+                data_id=None,
+                everything=False,
+                memory_only=True,
+            )
+            command.execute(args)
+
+        mock_warning.assert_not_called()
+
+    def test_execute_no_forget_target(self):
+        command = ForgetCommand()
+        args = argparse.Namespace(
+            dataset=None, dataset_id=None, data_id=None, everything=False, memory_only=False
+        )
+
+        # Should not raise, just print an error and return.
+        command.execute(args)
+
+    @patch("cognee.cli.commands.forget_command.asyncio.run")
+    def test_execute_with_exception(self, mock_asyncio_run):
+        mock_asyncio_run.side_effect = Exception("Forget error")
+
+        command = ForgetCommand()
+        args = argparse.Namespace(
+            dataset="my_dataset",
+            dataset_id=None,
+            data_id=None,
+            everything=False,
+            memory_only=False,
+        )
 
         with pytest.raises(CliCommandException):
             command.execute(args)

--- a/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
@@ -184,7 +184,7 @@ async def test_forget_dataset_memory_clears_graph_and_resets_pipeline(monkeypatc
     mock_reset_status.assert_awaited_once_with(
         dataset_id=DATASET_ID,
         user=USER,
-        pipeline_names=["cognify_pipeline"],
+        pipeline_names=["cognify_pipeline", "code_graph_pipeline"],
     )
 
     # pipeline_status should have dataset entry removed
@@ -195,6 +195,79 @@ async def test_forget_dataset_memory_clears_graph_and_resets_pipeline(monkeypatc
     assert len(data_a.pipeline_status["cognify"]) == 1
 
     assert session.committed
+
+
+@pytest.mark.asyncio
+async def test_forget_dataset_memory_folds_in_fallback_reset_deleted_elements(monkeypatch):
+    """Findings 2/9 (COG-6335 review): when ensure_graph_memory_cleared's
+    fallback reset removes real graph/vector content with no deletion
+    provenance, its ids must be folded into deleted_elements BEFORE both the
+    reported nodes_deleted/edges_deleted counts and the session-invalidation
+    call — otherwise a fallback reset stays invisible in the response and
+    dataset-unattributed sessions referencing that wiped content never get
+    cleaned up.
+    """
+    session = _FakeSession([])
+    engine = _FakeEngine(session)
+
+    mock_delete = AsyncMock(return_value=DeletedGraphElements(node_ids={"provenance_node"}))
+    mock_invalidate_deleted_data = AsyncMock()
+    mock_ensure_cleared = AsyncMock(
+        return_value=GraphMemoryStatus(
+            cleared=True,
+            note="Cleared by resetting this dataset's isolated graph and vector store.",
+            deleted_elements=DeletedGraphElements(node_ids={"reset_node"}, edge_ids={"reset_edge"}),
+        )
+    )
+    monkeypatch.setattr(
+        forget_module,
+        "_resolve_dataset_id",
+        AsyncMock(return_value=DATASET_ID),
+    )
+
+    with (
+        patch.object(
+            delete_dataset_nodes_and_edges_module,
+            "delete_dataset_nodes_and_edges",
+            mock_delete,
+        ),
+        patch.object(
+            ensure_graph_memory_cleared_module,
+            "ensure_graph_memory_cleared",
+            mock_ensure_cleared,
+        ),
+        patch(
+            "cognee.modules.session_lifecycle.invalidate_sessions.invalidate_sessions_for_dataset",
+            AsyncMock(),
+        ),
+        patch(
+            "cognee.modules.session_lifecycle.invalidate_sessions.invalidate_sessions_for_deleted_data",
+            mock_invalidate_deleted_data,
+        ),
+        patch(
+            "cognee.infrastructure.databases.relational.get_relational_engine",
+            return_value=engine,
+        ),
+        patch.object(
+            reset_dataset_pipeline_run_status_module,
+            "reset_dataset_pipeline_run_status",
+            AsyncMock(),
+        ),
+    ):
+        result = await forget_module._forget_dataset_memory(str(DATASET_ID), USER)
+
+    # Both the provenance-driven step's node and the fallback reset's
+    # node/edge are counted.
+    assert result["nodes_deleted"] == 2
+    assert result["edges_deleted"] == 1
+    assert result["graph_memory_cleared"] is True
+
+    mock_invalidate_deleted_data.assert_awaited_once_with(
+        DATASET_ID,
+        {"provenance_node", "reset_node"},
+        {"reset_edge"},
+        user_id=USER.id,
+    )
 
 
 @pytest.mark.asyncio
@@ -312,7 +385,9 @@ async def test_forget_data_memory_clears_graph_and_resets_pipeline(monkeypatch):
     session = _FakeSession([data_record])
     engine = _FakeEngine(session)
 
-    mock_delete = AsyncMock()
+    mock_delete = AsyncMock(
+        return_value=DeletedGraphElements(node_ids={"n1", "n2"}, edge_ids={"e1"})
+    )
     monkeypatch.setattr(
         forget_module,
         "_resolve_dataset_id",
@@ -336,6 +411,12 @@ async def test_forget_data_memory_clears_graph_and_resets_pipeline(monkeypatch):
     assert result["status"] == "success"
     assert result["data_id"] == str(DATA_ID_A)
     assert result["dataset_id"] == str(DATASET_ID)
+    # Finding 11 (COG-6335 review): counts, for consistency with
+    # _forget_dataset_memory's response. No graph_memory_cleared field here —
+    # see _forget_data_memory's docstring for why.
+    assert result["nodes_deleted"] == 2
+    assert result["edges_deleted"] == 1
+    assert "graph_memory_cleared" not in result
 
     mock_delete.assert_awaited_once_with(DATASET_ID, DATA_ID_A, USER.id)
 
@@ -364,7 +445,7 @@ async def test_forget_data_memory_no_record_found(monkeypatch):
         patch.object(
             delete_data_nodes_and_edges_module,
             "delete_data_nodes_and_edges",
-            AsyncMock(),
+            AsyncMock(return_value=DeletedGraphElements()),
         ),
         patch(
             "cognee.infrastructure.databases.relational.get_relational_engine",
@@ -374,6 +455,8 @@ async def test_forget_data_memory_no_record_found(monkeypatch):
         result = await forget_module._forget_data_memory(DATA_ID_A, str(DATASET_ID), USER)
 
     assert result["status"] == "success"
+    assert result["nodes_deleted"] == 0
+    assert result["edges_deleted"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from cognee.modules.graph.methods.deleted_graph_elements import DeletedGraphElements
+from cognee.modules.graph.methods.ensure_graph_memory_cleared import GraphMemoryStatus
 
 # Import the actual module (not the function) to access private helpers
 forget_module = importlib.import_module("cognee.api.v1.forget.forget")
@@ -25,6 +26,9 @@ delete_dataset_nodes_and_edges_module = importlib.import_module(
 )
 delete_data_nodes_and_edges_module = importlib.import_module(
     "cognee.modules.graph.methods.delete_data_nodes_and_edges"
+)
+ensure_graph_memory_cleared_module = importlib.import_module(
+    "cognee.modules.graph.methods.ensure_graph_memory_cleared"
 )
 reset_dataset_pipeline_run_status_module = importlib.import_module(
     "cognee.modules.pipelines.layers.reset_dataset_pipeline_run_status"
@@ -122,6 +126,7 @@ async def test_forget_dataset_memory_clears_graph_and_resets_pipeline(monkeypatc
     mock_delete = AsyncMock(return_value=DeletedGraphElements(node_ids={"node_deleted"}))
     mock_reset_status = AsyncMock()
     mock_invalidate_deleted_data = AsyncMock()
+    mock_ensure_cleared = AsyncMock(return_value=GraphMemoryStatus(cleared=True))
     monkeypatch.setattr(
         forget_module,
         "_resolve_dataset_id",
@@ -133,6 +138,11 @@ async def test_forget_dataset_memory_clears_graph_and_resets_pipeline(monkeypatc
             delete_dataset_nodes_and_edges_module,
             "delete_dataset_nodes_and_edges",
             mock_delete,
+        ),
+        patch.object(
+            ensure_graph_memory_cleared_module,
+            "ensure_graph_memory_cleared",
+            mock_ensure_cleared,
         ),
         patch(
             "cognee.modules.session_lifecycle.invalidate_sessions.invalidate_sessions_for_dataset",
@@ -158,8 +168,13 @@ async def test_forget_dataset_memory_clears_graph_and_resets_pipeline(monkeypatc
     assert result["status"] == "success"
     assert result["dataset_id"] == str(DATASET_ID)
     assert result["data_records_reset"] == 2
+    assert result["nodes_deleted"] == 1
+    assert result["edges_deleted"] == 0
+    assert result["graph_memory_cleared"] is True
+    assert result["graph_memory_note"] is None
 
     mock_delete.assert_awaited_once_with(DATASET_ID, USER.id)
+    mock_ensure_cleared.assert_awaited_once_with(DATASET_ID, USER)
     mock_invalidate_deleted_data.assert_awaited_once_with(
         DATASET_ID,
         {"node_deleted"},
@@ -204,6 +219,11 @@ async def test_forget_dataset_memory_skips_records_without_pipeline_status(monke
             "delete_dataset_nodes_and_edges",
             AsyncMock(return_value=DeletedGraphElements()),
         ),
+        patch.object(
+            ensure_graph_memory_cleared_module,
+            "ensure_graph_memory_cleared",
+            AsyncMock(return_value=GraphMemoryStatus(cleared=True)),
+        ),
         patch(
             "cognee.infrastructure.databases.relational.get_relational_engine",
             return_value=engine,
@@ -218,7 +238,60 @@ async def test_forget_dataset_memory_skips_records_without_pipeline_status(monke
 
     assert result["status"] == "success"
     assert result["data_records_reset"] == 2
+    assert result["nodes_deleted"] == 0
+    assert result["edges_deleted"] == 0
     mock_reset_status.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_forget_dataset_memory_reports_incomplete_clear_without_raising(monkeypatch):
+    """COG-6335: a dataset with content that has no deletion provenance (e.g.
+    remember(content_type="code")) must not be reported as a plain success —
+    but it also must not raise, so forget() stays safe to call repeatedly on
+    an already-forgotten or never-populated dataset."""
+    session = _FakeSession([])
+    engine = _FakeEngine(session)
+
+    monkeypatch.setattr(
+        forget_module,
+        "_resolve_dataset_id",
+        AsyncMock(return_value=DATASET_ID),
+    )
+
+    with (
+        patch.object(
+            delete_dataset_nodes_and_edges_module,
+            "delete_dataset_nodes_and_edges",
+            AsyncMock(return_value=DeletedGraphElements()),
+        ),
+        patch.object(
+            ensure_graph_memory_cleared_module,
+            "ensure_graph_memory_cleared",
+            AsyncMock(
+                return_value=GraphMemoryStatus(
+                    cleared=False, note="content had no deletion provenance"
+                )
+            ),
+        ),
+        patch(
+            "cognee.infrastructure.databases.relational.get_relational_engine",
+            return_value=engine,
+        ),
+        patch.object(
+            reset_dataset_pipeline_run_status_module,
+            "reset_dataset_pipeline_run_status",
+            AsyncMock(),
+        ),
+    ):
+        result = await forget_module._forget_dataset_memory(str(DATASET_ID), USER)
+
+    # Never raises, and status stays "success" — the call itself completed and
+    # is safe to retry — but the caller can tell memory was not fully cleared.
+    assert result["status"] == "success"
+    assert result["nodes_deleted"] == 0
+    assert result["edges_deleted"] == 0
+    assert result["graph_memory_cleared"] is False
+    assert result["graph_memory_note"] == "content had no deletion provenance"
 
 
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_dataset_database_handler.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_dataset_database_handler.py
@@ -1,0 +1,182 @@
+"""Tests for LadybugDatasetDatabaseHandler.delete_dataset's shared-lock use
+(Findings 3/4, COG-6335 review).
+
+LadybugAdapter.query() takes a cross-process Redis lock before opening the
+native ladybug.Database when SHARED_LADYBUG_LOCK is enabled, and
+LadybugAdapter.delete_graph() already takes that same lock before removing
+files, for the same reason. delete_dataset must take the identical lock
+before evicting the cache and removing files, or a concurrent query()/search()
+in another process could be mid-query (holding the on-disk file lock) when
+this method deletes its files, or could open the file right between the drop
+and a later recreate.
+
+Covers:
+- SHARED_LADYBUG_LOCK enabled: the lock is acquired before eviction/file
+  removal and released afterward, even when eviction/removal raises
+- the lock key matches LadybugAdapter's own key derivation for this exact
+  dataset's db path
+- SHARED_LADYBUG_LOCK disabled (default): no lock is touched at all --
+  behavior is unchanged for deployments that have not opted in
+"""
+
+import importlib
+import os
+from types import SimpleNamespace
+from uuid import NAMESPACE_OID, uuid4, uuid5
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Import order matters here: cognee.infrastructure.databases.dataset_database_handler
+# (the registry) and LadybugDatasetDatabaseHandler import each other (the
+# registry lists every handler; each handler implements the registry's
+# interface). Importing the registry package first lets that pre-existing
+# cycle resolve normally -- importing LadybugDatasetDatabaseHandler as the
+# very first thing raises "cannot import name ... from partially initialized
+# module", unrelated to this fix and reproducible on main too.
+import cognee.infrastructure.databases.dataset_database_handler  # noqa: F401
+
+handler_module = importlib.import_module(
+    "cognee.infrastructure.databases.graph.ladybug.LadybugDatasetDatabaseHandler"
+)
+get_cache_engine_module = importlib.import_module(
+    "cognee.infrastructure.databases.cache.get_cache_engine"
+)
+LadybugDatasetDatabaseHandler = handler_module.LadybugDatasetDatabaseHandler
+
+pytestmark = pytest.mark.asyncio
+
+OWNER_ID = uuid4()
+
+
+def _dataset_database(graph_db_name="dataset.lbug"):
+    return SimpleNamespace(owner_id=OWNER_ID, graph_database_name=graph_db_name)
+
+
+def _fake_file_storage():
+    storage = SimpleNamespace()
+    storage.is_file = AsyncMock(return_value=False)
+    storage.remove = AsyncMock()
+    storage.remove_all = AsyncMock()
+    return storage
+
+
+async def test_delete_dataset_holds_shared_lock_around_evict_and_file_removal(monkeypatch):
+    monkeypatch.setattr(
+        handler_module, "get_cache_config", lambda: SimpleNamespace(shared_ladybug_lock=True)
+    )
+    calls = []
+
+    class _FakeLock:
+        def acquire_lock(self):
+            calls.append("acquire")
+            return "lock-handle"
+
+        def release_lock(self, handle):
+            calls.append(("release", handle))
+
+    fake_lock = _FakeLock()
+
+    def _fake_get_cache_engine(lock_key):
+        calls.append(("get_cache_engine", lock_key))
+        return fake_lock
+
+    monkeypatch.setattr(get_cache_engine_module, "get_cache_engine", _fake_get_cache_engine)
+
+    async def _fake_aevict(_name):
+        calls.append("evict")
+        return 1
+
+    monkeypatch.setattr(
+        handler_module, "graph_engine_cache", SimpleNamespace(aevict_for_database=_fake_aevict)
+    )
+    file_storage = _fake_file_storage()
+    monkeypatch.setattr(handler_module, "get_file_storage", lambda _path: file_storage)
+
+    dataset_database = _dataset_database()
+    await LadybugDatasetDatabaseHandler.delete_dataset(dataset_database)
+
+    assert calls[0][0] == "get_cache_engine"
+    assert calls[1] == "acquire"
+    assert calls[2] == "evict"
+    assert calls[-1] == ("release", "lock-handle")
+
+
+async def test_delete_dataset_lock_key_matches_ladybug_adapter_db_path(monkeypatch):
+    """The lock key must be derived from the exact same db_path LadybugAdapter
+    uses -- get_graph_engine() resolves it as
+    os.path.join(system_root_directory/databases/<owner_id>, graph_database_name)."""
+    monkeypatch.setattr(
+        handler_module,
+        "get_base_config",
+        lambda: SimpleNamespace(system_root_directory="/system/root"),
+    )
+    monkeypatch.setattr(
+        handler_module, "get_cache_config", lambda: SimpleNamespace(shared_ladybug_lock=True)
+    )
+    seen_lock_keys = []
+
+    def _fake_get_cache_engine(lock_key):
+        seen_lock_keys.append(lock_key)
+        return SimpleNamespace(acquire_lock=lambda: None, release_lock=lambda _h: None)
+
+    monkeypatch.setattr(get_cache_engine_module, "get_cache_engine", _fake_get_cache_engine)
+    monkeypatch.setattr(
+        handler_module,
+        "graph_engine_cache",
+        SimpleNamespace(aevict_for_database=AsyncMock(return_value=0)),
+    )
+    monkeypatch.setattr(handler_module, "get_file_storage", lambda _path: _fake_file_storage())
+
+    dataset_database = _dataset_database(graph_db_name="my-dataset.lbug")
+    await LadybugDatasetDatabaseHandler.delete_dataset(dataset_database)
+
+    expected_db_path = os.path.join("/system/root", "databases", str(OWNER_ID), "my-dataset.lbug")
+    expected_key = "ladybug-lock-" + str(uuid5(NAMESPACE_OID, expected_db_path))
+    assert seen_lock_keys == [expected_key]
+
+
+async def test_delete_dataset_releases_lock_even_when_eviction_raises(monkeypatch):
+    monkeypatch.setattr(
+        handler_module, "get_cache_config", lambda: SimpleNamespace(shared_ladybug_lock=True)
+    )
+    released = []
+    monkeypatch.setattr(
+        get_cache_engine_module,
+        "get_cache_engine",
+        lambda lock_key: SimpleNamespace(
+            acquire_lock=lambda: "handle",
+            release_lock=lambda handle: released.append(handle),
+        ),
+    )
+    monkeypatch.setattr(
+        handler_module,
+        "graph_engine_cache",
+        SimpleNamespace(
+            aevict_for_database=AsyncMock(side_effect=RuntimeError("cache eviction failed"))
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="cache eviction failed"):
+        await LadybugDatasetDatabaseHandler.delete_dataset(_dataset_database())
+
+    assert released == ["handle"]
+
+
+async def test_delete_dataset_does_not_touch_lock_when_shared_lock_disabled(monkeypatch):
+    """Default (SHARED_LADYBUG_LOCK unset/false): behavior is unchanged."""
+    monkeypatch.setattr(
+        handler_module, "get_cache_config", lambda: SimpleNamespace(shared_ladybug_lock=False)
+    )
+    get_cache_engine_mock = MagicMock()
+    monkeypatch.setattr(get_cache_engine_module, "get_cache_engine", get_cache_engine_mock)
+    monkeypatch.setattr(
+        handler_module,
+        "graph_engine_cache",
+        SimpleNamespace(aevict_for_database=AsyncMock(return_value=0)),
+    )
+    monkeypatch.setattr(handler_module, "get_file_storage", lambda _path: _fake_file_storage())
+
+    await LadybugDatasetDatabaseHandler.delete_dataset(_dataset_database())
+
+    get_cache_engine_mock.assert_not_called()

--- a/cognee/tests/unit/infrastructure/databases/graph/test_turso_graph_dataset_database_handler.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_turso_graph_dataset_database_handler.py
@@ -1,0 +1,91 @@
+"""Tests for TursoGraphDatasetDatabaseHandler.delete_dataset (Finding 5,
+COG-6335 review).
+
+Covers:
+- eviction is by database name (aevict_for_database), matching the generic
+  key ensure_graph_memory_cleared's get_graph_engine() resolves, instead of
+  the old narrower exact-key evict() that could miss the live cache entry
+- the dataset's libSQL file and its WAL-mode companions (-wal/-shm) are
+  removed
+- a dataset with no graph_database_name never calls the cache at all
+  (nothing to evict by)
+"""
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+handler_module = importlib.import_module(
+    "cognee.infrastructure.databases.graph.turso.TursoGraphDatasetDatabaseHandler"
+)
+TursoGraphDatasetDatabaseHandler = handler_module.TursoGraphDatasetDatabaseHandler
+
+pytestmark = pytest.mark.asyncio
+
+
+def _dataset_database(url, graph_db_name="dataset-id"):
+    return SimpleNamespace(graph_database_url=url, graph_database_name=graph_db_name)
+
+
+async def test_delete_dataset_evicts_by_database_name(monkeypatch, tmp_path):
+    aevict = AsyncMock(return_value=1)
+    monkeypatch.setattr(
+        handler_module, "graph_engine_cache", SimpleNamespace(aevict_for_database=aevict)
+    )
+
+    await TursoGraphDatasetDatabaseHandler.delete_dataset(
+        _dataset_database(str(tmp_path / "graph_dataset-id.db"), graph_db_name="dataset-id")
+    )
+
+    aevict.assert_awaited_once_with("dataset-id")
+
+
+async def test_delete_dataset_removes_db_file_and_wal_companions(monkeypatch, tmp_path):
+    db_path = tmp_path / "graph_dataset-id.db"
+    wal_path = tmp_path / "graph_dataset-id.db-wal"
+    shm_path = tmp_path / "graph_dataset-id.db-shm"
+    for path in (db_path, wal_path, shm_path):
+        path.write_text("data")
+
+    monkeypatch.setattr(
+        handler_module, "graph_engine_cache", SimpleNamespace(aevict_for_database=AsyncMock())
+    )
+
+    await TursoGraphDatasetDatabaseHandler.delete_dataset(
+        _dataset_database(str(db_path), graph_db_name="dataset-id")
+    )
+
+    assert not db_path.exists()
+    assert not wal_path.exists()
+    assert not shm_path.exists()
+
+
+async def test_delete_dataset_tolerates_missing_wal_companions(monkeypatch, tmp_path):
+    """No -wal/-shm files (clean checkpointed close) must not raise."""
+    db_path = tmp_path / "graph_dataset-id.db"
+    db_path.write_text("data")
+
+    monkeypatch.setattr(
+        handler_module, "graph_engine_cache", SimpleNamespace(aevict_for_database=AsyncMock())
+    )
+
+    await TursoGraphDatasetDatabaseHandler.delete_dataset(
+        _dataset_database(str(db_path), graph_db_name="dataset-id")
+    )
+
+    assert not db_path.exists()
+
+
+async def test_delete_dataset_skips_eviction_when_no_database_name(monkeypatch, tmp_path):
+    aevict = AsyncMock()
+    monkeypatch.setattr(
+        handler_module, "graph_engine_cache", SimpleNamespace(aevict_for_database=aevict)
+    )
+
+    await TursoGraphDatasetDatabaseHandler.delete_dataset(
+        _dataset_database(str(tmp_path / "graph_x.db"), graph_db_name="")
+    )
+
+    aevict.assert_not_called()

--- a/cognee/tests/unit/infrastructure/databases/provenance/fakes.py
+++ b/cognee/tests/unit/infrastructure/databases/provenance/fakes.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass, field
 
 from cognee.infrastructure.databases.unified import GraphVectorStoreInterface
+from cognee.infrastructure.databases.unified.provenance_delete_planner import (
+    SourceRefRemovalResult,
+)
 
 
 @dataclass
@@ -11,11 +14,13 @@ class FakeGraphVectorStore(GraphVectorStoreInterface):
     deleted_dataset_ids: list[str] = field(default_factory=list)
     rolled_back_pipeline_run_ids: list[str] = field(default_factory=list)
 
-    async def delete_by_source_ref(self, source_ref_key: str) -> None:
+    async def delete_by_source_ref(self, source_ref_key: str) -> SourceRefRemovalResult:
         self.deleted_source_refs.append(source_ref_key)
+        return SourceRefRemovalResult()
 
-    async def delete_by_dataset_id(self, dataset_id: str) -> None:
+    async def delete_by_dataset_id(self, dataset_id: str) -> SourceRefRemovalResult:
         self.deleted_dataset_ids.append(dataset_id)
+        return SourceRefRemovalResult()
 
     async def rollback_by_pipeline_run_id(self, pipeline_run_id: str) -> None:
         self.rolled_back_pipeline_run_ids.append(pipeline_run_id)

--- a/cognee/tests/unit/infrastructure/databases/provenance/test_unified_graph_provenance_delete.py
+++ b/cognee/tests/unit/infrastructure/databases/provenance/test_unified_graph_provenance_delete.py
@@ -442,7 +442,7 @@ async def test_delete_by_dataset_id_preserves_cross_dataset_artifacts():
     vector = FakeVectorEngine()
     engine = _build_engine(graph, vector)
 
-    await engine.delete_by_dataset_id(str(dataset_a))
+    result = await engine.delete_by_dataset_id(str(dataset_a))
 
     # A-owned-only node is gone; B-only untouched; shared survives with ref_b.
     assert "only_a" not in graph.nodes
@@ -450,6 +450,11 @@ async def test_delete_by_dataset_id_preserves_cross_dataset_artifacts():
     assert graph.nodes["only_b"].source_ref_keys == [ref_b]
     assert "shared" in graph.nodes
     assert graph.nodes["shared"].source_ref_keys == [ref_b]
+
+    # The hard-deleted identities are returned, not discarded (COG-6335): a
+    # caller deciding whether a dataset had anything to delete reads this
+    # instead of re-deriving it.
+    assert result.deleted_node_ids == ["only_a"]
 
     assert ("Entity_name", ["only_a"]) in vector.deleted
     assert all(ids != ["only_b"] for _, ids in vector.deleted)

--- a/cognee/tests/unit/infrastructure/databases/test_delete_isolated_dataset_storage.py
+++ b/cognee/tests/unit/infrastructure/databases/test_delete_isolated_dataset_storage.py
@@ -49,3 +49,76 @@ async def test_delete_isolated_dataset_storage_drops_graph_and_vector(monkeypatc
 
     graph_delete.assert_awaited_once_with(dataset_database)
     vector_delete.assert_awaited_once_with(dataset_database)
+
+
+async def test_delete_isolated_dataset_storage_deletes_vector_before_graph(monkeypatch):
+    """Finding 1 (COG-6335 review): vector must be dropped BEFORE graph.
+    ensure_graph_memory_cleared's retry-safety net is graph_engine.is_empty()
+    — as long as the graph delete is last, a failure partway through always
+    leaves the graph non-empty, so a retried forget() re-triggers the full
+    reset instead of finding an already-empty graph and falsely reporting the
+    vector store cleared too.
+    """
+    dataset_database = SimpleNamespace(
+        graph_dataset_database_handler="ladybug",
+        vector_dataset_database_handler="lancedb",
+    )
+    call_order = []
+
+    async def graph_delete(_dataset_database):
+        call_order.append("graph")
+
+    async def vector_delete(_dataset_database):
+        call_order.append("vector")
+
+    monkeypatch.setattr(
+        module,
+        "get_graph_dataset_database_handler",
+        lambda _dataset_database: {
+            "handler_instance": SimpleNamespace(delete_dataset=graph_delete)
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "get_vector_dataset_database_handler",
+        lambda _dataset_database: {
+            "handler_instance": SimpleNamespace(delete_dataset=vector_delete)
+        },
+    )
+
+    await module.delete_isolated_dataset_storage(dataset_database)
+
+    assert call_order == ["vector", "graph"]
+
+
+async def test_delete_isolated_dataset_storage_skips_graph_delete_when_vector_delete_fails(
+    monkeypatch,
+):
+    """A vector-delete failure must leave the graph delete unattempted (and
+    therefore the graph left non-empty), so a retry's is_empty() check
+    correctly re-triggers a full reset instead of falsely short-circuiting."""
+    dataset_database = SimpleNamespace(
+        graph_dataset_database_handler="ladybug",
+        vector_dataset_database_handler="lancedb",
+    )
+    graph_delete = AsyncMock()
+    vector_delete = AsyncMock(side_effect=RuntimeError("vector store unreachable"))
+    monkeypatch.setattr(
+        module,
+        "get_graph_dataset_database_handler",
+        lambda _dataset_database: {
+            "handler_instance": SimpleNamespace(delete_dataset=graph_delete)
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "get_vector_dataset_database_handler",
+        lambda _dataset_database: {
+            "handler_instance": SimpleNamespace(delete_dataset=vector_delete)
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="vector store unreachable"):
+        await module.delete_isolated_dataset_storage(dataset_database)
+
+    graph_delete.assert_not_called()

--- a/cognee/tests/unit/infrastructure/databases/test_delete_isolated_dataset_storage.py
+++ b/cognee/tests/unit/infrastructure/databases/test_delete_isolated_dataset_storage.py
@@ -1,0 +1,51 @@
+"""Tests for delete_isolated_dataset_storage (COG-6335).
+
+This is the same graph+vector handler-drop primitive
+``cognee.modules.data.methods.delete_dataset`` uses before it removes the
+``Dataset`` row, factored out so a memory-only reset can reuse it without any
+relational cleanup. These tests only prove the two handler calls happen with
+the right arguments — the handlers' own delete_dataset() implementations
+(file removal, DROP DATABASE, ...) are covered by their own tests and by
+``cognee/tests/test_dataset_delete.py``.
+"""
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+module = importlib.import_module(
+    "cognee.infrastructure.databases.utils.delete_isolated_dataset_storage"
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_delete_isolated_dataset_storage_drops_graph_and_vector(monkeypatch):
+    dataset_database = SimpleNamespace(
+        graph_dataset_database_handler="ladybug",
+        vector_dataset_database_handler="lancedb",
+    )
+
+    graph_delete = AsyncMock()
+    vector_delete = AsyncMock()
+    monkeypatch.setattr(
+        module,
+        "get_graph_dataset_database_handler",
+        lambda _dataset_database: {
+            "handler_instance": SimpleNamespace(delete_dataset=graph_delete)
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "get_vector_dataset_database_handler",
+        lambda _dataset_database: {
+            "handler_instance": SimpleNamespace(delete_dataset=vector_delete)
+        },
+    )
+
+    await module.delete_isolated_dataset_storage(dataset_database)
+
+    graph_delete.assert_awaited_once_with(dataset_database)
+    vector_delete.assert_awaited_once_with(dataset_database)

--- a/cognee/tests/unit/infrastructure/databases/test_graph_vector_store_interface.py
+++ b/cognee/tests/unit/infrastructure/databases/test_graph_vector_store_interface.py
@@ -1,0 +1,34 @@
+"""Type-hint regression test for GraphVectorStoreInterface (Finding 14, COG-6335
+review).
+
+delete_by_dataset_id lost its ``-> None`` return-type annotation when it
+started returning a SourceRefRemovalResult, and never gained the replacement
+-- unlike UnifiedStoreEngine.delete_by_dataset_id, the concrete implementation,
+which already annotates its return type correctly.
+"""
+
+import importlib
+import inspect
+
+interface_module = importlib.import_module(
+    "cognee.infrastructure.databases.unified.graph_vector_store_interface"
+)
+unified_store_engine_module = importlib.import_module(
+    "cognee.infrastructure.databases.unified.unified_store_engine"
+)
+
+
+def test_delete_by_dataset_id_return_annotation_matches_concrete_implementation():
+    abstract_signature = inspect.signature(
+        interface_module.GraphVectorStoreInterface.delete_by_dataset_id
+    )
+    concrete_signature = inspect.signature(
+        unified_store_engine_module.UnifiedStoreEngine.delete_by_dataset_id
+    )
+
+    # unified_store_engine.py has ``from __future__ import annotations``
+    # (stringifying every annotation, quotes and all); the interface module
+    # does not, so its forward reference is the plain string itself. Strip
+    # any extra quoting so both forms compare as referring to the same type.
+    assert str(abstract_signature.return_annotation).strip("'\"") == "SourceRefRemovalResult"
+    assert str(concrete_signature.return_annotation).strip("'\"") == "SourceRefRemovalResult"

--- a/cognee/tests/unit/modules/data/test_delete_dataset.py
+++ b/cognee/tests/unit/modules/data/test_delete_dataset.py
@@ -1,0 +1,118 @@
+"""Tests for delete_dataset's isolated-storage teardown (Finding 15, COG-6335 review).
+
+delete_dataset used to inline the same two graph/vector handler.delete_dataset()
+calls that delete_isolated_dataset_storage already factors out for the
+memory-only reset path. This module must reuse that primitive instead of
+duplicating it.
+"""
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+module = importlib.import_module("cognee.modules.data.methods.delete_dataset")
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeScalarsResult:
+    def __init__(self, items):
+        self._items = items
+
+    def all(self):
+        return self._items
+
+
+class _FakeExecuteResult:
+    def __init__(self, items):
+        self._items = items
+
+    def scalars(self):
+        return _FakeScalarsResult(self._items)
+
+
+class _FakeSession:
+    def __init__(self, dataset_database, data_ids=(), dataset_row=None):
+        self._dataset_database = dataset_database
+        self._data_ids = list(data_ids)
+        self._dataset_row = dataset_row
+        self.commits = 0
+        self.deleted = []
+
+    async def execute(self, _statement):
+        # Covers both the sqlite PRAGMA text() call (return value unused) and
+        # select(Data.id)...scalars().all().
+        return _FakeExecuteResult(self._data_ids)
+
+    async def scalar(self, _statement):
+        return self._dataset_database
+
+    async def get(self, _model, _id):
+        return self._dataset_row
+
+    async def delete(self, row):
+        self.deleted.append(row)
+
+    async def commit(self):
+        self.commits += 1
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _FakeEngine:
+    def __init__(self, sessions):
+        self._sessions = list(sessions)
+        self.engine = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+        self.delete_data_entity = AsyncMock()
+
+    def get_async_session(self):
+        return self._sessions.pop(0)
+
+
+async def test_delete_dataset_reuses_delete_isolated_dataset_storage(monkeypatch):
+    dataset_database = SimpleNamespace(
+        graph_dataset_database_handler="ladybug",
+        vector_dataset_database_handler="lancedb",
+    )
+    dataset = SimpleNamespace(id="dataset-id")
+    session1 = _FakeSession(dataset_database, data_ids=[])
+    session2 = _FakeSession(dataset_database, dataset_row=dataset)
+    engine = _FakeEngine([session1, session2])
+
+    reset_mock = AsyncMock()
+    monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset_mock)
+    monkeypatch.setattr(module, "get_relational_engine", lambda: engine)
+
+    await module.delete_dataset(dataset)
+
+    reset_mock.assert_awaited_once_with(dataset_database)
+
+
+async def test_delete_dataset_skips_isolated_storage_reset_when_no_dataset_database_row(
+    monkeypatch,
+):
+    dataset = SimpleNamespace(id="dataset-id")
+    session1 = _FakeSession(dataset_database=None, data_ids=[])
+    session2 = _FakeSession(dataset_database=None, dataset_row=dataset)
+    engine = _FakeEngine([session1, session2])
+
+    reset_mock = AsyncMock()
+    monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset_mock)
+    monkeypatch.setattr(module, "get_relational_engine", lambda: engine)
+
+    await module.delete_dataset(dataset)
+
+    reset_mock.assert_not_called()
+
+
+async def test_delete_dataset_module_no_longer_imports_the_inline_handler_getters():
+    """The two handler-getter imports this module used to inline are now
+    unused -- delete_isolated_dataset_storage owns that call."""
+    assert not hasattr(module, "get_graph_dataset_database_handler")
+    assert not hasattr(module, "get_vector_dataset_database_handler")

--- a/cognee/tests/unit/modules/graph/test_ensure_graph_memory_cleared.py
+++ b/cognee/tests/unit/modules/graph/test_ensure_graph_memory_cleared.py
@@ -1,0 +1,304 @@
+"""Tests for ensure_graph_memory_cleared (COG-6335).
+
+Covers the fallback forget(memory_only=True) uses for graph content that
+carries no deletion provenance (e.g. remember(content_type="code")):
+
+- no access control + no code_graph_pipeline run on record -> cleared
+  (unchanged default behavior)
+- no access control + a code_graph_pipeline run on record -> NOT cleared,
+  named possibility, no reset attempted (nothing is safe to wipe when other
+  datasets could share the same store)
+- isolated + no DatasetDatabase row -> cleared, no reset attempted
+- already-empty graph -> cleared without touching storage
+- isolated + self-healing backend + graph still non-empty -> full store
+  reset and cleared, REGARDLESS of whether the provenance-driven step found
+  and removed content for this dataset or not (isolation guarantees nothing
+  left behind can belong to another dataset) — this is the common
+  documents+code-in-one-dataset case, since both remember(text) and
+  remember(content_type="code") default to dataset_name="main_dataset"
+- isolated + self-healing backend + graph still non-empty + a code
+  snapshot marker present -> reset clears it too, so a later
+  remember(content_type="code") does not skip re-ingestion (the COG-6335
+  end-to-end claim)
+- isolated + server-managed handler (e.g. neo4j) + graph still non-empty ->
+  NOT cleared, no reset attempted (dropping it would leave the dataset with
+  no backing database until something re-issues CREATE)
+- get_graph_engine() resolves the dataset-scoped engine active in the
+  caller's context, not some other dataset's or the process default
+- unexpected error -> NOT cleared instead of raising
+"""
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+module = importlib.import_module("cognee.modules.graph.methods.ensure_graph_memory_cleared")
+graph_engine_module = importlib.import_module(
+    "cognee.infrastructure.databases.graph.get_graph_engine"
+)
+pipelines_methods_module = importlib.import_module("cognee.modules.pipelines.methods")
+
+pytestmark = pytest.mark.asyncio
+
+DATASET_ID = uuid4()
+USER = SimpleNamespace(id=uuid4())
+
+
+def _dataset_database(graph_handler="ladybug", vector_handler="lancedb"):
+    return SimpleNamespace(
+        graph_dataset_database_handler=graph_handler,
+        vector_dataset_database_handler=vector_handler,
+    )
+
+
+class _FakeGraphEngine:
+    """Minimal in-memory stand-in with just what this module touches."""
+
+    def __init__(self, nodes=None):
+        self.nodes = dict(nodes or {})
+
+    async def is_empty(self) -> bool:
+        return not self.nodes
+
+    async def get_node(self, node_id):
+        return self.nodes.get(str(node_id))
+
+    def wipe(self) -> None:
+        self.nodes.clear()
+
+
+# ---------------------------------------------------------------------------
+# Non-isolated (ENABLE_BACKEND_ACCESS_CONTROL=false) — no reset is ever safe;
+# only the read-only PipelineRun honesty check applies.
+# ---------------------------------------------------------------------------
+
+
+async def test_no_access_control_and_no_code_run_reports_cleared(monkeypatch):
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: False)
+    monkeypatch.setattr(module, "get_pipeline_run_by_dataset", AsyncMock(return_value=None))
+    lookup = AsyncMock()
+    monkeypatch.setattr(module, "get_existing_dataset_database", lookup)
+    reset = AsyncMock()
+    monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset)
+
+    status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    assert status.cleared is True
+    lookup.assert_not_called()
+    reset.assert_not_called()
+
+
+async def test_no_access_control_with_code_run_on_record_reports_not_cleared(monkeypatch):
+    """Follow-up: a code_graph_pipeline PipelineRun row for this dataset means
+    content with no deletion provenance may still be sitting in the (shared)
+    graph — the same bug as the isolated case, just with no safe fallback, so
+    the report must say so instead of the previous unconditional cleared=True.
+    """
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: False)
+    monkeypatch.setattr(
+        module,
+        "get_pipeline_run_by_dataset",
+        AsyncMock(return_value=SimpleNamespace(pipeline_name="code_graph_pipeline")),
+    )
+    reset = AsyncMock()
+    monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset)
+
+    status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    assert status.cleared is False
+    assert "may remain" in status.note
+    reset.assert_not_called()
+
+
+async def test_no_access_control_queries_the_right_pipeline_name(monkeypatch):
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: False)
+    query = AsyncMock(return_value=None)
+    monkeypatch.setattr(module, "get_pipeline_run_by_dataset", query)
+
+    await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    query.assert_awaited_once_with(DATASET_ID, "code_graph_pipeline")
+
+
+# ---------------------------------------------------------------------------
+# Isolated store — no DatasetDatabase row, or already empty.
+# ---------------------------------------------------------------------------
+
+
+async def test_no_dataset_database_row_reports_cleared_and_never_resets(monkeypatch):
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: True)
+    monkeypatch.setattr(module, "get_existing_dataset_database", AsyncMock(return_value=None))
+    engine_getter = AsyncMock()
+    monkeypatch.setattr(module, "get_graph_engine", engine_getter)
+    reset = AsyncMock()
+    monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset)
+
+    status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    assert status.cleared is True
+    engine_getter.assert_not_called()
+    reset.assert_not_called()
+
+
+async def test_already_empty_graph_reports_cleared_without_reset(monkeypatch):
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        module, "get_existing_dataset_database", AsyncMock(return_value=_dataset_database())
+    )
+    monkeypatch.setattr(module, "get_graph_engine", AsyncMock(return_value=_FakeGraphEngine()))
+    reset = AsyncMock()
+    monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset)
+
+    status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    assert status.cleared is True
+    reset.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Isolated store, still non-empty after the provenance-driven step — the
+# decision no longer depends on what that step found (see module docstring).
+# ---------------------------------------------------------------------------
+
+
+async def test_isolated_self_healing_backend_resets_even_when_provenance_found_content(
+    monkeypatch,
+):
+    """The documents+code-in-one-dataset case: the provenance-driven step
+    already found and removed this dataset's document content — that is not
+    relevant here any more, because isolation means whatever is left in the
+    store afterward cannot belong to any other dataset either way, so it is
+    always safe to reset once the store is confirmed isolated and self-healing.
+    """
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        module, "get_existing_dataset_database", AsyncMock(return_value=_dataset_database())
+    )
+    monkeypatch.setattr(
+        module, "get_graph_engine", AsyncMock(return_value=_FakeGraphEngine({"n1": {}}))
+    )
+    reset = AsyncMock()
+    monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset)
+
+    status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    assert status.cleared is True
+    assert "reset" in status.note
+    reset.assert_awaited_once()
+
+
+async def test_unsupported_backend_reports_not_cleared_and_never_resets(monkeypatch):
+    """The graph is non-empty (whether the provenance step found something for
+    this dataset or not makes no difference — see above), but the per-dataset
+    store is server-managed (e.g. Neo4j) — dropping it would leave the dataset
+    with no backing database until something re-issues CREATE, so the reset is
+    intentionally not attempted."""
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        module,
+        "get_existing_dataset_database",
+        AsyncMock(return_value=_dataset_database(graph_handler="neo4j")),
+    )
+    monkeypatch.setattr(
+        module, "get_graph_engine", AsyncMock(return_value=_FakeGraphEngine({"n1": {}}))
+    )
+    reset = AsyncMock()
+    monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset)
+
+    status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    assert status.cleared is False
+    assert "neo4j" in status.note
+    reset.assert_not_called()
+
+
+async def test_unexpected_error_reports_not_cleared_instead_of_raising(monkeypatch):
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        module,
+        "get_existing_dataset_database",
+        AsyncMock(side_effect=RuntimeError("relational engine unavailable")),
+    )
+
+    status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    assert status.cleared is False
+    assert status.note
+
+
+async def test_isolated_self_healing_backend_resets_and_clears_snapshot_marker(monkeypatch):
+    """The COG-6335 end-to-end claim: a code dataset (isolated store,
+    self-healing backend) gets a full store reset, and the CodeRepository
+    snapshot marker that used to make extract_code_graph skip re-ingestion is
+    gone afterward, so the next remember(content_type="code") does a full
+    load instead of "already matches snapshot ...; skipping load."
+    """
+    from cognee.tasks.code_graph.extract_code_graph import _stored_snapshot_identity, fact_node_id
+
+    repo = "demo_repo"
+    node_id = str(fact_node_id(repo, "repository", repo))
+    fake_graph = _FakeGraphEngine({node_id: {"last_snapshot_id": "sha256:old"}})
+
+    # extract_code_graph's own snapshot lookup goes through get_graph_engine too
+    # (a local import inside _stored_snapshot_identity), so patch it at the
+    # source module to share the same fake engine.
+    monkeypatch.setattr(graph_engine_module, "get_graph_engine", AsyncMock(return_value=fake_graph))
+    assert await _stored_snapshot_identity(repo) == "sha256:old"
+
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        module, "get_existing_dataset_database", AsyncMock(return_value=_dataset_database())
+    )
+    monkeypatch.setattr(module, "get_graph_engine", AsyncMock(return_value=fake_graph))
+
+    async def _wipe(_dataset_database):
+        fake_graph.wipe()
+
+    reset = AsyncMock(side_effect=_wipe)
+    monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset)
+
+    status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    assert status.cleared is True
+    assert "reset" in status.note
+    reset.assert_awaited_once()
+
+    # The end-to-end claim: the marker is gone, so a later ingest will not skip.
+    assert await _stored_snapshot_identity(repo) is None
+
+
+async def test_get_graph_engine_resolves_the_active_per_dataset_context(monkeypatch):
+    """_forget_dataset_memory always calls ensure_graph_memory_cleared from
+    inside set_database_global_context_variables(resolved_dataset_id,
+    user.id). Prove get_graph_engine() here actually picks up THAT ambient
+    per-dataset context (via get_graph_context_config reading the
+    graph_db_config ContextVar the same way set_database_global_context_variables
+    sets it) rather than some other dataset's or the process-wide default."""
+    from cognee.context_global_variables import graph_db_config
+    from cognee.infrastructure.databases.graph.config import get_graph_context_config
+
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        module, "get_existing_dataset_database", AsyncMock(return_value=_dataset_database())
+    )
+
+    seen_graph_database_name = None
+
+    async def _fake_get_graph_engine():
+        nonlocal seen_graph_database_name
+        seen_graph_database_name = get_graph_context_config().get("graph_database_name")
+        return _FakeGraphEngine()
+
+    monkeypatch.setattr(module, "get_graph_engine", _fake_get_graph_engine)
+
+    this_dataset_marker = f"{DATASET_ID}.lbug"
+    token = graph_db_config.set({"graph_database_name": this_dataset_marker})
+    try:
+        await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+    finally:
+        graph_db_config.reset(token)
+
+    assert seen_graph_database_name == this_dataset_marker

--- a/cognee/tests/unit/modules/graph/test_ensure_graph_memory_cleared.py
+++ b/cognee/tests/unit/modules/graph/test_ensure_graph_memory_cleared.py
@@ -25,12 +25,25 @@ carries no deletion provenance (e.g. remember(content_type="code")):
   no backing database until something re-issues CREATE)
 - get_graph_engine() resolves the dataset-scoped engine active in the
   caller's context, not some other dataset's or the process default
-- unexpected error -> NOT cleared instead of raising
+- unexpected error -> NOT cleared instead of raising, and logged with a
+  traceback (exc_info=True)
+- isolated + self-healing backend + EMPTY graph + a code_graph_pipeline run
+  on record -> still resets (an empty graph does not prove the vector store
+  is empty: index_vectors=True embeddings are never swept by the code-graph
+  pipeline's own stale-content sweep)
+- isolated + non-self-healing backend + empty graph + a code_graph_pipeline
+  run on record -> NOT cleared, no reset attempted (same honesty behavior as
+  the non-empty case)
+- a reset captures the node/edge ids it is about to remove (via
+  get_graph_data()) BEFORE wiping the store, and returns them as
+  GraphMemoryStatus.deleted_elements
+- a reset invalidates the CODE search snapshot cache for this dataset
+- _UNPROVENANCED_PIPELINE_NAMES is a frozenset, not a single hardcoded string
 """
 
 import importlib
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -40,6 +53,7 @@ graph_engine_module = importlib.import_module(
     "cognee.infrastructure.databases.graph.get_graph_engine"
 )
 pipelines_methods_module = importlib.import_module("cognee.modules.pipelines.methods")
+code_retriever_module = importlib.import_module("cognee.modules.retrieval.code_retriever")
 
 pytestmark = pytest.mark.asyncio
 
@@ -57,8 +71,9 @@ def _dataset_database(graph_handler="ladybug", vector_handler="lancedb"):
 class _FakeGraphEngine:
     """Minimal in-memory stand-in with just what this module touches."""
 
-    def __init__(self, nodes=None):
+    def __init__(self, nodes=None, edges=None):
         self.nodes = dict(nodes or {})
+        self.edges = list(edges or [])
 
     async def is_empty(self) -> bool:
         return not self.nodes
@@ -66,8 +81,12 @@ class _FakeGraphEngine:
     async def get_node(self, node_id):
         return self.nodes.get(str(node_id))
 
+    async def get_graph_data(self):
+        return list(self.nodes.items()), list(self.edges)
+
     def wipe(self) -> None:
         self.nodes.clear()
+        self.edges.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -149,12 +168,19 @@ async def test_already_empty_graph_reports_cleared_without_reset(monkeypatch):
         module, "get_existing_dataset_database", AsyncMock(return_value=_dataset_database())
     )
     monkeypatch.setattr(module, "get_graph_engine", AsyncMock(return_value=_FakeGraphEngine()))
+    query = AsyncMock(return_value=None)
+    monkeypatch.setattr(module, "get_pipeline_run_by_dataset", query)
     reset = AsyncMock()
     monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset)
 
     status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
 
     assert status.cleared is True
+    assert status.deleted_elements is None
+    # Finding 6: an empty graph alone is not trusted -- the same cheap
+    # unprovenanced-pipeline signal used for the non-isolated honesty check
+    # is consulted here too, before short-circuiting to cleared=True.
+    query.assert_awaited_once_with(DATASET_ID, "code_graph_pipeline")
     reset.assert_not_called()
 
 
@@ -172,22 +198,48 @@ async def test_isolated_self_healing_backend_resets_even_when_provenance_found_c
     relevant here any more, because isolation means whatever is left in the
     store afterward cannot belong to any other dataset either way, so it is
     always safe to reset once the store is confirmed isolated and self-healing.
+
+    Also covers Findings 2/9 (deleted_elements captured before the wipe) and 7
+    (CODE snapshot cache invalidated after a reset).
     """
+    from cognee.modules.engine.utils import generate_edge_object_id
+
     monkeypatch.setattr(module, "backend_access_control_enabled", lambda: True)
     monkeypatch.setattr(
         module, "get_existing_dataset_database", AsyncMock(return_value=_dataset_database())
     )
     monkeypatch.setattr(
-        module, "get_graph_engine", AsyncMock(return_value=_FakeGraphEngine({"n1": {}}))
+        module,
+        "get_graph_engine",
+        AsyncMock(
+            return_value=_FakeGraphEngine(
+                nodes={"n1": {}, "n2": {}},
+                edges=[("n1", "n2", "calls", {})],
+            )
+        ),
     )
     reset = AsyncMock()
     monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset)
+    query = AsyncMock(return_value=None)
+    monkeypatch.setattr(module, "get_pipeline_run_by_dataset", query)
+    invalidate_mock = MagicMock()
+    monkeypatch.setattr(
+        code_retriever_module, "invalidate_code_graph_snapshot_cache", invalidate_mock
+    )
 
     status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
 
     assert status.cleared is True
     assert "reset" in status.note
     reset.assert_awaited_once()
+    # The graph was already non-empty, so the extra unprovenanced-pipeline
+    # check (only needed for an empty graph — see Finding 6) never runs.
+    query.assert_not_called()
+
+    assert status.deleted_elements is not None
+    assert status.deleted_elements.node_ids == {"n1", "n2"}
+    assert status.deleted_elements.edge_ids == {str(generate_edge_object_id("n1", "n2", "calls"))}
+    invalidate_mock.assert_called_once_with(dataset_id=DATASET_ID)
 
 
 async def test_unsupported_backend_reports_not_cleared_and_never_resets(monkeypatch):
@@ -227,6 +279,25 @@ async def test_unexpected_error_reports_not_cleared_instead_of_raising(monkeypat
 
     assert status.cleared is False
     assert status.note
+
+
+async def test_unexpected_error_is_logged_with_a_traceback(monkeypatch):
+    """Finding 12 (COG-6335 review): the broad except block must log with
+    exc_info=True so a traceback reaches the logs, instead of only str(error)."""
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        module,
+        "get_existing_dataset_database",
+        AsyncMock(side_effect=RuntimeError("relational engine unavailable")),
+    )
+    mock_warning = MagicMock()
+    monkeypatch.setattr(module.logger, "warning", mock_warning)
+
+    await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    mock_warning.assert_called_once()
+    _, kwargs = mock_warning.call_args
+    assert kwargs.get("exc_info") is True
 
 
 async def test_isolated_self_healing_backend_resets_and_clears_snapshot_marker(monkeypatch):
@@ -284,6 +355,7 @@ async def test_get_graph_engine_resolves_the_active_per_dataset_context(monkeypa
     monkeypatch.setattr(
         module, "get_existing_dataset_database", AsyncMock(return_value=_dataset_database())
     )
+    monkeypatch.setattr(module, "get_pipeline_run_by_dataset", AsyncMock(return_value=None))
 
     seen_graph_database_name = None
 
@@ -302,3 +374,99 @@ async def test_get_graph_engine_resolves_the_active_per_dataset_context(monkeypa
         graph_db_config.reset(token)
 
     assert seen_graph_database_name == this_dataset_marker
+
+
+# ---------------------------------------------------------------------------
+# Finding 6 (COG-6335 review): an empty graph does not prove the isolated
+# vector store is empty too (remember(content_type="code", index_vectors=True)
+# writes vector embeddings the code-graph pipeline's own stale-sweep never
+# touches) — a code_graph_pipeline run on record routes an otherwise-empty
+# graph into the same reset path used for a non-empty one.
+# ---------------------------------------------------------------------------
+
+
+async def test_isolated_self_healing_backend_resets_when_graph_empty_but_code_run_on_record(
+    monkeypatch,
+):
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        module, "get_existing_dataset_database", AsyncMock(return_value=_dataset_database())
+    )
+    monkeypatch.setattr(module, "get_graph_engine", AsyncMock(return_value=_FakeGraphEngine()))
+    monkeypatch.setattr(
+        module,
+        "get_pipeline_run_by_dataset",
+        AsyncMock(return_value=SimpleNamespace(pipeline_name="code_graph_pipeline")),
+    )
+    reset = AsyncMock()
+    monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset)
+    monkeypatch.setattr(code_retriever_module, "invalidate_code_graph_snapshot_cache", MagicMock())
+
+    status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    assert status.cleared is True
+    assert "vector" in status.note
+    reset.assert_awaited_once()
+    # Nothing was in the graph to capture, but the reset still ran (for the
+    # vector store's sake) — deleted_elements reflects that: present, empty.
+    assert status.deleted_elements is not None
+    assert status.deleted_elements.node_ids == set()
+    assert status.deleted_elements.edge_ids == set()
+
+
+async def test_isolated_non_self_healing_backend_with_graph_empty_and_code_run_reports_not_cleared(
+    monkeypatch,
+):
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        module,
+        "get_existing_dataset_database",
+        AsyncMock(return_value=_dataset_database(graph_handler="neo4j")),
+    )
+    monkeypatch.setattr(module, "get_graph_engine", AsyncMock(return_value=_FakeGraphEngine()))
+    monkeypatch.setattr(
+        module,
+        "get_pipeline_run_by_dataset",
+        AsyncMock(return_value=SimpleNamespace(pipeline_name="code_graph_pipeline")),
+    )
+    reset = AsyncMock()
+    monkeypatch.setattr(module, "delete_isolated_dataset_storage", reset)
+
+    status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    assert status.cleared is False
+    assert "neo4j" in status.note
+    assert status.deleted_elements is None
+    reset.assert_not_called()
+
+
+async def test_isolated_reset_skips_snapshot_cache_invalidation_when_no_reset_ran(monkeypatch):
+    """invalidate_code_graph_snapshot_cache is only called in the branch where
+    a reset actually happened — not on every call (would be wasted work on
+    the far more common already-cleared path)."""
+    monkeypatch.setattr(module, "backend_access_control_enabled", lambda: True)
+    monkeypatch.setattr(
+        module, "get_existing_dataset_database", AsyncMock(return_value=_dataset_database())
+    )
+    monkeypatch.setattr(module, "get_graph_engine", AsyncMock(return_value=_FakeGraphEngine()))
+    monkeypatch.setattr(module, "get_pipeline_run_by_dataset", AsyncMock(return_value=None))
+    invalidate_mock = MagicMock()
+    monkeypatch.setattr(
+        code_retriever_module, "invalidate_code_graph_snapshot_cache", invalidate_mock
+    )
+
+    status = await module.ensure_graph_memory_cleared(DATASET_ID, USER)
+
+    assert status.cleared is True
+    invalidate_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Finding 13 (COG-6335 review): a frozenset, not a single hardcoded string, so
+# a future unprovenanced pipeline is a one-line addition.
+# ---------------------------------------------------------------------------
+
+
+async def test_unprovenanced_pipeline_names_is_a_frozenset_containing_code_graph_pipeline():
+    assert isinstance(module._UNPROVENANCED_PIPELINE_NAMES, frozenset)
+    assert "code_graph_pipeline" in module._UNPROVENANCED_PIPELINE_NAMES

--- a/cognee/tests/unit/modules/graph/test_graph_provenance_delete_routing.py
+++ b/cognee/tests/unit/modules/graph/test_graph_provenance_delete_routing.py
@@ -21,7 +21,7 @@ import pytest
 import cognee.modules.graph.methods.delete_data_nodes_and_edges  # noqa: F401
 import cognee.modules.graph.methods.delete_dataset_nodes_and_edges  # noqa: F401
 import cognee.modules.graph.methods.try_delete_data_by_graph_provenance  # noqa: F401
-from cognee.infrastructure.databases.provenance import make_source_ref_key
+from cognee.infrastructure.databases.provenance import EdgeIdentity, make_source_ref_key
 from cognee.infrastructure.databases.unified.provenance_delete_planner import (
     SourceRefRemovalResult,
 )
@@ -41,7 +41,7 @@ def _unified(graph_provenance_supported=True):
         supports_graph_provenance_delete=lambda: graph_provenance_supported,
         graph=object(),
         delete_by_source_ref=AsyncMock(return_value=SourceRefRemovalResult()),
-        delete_by_dataset_id=AsyncMock(),
+        delete_by_dataset_id=AsyncMock(return_value=SourceRefRemovalResult()),
     )
 
 
@@ -120,8 +120,18 @@ async def test_delete_data_routes_graph_provenance():
 
 
 async def test_delete_dataset_routes_graph_provenance():
+    """The real SourceRefRemovalResult from delete_by_dataset_id is threaded
+    through, not discarded — a regression guard for COG-6335, where the graph-
+    provenance branch used to hardcode an empty DeletedGraphElements() no
+    matter what delete_by_dataset_id actually removed."""
     dataset_id, user_id = uuid4(), uuid4()
     unified = _unified()
+    unified.delete_by_dataset_id = AsyncMock(
+        return_value=SourceRefRemovalResult(
+            deleted_node_ids=["n1"],
+            deleted_edges=[EdgeIdentity("n1", "n2", "relates_to")],
+        )
+    )
 
     with (
         patch.object(ddsne_module, "get_user", AsyncMock(return_value=SimpleNamespace(id=user_id))),
@@ -138,7 +148,8 @@ async def test_delete_dataset_routes_graph_provenance():
 
     unified.delete_by_dataset_id.assert_awaited_once_with(str(dataset_id))
     legacy_delete.assert_not_called()
-    assert result == DeletedGraphElements()
+    assert result.node_ids == {"n1"}
+    assert len(result.edge_ids) == 1
 
 
 async def test_delete_data_old_graph_uses_legacy():

--- a/cognee/tests/unit/modules/integrations/test_response_url.py
+++ b/cognee/tests/unit/modules/integrations/test_response_url.py
@@ -45,9 +45,12 @@ def test_accepts_real_slack_response_urls(url):
 @pytest.mark.parametrize(
     ("url", "why"),
     [
-        ("https://hooks.slack.com/services/T0/B0/tok", "Incoming Webhook: same host, and it "
-         "accepts the exact body this module sends, so a forged payload would exfiltrate "
-         "the answer into an attacker's workspace"),
+        (
+            "https://hooks.slack.com/services/T0/B0/tok",
+            "Incoming Webhook: same host, and it "
+            "accepts the exact body this module sends, so a forged payload would exfiltrate "
+            "the answer into an attacker's workspace",
+        ),
         ("https://hooks.slack.com.evil.com/commands/x", "suffix host"),
         ("https://hooks.slack.com@evil.com/commands/x", "userinfo host"),
         ("http://hooks.slack.com/commands/T0/1/a", "scheme downgrade"),


### PR DESCRIPTION
## Description
<!-- Write this in your own words — the repo explicitly asks for the description to come from you, not an AI. The facts below are just a reminder: -->

- Follow-up to COG-6335 (commit b0bec7e11): that commit fixed forget(memory_only=True) so it actually clears code-graph content instead of falsely reporting success.
- After an xhigh-effort code review of that commit (10 finder agents + 11 independent verifications + a gap sweep), 15 CONFIRMED findings turned up in the reset path itself.
- This PR fixes all 15: orphaned vector store on a partial failure (delete order reversed), wrong nodes_deleted/edges_deleted counts, a session-invalidation gap for dataset-unattributed sessions, a concurrent search/recall race + multi-worker lock gap (reusing SHARED_LADYBUG_LOCK), a Turso cache-key mismatch, a vector-only blindspot with index_vectors=True, CODE search snapshot cache staleness, a missing --memory-only CLI flag, code_graph_pipeline's status never being reset, an inconsistent response shape on _forget_data_memory, and a few smaller ones (traceback logging, an extensible pipeline-name set, a restored type-hint annotation, removed duplication in delete_dataset.py).
- Also fixed an unrelated pre-existing bug found along the way: --api-url forget dispatch was reading args.dataset_name, a field the CLI parser never sets (its flag is --dataset), silently dropping --dataset in that mode.

## Acceptance Criteria
- forget(memory_only=True) on a dataset with remember(content_type="code") content actually clears the graph and vector store, not just reports success.
- A partial failure during the reset (e.g. vector delete fails after the graph delete succeeds) leaves the dataset in a state a retry correctly completes, with no permanently orphaned content.
- nodes_deleted/edges_deleted in the response match graph_memory_cleared (never 0/0 with cleared=True).
- cognee-cli forget --memory-only works identically locally and via --api-url.
- All existing and new tests pass; ruff check/format clean.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<!-- Backend-only change, no UI to screenshot. Attaching pytest output instead. -->
5159 passed, 68 skipped, 0 failed (`pytest cognee/tests/unit -k "not enola"`)

## Pre-submission Checklist
- [x] All new and existing tests pass — verified independently, twice (the fix agent's run plus my own separate run)
- [x] I have added tests that prove my fix is effective — new tests for every finding
- [x] My code follows the project's coding standards and style guidelines — ruff check + format clean on all 18 touched files
- [ ] I have tested my changes thoroughly before submitting this PR — your confirmation
- [ ] This PR contains minimal changes necessary to address the issue/feature — your call (15 findings justify a large diff, but confirm you agree)
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already — your check
- [ ] I have linked any relevant issues in the description — add the COG-6335 link
- [ ] My commits have clear and descriptive messages — holds if you use the commit message I gave you earlier

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.