### PR TITLE
fix: PlainFileHandler never rotates, regression of #2538

### DIFF
--- a/cognee/shared/logging_utils.py
+++ b/cognee/shared/logging_utils.py
@@ -160,6 +160,23 @@ class PlainFileHandler(logging.handlers.RotatingFileHandler):
             if self.stream is None:
                 self.stream = self._open()
 
+            # This method fully overrides RotatingFileHandler.emit() (needed
+            # for structlog-aware formatting below), which means the parent
+            # class's rotation trigger (shouldRollover()/doRollover(), called
+            # from ITS emit()) is never reached -- maxBytes/backupCount were
+            # accepted by __init__ but had no effect. Check size directly
+            # instead of calling self.shouldRollover(record): its stock
+            # implementation estimates the pending message's length via
+            # self.format(record), which assumes a plain-string message --
+            # this handler exists specifically for structlog dict-shaped
+            # records (record.msg is often a dict), so running the stock
+            # formatter just to estimate a length risks raising on the very
+            # record this check is meant to protect.
+            if self.maxBytes > 0:
+                self.stream.seek(0, 2)
+                if self.stream.tell() >= self.maxBytes:
+                    self.doRollover()
+
             # Extract the message from the structlog record
             if isinstance(record.msg, dict) and "event" in record.msg:
                 # Extract the basic message


### PR DESCRIPTION
## Summary
- `PlainFileHandler.emit()` fully overrides `RotatingFileHandler.emit()` (needed for its structlog dict-message formatting) and never calls `shouldRollover()`/`doRollover()`. `maxBytes`/`backupCount` are accepted and stored, and the class docstring claims automatic rotation, but nothing ever triggers it.
- This is a regression of #2538: that issue was closed by switching this class's base from `FileHandler` to `RotatingFileHandler`, but the pre-existing `emit()` override was never updated to actually call the rotation check, so the original unbounded-growth symptom recurs under a different shape (one huge file instead of many small ones).
- Confirmed locally: an install with `LOG_FILE_NAME` pinned to one path grew that file to 297MB with zero `.1`/`.2` backups ever appearing.
- Fix adds a direct stream-size check rather than calling `self.shouldRollover(record)` — its stock implementation estimates the pending message's length via `self.format(record)`, which assumes a plain-string message. Since this handler exists specifically for structlog dict-shaped records (`record.msg` is often a `dict`), running the stock formatter just to estimate a length risks raising on the very record the check is meant to protect.

Fixes #4823

## Test plan
- [x] `python -m py_compile cognee/shared/logging_utils.py`
- [x] Isolated test: 200 real structlog dict-message `logger.info({"event": ..., "logger": ...})` calls against a throwaway file with `maxBytes=2000, backupCount=2` — rotation fires correctly, `.1`/`.2` backups created, current file stays bounded, zero exceptions raised by the new check, zero malformed/truncated lines in any retained file.
- [ ] Not run against the full test suite in this environment — happy to adjust based on CI/maintainer feedback.