### PR TITLE
COG-6343 feat: Resolve the UI backend URL at runtime

### DIFF
--- a/cognee-frontend/.env.template
+++ b/cognee-frontend/.env.template
@@ -1,3 +1,18 @@
-NEXT_PUBLIC_BACKEND_API_URL=http://localhost:8000/api
+# Backend the UI talks to.
+#
+# Read at run time, so the same built image (and the published
+# cognee/cognee-ui container) can be pointed anywhere:
+#
+#   docker run -e COGNEE_BACKEND_URL=http://cognee:8000 cognee/cognee-ui
+#
+# Leave it unset for the usual localhost setup: the browser then derives the
+# backend host from the address the UI was loaded from, on port 8000.
+# COGNEE_BACKEND_URL=http://localhost:8000
+
+# Build-time alternative, kept for existing setups. Baked into the bundle by
+# `next build`, so it cannot be changed on a prebuilt image.
+# NEXT_PUBLIC_LOCAL_API_URL=http://localhost:8000
+
 # The shared frontend defaults to cloud mode; OSS/local runs must opt out.
+# Already baked into the published image, so it only matters for `npm run dev`.
 NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT=false

--- a/cognee-frontend/src/app/(app)/api-keys/ApiKeysPage.tsx
+++ b/cognee-frontend/src/app/(app)/api-keys/ApiKeysPage.tsx
@@ -12,6 +12,7 @@ import getMyUserId from "@/modules/apiKeys/getMyUserId";
 import { TrackPageView, trackEvent } from "@/modules/analytics";
 import { isCloudEnvironment } from "@/utils";
 import { notifications } from "@mantine/notifications";
