### PR TITLE
fix(dataset-queue): bound distinct datasets, not (task, dataset) pairs (CLO-604 / #4673)

### DIFF
--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -105,6 +105,33 @@ def _make_release(semaphore: asyncio.Semaphore) -> Callable[[], None]:
     return _release
 
 
+def _noop_release() -> None:
+    """No-op releaser for a per-task dataset ``SlotEntry``.
+
+    The real semaphore permit is owned per dataset by ``_DatasetPermit`` and
+    freed exactly once by the last holder, so the per-task entry must not
+    release anything itself.
+    """
+    return None
+
+
+class _DatasetPermit:
+    """The single semaphore permit shared by every task using one dataset.
+
+    ``holders`` counts the tasks currently holding the dataset; the permit is
+    acquired when it rises 0 -> 1 and released when it falls back to 0. This is
+    what makes concurrent requests to the *same* dataset share ONE budget slot
+    (they share ONE engine — the cache pins a single proxy per dataset) instead
+    of each taking their own, which let a single hot dataset exhaust the budget.
+    """
+
+    __slots__ = ("release", "holders")
+
+    def __init__(self, release: Callable[[], None]) -> None:
+        self.release = release
+        self.holders = 0
+
+
 class SlotEntry:
     """A single acquired slot with a nesting depth counter."""
 
@@ -150,6 +177,60 @@ class DatasetQueue:
         # Track which tasks already have a done-callback registered so we
         # don't register multiple cleanup handlers for a single task.
         self._registered_tasks: Set[int] = set()
+        # Semaphore permits are owned per DATASET, not per (task, dataset):
+        # concurrent tasks on the same dataset share ONE permit, so a hot
+        # dataset can no longer exhaust the budget with its own concurrency.
+        # First holder acquires, last holder releases (see ensure_slot /
+        # _drop_dataset_holder). ``active_dataset_ids`` and the engine caches
+        # already keyed pinning by dataset; this aligns the permit with them.
+        self._dataset_permit: Dict[str, _DatasetPermit] = {}
+        # Per-dataset lock guarding the first-acquire / last-release transition
+        # so two tasks racing to be the first holder cannot double-acquire.
+        # Distinct datasets take distinct locks and never serialize together.
+        self._dataset_locks: Dict[str, asyncio.Lock] = {}
+
+    # ----------------------------------------------------- per-dataset permits
+    def _ds_lock(self, ds_key: str) -> asyncio.Lock:
+        """Return the lock guarding ``ds_key``'s first-acquire / last-release.
+
+        Created on first use and kept for the process lifetime: the number of
+        distinct datasets one process serves is bounded (one tenant per process
+        in the cloud deployment), and a lock is never removed because a
+        concurrent waiter may still hold a reference to it.
+        """
+        lock = self._dataset_locks.get(ds_key)
+        if lock is None:
+            lock = self._dataset_locks[ds_key] = asyncio.Lock()
+        return lock
+
+    def _drop_dataset_holder(self, ds_key: str, *, evict: bool) -> None:
+        """Decrement ``ds_key``'s permit; the last holder frees engines + slot.
+
+        Synchronous, so the async release path and the task-end backstop (a
+        done-callback that cannot await) share one implementation.
+
+        ``evict`` controls the engine teardown. The normal release path passes
+        ``evict=True``: on the last holder the subprocess engines are torn down
+        (kept warm under the idle TTL, force-close evicted otherwise) and then
+        the permit is freed. The task-end backstop passes ``evict=False``: it
+        runs in a done-callback, outside the crashed task's ContextVar context,
+        so it must not read that context to evict — it only frees the permit,
+        exactly as the pre-change backstop did (it never evicted either).
+
+        The permit is released in a ``finally`` so a raising teardown still
+        frees the semaphore slot, never leaking a permit.
+        """
+        permit = self._dataset_permit.get(ds_key)
+        if permit is None:
+            return
+        permit.holders -= 1
+        if permit.holders <= 0:
+            self._dataset_permit.pop(ds_key, None)
+            try:
+                if evict:
+                    self._release_subprocess_engines()
+            finally:
+                permit.release()
 
     # ------------------------------------------------------ active datasets
     def active_dataset_ids(self) -> set:
@@ -190,9 +271,16 @@ class DatasetQueue:
         def _release_all_on_done(_t: asyncio.Task, _tid: int = task_id) -> None:
             slots = self._task_slots.pop(_tid, {})
             self._registered_tasks.discard(_tid)
-            for entry in slots.values():
-                # Backstop: release whatever's left regardless of depth.
-                entry.release()
+            # Backstop for a task that exits without releasing. Dataset slots
+            # decrement the shared per-dataset permit (freeing it iff this was
+            # the last holder); scoped acquire() slots own their permit and
+            # release it directly. Runs in a done-callback (synchronous, no
+            # await), so it never interleaves inside a coroutine step.
+            for slot_key, entry in slots.items():
+                if slot_key.startswith("ds:"):
+                    self._drop_dataset_holder(slot_key, evict=False)
+                else:
+                    entry.release()
 
         task.add_done_callback(_release_all_on_done)
 
@@ -229,14 +317,30 @@ class DatasetQueue:
             entry.depth += 1
             return
 
-        # Acquire a fresh slot for this (task, dataset).
-        logger.debug("Task %d acquiring dataset queue slot for dataset_id=%s", task_id, dataset_id)
-        await self._semaphore.acquire()
-        release = _make_release(self._semaphore)
-
-        self._ensure_task_cleanup_registered(task, task_id)
-        # After registration, the task entry exists in ``_task_slots``.
-        self._task_slots[task_id][ds_key] = SlotEntry(release, depth=1)
+        # First time THIS task touches ds_key. The semaphore permit is owned
+        # per DATASET: concurrent tasks on the SAME dataset share ONE permit,
+        # because they share ONE engine (the cache pins a single proxy per
+        # dataset). Only the first holder acquires the semaphore; the last
+        # holder releases it (see _drop_dataset_holder). The per-dataset lock
+        # makes the "is there already a permit?" check and the acquire atomic,
+        # so two tasks racing to be the first holder cannot double-acquire; a
+        # task waiting for the budget on one dataset never blocks another.
+        async with self._ds_lock(ds_key):
+            permit = self._dataset_permit.get(ds_key)
+            if permit is None:
+                logger.debug(
+                    "Task %d acquiring dataset queue permit for dataset_id=%s",
+                    task_id,
+                    dataset_id,
+                )
+                await self._semaphore.acquire()
+                permit = _DatasetPermit(release=_make_release(self._semaphore))
+                self._dataset_permit[ds_key] = permit
+            permit.holders += 1
+            self._ensure_task_cleanup_registered(task, task_id)
+            # The per-task entry's releaser is a no-op: the shared permit is
+            # released by the last holder in _drop_dataset_holder, not here.
+            self._task_slots[task_id][ds_key] = SlotEntry(_noop_release, depth=1)
 
     # ----------------------------------------- subprocess engine teardown
     def _release_subprocess_engines(self) -> None:
@@ -423,25 +527,19 @@ class DatasetQueue:
         if entry.depth > 0:
             return
 
-        # About to fully release.  Release subprocess engines only when no
-        # other task holds the same dataset: kept warm under the idle TTL,
-        # force-close evicted otherwise (see ``_release_subprocess_engines``).
-        # The caller's response must not wait on the close of engines it has
-        # already finished using.
-        try:
-            other_holds = any(
-                ds_key in slots for tid, slots in self._task_slots.items() if tid != task_id
-            )
-            if not other_holds:
-                self._release_subprocess_engines()
-        finally:
-            self._task_slots.get(task_id, {}).pop(ds_key, None)
-            logger.debug(
-                "Task %d releasing dataset queue slot for dataset_id=%s",
-                task_id,
-                dataset_id,
-            )
-            entry.release()
+        # This task is fully done with ds_key. Drop its entry, then decrement
+        # the dataset-owned permit; the LAST holder across all tasks frees the
+        # subprocess engines (kept warm under the idle TTL, force-close evicted
+        # otherwise) and the single semaphore permit. The per-dataset lock
+        # serialises this against a concurrent ensure_slot sharing the permit.
+        self._task_slots.get(task_id, {}).pop(ds_key, None)
+        async with self._ds_lock(ds_key):
+            self._drop_dataset_holder(ds_key, evict=True)
+        logger.debug(
+            "Task %d releasing dataset queue slot for dataset_id=%s",
+            task_id,
+            dataset_id,
+        )
 
     # ---------------------------------------------------------------- acquire
     @asynccontextmanager

--- a/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue_per_dataset_permit.py
+++ b/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue_per_dataset_permit.py
@@ -1,0 +1,168 @@
+"""The dataset-queue budget bounds DISTINCT datasets, not (task, dataset) pairs.
+
+Regression tests for the cloud add/search hang (#4673): concurrent requests to
+the *same* dataset used to each take their own semaphore permit, so a single hot
+dataset hit by ``max_concurrent`` requests exhausted the whole budget and wedged
+every later ``/add`` and ``/search`` — even though those requests share ONE
+engine. The permit is now owned per dataset: the first holder acquires it, the
+last holder releases it.
+
+Engine teardown (``_release_subprocess_engines``) is patched out: these tests
+exercise the permit accounting, which is orthogonal to subprocess lifecycle.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
+
+
+def _queue(max_concurrent: int) -> DatasetQueue:
+    q = DatasetQueue(enabled=True, max_concurrent=max_concurrent, idle_ttl_seconds=0.0)
+    # Orthogonal to permit accounting, and needs no real DB context.
+    q._release_subprocess_engines = MagicMock()
+    return q
+
+
+async def _hold_same_dataset(q: DatasetQueue, n: int, ds: str):
+    """Spawn ``n`` tasks that all hold ``ds`` at once, then release together."""
+    entered = [asyncio.Event() for _ in range(n)]
+    release = asyncio.Event()
+
+    async def worker(i: int) -> None:
+        await q.ensure_slot(ds)
+        entered[i].set()
+        await release.wait()
+        await q.release_slot_for(ds)
+
+    tasks = [asyncio.create_task(worker(i)) for i in range(n)]
+    # Before the fix, only ``max_concurrent`` workers ever enter and this
+    # times out; after it, all ``n`` share one permit and enter immediately.
+    await asyncio.wait_for(asyncio.gather(*(e.wait() for e in entered)), timeout=3.0)
+    value_while_held = q._semaphore._value
+    active = q.active_dataset_ids()
+    release.set()
+    await asyncio.wait_for(asyncio.gather(*tasks), timeout=3.0)
+    return value_while_held, active
+
+
+def test_many_concurrent_requests_to_one_dataset_take_one_permit():
+    """N concurrent holders of the SAME dataset consume exactly one budget slot."""
+
+    async def body():
+        q = _queue(max_concurrent=2)
+        # 5 concurrent requests, budget of 2: pre-fix this wedges at the 3rd.
+        value_while_held, active = await _hold_same_dataset(q, n=5, ds="hot")
+        assert value_while_held == 1, (
+            f"one dataset must hold ONE permit; budget=2 → value should be 1, got {value_while_held}"
+        )
+        assert active == {"hot"}
+        # Everything released: full budget restored, last holder tore down once.
+        assert q._semaphore._value == 2
+        assert q.active_dataset_ids() == set()
+        q._release_subprocess_engines.assert_called_once()
+
+    asyncio.run(body())
+
+
+def test_distinct_datasets_still_bounded_by_budget():
+    """The fix must not remove the bound: DISTINCT datasets still cap at budget.
+
+    Each dataset is held by a live worker (a bare ``ensure_slot`` task would
+    finish and the task-end backstop would free its permit at once).
+    """
+
+    async def body():
+        q = _queue(max_concurrent=2)
+        entered = {ds: asyncio.Event() for ds in ("d0", "d1", "d2")}
+        release = {ds: asyncio.Event() for ds in ("d0", "d1", "d2")}
+
+        async def worker(ds: str):
+            await q.ensure_slot(ds)
+            entered[ds].set()
+            await release[ds].wait()
+            await q.release_slot_for(ds)
+
+        t0 = asyncio.create_task(worker("d0"))
+        t1 = asyncio.create_task(worker("d1"))
+        await asyncio.wait_for(
+            asyncio.gather(entered["d0"].wait(), entered["d1"].wait()), timeout=2.0
+        )
+        assert q._semaphore._value == 0, "two distinct datasets must consume both slots"
+
+        t2 = asyncio.create_task(worker("d2"))
+        await asyncio.sleep(0.2)
+        assert not entered["d2"].is_set(), "a 3rd distinct dataset must block on a full budget"
+
+        release["d0"].set()  # free one slot
+        await asyncio.wait_for(entered["d2"].wait(), timeout=2.0)  # d2 now proceeds
+        assert q._semaphore._value == 0
+
+        release["d1"].set()
+        release["d2"].set()
+        await asyncio.wait_for(asyncio.gather(t0, t1, t2), timeout=2.0)
+        assert q._semaphore._value == 2
+
+    asyncio.run(body())
+
+
+def test_last_holder_releases_not_the_first():
+    """Releasing all-but-one holder keeps the permit; the last one frees it."""
+
+    async def body():
+        q = _queue(max_concurrent=3)
+        holders = [asyncio.Event() for _ in range(3)]
+        go = asyncio.Event()
+        step = asyncio.Queue()
+
+        async def worker(i: int):
+            await q.ensure_slot("shared")
+            holders[i].set()
+            await go.wait()
+            await step.get()  # released one at a time by the test
+            await q.release_slot_for("shared")
+
+        tasks = [asyncio.create_task(worker(i)) for i in range(3)]
+        await asyncio.wait_for(asyncio.gather(*(h.wait() for h in holders)), timeout=3.0)
+        assert q._semaphore._value == 2  # one permit for three holders
+        go.set()
+
+        step.put_nowait(None)  # release holder 0
+        await asyncio.sleep(0.1)
+        assert q._semaphore._value == 2, "permit must survive while holders remain"
+        q._release_subprocess_engines.assert_not_called()
+
+        step.put_nowait(None)  # release holder 1
+        await asyncio.sleep(0.1)
+        assert q._semaphore._value == 2
+
+        step.put_nowait(None)  # release holder 2 — the last
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=3.0)
+        assert q._semaphore._value == 3, "last holder frees the permit"
+        q._release_subprocess_engines.assert_called_once()
+
+    asyncio.run(body())
+
+
+def test_same_task_reentrancy_uses_one_permit():
+    """Nested ensure_slot for one task+dataset is depth-counted, not re-acquired."""
+
+    async def body():
+        q = _queue(max_concurrent=2)
+        await q.ensure_slot("D")
+        await q.ensure_slot("D")  # re-entrant
+        assert q._semaphore._value == 1
+        await q.release_slot_for("D")  # depth 2 -> 1, still held
+        assert q._semaphore._value == 1
+        q._release_subprocess_engines.assert_not_called()
+        await q.release_slot_for("D")  # depth 1 -> 0, freed
+        assert q._semaphore._value == 2
+        q._release_subprocess_engines.assert_called_once()
+
+    asyncio.run(body())
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Description

Fixes the root cause of the cloud add/search hang in #4673: the dataset-queue budget was counting the **wrong thing**.

The dataset queue exists to keep the number of live per-dataset DB engines ≤ the engine LRU cache size (`DATABASE_MAX_LRU_CACHE_SIZE`, **4** on cloud), so the cache never evicts an engine a request is still using. But it acquired **one semaphore permit per `(task, dataset)`**. The engine cache pins a *single shared proxy per dataset*, so concurrent requests to the same dataset share **one** engine — yet each took its **own** permit. So `max_concurrent` concurrent requests to a single **hot dataset** exhausted the entire budget, and every later `/add` and `/search` blocked forever on the un-timed `acquire()`.

That's the 56-hour outage: `/health` and `/datasets` (which take no slot) stayed fast; `/add` and `/search` (which do) wedged.

## The fix

Make the permit **dataset-owned**, aligning it with the engine teardown, which was *already* dataset-scoped (`release_slot_for`: "release only when no other task holds the same dataset"):

- A `_DatasetPermit` per dataset holds the single permit + a holder count. First task to touch a dataset acquires; last to release frees it. **Concurrent requests to the same dataset now share one permit** — a hot dataset can't starve the budget with its own concurrency.
- A **per-dataset lock** makes the "is there already a permit?" check and the acquire atomic, so two tasks racing to be the first holder can't double-acquire. Distinct datasets take distinct locks — waiting for the budget on one dataset never blocks another.
- **Distinct datasets are still bounded exactly as before.**

## Scope — what this deliberately does *not* do

This fixes **only the mis-count**. Two complementary pieces belong in their own changes:

- **Load-shed timeout** (the useful half of #4690): `acquire()` is still un-timed here. Converting *genuine* saturation into a bounded 503 instead of a wait should land too — but it's orthogonal to counting the right thing.
- **The `/add` migration-lock wedge** is a separate front door, owned by #357 / a timeout on `run_migrations_and_block`.

## Acceptance Criteria

- [ ] N concurrent requests to one dataset consume **one** budget slot (was: N).
- [ ] N distinct datasets still consume N slots; an (N+1)th still blocks.
- [ ] The **last** holder — not the first — releases the permit and fires engine teardown.

## Test evidence

New regression test `test_dataset_queue_per_dataset_permit.py`:

```
# against current dev (unpatched):
test_many_concurrent_requests_to_one_dataset_take_one_permit → TimeoutError
  (the 3rd+ concurrent same-dataset request blocks on its own acquire)

# with this change:
4 passed  — same-dataset shares one permit; distinct datasets still bounded;
            last-holder release; same-task re-entrancy
```

All **45** existing queue unit tests + the integration suite pass (`48 passed`). Two existing tests caught real subtleties this change had to preserve, and did:
- the task-end backstop must free a slot **without** evicting (it runs in a done-callback, outside the crashed task's ContextVar context);
- a **raising** engine teardown must still release the permit (`finally`), never leaking a slot.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Notes / open questions

**Draft on purpose.** This touches `dataset_queue/queue.py` — the most eviction- and cross-event-loop-sensitive module in the tree (see its git history). The concurrency reasoning is in the code comments and the tests, but I'd want a **careful review + a load test** before merge, not just green CI. Happy to pair the load-shed timeout onto this or keep it separate — reviewer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
