### PR TITLE
COG-6319 feat: Publish the cognee UI as a Docker image

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -817,8 +817,15 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #DEBUG=false
 #DEBUG_PORT=5678
 
-# -- Frontend (cognee-frontend image / compose `ui` profile) ------------------
-#NEXT_PUBLIC_BACKEND_API_URL=http://localhost:8000
+# -- Frontend (cognee-ui image / compose `ui` and `ui-dev` profiles) ----------
+# Backend the UI talks to, read when the container starts, so one published
+# image works against any backend. The browser calls the backend directly, so
+# this must be the address as seen from the browser, not a compose service
+# name. Leave it unset for the usual localhost setup: the UI then derives the
+# backend host from the address the page was loaded from, on port 8000.
+#COGNEE_BACKEND_URL=http://localhost:8000
+# Tag of the published UI image the `ui` profile runs.
+#COGNEE_UI_TAG=latest
 
 
 ###############################################################################

--- a/.github/workflows/dockerhub-ui.yml
+++ b/.github/workflows/dockerhub-ui.yml
@@ -1,0 +1,51 @@
+name: build | Build and Push Cognee UI Docker Image to dockerhub
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: cognee/cognee-ui
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./cognee-frontend
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=cognee/cognee-ui:buildcache
+          cache-to: type=registry,ref=cognee/cognee-ui:buildcache,mode=max
+
+      - name: Image digest
+        run: echo ${{ steps.build.outputs.digest }}

--- a/.github/workflows/frontend_docker_build_test.yml
+++ b/.github/workflows/frontend_docker_build_test.yml
@@ -1,0 +1,105 @@
+name: build test | UI Docker image
+
+# The UI image is only ever exercised by `npm run dev` elsewhere, so without
+# this job a broken production build (a type error, a lockfile drift, a missing
+# file in the build context) reaches Docker Hub instead of a pull request.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build_ui_docker:
+    name: Build Cognee UI Docker Image
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out Cognee code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the published UI image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./cognee-frontend
+          # Single platform: this guards the build itself, and the release
+          # workflow is what produces the multi-arch manifest.
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: cognee-ui:ci
+
+      - name: Serve a page from the built image
+        # Proves more than "it compiled": the standalone server boots, and the
+        # backend URL reaching the browser is the one this container was
+        # started with rather than a value frozen in at build time.
+        run: |
+          set -euo pipefail
+          docker run -d --name cognee-ui-ci -p 3000:3000 \
+            -e COGNEE_BACKEND_URL=http://backend.test:8000 cognee-ui:ci
+
+          for attempt in $(seq 1 30); do
+            if curl -fsS http://localhost:3000/local-login -o /tmp/page.html; then
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "::error::UI container never served a page"
+              docker logs cognee-ui-ci
+              exit 1
+            fi
+            sleep 2
+          done
+
+          # The JSON the layout renders into <head> is the contract the client
+          # reads; assert on it rather than on the diagnostics route, which the
+          # app itself does not use.
+          grep -q '"backendUrl":"http://backend.test:8000"' /tmp/page.html || {
+            echo "::error::page did not carry COGNEE_BACKEND_URL to the browser"
+            grep -o 'id="cognee-runtime-config"[^<]*' /tmp/page.html || echo "(no config element at all)"
+            exit 1
+          }
+
+          curl -fsS http://localhost:3000/api/runtime-config
+
+      - name: Reject a misconfigured backend URL
+        # The container must refuse to start and name the variable, instead of
+        # booting and failing every request for a reason the operator cannot
+        # see, or worse, quietly falling back to localhost.
+        run: |
+          set -euo pipefail
+          # Bounded foreground run: if the guard ever regresses the container
+          # starts a server and never exits, and an unbounded run would hang the
+          # job for the full 360 minutes rather than failing it.
+          status=0
+          timeout 60 docker run --name cognee-ui-bad \
+            -e COGNEE_BACKEND_URL=cognee:8000 \
+            cognee-ui:ci > /tmp/bad.log 2>&1 || status=$?
+
+          cat /tmp/bad.log
+
+          case "$status" in
+            0)
+              echo "::error::a malformed COGNEE_BACKEND_URL was accepted"
+              exit 1
+              ;;
+            124)
+              echo "::error::container kept running on a malformed COGNEE_BACKEND_URL"
+              exit 1
+              ;;
+          esac
+
+          grep -q "COGNEE_BACKEND_URL" /tmp/bad.log || {
+            echo "::error::startup failure does not name the misconfigured variable"
+            exit 1
+          }
+
+      - name: Report image size
+        if: always()
+        run: docker image ls cognee-ui:ci --format '{{.Repository}}:{{.Tag}} {{.Size}}'
+
+      - name: Tear down
+        if: always()
+        run: docker rm -f cognee-ui-ci cognee-ui-bad 2>/dev/null || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,40 @@ jobs:
           cache-from: type=registry,ref=cognee/cognee:buildcache
           cache-to: type=registry,ref=cognee/cognee:buildcache,mode=max
 
