### PR TITLE
COG-6341 feat: Add --memory-only flag to cognee-cli forget

### DIFF
--- a/cognee/cli/api_dispatch.py
+++ b/cognee/cli/api_dispatch.py
@@ -377,12 +377,24 @@ def _dispatch_improve(client: CogneeApiClient, args: argparse.Namespace) -> None
 
 def _dispatch_forget(client: CogneeApiClient, args: argparse.Namespace) -> None:
     everything = getattr(args, "everything", False)
-    dataset = getattr(args, "dataset_name", None)
+    # ForgetCommand's own flag is --dataset (-> args.dataset), not --dataset-name;
+    # reading dataset_name here always returned None, silently dropping --dataset
+    # in --api-url mode.
+    dataset = getattr(args, "dataset", None)
     dataset_id = getattr(args, "dataset_id", None)
     data_id = getattr(args, "data_id", None)
+    memory_only = getattr(args, "memory_only", False)
+    if dataset and dataset_id:
+        fmt.error("Provide either --dataset or --dataset-id, not both.")
+        return
     if not everything and not dataset and not dataset_id and not data_id:
+        fmt.error("Specify --dataset or --dataset-id, --data-id with dataset, or --everything.")
+        return
+    if everything and memory_only:
         fmt.error(
-            "Specify --dataset-name or --dataset-id, --data-id with dataset, or --everything."
+            "--memory-only has no effect with --everything: everything deletes all "
+            "datasets and data outright. Specify --dataset or --dataset-id with "
+            "--memory-only instead."
         )
         return
     result = client.forget(
@@ -390,5 +402,6 @@ def _dispatch_forget(client: CogneeApiClient, args: argparse.Namespace) -> None:
         dataset_id=dataset_id,
         data_id=data_id,
         everything=everything,
+        memory_only=memory_only,
     )
     fmt.success(f"Done: {result}")

--- a/cognee/cli/commands/forget_command.py
+++ b/cognee/cli/commands/forget_command.py
@@ -17,7 +17,9 @@ class ForgetCommand(SupportsCliCommand):
 Remove data from the knowledge graph.
 
 Use --everything (alias --all) to delete all user data, --dataset/--dataset-id
