### PR TITLE
feat(retrieval): scope summary search to node sets

### DIFF
--- a/cognee/modules/retrieval/summaries_retriever.py
+++ b/cognee/modules/retrieval/summaries_retriever.py
@@ -20,12 +20,35 @@ class SummariesRetriever(BaseRetriever):
 
     Instance variables:
     - top_k: int - Number of top summaries to retrieve.
+    - node_name: Optional[List[str]] - Node set names the search is scoped to.
+    - node_name_filter_operator: str - How multiple node_name values combine.
     """
 
-    def __init__(self, top_k: int = 5, session_id: Optional[str] = None):
-        """Initialize retriever with search parameters."""
+    def __init__(
+        self,
+        top_k: int = 5,
+        session_id: Optional[str] = None,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: str = "OR",
+    ):
+        """
+        Initialize retriever with search parameters.
+
+        Parameters:
+        -----------
+
+            - top_k (int): Maximum number of summaries to retrieve. Defaults to 5.
+            - session_id (Optional[str]): Session the search belongs to. Defaults to None.
+            - node_name (Optional[List[str]]): Node set names used to filter summaries by
+              their belongs_to_set relationship. Defaults to None, which applies no node
+              set filtering.
+            - node_name_filter_operator (str): Logical operator used when applying multiple
+              node_name filters, such as "OR" or "AND". Defaults to "OR".
+        """
         self.top_k = top_k
         self.session_id = session_id
+        self.node_name = node_name
+        self.node_name_filter_operator = node_name_filter_operator
 
     async def get_retrieved_objects(self, query: str) -> Any:
         """
@@ -53,7 +76,12 @@ class SummariesRetriever(BaseRetriever):
 
         try:
             summaries_results = await vector_engine.search(
-                "TextSummary_text", query, limit=self.top_k, include_payload=True
+                "TextSummary_text",
+                query,
+                limit=self.top_k,
+                include_payload=True,
+                node_name=self.node_name,
+                node_name_filter_operator=self.node_name_filter_operator,
             )
             logger.info(f"Found {len(summaries_results)} summaries from vector search")
 

--- a/cognee/modules/search/methods/get_search_type_retriever_instance.py
+++ b/cognee/modules/search/methods/get_search_type_retriever_instance.py
@@ -98,7 +98,15 @@ async def get_search_type_retriever_instance(
             CodeRetriever,
             {"config": retriever_specific_config},
         ),
