### PR TITLE
COG-6340 fix: Evict Turso engine by name, clean WAL files on delete

### DIFF
--- a/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
@@ -63,14 +63,29 @@ class TursoGraphDatasetDatabaseHandler:
     @classmethod
     async def delete_dataset(cls, dataset_database: DatasetDatabase) -> None:
         dataset_url = str(dataset_database.graph_database_url or "")
+        graph_db_name = dataset_database.graph_database_name
 
-        graph_engine_cache.evict(
-            graph_database_provider="turso",
-            graph_file_path="",
-            graph_database_url=dataset_url,
-            graph_database_key="",
-        )
+        # The engine cache key ensure_graph_memory_cleared's get_graph_engine()
+        # resolves (built generically from graph_file_path/graph_database_name/
+        # handler name by apply_database_context_variables) differs from the
+        # narrower key an exact-match evict() here would target (graph_file_path=
+        # "", no graph_database_name, default handler name) -- an exact-key evict
+        # would miss the live cache entry and leave a stale engine with an open
+        # connection to the file this method is about to remove. Evict by
+        # database name instead, same pattern LadybugDatasetDatabaseHandler.
+        # delete_dataset uses, and wait for any in-flight close (this adapter is
+        # file-based, same reasoning as Ladybug's) before touching the file below.
+        if graph_db_name:
+            await graph_engine_cache.aevict_for_database(graph_db_name)
 
-        # Remove the dataset's libSQL file.
-        if dataset_url.startswith("/") and os.path.exists(dataset_url):
+        # Remove the dataset's libSQL file and its WAL-mode companions. This
+        # adapter runs PRAGMA journal_mode=WAL, so SQLite keeps write-ahead-log
+        # state in "<file>-wal"/"<file>-shm" until a clean close checkpoints
+        # them into the main file -- leaving them behind risks stale data
+        # surviving under a same-name recreate.
+        if dataset_url and os.path.isabs(dataset_url) and os.path.exists(dataset_url):
             os.remove(dataset_url)
+            for suffix in ("-wal", "-shm"):
+                companion_path = dataset_url + suffix
+                if os.path.exists(companion_path):
+                    os.remove(companion_path)