+      - name: Build and push Dev UI Docker Image
+        if: ${{ github.ref_name == 'dev' }}
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
+        with:
+          context: ./cognee-frontend
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: mode=max
+          sbom: true
+          tags: cognee/cognee-ui:${{ needs.release-github.outputs.version }}
+          labels: |
+            version=${{ needs.release-github.outputs.version }}
+            flavour=${{ github.ref_name }}
+          cache-from: type=registry,ref=cognee/cognee-ui:buildcache
+          cache-to: type=registry,ref=cognee/cognee-ui:buildcache,mode=max
+
+      - name: Build and push Main UI Docker Image
+        if: ${{ github.ref_name == 'main' }}
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
+        with:
+          context: ./cognee-frontend
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: mode=max
+          sbom: true
+          tags: |
+            cognee/cognee-ui:${{ needs.release-github.outputs.version }}
+            cognee/cognee-ui:latest
+          labels: |
+            version=${{ needs.release-github.outputs.version }}
+            flavour=${{ github.ref_name }}
+          cache-from: type=registry,ref=cognee/cognee-ui:buildcache
+          cache-to: type=registry,ref=cognee/cognee-ui:buildcache,mode=max
+
       - name: Check MCP lockfile ships the released cognee version
         # The MCP image installs cognee from PyPI via cognee-mcp/uv.lock, which
         # can only be re-locked after the new version is published — a manual

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -224,6 +224,11 @@ jobs:
     uses: ./.github/workflows/backend_docker_build_test.yml
     secrets: inherit
 
+  ui-docker-ci-test:
+    name: UI Docker CI test
+    uses: ./.github/workflows/frontend_docker_build_test.yml
+    secrets: inherit
+
   temporal-graph-tests:
     name: Temporal Graph Test
     needs: [ build-ci-env ]
@@ -271,6 +276,7 @@ jobs:
       mcp-test,
       docker-compose-test,
       docker-ci-test,
+      ui-docker-ci-test,
       temporal-graph-tests,
       search-db-tests,
       relational-db-migration-tests,
@@ -297,6 +303,7 @@ jobs:
                 "${{ needs.mcp-test.result }}" == "success" &&
                 "${{ needs.docker-compose-test.result }}" == "success" &&
                 "${{ needs.docker-ci-test.result }}" == "success" &&
+                "${{ needs.ui-docker-ci-test.result }}" == "success" &&
                 "${{ needs.temporal-graph-tests.result }}" == "success" &&
                 "${{ needs.search-db-tests.result }}" == "success" &&
                 "${{ needs.relational-db-migration-tests.result }}" == "success" ]]; then

--- a/README.md
+++ b/README.md
@@ -219,14 +219,20 @@ cp .env.template .env   # then edit .env and set LLM_API_KEY
 docker compose up
 
 # Optional profiles (combine as needed):
-docker compose --profile ui up        # + frontend on http://localhost:3000
+docker compose --profile ui up        # + UI on http://localhost:3000
 docker compose --profile mcp up       # + MCP server on http://localhost:8001
 docker compose --profile postgres up  # + Postgres/PGVector
 docker compose --profile neo4j up     # + Neo4j