-        SearchType.SUMMARIES: (SummariesRetriever, {"top_k": top_k, "session_id": session_id}),
+        SearchType.SUMMARIES: (
+            SummariesRetriever,
+            {
+                "top_k": top_k,
+                "session_id": session_id,
+                "node_name": node_name,
+                "node_name_filter_operator": node_name_filter_operator,
+            },
+        ),
         SearchType.CHUNKS: (
             ChunksRetriever,
             {

--- a/cognee/tests/unit/modules/retrieval/summaries_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/summaries_retriever_test.py
@@ -47,7 +47,12 @@ async def test_get_context_success(mock_vector_engine):
     assert completion[0]["text"] == "S.R."
     assert completion[1]["text"] == "M.B."
     mock_vector_engine.search.assert_awaited_once_with(
-        "TextSummary_text", "test query", limit=5, include_payload=True
+        "TextSummary_text",
+        "test query",
+        limit=5,
+        include_payload=True,
+        node_name=None,
+        node_name_filter_operator="OR",
     )
 
 
@@ -101,7 +106,12 @@ async def test_get_objects_top_k_limit(mock_vector_engine):
 
     assert len(objects) == 3
     mock_vector_engine.search.assert_awaited_once_with(
-        "TextSummary_text", "test query", limit=3, include_payload=True
+        "TextSummary_text",
+        "test query",
+        limit=3,
+        include_payload=True,
+        node_name=None,
+        node_name_filter_operator="OR",
     )
 
 
@@ -145,6 +155,8 @@ async def test_init_defaults():
     retriever = SummariesRetriever()
 
     assert retriever.top_k == 5
+    assert retriever.node_name is None
+    assert retriever.node_name_filter_operator == "OR"
 
 
 @pytest.mark.asyncio
@@ -194,3 +206,65 @@ async def test_get_completion_with_session_id(mock_vector_engine):
 
     assert len(completion) == 1
     assert completion[0]["text"] == "S.R."
+
+
+@pytest.mark.asyncio
+async def test_get_objects_forwards_nodeset_filter_to_vector_search(mock_vector_engine):
+    """Test that node_name filtering is passed through to the vector engine."""
+    mock_vector_engine.search.return_value = []
+
+    retriever = SummariesRetriever(
+        top_k=30,
+        node_name=["KEN", "src_type:figure"],
+        node_name_filter_operator="AND",
+    )
+
+    with patch(
+        "cognee.modules.retrieval.summaries_retriever.get_unified_engine",
+        return_value=_make_unified_mock(mock_vector_engine),
+    ):
+        await retriever.get_retrieved_objects("land cover")
+
+    mock_vector_engine.search.assert_awaited_once_with(
+        "TextSummary_text",
+        "land cover",
+        limit=30,
+        include_payload=True,
+        node_name=["KEN", "src_type:figure"],
+        node_name_filter_operator="AND",
+    )
+
+
+@pytest.mark.asyncio
+async def test_scoped_search_that_matches_nothing_returns_no_summaries(mock_vector_engine):
+    """A node set with no summaries is an empty result, not a missing collection.
+
+    NoDataError says the system holds no data, which stays reserved for the
+    CollectionNotFoundError path; a filter that matches nothing must not borrow it.
+    """
+    mock_vector_engine.search.return_value = []
+
+    retriever = SummariesRetriever(node_name=["empty-node-set"])
+
+    with patch(
+        "cognee.modules.retrieval.summaries_retriever.get_unified_engine",
+        return_value=_make_unified_mock(mock_vector_engine),
+    ):
+        objects = await retriever.get_retrieved_objects("test query")
+        context = await retriever.get_context_from_objects("test query", objects)
+        completion = await retriever.get_completion_from_context("test query", objects, context)
+
+    assert objects == []
+    assert context == ""
+    assert completion == []
+
+
+@pytest.mark.asyncio
+async def test_init_custom_nodeset_filter():
+    """Test SummariesRetriever initialization with node set filtering."""
+    retriever = SummariesRetriever(
+        node_name=["tenant-a", "tenant-b"], node_name_filter_operator="AND"
+    )
+
+    assert retriever.node_name == ["tenant-a", "tenant-b"]
+    assert retriever.node_name_filter_operator == "AND"

--- a/cognee/tests/unit/modules/search/test_get_search_type_retriever_instance.py
+++ b/cognee/tests/unit/modules/search/test_get_search_type_retriever_instance.py
@@ -161,6 +161,25 @@ async def test_chunks_retriever_receives_nodeset_filter_arguments():
 
 
 @pytest.mark.asyncio
+async def test_summaries_retriever_receives_nodeset_filter_arguments():
+    import cognee.modules.search.methods.get_search_type_retriever_instance as mod
+    from cognee.modules.retrieval.summaries_retriever import SummariesRetriever
+
+    retriever_instance = await mod.get_search_type_retriever_instance(
+        SearchType.SUMMARIES,
+        query_text="land cover",
+        top_k=30,
+        node_name=["KEN", "src_type:figure"],
+        node_name_filter_operator="AND",
+    )
+
+    assert isinstance(retriever_instance, SummariesRetriever)
+    assert retriever_instance.top_k == 30
+    assert retriever_instance.node_name == ["KEN", "src_type:figure"]
+    assert retriever_instance.node_name_filter_operator == "AND"
+
+
+@pytest.mark.asyncio
 async def test_rag_completion_retriever_receives_nodeset_filter_arguments():
     import cognee.modules.search.methods.get_search_type_retriever_instance as mod
     from cognee.modules.retrieval.completion_retriever import CompletionRetriever


### PR DESCRIPTION
Self-found, no issue.

`SearchType.CHUNKS`, `RAG_COMPLETION`, `TRIPLET_COMPLETION`, `HYBRID_COMPLETION` and every graph-completion variant take `node_name` and `node_name_filter_operator`. `SearchType.SUMMARIES` did not: the factory built `SummariesRetriever` with `{"top_k", "session_id"}` alone, and the retriever called `vector_engine.search("TextSummary_text", query, limit, include_payload)` with no filter.

So passing `node_name` to a summary search was accepted and ignored. A caller who scopes a chunk search to a node set and then switches to `SUMMARIES` for a shorter answer silently searches the whole corpus, with nothing in the result to say the scope was dropped. That is the same gap #4675 fixes for `CHUNKS_LEXICAL`, and after both, `SUMMARIES` is the last vector-backed retriever that was ignoring node sets.

## Why this stays a two-argument change

The interesting part was checking the data was already there rather than assuming it, because a filter on a field that summaries do not carry would return nothing rather than everything, which is a worse failure than the one being fixed. The chain holds end to end:

- `summarize_text.py` builds each `TextSummary` with `belongs_to_set=chunk.belongs_to_set`, and the chunk got it from its document in `extract_chunks_from_documents.py`. Summaries are node-set tagged already.
- `get_graph_from_model` treats `belongs_to_set` as the one DataPoint-valued field it keeps as a node property, reducing it to names, and says why in `_node_set_names`: *"Nodeset names as a scalar property, so the vector database can filter on them."*
- `add_data_points` hands those same nodes to `index_data_points`, so the vector payload carries the names, not the NodeSet objects. `test_pgvector.py` asserts exactly that against a real pipeline (`nodeset in node_set for nodeset in result[0].payload["belongs_to_set"]`).
- Both adapters filter that key: PGVector with `payload->'belongs_to_set' ?| ARRAY[...]`, LanceDB with `array_has_any(payload.belongs_to_set, [...])`.

Nothing new is needed at the adapter or graph layer, and the filter works wherever summary search already works.

## Two things checked that could have made this wrong

**An empty scoped result must not raise `NoDataError`.** That error says the system holds no data and the user should add some, which would be false for a node set that simply has no summaries. Here the existing code was already right: `NoDataError` is raised only from `CollectionNotFoundError`, and an empty result list falls through to `""` and `[]`. Worth pinning rather than assuming, since a new filter can turn an existing error message into a lie, so there is a test for it.

**Nothing else is derived from the filtered set.** `SummariesRetriever` joins the payload texts and returns the payloads, with no corpus-level statistics that would end up describing the whole graph while the results describe a subset.

## Verification

`SummariesRetriever` and the factory reverted to `dev` with the tests kept: **7 of 40 fail**. Restored, all 40 pass.

```
FAILED test_get_context_success
FAILED test_get_objects_top_k_limit
FAILED test_get_objects_forwards_nodeset_filter_to_vector_search
FAILED test_scoped_search_that_matches_nothing_returns_no_summaries
FAILED test_init_defaults
FAILED test_init_custom_nodeset_filter
FAILED test_summaries_retriever_receives_nodeset_filter_arguments
```

The first two are existing tests whose `assert_awaited_once_with` now pins the two new arguments on the unfiltered path, so the default stays `node_name=None` rather than drifting. `ruff check` and `ruff format --check` are clean repo-wide at the pinned 0.15.11. `ty` does not cover `cognee/modules/retrieval` or `cognee/modules/search`, neither directory being in `[tool.ty.src] include`.

Tests mirror the `ChunksRetriever` ones so the two retrievers stay comparable, and they live in the existing `summaries_retriever_test.py` and `test_get_search_type_retriever_instance.py` rather than new files.

This touches `get_search_type_retriever_instance.py`, which my open #4675 also edits, but at a different entry in the registry (`SUMMARIES` rather than `CHUNKS_LEXICAL`) and in a different test region, so the two do not conflict.
