### PR TITLE
COG-6475 fix: classify budget exhaustion in embedding path

### DIFF
--- a/cognee/infrastructure/databases/exceptions/__init__.py
+++ b/cognee/infrastructure/databases/exceptions/__init__.py
@@ -10,6 +10,7 @@ from .exceptions import (
     UnsupportedProvenanceCapability,
     DatabaseNotCreatedError,
     EmbeddingContextWindowTooSmallError,
+    EmbeddingCredentialsError,
     EmbeddingException,
     MissingQueryParameterError,
     MutuallyExclusiveQueryParametersError,

--- a/cognee/infrastructure/databases/exceptions/exceptions.py
+++ b/cognee/infrastructure/databases/exceptions/exceptions.py
@@ -136,6 +136,28 @@ class EmbeddingContextWindowTooSmallError(EmbeddingException):
         super().__init__(message, name, status_code)
 
 
+class EmbeddingCredentialsError(EmbeddingException):
+    """
+    Raised when the embedding endpoint rejects the request's credentials.
+
+    Covers both directions: credentials the server does not accept (401) and
+    credentials it accepts but does not permit for this model or organization
+    (403). Neither can clear inside a retry window, so engines raise this
+    instead of the provider's own class: keeping the failure inside the
+    ``CogneeApiError`` family is what lets the API return an actionable 422
+    rather than a 500, while listing it as terminal is what stops the backoff
+    ladder. The provider's own message is carried through as *message*.
+    """
+
+    def __init__(
+        self,
+        message: str = "Embedding endpoint rejected the credentials.",
+        name: str = "EmbeddingCredentialsError",
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+    ):
+        super().__init__(message, name, status_code)
+
+
 class MissingQueryParameterError(CogneeValidationError):
     """
     Raised when neither 'query_text' nor 'query_vector' is provided,

--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -251,6 +251,14 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
                 return handle_embedding_response(text, embedding_response, self.dimensions)
 
         except litellm.exceptions.BadRequestError as error:
+            # A spend cap can arrive as a 400 depending on how the proxy maps it, and this
+            # clause catches every BadRequestError before the conversion further down, so
+            # without this the same failure surfaces as a raw provider error on one
+            # transport status and as the 402 on another. Ahead of the length check because
+            # a budget rejection carries no length wording, so it would fall through to the
+            # bare re-raise below and never reach any conversion at all.
+            raise_if_budget_exhausted(error)
+
             # ContextWindowExceededError subclasses BadRequestError. litellm raises
             # it for chat context-length errors, but the embeddings API returns a
             # plain BadRequestError for over-length input (OpenAI 400: "maximum input

--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -10,7 +10,6 @@ from tenacity import (
     retry,
     stop_after_delay,
     wait_exponential_jitter,
-    retry_if_not_exception_type,
     before_sleep_log,
 )
 import litellm
@@ -23,6 +22,10 @@ from cognee.infrastructure.databases.exceptions import (
     EmbeddingException,
 )
 
+from cognee.infrastructure.databases.vector.embeddings.retry_config import (
+    embedding_retry_condition,
+)
+from cognee.infrastructure.llm.exceptions import raise_if_budget_exhausted
 from cognee.infrastructure.llm.tokenizer.resolver import resolve_embedding_tokenizer
 from cognee.shared.rate_limiting import embedding_rate_limiter_context_manager
 from cognee.infrastructure.databases.vector.embeddings.utils import (
@@ -152,14 +155,14 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
         # ~2 minutes of user wall clock on a mis-typed API key. Superset of
         # the LLM adapter exclusion set (adds PermissionDeniedError); see
         # cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py.
-        retry=retry_if_not_exception_type(
-            (
-                EmbeddingContextWindowTooSmallError,
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                litellm.exceptions.PermissionDeniedError,
-                asyncio.CancelledError,
-            )
+        # Budget exhaustion is terminal as well, but it is classified by
+        # predicate rather than by class: see embeddings/retry_config.py.
+        retry=embedding_retry_condition(
+            EmbeddingContextWindowTooSmallError,
+            litellm.exceptions.NotFoundError,
+            litellm.exceptions.AuthenticationError,
+            litellm.exceptions.PermissionDeniedError,
+            asyncio.CancelledError,
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
@@ -319,7 +322,7 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
             litellm.exceptions.PermissionDeniedError,
         ):
             # Terminal auth failures must reach tenacity unwrapped so
-            # ``retry_if_not_exception_type`` can short-circuit the backoff
+            # ``embedding_retry_condition`` can short-circuit the backoff
             # ladder. Deliberately diverges from the EmbeddingException
             # contract of the other branches: keeping the litellm class (and
             # its message) intact lets the CLI's first-run remediation match
@@ -335,6 +338,13 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
             raise EmbeddingException(f"Failed to index data points using model {self.model}") from e
 
         except Exception as error:
+            # A proxy spend cap lands here, either as litellm's own
+            # BudgetExceededError or as the plain RateLimitError the client gets
+            # for a proxy 429. Raise the same actionable 402 the LLM path does,
+            # so the failure is not buried under the endpoint-and-settings
+            # message below, which points at the wrong problem entirely.
+            raise_if_budget_exhausted(error)
+
             # Fall back to a clear, actionable message for connectivity/misconfiguration issues
             logger.error(
                 "Error embedding text: %s. EMBEDDING_ENDPOINT='%s'.",

--- a/cognee/infrastructure/databases/vector/embeddings/OllamaEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/OllamaEmbeddingEngine.py
@@ -12,12 +12,15 @@ from tenacity import (
     retry,
     stop_after_delay,
     wait_exponential_jitter,
-    retry_if_not_exception_type,
     before_sleep_log,
 )
 
 from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import EmbeddingEngine
 from cognee.infrastructure.databases.exceptions import EmbeddingException
+from cognee.infrastructure.databases.vector.embeddings.retry_config import (
+    embedding_retry_condition,
+)
+from cognee.infrastructure.llm.exceptions import raise_if_budget_exhausted
 from cognee.infrastructure.llm.tokenizer.resolver import resolve_embedding_tokenizer
 from cognee.shared.rate_limiting import embedding_rate_limiter_context_manager
 from cognee.shared.utils import create_secure_ssl_context
@@ -108,6 +111,11 @@ class OllamaEmbeddingEngine(EmbeddingEngine):
             )
             return handle_embedding_response(original_texts, embeddings, self.dimensions)
         except Exception as error:
+            # A spend cap is terminal and is neither a context-window nor a
+            # connectivity problem, so it must not fall through to the branches
+            # below. Same actionable 402 the other engines raise.
+            raise_if_budget_exhausted(error)
+
             error_str = str(error).lower()
             context_error_patterns = (
                 "context length",
@@ -154,8 +162,22 @@ class OllamaEmbeddingEngine(EmbeddingEngine):
     @retry(
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(8, 128),
-        retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, ValueError, asyncio.CancelledError)
+        # Budget exhaustion is terminal here too: EMBEDDING_ENDPOINT is not
+        # validated for provider shape, and a proxy's OpenAI-shaped response
+        # body is handled by the "data" branch below, so this engine can be
+        # pointed at a LiteLLM proxy and reach its spend cap. The rejection
+        # arrives as a RuntimeError built from the error body, which no type
+        # tuple can match -- see embeddings/retry_config.py.
+        #
+        # Not at parity with the other two engines: rebuilding the failure as a
+        # bare RuntimeError drops the status code and the response object, so
+        # only the message-text signal survives. A rejection whose body carries
+        # ``type: budget_exceeded`` but no budget sentence, or a reworded or
+        # truncated sentence, is not classified here and runs the full ladder.
+        # Closing that means classifying inside ``_get_embedding``, while the
+        # status and the parsed body are still in hand.
+        retry=embedding_retry_condition(
+            litellm.exceptions.NotFoundError, ValueError, asyncio.CancelledError
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
@@ -186,7 +208,13 @@ class OllamaEmbeddingEngine(EmbeddingEngine):
                     data = await response.json()
 
                     if "error" in data:
-                        error_msg = data["error"]
+                        # The body shape varies by server: Ollama sends a string,
+                        # an OpenAI-compatible proxy sends an object, and either
+                        # can send null. Coerce before the membership tests below,
+                        # which would otherwise test dict keys (always False) or
+                        # raise TypeError on None, turning a terminal over-length
+                        # error into a retryable one that burns the full ladder.
+                        error_msg = str(data["error"])
                         logger.error(f"Ollama embedding error: {error_msg}")
                         if "context length" in error_msg or "input length" in error_msg:
                             raise ValueError(f"Text too long for embedding model: {error_msg}")

--- a/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
@@ -20,6 +20,7 @@ from typing import List, Optional
 
 import httpx
 import numpy as np
+import openai
 from openai import AsyncOpenAI
 from tenacity import (
     before_sleep_log,
@@ -42,6 +43,7 @@ from cognee.infrastructure.databases.vector.embeddings.utils import (
 )
 from cognee.infrastructure.databases.exceptions import (
     EmbeddingContextWindowTooSmallError,
+    EmbeddingCredentialsError,
     EmbeddingException,
 )
 from cognee.shared.rate_limiting import embedding_rate_limiter_context_manager
@@ -121,7 +123,10 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
         # OpenAI-compatible base URL, a LiteLLM proxy included. It is classified
         # by predicate rather than by class -- see embeddings/retry_config.py.
         retry=embedding_retry_condition(
-            EmbeddingContextWindowTooSmallError, ValueError, asyncio.CancelledError
+            EmbeddingContextWindowTooSmallError,
+            EmbeddingCredentialsError,
+            ValueError,
+            asyncio.CancelledError,
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
@@ -224,6 +229,31 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
                 raise EmbeddingException(
                     "Cannot connect to embedding endpoint. Check EMBEDDING_ENDPOINT."
                 ) from error
+
+            if isinstance(error, (openai.AuthenticationError, openai.PermissionDeniedError)):
+                # Terminal credential failures are re-raised as a cognee type,
+                # not as the openai class: the class is what the exclusion list
+                # cannot use (the generic wrap below would hide it from the
+                # predicate anyway), and staying inside CogneeApiError is what
+                # keeps the API's 422 instead of falling through a router's
+                # ``except Exception`` into a 500. Diverges from
+                # LiteLLMEmbeddingEngine, which re-raises litellm's class bare so
+                # the CLI's remediation can match its message; that message shape
+                # is litellm's, not this SDK's, so the rationale does not carry
+                # over. The provider's text is preserved in the message instead.
+                #
+                # NotFoundError is deliberately left retryable here, unlike in
+                # LiteLLMEmbeddingEngine: an ingress or reverse proxy in front of
+                # a self-hosted server can 404 transiently during a rolling
+                # deploy, which is realistic for exactly this engine. The cost is
+                # that a permanent 404 (a typo'd model name, a wrong base path)
+                # still burns the full ladder.
+                logger.error(
+                    "Embedding endpoint rejected the request: %s. EMBEDDING_ENDPOINT='%s'.",
+                    str(error),
+                    self.endpoint,
+                )
+                raise EmbeddingCredentialsError(str(error)) from error
 
             logger.error(
                 "Error embedding text: %s. EMBEDDING_ENDPOINT='%s'.",

--- a/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
@@ -24,7 +24,6 @@ from openai import AsyncOpenAI
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     stop_after_delay,
     wait_exponential_jitter,
 )
@@ -32,6 +31,10 @@ from tenacity import (
 from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import (
     EmbeddingEngine,
 )
+from cognee.infrastructure.databases.vector.embeddings.retry_config import (
+    embedding_retry_condition,
+)
+from cognee.infrastructure.llm.exceptions import raise_if_budget_exhausted
 from cognee.infrastructure.llm.tokenizer.resolver import resolve_embedding_tokenizer
 from cognee.infrastructure.databases.vector.embeddings.utils import (
     handle_embedding_response,
@@ -114,8 +117,11 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
     @retry(
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type(
-            (EmbeddingContextWindowTooSmallError, ValueError, asyncio.CancelledError)
+        # Budget exhaustion is terminal too: this engine talks to any
+        # OpenAI-compatible base URL, a LiteLLM proxy included. It is classified
+        # by predicate rather than by class -- see embeddings/retry_config.py.
+        retry=embedding_retry_condition(
+            EmbeddingContextWindowTooSmallError, ValueError, asyncio.CancelledError
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
@@ -161,6 +167,11 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
             embeddings = [item.embedding for item in response.data]
 
         except Exception as error:
+            # A proxy spend cap is terminal, and none of the branches below can
+            # read it correctly: it is neither a context-window problem nor a
+            # connectivity one. Raise the same actionable 402 the LLM path does.
+            raise_if_budget_exhausted(error)
+
             error_str = str(error).lower()
 
             # Handle context window exceeded by splitting input

--- a/cognee/infrastructure/databases/vector/embeddings/retry_config.py
+++ b/cognee/infrastructure/databases/vector/embeddings/retry_config.py
@@ -1,0 +1,46 @@
+"""Shared tenacity retry policy for embedding calls.
+
+The mirror of ``cognee.infrastructure.llm.retry_config`` for the embedding side:
+each engine keeps its own terminal error classes at the decorator, while the one
+rule every engine needs -- a spend cap cannot clear by retrying -- lives here.
+
+Budget exhaustion cannot be recognised by exception class:
+
+* ``litellm.BudgetExceededError`` subclasses plain ``Exception``, so no base
+  class in a type tuple can match it;
+* against a LiteLLM *proxy* -- the deployment where budgets are configured at
+  all -- the client never receives that class. The proxy raises it server-side
+  and the client-side litellm maps the status to an ordinary ``RateLimitError``;
+* the engines re-raise provider failures as ``EmbeddingException(...) from
+  error``, which hides the provider class from ``retry_if_not_exception_type``
+  even when the class would have matched.
+
+``is_budget_exhausted_error`` classifies on the signals that survive all three
+(a 402 status, litellm's own class, the proxy's ``budget_exceeded`` body, and
+the provider's budget sentence) and walks the ``__cause__`` chain, so it is
+applied as a predicate rather than as a type tuple.
+"""
+
+from tenacity import retry_if_exception
+
+from cognee.infrastructure.llm.exceptions import (
+    LLMPaymentRequiredError,
+    is_budget_exhausted_error,
+)
+
+
+def embedding_retry_condition(*terminal_types: type[BaseException]) -> retry_if_exception:
+    """Retry transient failures, but never *terminal_types* or budget exhaustion.
+
+    ``LLMPaymentRequiredError`` is terminal for every engine, so an engine that
+    converts a budget rejection into the actionable 402 itself does not then run
+    the backoff ladder on its own exception.
+    """
+    non_retryable: tuple[type[BaseException], ...] = (LLMPaymentRequiredError, *terminal_types)
+
+    def should_retry(error: BaseException) -> bool:
+        if isinstance(error, non_retryable):
+            return False
+        return not is_budget_exhausted_error(error)
+
+    return retry_if_exception(should_retry)

--- a/cognee/tests/unit/infrastructure/llm/test_budget_exhaustion.py
+++ b/cognee/tests/unit/infrastructure/llm/test_budget_exhaustion.py
@@ -68,6 +68,14 @@ LITELLM_BUDGET_MESSAGES = [
     # Shape 3 -- per-model budget caps (model_max_budget_limiter.py:80,135)
     "LiteLLM Virtual Key: tok, key_alias: ka, exceeded budget for model=gpt-4o",
     "LiteLLM End User: e1, exceeded budget for model=gpt-4o",
+    # Observed verbatim from a real proxy (ghcr.io/berriai/litellm:main-stable,
+    # a virtual key driven past its cap, HTTP 429) rather than read from
+    # litellm's source. Appended rather than inserted: index 0 is the default
+    # for ``_wrapped_budget_error`` and other tests key off its exact wording.
+    # The key alias and key hint sit mid-sentence, which is the span the bounded
+    # wildcard in ``_BUDGET_SENTENCE_RE`` has to cross.
+    "Budget has been exceeded! Key=my-key-alias (sk-...-VGw) "
+    "Current cost: 20.00066499999998, Max budget: 0.01",
 ]
 
 # Prose that a cognified document could plausibly contain. None of it may be

--- a/cognee/tests/unit/test_embedding_budget_fastfail.py
+++ b/cognee/tests/unit/test_embedding_budget_fastfail.py
@@ -156,11 +156,12 @@ async def test_litellm_proxy_budget_rejection_bypasses_retry(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_litellm_budget_rejection_as_bad_request_bypasses_retry(monkeypatch):
-    """A budget rejection arriving as a 400 still fails fast.
+    """A budget rejection arriving as a 400 gets the same 402 as every other shape.
 
-    This shape is re-raised unchanged by the ``BadRequestError`` handler, ahead
-    of the 402 conversion, so it keeps the litellm class. What matters is that
-    the retry predicate classifies it: no ladder either way.
+    The proxy's transport status must not decide the API error family: this is the
+    same spend cap as the 429 above, so the caller must not have to handle two
+    types for it. The ``BadRequestError`` clause catches this before the handler
+    that converts, so the conversion has to happen inside that clause.
     """
     monkeypatch.setenv("MOCK_EMBEDDING", "false")
     engine = LiteLLMEmbeddingEngine(dimensions=4)
@@ -177,10 +178,12 @@ async def test_litellm_budget_rejection_as_bad_request_bypasses_retry(monkeypatc
 
     monkeypatch.setattr(litellm, "aembedding", _raise_bad_request_budget)
 
-    with pytest.raises(litellm.exceptions.BadRequestError):
+    with pytest.raises(LLMPaymentRequiredError) as exc_info:
         await engine.embed_text(["hello world"])
 
     assert calls["count"] == 1
+    assert exc_info.value.status_code == 402
+    assert "Budget has been exceeded" in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/test_embedding_budget_fastfail.py
+++ b/cognee/tests/unit/test_embedding_budget_fastfail.py
@@ -1,0 +1,398 @@
+"""Regression test: the embedding path must NOT retry a budget rejection.
+
+Rationale (COG-6475): a LiteLLM spend cap cannot clear inside a retry window,
+but the embedding engines classified terminal errors by exception class only, so
+a budget rejection ran the full ``stop_after_delay(128)`` ladder -- 7 attempts,
+~130s -- for every doomed batch. Embedding batches are gated by a semaphore of
+``embedding_max_concurrent_data_points // batch_size`` (4 by default), so each
+doomed batch also holds a slot for that whole time.
+
+Class-based exclusion cannot fix this, which is why these tests exercise the
+engines rather than a type tuple:
+
+* ``litellm.BudgetExceededError`` subclasses plain ``Exception``;
+* against a LiteLLM proxy the client receives an ordinary ``RateLimitError``
+  instead of that class;
+* the engines re-raise provider failures as ``EmbeddingException(...) from
+  error``, so by the time tenacity sees the failure the provider class is gone.
+
+Both failure directions matter. A false negative resurrects the ladder; a false
+positive turns a genuinely transient rate limit into a hard 402, which is why
+the transient cases below are pinned just as tightly.
+"""
+
+import asyncio
+
+import aiohttp
+import httpx
+import litellm
+import openai
+import pytest
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine import (
+    LiteLLMEmbeddingEngine,
+)
+from cognee.infrastructure.databases.vector.embeddings.OpenAICompatibleEmbeddingEngine import (
+    OpenAICompatibleEmbeddingEngine,
+)
+from cognee.infrastructure.databases.exceptions import EmbeddingException
+from cognee.infrastructure.llm.exceptions import LLMPaymentRequiredError
+
+BUDGET_MESSAGE = "Budget has been exceeded! Current cost: 20.00066499999998, Max budget: 20.0"
+
+
+def _proxy_budget_error(message: str = BUDGET_MESSAGE) -> litellm.RateLimitError:
+    """The client-side error litellm raises for a LiteLLM-proxy spend-cap 429.
+
+    The proxy raises ``BudgetExceededError`` server-side; the client only ever
+    sees the status mapped back onto a generic ``RateLimitError``.
+    """
+    return litellm.RateLimitError(
+        message=f"litellm.RateLimitError: RateLimitError: Litellm_proxyException - {message}",
+        llm_provider="openai",
+        model="litellm_proxy/litellm",
+    )
+
+
+def _openai_structured_budget_error() -> openai.RateLimitError:
+    """A proxy 429 whose body is still readable: the structured signal.
+
+    litellm's own client consumes the response body before cognee sees the
+    error, so the LLM side can only ever match on message text. Through the
+    openai SDK the body survives and the proxy's ``error.type`` is the more
+    robust signal, so the message here deliberately omits the budget sentence:
+    only the structured check can classify this one.
+    """
+    response = httpx.Response(
+        status_code=429,
+        request=httpx.Request("POST", "http://localhost:8099/v1/embeddings"),
+        json={
+            "error": {
+                "message": "Rejected by proxy",
+                "type": "budget_exceeded",
+                "code": "429",
+            }
+        },
+    )
+    return openai.RateLimitError("Rejected by proxy", response=response, body=None)
+
+
+def _auth_error() -> litellm.exceptions.AuthenticationError:
+    """A terminal error used to stop a ladder that is expected to run."""
+    return litellm.exceptions.AuthenticationError(
+        message="invalid api key",
+        llm_provider="openai",
+        model="text-embedding-3-large",
+    )
+
+
+@pytest.mark.asyncio
+async def test_litellm_budget_error_bypasses_retry(monkeypatch):
+    """litellm's own budget error: one attempt, surfaced as the actionable 402."""
+    monkeypatch.setenv("MOCK_EMBEDDING", "false")
+    engine = LiteLLMEmbeddingEngine(dimensions=4)
+
+    calls = {"count": 0}
+
+    async def _raise_budget(**kwargs):
+        calls["count"] += 1
+        raise litellm.BudgetExceededError(current_cost=20.0, max_budget=20.0)
+
+    monkeypatch.setattr(litellm, "aembedding", _raise_budget)
+
+    with pytest.raises(LLMPaymentRequiredError):
+        await engine.embed_text(["hello world"])
+
+    # The critical assertion: exactly one attempt, no backoff ladder.
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_litellm_proxy_budget_rejection_bypasses_retry(monkeypatch):
+    """The shape production actually produces: a 429 carrying the budget sentence."""
+    monkeypatch.setenv("MOCK_EMBEDDING", "false")
+    engine = LiteLLMEmbeddingEngine(dimensions=4)
+
+    calls = {"count": 0}
+
+    async def _raise_proxy_budget(**kwargs):
+        calls["count"] += 1
+        raise _proxy_budget_error()
+
+    monkeypatch.setattr(litellm, "aembedding", _raise_proxy_budget)
+
+    with pytest.raises(LLMPaymentRequiredError) as exc_info:
+        await engine.embed_text(["hello world"])
+
+    assert calls["count"] == 1
+    # The provider's own sentence is carried through, so the 402 is actionable.
+    assert "Budget has been exceeded" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_litellm_budget_rejection_as_bad_request_bypasses_retry(monkeypatch):
+    """A budget rejection arriving as a 400 still fails fast.
+
+    This shape is re-raised unchanged by the ``BadRequestError`` handler, ahead
+    of the 402 conversion, so it keeps the litellm class. What matters is that
+    the retry predicate classifies it: no ladder either way.
+    """
+    monkeypatch.setenv("MOCK_EMBEDDING", "false")
+    engine = LiteLLMEmbeddingEngine(dimensions=4)
+
+    calls = {"count": 0}
+
+    async def _raise_bad_request_budget(**kwargs):
+        calls["count"] += 1
+        raise litellm.exceptions.BadRequestError(
+            message=f"Litellm_proxyException - {BUDGET_MESSAGE}",
+            llm_provider="openai",
+            model="litellm_proxy/litellm",
+        )
+
+    monkeypatch.setattr(litellm, "aembedding", _raise_bad_request_budget)
+
+    with pytest.raises(litellm.exceptions.BadRequestError):
+        await engine.embed_text(["hello world"])
+
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_transient_rate_limit_is_still_retried(monkeypatch):
+    """A per-minute rate limit is transient and must keep its ladder.
+
+    The second attempt raises a terminal auth error purely to stop the ladder
+    after one backoff instead of running the full 128s.
+    """
+    monkeypatch.setenv("MOCK_EMBEDDING", "false")
+    engine = LiteLLMEmbeddingEngine(dimensions=4)
+
+    calls = {"count": 0}
+
+    async def _raise_transient_then_terminal(**kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise litellm.RateLimitError(
+                message="litellm.RateLimitError: Rate limit reached for gpt-4o",
+                llm_provider="openai",
+                model="text-embedding-3-large",
+            )
+        raise _auth_error()
+
+    monkeypatch.setattr(litellm, "aembedding", _raise_transient_then_terminal)
+
+    with pytest.raises(litellm.exceptions.AuthenticationError):
+        await engine.embed_text(["hello world"])
+
+    assert calls["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_transient_error_mentioning_a_budget_is_still_retried(monkeypatch):
+    """False-positive guard: prose about a budget is not a proxy rejection.
+
+    A provider message can mention an exceeded budget without being a spend-cap
+    rejection, so this stays retryable: only the provider's whole sentence
+    counts. Text that does carry that whole sentence is classified as a budget
+    error, which is an accepted limitation pinned by ``test_budget_exhaustion``
+    rather than something this test covers.
+    """
+    monkeypatch.setenv("MOCK_EMBEDDING", "false")
+    engine = LiteLLMEmbeddingEngine(dimensions=4)
+
+    calls = {"count": 0}
+
+    async def _raise_innocent_then_terminal(**kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise litellm.RateLimitError(
+                message=(
+                    "litellm.RateLimitError: Rate limit reached. Context: "
+                    "'The marketing budget has been exceeded! Please review before Friday.'"
+                ),
+                llm_provider="openai",
+                model="text-embedding-3-large",
+            )
+        raise _auth_error()
+
+    monkeypatch.setattr(litellm, "aembedding", _raise_innocent_then_terminal)
+
+    with pytest.raises(litellm.exceptions.AuthenticationError):
+        await engine.embed_text(["hello world"])
+
+    assert calls["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_budget_rejection_bypasses_retry(monkeypatch):
+    """The same guarantee for the engine that talks to any OpenAI-compatible URL.
+
+    A LiteLLM proxy is a valid ``EMBEDDING_ENDPOINT`` for this engine too, so it
+    can see the identical rejection.
+    """
+    monkeypatch.delenv("MOCK_EMBEDDING", raising=False)
+    engine = OpenAICompatibleEmbeddingEngine(
+        model="test-model",
+        dimensions=4,
+        endpoint="http://localhost:8099",
+        api_key="test-key",
+    )
+
+    engine._client = MagicMock()
+    engine._client.embeddings.create = AsyncMock(side_effect=_proxy_budget_error())
+
+    with pytest.raises(LLMPaymentRequiredError):
+        await engine.embed_text(["hello world"])
+
+    assert engine._client.embeddings.create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_still_bypasses_retry(monkeypatch):
+    """Existing behaviour, kept as a guard rail against the predicate swap."""
+    monkeypatch.setenv("MOCK_EMBEDDING", "false")
+    engine = LiteLLMEmbeddingEngine(dimensions=4)
+
+    calls = {"count": 0}
+
+    async def _raise_cancelled(**kwargs):
+        calls["count"] += 1
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(litellm, "aembedding", _raise_cancelled)
+
+    with pytest.raises(asyncio.CancelledError):
+        await engine.embed_text(["hello world"])
+
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_structured_budget_rejection_bypasses_retry():
+    """The structured ``error.type`` signal alone must be enough.
+
+    A proxy that changes its wording still sets ``type: budget_exceeded``, and
+    through the openai SDK the body is readable, so this path must not depend on
+    the message regex.
+    """
+    engine = OpenAICompatibleEmbeddingEngine(
+        model="test-model",
+        dimensions=4,
+        endpoint="http://localhost:8099",
+        api_key="test-key",
+    )
+
+    engine._client = MagicMock()
+    engine._client.embeddings.create = AsyncMock(side_effect=_openai_structured_budget_error())
+
+    with pytest.raises(LLMPaymentRequiredError):
+        await engine.embed_text(["hello world"])
+
+    assert engine._client.embeddings.create.await_count == 1
+
+
+class _FakeAiohttpResponse:
+    """Minimal stand-in for the aiohttp response ``_get_embedding`` reads."""
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    async def json(self) -> dict:
+        return self._payload
+
+    async def __aenter__(self) -> "_FakeAiohttpResponse":
+        return self
+
+    async def __aexit__(self, *exc_info) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_ollama_engine_budget_rejection_bypasses_retry(monkeypatch):
+    """``EMBEDDING_PROVIDER=ollama`` can be pointed at a LiteLLM proxy.
+
+    The endpoint is never validated for provider shape and a proxy's
+    OpenAI-shaped success body is accepted by the ``"data"`` branch, so this
+    engine works against a proxy until the spend cap. The rejection then
+    arrives as a ``RuntimeError`` built from the error body, which is why the
+    classification cannot be a type tuple here either.
+    """
+    monkeypatch.setenv("MOCK_EMBEDDING", "false")
+
+    with patch(
+        "cognee.infrastructure.databases.vector.embeddings.OllamaEmbeddingEngine."
+        "OllamaEmbeddingEngine.get_tokenizer",
+        return_value=Mock(),
+    ):
+        from cognee.infrastructure.databases.vector.embeddings.OllamaEmbeddingEngine import (
+            OllamaEmbeddingEngine,
+        )
+
+        engine = OllamaEmbeddingEngine(model="test-model", dimensions=4)
+
+    calls = {"count": 0}
+    proxy_body = {
+        "error": {
+            "message": f"litellm.BudgetExceededError: {BUDGET_MESSAGE}",
+            "type": "budget_exceeded",
+            "code": "429",
+        }
+    }
+
+    def _fake_post(self, *args, **kwargs):
+        calls["count"] += 1
+        return _FakeAiohttpResponse(proxy_body)
+
+    monkeypatch.setattr(aiohttp.ClientSession, "post", _fake_post)
+
+    with pytest.raises(LLMPaymentRequiredError):
+        await engine.embed_text(["hello world"])
+
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_ollama_engine_object_shaped_context_window_error_is_terminal(monkeypatch):
+    """An over-length error in an object-shaped body must not be retried.
+
+    The membership tests in ``_get_embedding`` read the error body directly, so
+    an OpenAI-compatible proxy's object body used to test dict keys, always
+    False, and a terminal over-length error became a retryable RuntimeError that
+    burned the full ladder before ``embed_text`` could split. Reachable through
+    the same misconfiguration that makes the budget case above reachable.
+    """
+    monkeypatch.setenv("MOCK_EMBEDDING", "false")
+
+    with patch(
+        "cognee.infrastructure.databases.vector.embeddings.OllamaEmbeddingEngine."
+        "OllamaEmbeddingEngine.get_tokenizer",
+        return_value=Mock(),
+    ):
+        from cognee.infrastructure.databases.vector.embeddings.OllamaEmbeddingEngine import (
+            OllamaEmbeddingEngine,
+        )
+
+        engine = OllamaEmbeddingEngine(model="test-model", dimensions=4)
+
+    calls = {"count": 0}
+    proxy_body = {
+        "error": {
+            "message": "This model's maximum context length is 8192 tokens",
+            "type": "invalid_request_error",
+        }
+    }
+
+    def _fake_post(self, *args, **kwargs):
+        calls["count"] += 1
+        return _FakeAiohttpResponse(proxy_body)
+
+    monkeypatch.setattr(aiohttp.ClientSession, "post", _fake_post)
+
+    # "ab" cannot be split further, so the recovery path gives up immediately and
+    # the call count is the whole assertion: one attempt, no ladder.
+    with pytest.raises(EmbeddingException, match="too short to split further"):
+        await engine.embed_text(["ab"])
+
+    assert calls["count"] == 1

--- a/cognee/tests/unit/test_embedding_budget_fastfail.py
+++ b/cognee/tests/unit/test_embedding_budget_fastfail.py
@@ -36,7 +36,10 @@ from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine im
 from cognee.infrastructure.databases.vector.embeddings.OpenAICompatibleEmbeddingEngine import (
     OpenAICompatibleEmbeddingEngine,
 )
-from cognee.infrastructure.databases.exceptions import EmbeddingException
+from cognee.infrastructure.databases.exceptions import (
+    EmbeddingCredentialsError,
+    EmbeddingException,
+)
 from cognee.infrastructure.llm.exceptions import LLMPaymentRequiredError
 
 BUDGET_MESSAGE = "Budget has been exceeded! Current cost: 20.00066499999998, Max budget: 20.0"
@@ -76,6 +79,27 @@ def _openai_structured_budget_error() -> openai.RateLimitError:
         },
     )
     return openai.RateLimitError("Rejected by proxy", response=response, body=None)
+
+
+def _openai_transient_rate_limit() -> openai.RateLimitError:
+    """A per-minute rate limit: readable body, but not a spend cap."""
+    response = httpx.Response(
+        status_code=429,
+        request=httpx.Request("POST", "http://localhost:8099/v1/embeddings"),
+        json={"error": {"message": "Rate limit reached", "type": "rate_limit_error"}},
+    )
+    return openai.RateLimitError("Rate limit reached", response=response, body=None)
+
+
+def _openai_auth_error() -> openai.AuthenticationError:
+    return openai.AuthenticationError(
+        "invalid api key",
+        response=httpx.Response(
+            status_code=401,
+            request=httpx.Request("POST", "http://localhost:8099/v1/embeddings"),
+        ),
+        body=None,
+    )
 
 
 def _auth_error() -> litellm.exceptions.AuthenticationError:
@@ -293,6 +317,42 @@ async def test_openai_compatible_structured_budget_rejection_bypasses_retry():
     assert engine._client.embeddings.create.await_count == 1
 
 
+@pytest.mark.asyncio
+async def test_openai_compatible_transient_rate_limit_is_still_retried():
+    """The transient mirror for the engine whose conversion sits highest.
+
+    ``raise_if_budget_exhausted`` runs ahead of this engine's context-window
+    split recovery, so a false positive here would be the most damaging one in
+    the change. The second attempt raises an auth error, which is terminal only
+    because it is re-raised unwrapped, so this also pins that.
+    """
+    engine = OpenAICompatibleEmbeddingEngine(
+        model="test-model",
+        dimensions=4,
+        endpoint="http://localhost:8099",
+        api_key="test-key",
+    )
+
+    calls = {"count": 0}
+
+    async def _transient_then_terminal(**kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise _openai_transient_rate_limit()
+        raise _openai_auth_error()
+
+    engine._client = MagicMock()
+    engine._client.embeddings.create = AsyncMock(side_effect=_transient_then_terminal)
+
+    with pytest.raises(EmbeddingCredentialsError):
+        await engine.embed_text(["hello world"])
+
+    # A callable, not a two-item list: if the auth branch regressed, call 3+
+    # keeps raising the auth error instead of StopAsyncIteration, so the failure
+    # names the real cause instead of running the full ladder first.
+    assert calls["count"] == 2
+
+
 class _FakeAiohttpResponse:
     """Minimal stand-in for the aiohttp response ``_get_embedding`` reads."""
 
@@ -396,3 +456,31 @@ async def test_ollama_engine_object_shaped_context_window_error_is_terminal(monk
         await engine.embed_text(["ab"])
 
     assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_credentials_error_is_terminal_and_stays_a_422():
+    """A rejected key must fail fast without becoming a 500.
+
+    Re-raising the openai class bare would fast-fail too, but it leaves the
+    ``CogneeApiError`` family, so a router's ``except Exception`` turns a
+    configuration mistake into "Internal server error". The status code is as
+    much part of this contract as the attempt count.
+    """
+    engine = OpenAICompatibleEmbeddingEngine(
+        model="test-model",
+        dimensions=4,
+        endpoint="http://localhost:8099",
+        api_key="wrong-key",
+    )
+
+    engine._client = MagicMock()
+    engine._client.embeddings.create = AsyncMock(side_effect=_openai_auth_error())
+
+    with pytest.raises(EmbeddingCredentialsError) as exc_info:
+        await engine.embed_text(["hello world"])
+
+    assert engine._client.embeddings.create.await_count == 1
+    assert exc_info.value.status_code == 422
+    # The provider's own text is what makes the 422 actionable.
+    assert "invalid api key" in exc_info.value.message


### PR DESCRIPTION
## Description

A LiteLLM spend cap cannot clear inside a retry window, but the embedding engines only
recognised terminal failures by exception class, so every doomed batch ran the full
`stop_after_delay(128)` ladder. `index_data_points` gates batches with a semaphore of
`max(1, embedding_max_concurrent_data_points // embedding_batch_size)`, which is 4 on
defaults, so each doomed batch also held a quarter of the embedding stage's concurrency for
that whole time. The caller then got "Verify EMBEDDING_ENDPOINT and provider settings",
which points at the wrong problem entirely.

COG-6329 (`e4ef19a2e`) fixed this on the LLM path. This is the embedding half:
`is_budget_exhausted_error` had zero call sites outside `cognee/infrastructure/llm/`.

The obvious patch does not work, and I checked before ruling it out. Adding
`litellm.exceptions.BudgetExceededError` to `retry_if_not_exception_type(...)` changes
nothing, for three independent reasons:

- `BudgetExceededError` subclasses plain `Exception`, so no base class in a tuple matches it;
- against a proxy, which is the only deployment where budgets exist, the client never
  receives that class. The proxy raises it server-side and the client maps the status onto an
  ordinary `RateLimitError`;
- the engines re-raise provider failures as `EmbeddingException(...) from error`, so by the
  time tenacity sees the failure the provider class is gone even when it would have matched.

So classification moves to a predicate over the `__cause__` chain, reusing the detector the
LLM path already relies on, and a budget rejection converts to the actionable 402 the API
already surfaces.

Three engines are covered. Ollama is included because `EMBEDDING_ENDPOINT` is never
validated for provider shape and a proxy's OpenAI-shaped body is accepted by its `"data"`
branch, so it works against a proxy until the cap. Fastembed is excluded because it embeds
in process and issues no requests at all.

Second commit, split so it can be reverted on its own: a rejected key on the
OpenAI-compatible engine ran the same ladder, and the obvious one-line fix would have been
dead code for the same wrapping reason as above. It now raises a cognee type that is both
terminal and inside the `CogneeApiError` family, so it fails on the first attempt without a
router's `except Exception` turning a configuration mistake into a 500.

## Acceptance Criteria

Measured end to end against a real budget-exhausted proxy, not inferred from source:
`ghcr.io/berriai/litellm:main-stable` with Postgres, a real virtual key with
`max_budget: 0.01` driven past its cap. One doomed batch:

| engine | | attempts | wall clock | HTTP requests | raised |
| --- | --- | --- | --- | --- | --- |
| LiteLLM | before | 7 | 138.4s | 21 | `EmbeddingException` 422 |
| LiteLLM | after | 1 | 1.6s | 3 | `LLMPaymentRequiredError` 402 |
| OpenAI-compatible | before | 7 | 135.9s | 21 | `EmbeddingException` 422 |
| OpenAI-compatible | after | 1 | 1.5s | 3 | `LLMPaymentRequiredError` 402 |

That run also settled two open questions from the ticket. The proxy answers 429, not the 400
the incident report described. And the 3 remaining requests per attempt are the provider
SDK's own `max_retries=2`, now tracked as COG-6478 rather than guessed at.

Which signal actually classifies differs by client, which is why this is a predicate and not
a type check: on the litellm path the response body is already consumed (`response.json()`
raises `JSONDecodeError`) so only the message regex works, while through the openai SDK the
body survives and `error.type == "budget_exceeded"` fires as well. Both are covered by tests.

Tests: 12 in `cognee/tests/unit/test_embedding_budget_fastfail.py` covering both budget
shapes on the litellm engine, the structured-body shape through the openai SDK, the 400
shape, the Ollama proxy shape, two transient negatives including prose that merely mentions a
budget, `CancelledError`, and the credentials contract (one attempt, 422, provider text
preserved). The message a real proxy sends is now pinned verbatim in the corpus in
`test_budget_exhaustion.py` as the one entry observed from a running proxy rather than read
from litellm's source.

Non-vacuity was checked by reverting the engine files and re-running: the budget test fails
after 2:11 with the wrong exception type.

Full `cognee/tests/unit`: 5179 passed, 69 skipped, 0 failed.

Not in this PR: budget rejections still count as provider-overload evidence, so the 900s
pacing window keeps rolling and throttles recovery after the budget clears (COG-6476, which
has a stronger claim on the incident's duration than anything fixed here); wrong exception
types on the remaining paths (COG-6477); the provider SDK's own retries (COG-6478). The
incident's symptom, event-loop saturation and probe timeouts, does not follow from this code
path and is not addressed here: retry backoff sleeps with `asyncio.sleep`, which yields the
loop. What this removes is the slot starvation, not the symptom.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<!-- terminal output of:
     .venv/bin/python -m pytest -q cognee/tests/unit/test_embedding_budget_fastfail.py -->

## Pre-submission Checklist

- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.