+
+# Backend, MCP server and UI together
+docker compose --profile mcp --profile ui up
 ```
 
 > The `cognee` and `cognee-mcp` services publish different host ports (`8000` vs `8001`),
 > so you can run both at once.
+
+> The `ui` profile runs the published `cognee/cognee-ui` image. To build the UI from
+> your working tree instead, with hot reload, use `--profile ui-dev`.
 
 ### Option B — Pull the prebuilt image (no clone required)
 
@@ -240,7 +246,28 @@ docker run --env-file ./.env -p 8000:8000 --rm -it cognee/cognee:main
 # MCP server (HTTP transport)
 docker pull cognee/cognee-mcp:main
 docker run -e TRANSPORT_MODE=http --env-file ./.env -p 8000:8000 --rm -it cognee/cognee-mcp:main
+
+# UI (http://localhost:3000)
+docker pull cognee/cognee-ui:main
+docker run -p 3000:3000 --rm -it cognee/cognee-ui:main
 ```
+
+The UI needs no configuration when the backend is reachable at port 8000 on the same
+host you browse to: it derives the backend address from the page URL. Point it
+somewhere else with `COGNEE_BACKEND_URL`, which is read when the container starts, so
+one image works against any backend:
+
+```bash
+docker run -p 3000:3000 -e COGNEE_BACKEND_URL=https://cognee.example.com \
+  --rm -it cognee/cognee-ui:main
+
+# What backend did this container resolve?
+curl http://localhost:3000/api/runtime-config
+```
+
+The browser talks to the backend directly, so `COGNEE_BACKEND_URL` must be the address
+as seen from the browser, and the backend must allow the UI's origin through
+`CORS_ALLOWED_ORIGINS`.
 
 See the [MCP server README](cognee-mcp/README.md) for SSE/stdio transports, optional
 extras, and MCP client configuration.

--- a/cognee-frontend/.dockerignore
+++ b/cognee-frontend/.dockerignore
@@ -1,2 +1,18 @@
-.next
+# Build artefacts and installed dependencies: the image installs its own.
 node_modules
+.next
+*.tsbuildinfo
+
+# Never bake a developer's environment into a published image.
+.env
+.env.*
+!.env.template
+
+# Not needed to produce a production build. Note the leading **: a bare
+# name only matches a top-level path segment, and every __tests__ here is
+# nested.
+**/__tests__
+Dockerfile
+.dockerignore
+.git
+.gitignore

--- a/cognee-frontend/Dockerfile
+++ b/cognee-frontend/Dockerfile
@@ -1,22 +1,97 @@
-# Use an official Node.js runtime as a parent image
-FROM node:22-alpine
+# syntax=docker/dockerfile:1
 
-# Set the working directory to /app
+# Production image for the cognee UI.
+#
+# The backend it talks to is chosen at *run* time via COGNEE_BACKEND_URL, not
+# at build time, so one published image works against a local Docker backend,
+# a `cognee-cli` backend, or a remote one. See
+# cognee-frontend/src/modules/config/runtimeConfig.ts for how that is wired.
+
+# ---------------------------------------------------------------- deps ------
+FROM node:22-alpine AS deps
 WORKDIR /app
 
-# Copy package.json and package-lock.json to the working directory
+# Next's native toolchain (@tailwindcss/oxide, lightningcss) expects glibc
+# symbols that musl does not provide on its own.
+RUN apk add --no-cache libc6-compat
+
 COPY package.json package-lock.json ./
-
-# Install any needed packages specified in package.json
+# `npm ci` fails on a lockfile that drifted from package.json, which is the
+# class of breakage that reached main as COG-6035.
 RUN npm ci
-RUN npm rebuild lightningcss
 
-# Copy the rest of the application code to the working directory
-COPY src ./src
-COPY public ./public
-COPY next.config.mjs .
-COPY postcss.config.mjs .
-COPY tsconfig.json .
+# ------------------------------------------------------------- builder ------
+FROM node:22-alpine AS builder
+WORKDIR /app
 