-to delete a dataset, or dataset + --data-id to delete a single item.
+to delete a dataset, or dataset + --data-id to delete a single item. Add
+--memory-only to clear graph/vector memory while keeping raw files and data
+records, so the dataset (or item) can be re-cognified later.
     """
 
     def configure_parser(self, parser: argparse.ArgumentParser) -> None:
@@ -36,6 +38,16 @@ to delete a dataset, or dataset + --data-id to delete a single item.
             action="store_true",
             default=False,
             help="Delete all datasets and data",
+        )
+        parser.add_argument(
+            "--memory-only",
+            action="store_true",
+            default=False,
+            help=(
+                "Delete only graph/vector memory (requires --dataset or --dataset-id); "
+                "raw files and data records are preserved so the dataset can be "
+                "re-cognified with different settings"
+            ),
         )
 
     def execute(self, args: argparse.Namespace) -> None:
@@ -56,6 +68,14 @@ to delete a dataset, or dataset + --data-id to delete a single item.
                 )
                 return
 
+            if args.everything and args.memory_only:
+                fmt.error(
+                    "--memory-only has no effect with --everything: everything deletes all "
+                    "datasets and data outright. Specify --dataset or --dataset-id with "
+                    "--memory-only instead."
+                )
+                return
+
             async def run_forget():
                 try:
                     return await cognee.forget(
@@ -63,6 +83,7 @@ to delete a dataset, or dataset + --data-id to delete a single item.
                         dataset=dataset,
                         dataset_id=dataset_id,
                         everything=args.everything,
+                        memory_only=args.memory_only,
                     )
                 except Exception as e:
                     raise CliCommandInnerException(f"Failed to forget: {str(e)}") from e

--- a/cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py
@@ -177,3 +177,102 @@ class TestUserIdHeader:
         call_kwargs = MockClient.call_args
         headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
         assert "X-User-Id" not in headers
+
+
+class TestForgetDispatch:
+    """Finding 8 (COG-6335 review): --memory-only must reach the API client,
+    and a --dataset value must reach it too (args.dataset, not the
+    never-set args.dataset_name the dispatcher used to read)."""
+
+    @patch("cognee.cli.api_dispatch.CogneeApiClient")
+    def test_memory_only_and_dataset_forwarded_to_client(self, MockClient):
+        mock_instance = MagicMock()
+        mock_instance.forget.return_value = {
+            "status": "success",
+            "dataset_id": "ds-id",
+            "data_records_reset": 0,
+        }
+        MockClient.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+        args = argparse.Namespace(
+            api_url="http://localhost:8000",
+            command="forget",
+            user_id=None,
+            dataset="my_dataset",
+            dataset_id=None,
+            data_id=None,
+            everything=False,
+            memory_only=True,
+        )
+        dispatch(args)
+
+        mock_instance.forget.assert_called_once_with(
+            dataset="my_dataset",
+            dataset_id=None,
+            data_id=None,
+            everything=False,
+            memory_only=True,
+        )
+
+    @patch("cognee.cli.api_dispatch.CogneeApiClient")
+    def test_everything_with_memory_only_does_not_call_client(self, MockClient):
+        """--memory-only has no effect with --everything (which deletes
+        outright) -- must error instead of silently doing a full wipe."""
+        mock_instance = MagicMock()
+        MockClient.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+        args = argparse.Namespace(
+            api_url="http://localhost:8000",
+            command="forget",
+            user_id=None,
+            dataset=None,
+            dataset_id=None,
+            data_id=None,
+            everything=True,
+            memory_only=True,
+        )
+        dispatch(args)
+
+        mock_instance.forget.assert_not_called()
+
+    @patch("cognee.cli.api_dispatch.CogneeApiClient")
+    def test_dataset_and_dataset_id_both_set_does_not_call_client(self, MockClient):
+        mock_instance = MagicMock()
+        MockClient.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+        args = argparse.Namespace(
+            api_url="http://localhost:8000",
+            command="forget",
+            user_id=None,
+            dataset="my_dataset",
+            dataset_id="11111111-1111-1111-1111-111111111111",
+            data_id=None,
+            everything=False,
+            memory_only=False,
+        )
+        dispatch(args)
+
+        mock_instance.forget.assert_not_called()
+
+    @patch("cognee.cli.api_dispatch.CogneeApiClient")
+    def test_missing_forget_target_does_not_call_client(self, MockClient):
+        mock_instance = MagicMock()
+        MockClient.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+        args = argparse.Namespace(
+            api_url="http://localhost:8000",
+            command="forget",
+            user_id=None,
+            dataset=None,
+            dataset_id=None,
+            data_id=None,
+            everything=False,
+            memory_only=False,
+        )
+        dispatch(args)
+
+        mock_instance.forget.assert_not_called()

--- a/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
@@ -15,6 +15,7 @@ from cognee.cli.commands.search_command import SearchCommand
 from cognee.cli.commands.recall_command import RecallCommand
 from cognee.cli.commands.cognify_command import CognifyCommand
 from cognee.cli.commands.delete_command import DeleteCommand
+from cognee.cli.commands.forget_command import ForgetCommand
 from cognee.cli.commands.config_command import ConfigCommand
 from cognee.cli.exceptions import CliCommandException
 from cognee.modules.data.methods.get_deletion_counts import DeletionCountsPreview
@@ -611,6 +612,98 @@ class TestDeleteCommand:
         args = argparse.Namespace(dataset_name="test_dataset", user_id=None, all=False, force=True)
 
         mock_asyncio_run.side_effect = Exception("Delete error")
+
+        with pytest.raises(CliCommandException):
+            command.execute(args)
+
+
+class TestForgetCommand:
+    """Test the ForgetCommand class"""
+
+    def test_command_properties(self):
+        command = ForgetCommand()
+        assert command.command_string == "forget"
+        assert "Remove data" in command.help_string
+        assert command.docs_url is not None
+
+    def test_configure_parser(self):
+        command = ForgetCommand()
+        parser = argparse.ArgumentParser()
+
+        command.configure_parser(parser)
+
+        actions = {action.dest: action for action in parser._actions}
+        assert "dataset" in actions
+        assert "dataset_id" in actions
+        assert "data_id" in actions
+        assert "everything" in actions
+        assert "memory_only" in actions
+        assert actions["memory_only"].default is False
+
+    @patch("cognee.cli.commands.forget_command.asyncio.run", side_effect=_mock_run)
+    def test_execute_threads_memory_only_flag(self, mock_asyncio_run):
+        """--memory-only must reach cognee.forget(memory_only=True)."""
+        mock_cognee = MagicMock()
+        mock_cognee.forget = AsyncMock(
+            return_value={"status": "success", "dataset_id": "ds", "data_records_reset": 0}
+        )
+
+        with patch.dict(sys.modules, {"cognee": mock_cognee}):
+            command = ForgetCommand()
+            args = argparse.Namespace(
+                dataset="my_dataset",
+                dataset_id=None,
+                data_id=None,
+                everything=False,
+                memory_only=True,
+            )
+            command.execute(args)
+
+        mock_cognee.forget.assert_awaited_once_with(
+            data_id=None,
+            dataset="my_dataset",
+            dataset_id=None,
+            everything=False,
+            memory_only=True,
+        )
+
+    def test_execute_everything_with_memory_only_errors(self):
+        """--memory-only has no effect with --everything (which deletes
+        outright) -- must error instead of silently doing a full wipe."""
+        mock_cognee = MagicMock()
+        mock_cognee.forget = AsyncMock()
+
+        with patch.dict(sys.modules, {"cognee": mock_cognee}):
+            command = ForgetCommand()
+            args = argparse.Namespace(
+                dataset=None, dataset_id=None, data_id=None, everything=True, memory_only=True
+            )
+            # Should not raise, just print an error and return without calling forget().
+            command.execute(args)
+
+        mock_cognee.forget.assert_not_awaited()
+
+    def test_execute_no_forget_target(self):
+        command = ForgetCommand()
+        args = argparse.Namespace(
+            dataset=None, dataset_id=None, data_id=None, everything=False, memory_only=False
+        )
+
+        # Should not raise, just print an error and return.
+        command.execute(args)
+
+    @patch("cognee.cli.commands.forget_command.asyncio.run")
+    def test_execute_with_exception(self, mock_asyncio_run):
+        mock_asyncio_run.side_effect = Exception("Forget error")
+
+        command = ForgetCommand()
+        args = argparse.Namespace(
+            dataset="my_dataset",
+            dataset_id=None,
+            data_id=None,
+            everything=False,
+            memory_only=False,
+        )
 
         with pytest.raises(CliCommandException):
             command.execute(args)


### PR DESCRIPTION
## Description

Added --memory-only to cognee-cli forget, was missing even though the SDK already supports it (both locally and through --api-url). Also fixed --dataset getting silently dropped in --api-url mode (wrong arg name) and made --everything --memory-only error instead of just doing a full wipe.

## Acceptance Criteria
- --memory-only reaches forget() locally and via --api-url
- --dataset works again in --api-url mode
- --everything --memory-only errors instead of wiping everything

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
CLI only, no UI. 164 passed.

## Pre-submission Checklist
- [x] All new and existing tests pass
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.