+import { getLocalApiUrl } from "@/modules/users/getLocalApiUrl";
 
 function StatusDot({ label, ready }: { label: string; ready: boolean }) {
   return (
@@ -47,15 +48,13 @@ function CheckIcon() {
   );
 }
 
-const localApiUrl = process.env.NEXT_PUBLIC_LOCAL_API_URL || "http://localhost:8000";
-
 export default function ApiKeysPage() {
   const { cogniInstance, serviceUrl, isInitializing } = useCogniInstance();
   const { tenant, hasAccess, tenantReady } = useTenant();
   const isCloud = isCloudEnvironment();
   // In cloud, never fall back to localhost — show the real tenant URL when known,
   // otherwise treat as provisioning. Only local/OSS mode uses localApiUrl.
-  const baseUrl = isCloud ? serviceUrl : (serviceUrl || localApiUrl);
+  const baseUrl = isCloud ? serviceUrl : (serviceUrl || getLocalApiUrl());
   const urlProvisioning = isCloud && !serviceUrl;
   const [keys, setKeys] = useState<ApiKey[]>([]);
   const [loading, setLoading] = useState(true);

--- a/cognee-frontend/src/app/api/local-signout/route.ts
+++ b/cognee-frontend/src/app/api/local-signout/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-
-const localApiUrl = process.env.NEXT_PUBLIC_LOCAL_API_URL || "http://localhost:8000";
+import { getServerBackendUrl } from "@/modules/config/serverRuntimeConfig";
 
 export async function GET(request: Request) {
+  const localApiUrl = getServerBackendUrl();
   // Call the local backend's logout endpoint to invalidate the session
   try {
     await fetch(`${localApiUrl}/api/v1/auth/logout`, {

--- a/cognee-frontend/src/app/api/runtime-config/route.ts
+++ b/cognee-frontend/src/app/api/runtime-config/route.ts
@@ -1,0 +1,18 @@
+import { collectRuntimeConfig } from "@/modules/config/serverRuntimeConfig";
+
+/**
+ * Diagnostics endpoint: reports the backend this container resolved.
+ *
+ * The app does not depend on it. Pages read their config from the inert JSON
+ * the root layout renders into <head>. This route exists so an operator can
+ * answer "what backend does this container think it has?" with a single curl,
+ * and so the image's HEALTHCHECK has something cheap to probe that also proves
+ * the configuration resolved rather than merely that a port is open.
+ */
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return Response.json(collectRuntimeConfig(), {
+    headers: { "Cache-Control": "no-store" },
+  });
+}

--- a/cognee-frontend/src/app/api/schema-provenance/route.ts
+++ b/cognee-frontend/src/app/api/schema-provenance/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-
-const localApiUrl = process.env.NEXT_PUBLIC_LOCAL_API_URL || "http://localhost:8000";
+import { getServerBackendUrl } from "@/modules/config/serverRuntimeConfig";
 
 // Proxies the cognee /v1/schema/provenance HTML view (memory-provenance graph:
 // Tenant -> User -> Agent -> Brain -> File -> memory) so it can be embedded in
 // an iframe. Mirrors the /api/visualize proxy, including default-user login.
 export async function GET(request: NextRequest) {
+  const localApiUrl = getServerBackendUrl();
   const headers: Record<string, string> = {};
   const cookie = request.headers.get("cookie");
   if (cookie) headers["cookie"] = cookie;

--- a/cognee-frontend/src/app/api/schema/inventory/route.ts
+++ b/cognee-frontend/src/app/api/schema/inventory/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-
-const localApiUrl = process.env.NEXT_PUBLIC_LOCAL_API_URL || "http://localhost:8000";
+import { getServerBackendUrl } from "@/modules/config/serverRuntimeConfig";
 
 export async function GET(request: NextRequest) {
+  const localApiUrl = getServerBackendUrl();
   const { searchParams } = request.nextUrl;
   const datasetId = searchParams.get("dataset_id");
   console.log("[api/schema/inventory] request received, dataset_id:", datasetId);

--- a/cognee-frontend/src/app/api/schema/provenance/route.ts
+++ b/cognee-frontend/src/app/api/schema/provenance/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-
-const localApiUrl = process.env.NEXT_PUBLIC_LOCAL_API_URL || "http://localhost:8000";
+import { getServerBackendUrl } from "@/modules/config/serverRuntimeConfig";
 
 export async function GET(request: NextRequest) {
+  const localApiUrl = getServerBackendUrl();
   const headers: Record<string, string> = {};
   const cookie = request.headers.get("cookie");
   if (cookie) headers["cookie"] = cookie;

--- a/cognee-frontend/src/app/api/visualize/route.ts
+++ b/cognee-frontend/src/app/api/visualize/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-
-const localApiUrl = process.env.NEXT_PUBLIC_LOCAL_API_URL || "http://localhost:8000";
+import { getServerBackendUrl } from "@/modules/config/serverRuntimeConfig";
 
 export async function GET(request: NextRequest) {
+  const localApiUrl = getServerBackendUrl();
   const datasetId = request.nextUrl.searchParams.get("dataset_id");
   if (!datasetId) {
     return NextResponse.json({ error: "dataset_id required" }, { status: 400 });

--- a/cognee-frontend/src/app/layout.tsx
+++ b/cognee-frontend/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { mantineHtmlProps, MantineProvider } from "@mantine/core";
 import theme from "@/ui/theme/theme";
 import { Notifications } from "@mantine/notifications";
 import QueryProvider from "@/modules/query/QueryProvider";
+import RuntimeConfigScript from "@/modules/config/RuntimeConfigScript";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -18,6 +19,11 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
+
+// RuntimeConfigScript below reads COGNEE_BACKEND_URL at render time. Without
+// this, the pages that Next can prerender would bake the value in at build
+// time and ignore whatever the container was started with.
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Cognee",
@@ -31,6 +37,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="h-full" {...mantineHtmlProps}>
+      <head>
+        <RuntimeConfigScript />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased h-full`}
       >

--- a/cognee-frontend/src/instrumentation.ts
+++ b/cognee-frontend/src/instrumentation.ts
@@ -1,1 +1,18 @@
-export async function register() {}
+import { getServerBackendUrl } from "@/modules/config/serverRuntimeConfig";
+
+/**
+ * Runs once when the server starts.
+ *
+ * Surfaces a broken COGNEE_BACKEND_URL in the first lines of the log rather
+ * than only in the 500 of whichever request happens to arrive first. The
+ * published image additionally refuses to start at all (see
+ * docker-entrypoint.sh); this covers the plain `next start` and
+ * `cognee-cli -ui` paths, where exiting the process is not ours to decide.
+ */
+export async function register() {
+  try {
+    getServerBackendUrl();
+  } catch (error) {
+    console.error(`[cognee-ui] ${(error as Error).message}`);
+  }
+}

--- a/cognee-frontend/src/modules/config/RuntimeConfigScript.tsx
+++ b/cognee-frontend/src/modules/config/RuntimeConfigScript.tsx
@@ -1,0 +1,21 @@
+import { RUNTIME_CONFIG_ELEMENT_ID, serializeRuntimeConfig } from "./runtimeConfig";
+import { collectRuntimeConfig } from "./serverRuntimeConfig";
+
+/**
+ * Renders the runtime config into <head> as inert JSON.
+ *
+ * Rendered from the root layout, which is marked force-dynamic so this is
+ * evaluated per request. Prerendering it would freeze the value into the
+ * build, which is precisely the problem this exists to solve.
+ */
+export default function RuntimeConfigScript() {
+  const config = serializeRuntimeConfig(collectRuntimeConfig());
+
+  return (
+    <script
+      id={RUNTIME_CONFIG_ELEMENT_ID}
+      type="application/json"
+      dangerouslySetInnerHTML={{ __html: config }}
+    />
+  );
+}

--- a/cognee-frontend/src/modules/config/__tests__/runtimeConfig.test.ts
+++ b/cognee-frontend/src/modules/config/__tests__/runtimeConfig.test.ts
@@ -1,0 +1,103 @@
+import {
+  RUNTIME_CONFIG_ELEMENT_ID,
+  normalizeBackendUrl,
+  serializeRuntimeConfig,
+  stripTrailingSlash,
+  readRuntimeConfig,
+} from "../runtimeConfig";
+
+function renderConfigElement(json: string): void {
+  const element = document.createElement("script");
+  element.id = RUNTIME_CONFIG_ELEMENT_ID;
+  element.type = "application/json";
+  element.textContent = json;
+  document.head.appendChild(element);
+}
+
+describe("normalizeBackendUrl", () => {
+  it("treats an unset, empty or blank value as not configured", () => {
+    expect(normalizeBackendUrl(undefined, "TEST_ENV")).toBeNull();
+    expect(normalizeBackendUrl("", "TEST_ENV")).toBeNull();
+    expect(normalizeBackendUrl("   ", "TEST_ENV")).toBeNull();
+  });
+
+  it("strips trailing slashes so concatenated paths stay single-slashed", () => {
+    expect(normalizeBackendUrl("http://cognee:8000/", "TEST_ENV")).toBe("http://cognee:8000");
+    expect(normalizeBackendUrl("http://cognee:8000///", "TEST_ENV")).toBe("http://cognee:8000");
+  });
+
+  it("rejects a host:port written without a scheme, the likeliest mistake", () => {
+    expect(() => normalizeBackendUrl("cognee:8000", "COGNEE_BACKEND_URL")).toThrow(
+      /COGNEE_BACKEND_URL must be an absolute http\(s\) URL, got "cognee:8000"/,
+    );
+  });
+
+  it("rejects protocols the browser cannot fetch from", () => {
+    expect(() => normalizeBackendUrl("ftp://cognee:8000", "COGNEE_BACKEND_URL")).toThrow(
+      /must be an absolute http\(s\) URL/,
+    );
+  });
+
+  it("rejects a value that only looks like a URL", () => {
+    expect(() => normalizeBackendUrl("http://", "COGNEE_BACKEND_URL")).toThrow(
+      /COGNEE_BACKEND_URL is not a valid URL/,
+    );
+  });
+});
+
+describe("serializeRuntimeConfig", () => {
+  it("escapes sequences that would break out of an inline script", () => {
+    const serialized = serializeRuntimeConfig({
+      backendUrl: "http://x/</script><script>alert(1)</script>",
+    });
+
+    expect(serialized).not.toContain("</script>");
+    expect(serialized).toContain("\\u003c");
+    expect(serialized).toContain("\\u003e");
+  });
+
+  it("escapes the line terminators that are legal in JSON but not in JS source", () => {
+    const serialized = serializeRuntimeConfig({
+      backendUrl: "http://x/\u2028\u2029",
+    });
+
+    expect(serialized).not.toContain("\u2028");
+    expect(serialized).not.toContain("\u2029");
+    expect(serialized).toContain("\\u2028");
+    expect(serialized).toContain("\\u2029");
+  });
+
+  it("round-trips through the same eval the browser performs", () => {
+    const config = { backendUrl: "https://cognee.example.com" };
+
+    expect(JSON.parse(serializeRuntimeConfig(config))).toEqual(config);
+  });
+});
+
+describe("readRuntimeConfig", () => {
+  afterEach(() => {
+    document.getElementById(RUNTIME_CONFIG_ELEMENT_ID)?.remove();
+  });
+
+  it("is empty when the server rendered nothing", () => {
+    expect(readRuntimeConfig()).toEqual({});
+  });
+
+  it("returns what the server rendered", () => {
+    renderConfigElement(JSON.stringify({ backendUrl: "http://cognee:8000" }));
+
+    expect(readRuntimeConfig()).toEqual({ backendUrl: "http://cognee:8000" });
+  });
+
+  it("degrades to the caller's fallback rather than throwing on a corrupt payload", () => {
+    renderConfigElement("{not json");
+
+    expect(readRuntimeConfig()).toEqual({});
+  });
+});
+
+describe("stripTrailingSlash", () => {
+  it("leaves a bare origin alone", () => {
+    expect(stripTrailingSlash("http://cognee:8000")).toBe("http://cognee:8000");
+  });
+});

--- a/cognee-frontend/src/modules/config/__tests__/serverRuntimeConfig.test.ts
+++ b/cognee-frontend/src/modules/config/__tests__/serverRuntimeConfig.test.ts
@@ -1,0 +1,75 @@
+import { collectRuntimeConfig, getServerBackendUrl } from "../serverRuntimeConfig";
+
+describe("server backend URL resolution", () => {
+  const original = {
+    runtime: process.env.COGNEE_BACKEND_URL,
+    buildTime: process.env.NEXT_PUBLIC_LOCAL_API_URL,
+  };
+
+  afterEach(() => {
+    for (const [key, value] of [
+      ["COGNEE_BACKEND_URL", original.runtime],
+      ["NEXT_PUBLIC_LOCAL_API_URL", original.buildTime],
+    ] as const) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("defaults to the local backend when nothing is configured", () => {
+    delete process.env.COGNEE_BACKEND_URL;
+    delete process.env.NEXT_PUBLIC_LOCAL_API_URL;
+
+    expect(getServerBackendUrl()).toBe("http://localhost:8000");
+  });
+
+  it("still honours a URL that was baked in at build time", () => {
+    delete process.env.COGNEE_BACKEND_URL;
+    process.env.NEXT_PUBLIC_LOCAL_API_URL = "http://baked-in:8000";
+
+    expect(getServerBackendUrl()).toBe("http://baked-in:8000");
+  });
+
+  it("prefers the runtime variable, which is the one a container can set", () => {
+    process.env.COGNEE_BACKEND_URL = "http://from-docker-run:9000/";
+    process.env.NEXT_PUBLIC_LOCAL_API_URL = "http://baked-in:8000";
+
+    expect(getServerBackendUrl()).toBe("http://from-docker-run:9000");
+  });
+
+  it("fails loudly instead of silently falling back", () => {
+    process.env.COGNEE_BACKEND_URL = "not-a-url";
+
+    expect(() => getServerBackendUrl()).toThrow(/COGNEE_BACKEND_URL/);
+  });
+});
+
+describe("collectRuntimeConfig", () => {
+  const original = {
+    runtime: process.env.COGNEE_BACKEND_URL,
+    buildTime: process.env.NEXT_PUBLIC_LOCAL_API_URL,
+  };
+
+  afterEach(() => {
+    for (const [key, value] of [
+      ["COGNEE_BACKEND_URL", original.runtime],
+      ["NEXT_PUBLIC_LOCAL_API_URL", original.buildTime],
+    ] as const) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("publishes nothing when no runtime URL is set, leaving the browser its own fallback", () => {
+    delete process.env.COGNEE_BACKEND_URL;
+    process.env.NEXT_PUBLIC_LOCAL_API_URL = "http://baked-in:8000";
+
+    expect(collectRuntimeConfig()).toEqual({ backendUrl: null });
+  });
+
+  it("publishes the runtime URL when one is set", () => {
+    process.env.COGNEE_BACKEND_URL = "https://cognee.example.com";
+
+    expect(collectRuntimeConfig()).toEqual({ backendUrl: "https://cognee.example.com" });
+  });
+});

--- a/cognee-frontend/src/modules/config/runtimeConfig.ts
+++ b/cognee-frontend/src/modules/config/runtimeConfig.ts
@@ -1,0 +1,97 @@
+/**
+ * Configuration the Next server hands to the browser on every request.
+ *
+ * `NEXT_PUBLIC_*` values are inlined into the client bundle when the app is
+ * built, so a published Docker image cannot be pointed at a different backend
+ * with `docker run -e ...`: every reader would still see whatever URL was
+ * baked in at build time. The server shell therefore renders the live
+ * environment into the document, and client readers prefer it over the
+ * build-time constant.
+ *
+ * It travels as `<script type="application/json">` in <head> rather than as an
+ * executable script, which removes the question of ordering. An executing
+ * snippet has to win a race against Next's async framework chunks, and
+ * next/script's "beforeInteractive" does not even try: it queues the URL for
+ * Next's own runtime to fetch after the bundle. Inert JSON needs only to be
+ * parsed, and <head> is finished before the body root element exists, so the
+ * data is in the DOM before React can render the component that reads it.
+ */
+
+export const RUNTIME_CONFIG_ELEMENT_ID = "cognee-runtime-config";
+
+export interface RuntimeConfig {
+  /** Absolute origin of the cognee backend, without a trailing slash. */
+  backendUrl: string | null;
+}
+
+/**
+ * Callers concatenate paths onto the backend URL ("/api/v1/..."), so a
+ * trailing slash would produce "//api" and miss on the backend.
+ */
+export function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+/**
+ * Normalise a configured backend URL, or return null when nothing is set.
+ *
+ * Throws when the value is set but unusable. A container started with a broken
+ * URL should say so in its logs, rather than quietly falling back to localhost
+ * and failing every request for a reason the operator cannot see.
+ */
+export function normalizeBackendUrl(
+  raw: string | undefined | null,
+  source: string,
+): string | null {
+  const value = raw?.trim();
+  if (!value) return null;
+
+  // Checked before parsing, because "cognee:8000" (the most likely mistake)
+  // is a *valid* URL with the scheme "cognee:", and reporting it as a protocol
+  // problem tells the operator nothing about what to type instead.
+  if (!/^https?:\/\//i.test(value)) {
+    throw new Error(
+      `${source} must be an absolute http(s) URL, got "${value}". Expected something like "http://cognee:8000".`,
+    );
+  }
+
+  try {
+    new URL(value);
+  } catch {
+    throw new Error(`${source} is not a valid URL: "${value}".`);
+  }
+
+  return stripTrailingSlash(value);
+}
+
+/**
+ * Client-side read of the config the server rendered into the document.
+ *
+ * Never throws: a missing or malformed element just means "not configured",
+ * and the caller's own fallback is a better outcome than a blank page.
+ */
+export function readRuntimeConfig(): Partial<RuntimeConfig> {
+  if (typeof document === "undefined") return {};
+
+  const element = document.getElementById(RUNTIME_CONFIG_ELEMENT_ID);
+  if (!element?.textContent) return {};
+
+  try {
+    return JSON.parse(element.textContent) as Partial<RuntimeConfig>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Serialise for embedding in the document. Escaped even though the payload is
+ * inert JSON: without it a value containing "</script>" would close the tag
+ * early and spill the rest into the page as markup.
+ */
+export function serializeRuntimeConfig(config: RuntimeConfig): string {
+  return JSON.stringify(config)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}

--- a/cognee-frontend/src/modules/config/serverRuntimeConfig.ts
+++ b/cognee-frontend/src/modules/config/serverRuntimeConfig.ts
@@ -1,0 +1,37 @@
+import { normalizeBackendUrl, type RuntimeConfig } from "./runtimeConfig";
+
+/**
+ * Read at request time, which is what lets one published image serve any
+ * backend. Deliberately not NEXT_PUBLIC_-prefixed: that prefix means "inline
+ * this at build time", the exact behaviour this variable exists to avoid.
+ */
+const BACKEND_URL_ENV = "COGNEE_BACKEND_URL";
+
+/** Still honoured so builds that baked in a URL keep working. */
+const BUILD_TIME_ENV = "NEXT_PUBLIC_LOCAL_API_URL";
+
+const DEFAULT_BACKEND_URL = "http://localhost:8000";
+
+/** The backend this server process should call from route handlers. */
+export function getServerBackendUrl(): string {
+  return (
+    normalizeBackendUrl(process.env.COGNEE_BACKEND_URL, BACKEND_URL_ENV) ??
+    normalizeBackendUrl(process.env.NEXT_PUBLIC_LOCAL_API_URL, BUILD_TIME_ENV) ??
+    DEFAULT_BACKEND_URL
+  );
+}
+
+/**
+ * The config advertised to the browser.
+ *
+ * Only COGNEE_BACKEND_URL is published: NEXT_PUBLIC_LOCAL_API_URL is already
+ * inlined in the client bundle, and the localhost default is deliberately left
+ * out so the browser keeps its own smarter fallback: deriving the backend
+ * host from window.location, which also works when the UI is reached from
+ * another machine.
+ */
+export function collectRuntimeConfig(): RuntimeConfig {
+  return {
+    backendUrl: normalizeBackendUrl(process.env.COGNEE_BACKEND_URL, BACKEND_URL_ENV),
+  };
+}

--- a/cognee-frontend/src/modules/users/__tests__/getLocalApiUrl.test.ts
+++ b/cognee-frontend/src/modules/users/__tests__/getLocalApiUrl.test.ts
@@ -5,6 +5,15 @@
  * @jest-environment-options {"url": "http://127.0.0.1:3000/local-login"}
  */
 import { getLocalApiUrl } from "../getLocalApiUrl";
+import { RUNTIME_CONFIG_ELEMENT_ID } from "@/modules/config/runtimeConfig";
+
+function renderRuntimeConfig(backendUrl: string | null): void {
+  const element = document.createElement("script");
+  element.id = RUNTIME_CONFIG_ELEMENT_ID;
+  element.type = "application/json";
+  element.textContent = JSON.stringify({ backendUrl });
+  document.head.appendChild(element);
+}
 
 describe("getLocalApiUrl", () => {
   const originalUrl = window.location.href;
@@ -12,6 +21,7 @@ describe("getLocalApiUrl", () => {
 
   afterEach(() => {
     window.history.replaceState({}, "", originalUrl);
+    document.getElementById(RUNTIME_CONFIG_ELEMENT_ID)?.remove();
     if (originalOverride === undefined) {
       delete process.env.NEXT_PUBLIC_LOCAL_API_URL;
     } else {
@@ -28,6 +38,29 @@ describe("getLocalApiUrl", () => {
   it("keeps an explicitly configured API URL unchanged", () => {
     process.env.NEXT_PUBLIC_LOCAL_API_URL = "https://api.example.com";
 
+    expect(getLocalApiUrl()).toBe("https://api.example.com");
+  });
+
+  it("prefers the server-injected runtime config over the build-time value", () => {
+    process.env.NEXT_PUBLIC_LOCAL_API_URL = "https://baked-in.example.com";
+    renderRuntimeConfig("https://from-docker-run.example.com");
+
+    expect(getLocalApiUrl()).toBe("https://from-docker-run.example.com");
+  });
+
+  it("falls through to the build-time value when the image ships no runtime config", () => {
+    process.env.NEXT_PUBLIC_LOCAL_API_URL = "https://baked-in.example.com";
+    renderRuntimeConfig(null);
+
+    expect(getLocalApiUrl()).toBe("https://baked-in.example.com");
+  });
+
+  it("normalises trailing slashes from either source", () => {
+    renderRuntimeConfig("https://api.example.com/");
+    expect(getLocalApiUrl()).toBe("https://api.example.com");
+
+    document.getElementById(RUNTIME_CONFIG_ELEMENT_ID)?.remove();
+    process.env.NEXT_PUBLIC_LOCAL_API_URL = "https://api.example.com/";
     expect(getLocalApiUrl()).toBe("https://api.example.com");
   });
 });

--- a/cognee-frontend/src/modules/users/getLocalApiUrl.ts
+++ b/cognee-frontend/src/modules/users/getLocalApiUrl.ts
@@ -1,8 +1,15 @@
+import { readRuntimeConfig, stripTrailingSlash } from "@/modules/config/runtimeConfig";
+
 const DEFAULT_LOCAL_API_PORT = "8000";
 
 export function getLocalApiUrl(): string {
+  // Runtime config wins: it is the only source a published Docker image can
+  // change, because NEXT_PUBLIC_* is frozen into the bundle at build time.
+  const runtimeUrl = readRuntimeConfig().backendUrl;
+  if (runtimeUrl) return stripTrailingSlash(runtimeUrl);
+
   const configuredUrl = process.env.NEXT_PUBLIC_LOCAL_API_URL;
-  if (configuredUrl) return configuredUrl;
+  if (configuredUrl) return stripTrailingSlash(configuredUrl);
 
   if (typeof window !== "undefined") {
     return `${window.location.protocol}//${window.location.hostname}:${DEFAULT_LOCAL_API_PORT}`;

--- a/cognee-frontend/src/modules/users/getLocalUser.ts
+++ b/cognee-frontend/src/modules/users/getLocalUser.ts
@@ -2,8 +2,6 @@
 
 import CogneeUser from "./CogneeUser";
 
-const localApiUrl = process.env.NEXT_PUBLIC_LOCAL_API_URL || "http://localhost:8000";
-
 export default async function getLocalUser(): Promise<CogneeUser | null> {
   // In local mode, we can't use Auth0 session.
   // Return a placeholder user — the actual auth is handled by


### PR DESCRIPTION
## Description

`NEXT_PUBLIC_*` gets inlined into the bundle at build time, so a prebuilt UI image can't be pointed at any other backend. Adds `COGNEE_BACKEND_URL`, read per request, rendered into `<head>` as inert JSON that the client reads before anything else runs.

Went with JSON instead of a script because both script options lose a race: `next/script beforeInteractive` doesn't emit a `<script src>` in Next 16 at all, it queues the URL for Next's runtime to fetch after the bundle, and an inline script in `<body>` lands after the async `_next` chunks. JSON in `<head>` only has to be parsed, so there's no race to lose.

Order is now: runtime config, then `NEXT_PUBLIC_LOCAL_API_URL`, then the existing `window.location` fallback. Unset behaves exactly like before.

Also drops `NEXT_PUBLIC_BACKEND_API_URL`, which compose set and `.env.template` documented but nothing read, and pulls the eight scattered call sites into one place.

Cost: `force-dynamic` on the root layout, which makes 12 prerendered routes render per request. They're all client pages with an empty shell, so it's cheap, but shout if you'd rather solve it another way.

## Acceptance Criteria

* `COGNEE_BACKEND_URL` changes the backend with no rebuild
* Unset behaves as before
* `NEXT_PUBLIC_LOCAL_API_URL` still works
* Bad value fails loudly and names the variable instead of falling back to localhost
* Trailing slashes normalised (`http://host:8000/` used to produce `//api`)

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

```
$ npx tsc --noEmit -p tsconfig.json
(no output)

$ npx jest
Test Suites: 14 passed, 14 total
Tests:       124 passed, 124 total

$ npm run build
✓ Compiled successfully in 2.2s
```

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.