-# Build the app and run it
+RUN apk add --no-cache libc6-compat
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# This one genuinely belongs at build time: the cloud shell is dead code in the
+# open-source image, so there is nothing to configure per container.
+ENV NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT=false
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build
+
+# ----------------------------------------------------------------- dev ------
+# Hot-reloading server for contributors: `docker compose --profile ui-dev up`.
+# Never published. `runner` is the last stage, so it stays the default target
+# and BuildKit skips this one entirely unless it is asked for by name.
+FROM node:22-alpine AS dev
+WORKDIR /app
+
+RUN apk add --no-cache libc6-compat
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ENV NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT=false
+ENV NEXT_TELEMETRY_DISABLED=1
+
+EXPOSE 3000
 CMD ["npm", "run", "dev"]
+
+# -------------------------------------------------------------- runner ------
+FROM node:22-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+# Empty means "ask the browser": the UI then derives the backend host from the
+# address it was loaded from, which is right for the common localhost setup.
+# Set it to point somewhere else, e.g.
+# -e COGNEE_BACKEND_URL=https://cognee.example.com. The browser calls the
+# backend directly, so this is the address as seen from the browser, never a
+# compose service name.
+ENV COGNEE_BACKEND_URL=""
+
+RUN addgroup -g 1001 -S nodejs \
+ && adduser -u 1001 -S nextjs -G nodejs
+
+# `output: "standalone"` emits a server plus only the node_modules the app
+# actually reaches: no dev dependencies, no npm install in this stage.
+RUN mkdir .next && chown nextjs:nodejs .next
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+USER nextjs
+EXPOSE 3000
+
+# Probes the runtime-config route rather than "/": it is the cheapest endpoint
+# that proves both that the server is up and that COGNEE_BACKEND_URL resolved.
+# node:22 has a global fetch, so the runtime image needs no curl.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3000)+'/api/runtime-config').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["node", "server.js"]

--- a/cognee-frontend/docker-entrypoint.sh
+++ b/cognee-frontend/docker-entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Refuse to start on a backend URL the UI cannot use.
+#
+# A container that cannot resolve its backend should fail visibly at startup,
+# with the reason in `docker logs`, rather than boot and answer every request
+# with a 500 that says nothing about the cause. Under a restart policy this
+# turns a silent misconfiguration into an obvious crash loop.
+#
+# Checked here rather than inside the app because it must run before the server
+# does, and because the Next build rejects process.exit in its instrumentation
+# hook. The rules below are the same ones normalizeBackendUrl applies in
+# src/modules/config/runtimeConfig.ts, expressed in node rather than in shell
+# globs so that trimming, the case-insensitive scheme and a bare "http://" all
+# behave identically in both places. Keep the two in step.
+set -e
+
+node -e '
+  const raw = process.env.COGNEE_BACKEND_URL;
+  const value = (raw ?? "").trim();
+  if (!value) process.exit(0);
+
+  const fail = (message) => {
+    console.error("[cognee-ui] COGNEE_BACKEND_URL " + message);
+    process.exit(1);
+  };
+
+  if (!/^https?:\/\//i.test(value)) {
+    fail(`must be an absolute http(s) URL, got "${value}". Expected something like "http://localhost:8000".`);
+  }
+  try {
+    new URL(value);
+  } catch {
+    fail(`is not a valid URL: "${value}".`);
+  }
+'
+
+exec "$@"