--- a/cognee/tests/unit/infrastructure/databases/graph/test_turso_graph_dataset_database_handler.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_turso_graph_dataset_database_handler.py
@@ -1,0 +1,186 @@
+"""Tests for TursoGraphDatasetDatabaseHandler.delete_dataset (Finding 5,
+COG-6335 review).
+
+Covers:
+- eviction is by database name (aevict_for_database), matching the generic
+  key ensure_graph_memory_cleared's get_graph_engine() resolves, instead of
+  the old narrower exact-key evict() that could miss the live cache entry
+- the dataset's libSQL file and its WAL-mode companions (-wal/-shm) are
+  removed
+- a dataset with no graph_database_name never calls the cache at all
+  (nothing to evict by)
+- delete_dataset actually removes the file at the URL create_dataset itself
+  produces, on the OS the test runs on -- not a hand-built clean path. On
+  POSIX, create_dataset's URL equals os.path.join's result verbatim; on
+  Windows, os.path.join returns a backslash drive-letter path that does not
+  start with "/", so create_dataset prepends one ("sqlite+aiosqlite:///
+  needs three slashes for absolute path"), and delete_dataset must still
+  find and remove the resulting file. Round-tripping through the real
+  create_dataset (mocking only get_base_config/get_graph_config/
+  create_graph_engine, not the path construction itself) is what lets
+  Windows CI -- not a POSIX dev machine -- be the actual judge of whether
+  the absolute-path check in delete_dataset works for what create_dataset
+  really produces on that platform.
+"""
+
+import importlib
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+handler_module = importlib.import_module(
+    "cognee.infrastructure.databases.graph.turso.TursoGraphDatasetDatabaseHandler"
+)
+TursoGraphDatasetDatabaseHandler = handler_module.TursoGraphDatasetDatabaseHandler
+
+pytestmark = pytest.mark.asyncio
+
+
+def _dataset_database(url, graph_db_name="dataset-id"):
+    return SimpleNamespace(graph_database_url=url, graph_database_name=graph_db_name)
+
+
+async def _create_real_dataset_url(tmp_path, dataset_id="dataset-id"):
+    """Round-trip through the real create_dataset to get the exact
+    graph_database_url it produces on this OS, without a live DB connection."""
+    fake_engine = MagicMock()
+    fake_engine.initialize = AsyncMock()
+
+    with (
+        patch.object(
+            handler_module,
+            "get_graph_config",
+            return_value=SimpleNamespace(graph_database_provider="turso"),
+        ),
+        patch.object(
+            handler_module,
+            "get_base_config",
+            return_value=SimpleNamespace(system_root_directory=str(tmp_path)),
+        ),
+        patch.object(handler_module, "create_graph_engine", return_value=fake_engine),
+    ):
+        info = await TursoGraphDatasetDatabaseHandler.create_dataset(dataset_id, None)
+
+    return info["graph_database_url"]
+
+
+async def test_delete_dataset_evicts_by_database_name(monkeypatch, tmp_path):
+    aevict = AsyncMock(return_value=1)
+    monkeypatch.setattr(
+        handler_module, "graph_engine_cache", SimpleNamespace(aevict_for_database=aevict)
+    )
+
+    await TursoGraphDatasetDatabaseHandler.delete_dataset(
+        _dataset_database(str(tmp_path / "graph_dataset-id.db"), graph_db_name="dataset-id")
+    )
+
+    aevict.assert_awaited_once_with("dataset-id")
+
+
+async def test_delete_dataset_removes_db_file_and_wal_companions(monkeypatch, tmp_path):
+    db_path = tmp_path / "graph_dataset-id.db"
+    wal_path = tmp_path / "graph_dataset-id.db-wal"
+    shm_path = tmp_path / "graph_dataset-id.db-shm"
+    for path in (db_path, wal_path, shm_path):
+        path.write_text("data")
+
+    monkeypatch.setattr(
+        handler_module, "graph_engine_cache", SimpleNamespace(aevict_for_database=AsyncMock())
+    )
+
+    await TursoGraphDatasetDatabaseHandler.delete_dataset(
+        _dataset_database(str(db_path), graph_db_name="dataset-id")
+    )
+
+    assert not db_path.exists()
+    assert not wal_path.exists()
+    assert not shm_path.exists()
+
+
+async def test_delete_dataset_tolerates_missing_wal_companions(monkeypatch, tmp_path):
+    """No -wal/-shm files (clean checkpointed close) must not raise."""
+    db_path = tmp_path / "graph_dataset-id.db"
+    db_path.write_text("data")
+
+    monkeypatch.setattr(
+        handler_module, "graph_engine_cache", SimpleNamespace(aevict_for_database=AsyncMock())
+    )
+
+    await TursoGraphDatasetDatabaseHandler.delete_dataset(
+        _dataset_database(str(db_path), graph_db_name="dataset-id")
+    )
+
+    assert not db_path.exists()
+
+
+async def test_delete_dataset_skips_eviction_when_no_database_name(monkeypatch, tmp_path):
+    aevict = AsyncMock()
+    monkeypatch.setattr(
+        handler_module, "graph_engine_cache", SimpleNamespace(aevict_for_database=aevict)
+    )
+
+    await TursoGraphDatasetDatabaseHandler.delete_dataset(
+        _dataset_database(str(tmp_path / "graph_x.db"), graph_db_name="")
+    )
+
+    aevict.assert_not_called()
+
+
+async def test_delete_dataset_removes_file_at_real_create_dataset_url(monkeypatch, tmp_path):
+    """Same assertion as test_delete_dataset_removes_db_file_and_wal_companions,
+    but against the URL create_dataset itself actually builds on this OS,
+    not a hand-constructed clean path -- see module docstring."""
+    dataset_url = await _create_real_dataset_url(tmp_path)
+
+    # Write the fixture file the same way delete_dataset checks/removes it:
+    # raw os-level calls on the exact URL string, not pathlib (pathlib parses
+    # a path string into components and could disagree with os.path's/the
+    # OS's own resolution of an unusual string like this one).
+    fd = os.open(dataset_url, os.O_CREAT | os.O_WRONLY)
+    os.close(fd)
+    assert os.path.exists(dataset_url)
+
+    monkeypatch.setattr(
+        handler_module, "graph_engine_cache", SimpleNamespace(aevict_for_database=AsyncMock())
+    )
+
+    await TursoGraphDatasetDatabaseHandler.delete_dataset(
+        _dataset_database(dataset_url, graph_db_name="dataset-id")
+    )
+
+    assert not os.path.exists(dataset_url)
+
+
+async def test_delete_dataset_evicts_before_removing_file(monkeypatch, tmp_path):
+    """Eviction must complete (and wait for any in-flight close) BEFORE the
+    file is removed -- the whole reason for aevict_for_database over a bare
+    evict() is to not delete a file a just-evicted engine might still be
+    closing. A future refactor that reordered these two steps would still
+    pass every other test in this file, since they assert eviction and file
+    removal independently; this one asserts the sequence."""
+    db_path = tmp_path / "graph_dataset-id.db"
+    db_path.write_text("data")
+
+    call_order = []
+
+    async def fake_aevict(name):
+        call_order.append("evict")
+
+    real_remove = os.remove
+
+    def tracking_remove(path):
+        call_order.append("remove")
+        real_remove(path)
+
+    monkeypatch.setattr(
+        handler_module, "graph_engine_cache", SimpleNamespace(aevict_for_database=fake_aevict)
+    )
+    monkeypatch.setattr(handler_module.os, "remove", tracking_remove)
+
+    await TursoGraphDatasetDatabaseHandler.delete_dataset(
+        _dataset_database(str(db_path), graph_db_name="dataset-id")
+    )
+
+    assert call_order == ["evict", "remove"]


### PR DESCRIPTION
## Description

Ran into this while poking at dataset deletion on Turso — `delete_dataset()` was calling `evict()` with a cache key that never actually matched what `get_graph_engine()` stores it under, so the entry stayed cached with an open connection while we deleted the file out from under it. Switched to `aevict_for_database`, same pattern the Ladybug handler already uses, and now we await the eviction before touching the file. Also fixed the absolute-path check (`startswith("/")` never matches on Windows, so the file never got deleted there) by switching to `os.path.isabs()`. Since this adapter runs SQLite in WAL mode, added cleanup for the `-wal`/`-shm` companion files that can be left behind next to the main db file.

## Acceptance Criteria

- `delete_dataset()` evicts the actual cached engine entry (by database name), not a key that never matches.
- Eviction is awaited before the file is removed — no race between "engine still closing" and "file gone".
- The dataset's main db file is removed on both POSIX and Windows absolute paths.
- `-wal` / `-shm` companion files are cleaned up when present, and their absence doesn't raise.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.