--- a/cognee-frontend/next.config.ts
+++ b/cognee-frontend/next.config.ts
@@ -1,6 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Emit .next/standalone: a self-contained server bundle with only the
+  // node_modules the app actually reaches. This is what the Docker runtime
+  // stage copies, and it is why the published image ships no dev dependencies.
+  output: "standalone",
   images: {
     remotePatterns: [{
       protocol: "https",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,19 +107,44 @@ services:
           cpus: "2.0"
           memory: 4GB
 
-  # NOTE: Frontend is a work in progress and supports minimum amount of features required to be functional.
-  # If you want to use Cognee with a UI environment you can integrate the Cognee MCP Server into Cursor / Claude Desktop / Visual Studio Code (through Cline/Roo)
+  # cognee UI. `--profile ui` runs the published image, so a user without the
+  # repo gets the same thing CI publishes; `--profile ui-dev` builds the
+  # hot-reloading stage from source for frontend work.
+  #
+  # NOTE: the UI is a work in progress and covers the minimum set of features
+  # needed to be functional. For a richer experience you can also integrate the
+  # cognee MCP server into Cursor / Claude Desktop / VS Code (through Cline/Roo).
   frontend:
     container_name: frontend
     restart: always
-    environment:
-      - NEXT_PUBLIC_BACKEND_API_URL=${NEXT_PUBLIC_BACKEND_API_URL:-http://localhost:8000}
-      - NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT=false
+    image: cognee/cognee-ui:${COGNEE_UI_TAG:-latest}
     profiles:
-        - ui
+      - ui
+    environment:
+      # Empty means "derive it from the address the browser used", which is
+      # correct for the default localhost setup. The browser talks to the
+      # backend directly, so when you do set this it must be the address as
+      # seen from the browser, not the `cognee` service name.
+      - COGNEE_BACKEND_URL=${COGNEE_BACKEND_URL:-}
+    depends_on:
+      cognee:
+        condition: service_healthy
+    ports:
+      - 3000:3000
+    networks:
+      - cognee-network
+
+  frontend-dev:
+    container_name: frontend-dev
+    restart: always
+    profiles:
+      - ui-dev
     build:
       context: ./cognee-frontend
       dockerfile: Dockerfile
+      target: dev
+    environment:
+      - COGNEE_BACKEND_URL=${COGNEE_BACKEND_URL:-}
     volumes:
       - ./cognee-frontend/src:/app/src
       - ./cognee-frontend/public:/app/public


### PR DESCRIPTION
## Description

Third piece of 6319. 6342 fixed the build, 6343 made the backend URL runtime, this is the image itself.

Old Dockerfile was a dev one: single stage, all dev deps, `npm run dev` as CMD. Replaced with deps/builder/dev/runner on Next's standalone output. Non-root, healthcheck, and an entrypoint that refuses to start on a bad `COGNEE_BACKEND_URL` instead of booting and 500ing every request. Put the check in the entrypoint rather than in the app because `next build` rejects `process.exit` in the instrumentation hook.

Publishing mirrors `cognee-mcp`: `dockerhub-ui.yml` on push to main, plus dev and main steps in `release.yml` with provenance and SBOM.

Added a build test because nothing built the UI anywhere, which is how COG-6035 got through. It builds the image, runs it, and checks the served HTML actually carries the runtime backend URL, then checks a malformed one kills the start.

Compose: `ui` now runs the published image, `ui-dev` builds the hot-reload stage from source so frontend work doesn't lose the dev loop.

Two things worth a look. Image is 411 MB, of which `public/` is 41 MB and 19 MB of that is five video files nothing references — didn't touch them, that's an asset call not a packaging one. And between merging this and the first publish, `--profile ui` has nothing to pull; workflow fires on push to main so the window is short.

## Acceptance Criteria

* `docker pull cognee/cognee-ui && docker run` serves the UI and talks to the configured backend
* Published automatically by the release workflow with version tags
* `docker compose --profile ui up` brings up backend + UI, documented in the README
* Multi-stage, no dev dependencies in the runtime layer

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

```
$ docker build -t cognee-ui .
Successfully built                                 411MB

$ docker run -e COGNEE_BACKEND_URL=cognee:8000 cognee-ui
[cognee-ui] COGNEE_BACKEND_URL must be an absolute http(s) URL, got "cognee:8000".
Expected something like "http://cognee:8000".
exit 1

$ docker run -p 3000:3000 -e COGNEE_BACKEND_URL=https://cognee.example.com/ cognee-ui
$ curl -s localhost:3000/api/runtime-config
{"backendUrl":"https://cognee.example.com"}
health: healthy

$ npx jest
Test Suites: 14 passed, 14 total
Tests:       124 passed, 124 total
```

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.