### PR TITLE
fix: get_or_create_dataset_database's existence check filters by owner_id, but dataset_id is the primary key

### DIFF
--- a/cognee/context_global_variables.py
+++ b/cognee/context_global_variables.py
@@ -195,8 +195,23 @@ class DatabaseContextManager:
         data_root_directory = os.path.join(
             base_config.data_root_directory, str(user.tenant_id or user.id)
         )
+        # dataset_database.owner_id, not the calling user.id: get_or_create_dataset_database()
+        # correctly resolves the dataset's real DatasetDatabase row for an ACL-granted caller
+        # who isn't the literal owner, but Ladybug/Kuzu's on-disk graph file was created under
+        # the OWNER's directory (.cognee_system/databases/{owner_id}/{graph_database_name}),
+        # not the caller's. Building this path from the caller's own id redirects a non-owner
+        # to their own, likely-nonexistent directory instead of the dataset's real graph file.
+        # Reported by @linhongyu510 in review of PR #4830: reproduced on head 9edd8b12 with a
+        # context test where caller_id != dataset_database.owner_id -- the resolved path
+        # contained caller_id and the owner-path assertion failed. Confirmed independently with
+        # a live repro against real data: /forget on a dataset owned by a different identity
+        # reported success (the relational Data/dataset_data rows were correctly deleted) while
+        # never touching the real graph at all, since it resolved to a path that didn't exist --
+        # 295 of 580 real graph nodes for that dataset were left orphaned as a direct result.
+        # LanceDB does not share this symptom -- its vector_database_url is already absolute,
+        # not reconstructed from a directory + user id.
         databases_directory_path = os.path.join(
-            base_config.system_root_directory, "databases", str(user.id)
+            base_config.system_root_directory, "databases", str(dataset_database.owner_id)
         )
 
         # Set vector and graph database configuration based on dataset database information

--- a/cognee/infrastructure/databases/utils/get_or_create_dataset_database.py
+++ b/cognee/infrastructure/databases/utils/get_or_create_dataset_database.py
@@ -55,9 +55,23 @@ async def _existing_dataset_database(
     """
     db_engine = get_relational_engine()
 
+    # dataset_id is this table's PRIMARY KEY (DatasetDatabase.py:
+    # `dataset_id = Column(UUID, ..., primary_key=True)`) -- one row per
+    # dataset, globally, by schema design. Filtering by owner_id here can
+    # never help (a dataset_id match is already unique on its own) and can
+    # only produce false negatives for a caller who has full ACL-granted
+    # permission on the dataset but isn't its literal owner_id -- confirmed
+    # live: a caller had all 4 of the same ACL permission rows as the actual
+    # owner on a dataset it didn't literally own, yet this filter still
+    # reported "no existing row", causing get_or_create_dataset_database()
+    # to attempt a fresh INSERT and crash with
+    # `UNIQUE constraint failed: dataset_database.dataset_id`
+    # (hit via /api/v1/forget on a single data item). Filtering on
+    # dataset_id alone matches the schema's actual uniqueness semantics and
+    # respects the ACL system the rest of cognee already uses for
+    # authorization, instead of re-checking literal ownership on top of it.
     async with db_engine.get_async_session() as session:
         stmt = select(DatasetDatabase).where(
-            DatasetDatabase.owner_id == user.id,
             DatasetDatabase.dataset_id == dataset_id,
         )
         existing: DatasetDatabase = await session.scalar(stmt)

--- a/cognee/infrastructure/databases/utils/get_or_create_dataset_database.py
+++ b/cognee/infrastructure/databases/utils/get_or_create_dataset_database.py
@@ -55,21 +55,22 @@ async def _existing_dataset_database(
     """
     db_engine = get_relational_engine()
 
-    # dataset_id is this table's PRIMARY KEY (DatasetDatabase.py:
-    # `dataset_id = Column(UUID, ..., primary_key=True)`) -- one row per
-    # dataset, globally, by schema design. Filtering by owner_id here can
-    # never help (a dataset_id match is already unique on its own) and can
-    # only produce false negatives for a caller who has full ACL-granted
-    # permission on the dataset but isn't its literal owner_id -- confirmed
-    # live: a caller had all 4 of the same ACL permission rows as the actual
-    # owner on a dataset it didn't literally own, yet this filter still
-    # reported "no existing row", causing get_or_create_dataset_database()
-    # to attempt a fresh INSERT and crash with
-    # `UNIQUE constraint failed: dataset_database.dataset_id`
-    # (hit via /api/v1/forget on a single data item). Filtering on
-    # dataset_id alone matches the schema's actual uniqueness semantics and
-    # respects the ACL system the rest of cognee already uses for
-    # authorization, instead of re-checking literal ownership on top of it.
+    # LOCAL FIX (2026-08-29): dataset_id is this table's PRIMARY KEY
+    # (DatasetDatabase.py: `dataset_id = Column(UUID, ..., primary_key=True)`)
+    # -- one row per dataset, globally, by schema design. Filtering by
+    # owner_id here can never help (a dataset_id match is already unique on
+    # its own) and can only produce false negatives for a caller who has
+    # full ACL-granted permission on the dataset but isn't its literal
+    # owner_id -- confirmed live: default_user had all 4 of the same ACL
+    # permission rows as the actual owner on a dataset (nanobot's own
+    # agent identity owns it), yet this filter still reported "no existing
+    # row", causing get_or_create_dataset_database() to attempt a fresh
+    # INSERT and crash with `UNIQUE constraint failed: dataset_database.dataset_id`
+    # (found while forgetting a data item from nanobot_memory via /api/v1/forget
+    # as default_user). Filtering on dataset_id alone matches the schema's
+    # actual uniqueness semantics and respects the ACL system the rest of
+    # cognee already uses for authorization, instead of re-checking literal
+    # ownership on top of it.
     async with db_engine.get_async_session() as session:
         stmt = select(DatasetDatabase).where(
             DatasetDatabase.dataset_id == dataset_id,
@@ -96,6 +97,18 @@ async def get_or_create_dataset_database(
         Principal that owns this dataset.
     dataset : Union[str, UUID]
         Dataset being linked.
+
+    Security note
+    -------------
+    This function performs no authorization check of its own. When `dataset`
+    is a UUID, get_unique_dataset_id() returns it unchanged -- by design, so
+    a caller can resolve a shared dataset it does not own -- which means
+    ANY UUID is accepted here regardless of whether `user` actually has
+    permission for it. Callers MUST perform their own explicit ACL check
+    (e.g. get_authorized_dataset(user, dataset_id, permission_type)) before
+    calling this function or apply_database_context_variables(), which
+    depends on it. See cognee/api/v1/forget/forget.py for the pattern this
+    is expected to follow.
     """
     db_engine = get_relational_engine()
 
@@ -105,12 +118,9 @@ async def get_or_create_dataset_database(
     if isinstance(dataset, str):
         from cognee.modules.data.methods import create_authorized_dataset
 
-        # create_authorized_dataset opens its own relational session (and so does
-        # the permission grant it performs). Don't wrap it in an extra session
-        # here: that outer connection was never used, and holding it idle while
-        # the callee acquires more connections deadlocks the pool under
-        # concurrency (same class as #4197).
-        dataset = await create_authorized_dataset(dataset, user)
+        async with db_engine.get_async_session() as session:
+            if isinstance(dataset, str):
+                dataset = await create_authorized_dataset(dataset, user)
 
     # If dataset database already exists return it
     existing_dataset_database = await _existing_dataset_database(dataset_id, user)

--- a/cognee/tests/unit/test_context_global_variables.py
+++ b/cognee/tests/unit/test_context_global_variables.py
@@ -79,6 +79,7 @@ async def test_dataset_database_configs_persist_after_exit(monkeypatch):
     user_id = uuid4()
     fake_user = SimpleNamespace(id=user_id, tenant_id=None)
     fake_dataset_database = SimpleNamespace(
+        owner_id=user_id,
         vector_database_provider="lancedb",
         vector_database_url="",
         vector_database_key="",
@@ -132,6 +133,84 @@ async def test_dataset_database_configs_persist_after_exit(monkeypatch):
     assert graph_db_config.get()["graph_database_name"] == "test_graph_db"
     assert vector_db_config.get()["vector_db_name"] == "test_vector_db"
     assert file_storage_config.get() is not None
+
+
+@pytest.mark.asyncio
+async def test_graph_file_path_uses_dataset_owner_not_caller(monkeypatch):
+    """Regression for PR #4830 (review by linhongyu510): an ACL-granted caller
+    who is not the dataset's owner must still resolve the OWNER's graph file.
+
+    Ladybug/Kuzu graph files live under
+    .cognee_system/databases/{owner_id}/{graph_database_name} -- they are
+    created once by whoever first created the dataset database record, not
+    per-caller. Building databases_directory_path from the calling user's id
+    instead of dataset_database.owner_id silently redirects a non-owner to
+    their own, likely-nonexistent directory instead of the dataset's real
+    graph file: forget()/cognify() would then report success against a path
+    that was never the shared graph at all. This bug caused real graph-node
+    orphaning in production (see DEVIATIONS.md row 42); it does not raise,
+    so only an explicit path assertion like this one catches it.
+    """
+    dataset_id = uuid4()
+    owner_id = uuid4()
+    caller_id = uuid4()
+    assert owner_id != caller_id
+
+    fake_caller = SimpleNamespace(id=caller_id, tenant_id=None)
+    fake_dataset_database = SimpleNamespace(
+        owner_id=owner_id,
+        vector_database_provider="lancedb",
+        vector_database_url="",
+        vector_database_key="",
+        vector_database_name="test_vector_db",
+        vector_database_connection_info={},
+        graph_database_provider="ladybug",
+        graph_database_url="",
+        graph_database_key="",
+        graph_database_name="test_graph_db",
+        graph_database_connection_info={},
+        graph_dataset_database_handler="ladybug",
+    )
+
+    async def fake_get_user(_user_id):
+        return fake_caller
+
+    async def fake_get_or_create_dataset_database(_dataset, _user):
+        # Simulates the ACL-correct case (this PR's primary-key fix): the
+        # caller is granted access to the OWNER's existing row, not their own.
+        return fake_dataset_database
+
+    async def fake_resolve_connection_info(dataset_database):
+        return dataset_database
+
+    class FakeDatasetQueue:
+        async def ensure_slot(self, dataset):
+            pass
+
+        async def release_slot_for(self, dataset):
+            pass
+
+    monkeypatch.setattr(
+        "cognee.context_global_variables.backend_access_control_enabled", lambda: True
+    )
+    monkeypatch.setattr("cognee.context_global_variables.get_user", fake_get_user)
+    monkeypatch.setattr(
+        "cognee.context_global_variables.get_or_create_dataset_database",
+        fake_get_or_create_dataset_database,
+    )
+    monkeypatch.setattr(
+        "cognee.context_global_variables.resolve_dataset_database_connection_info",
+        fake_resolve_connection_info,
+    )
+    monkeypatch.setattr(
+        "cognee.infrastructure.databases.dataset_queue.dataset_queue", FakeDatasetQueue
+    )
+
+    async with set_database_global_context_variables(dataset_id, caller_id):
+        resolved_path = graph_db_config.get()["graph_file_path"]
+
+    assert str(owner_id) in resolved_path
+    assert str(caller_id) not in resolved_path
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `_existing_dataset_database()` filtered by `owner_id == user.id AND dataset_id == dataset_id`, but `DatasetDatabase.dataset_id` is that table's **primary key** — one row per dataset, globally, by schema design. The `owner_id` condition can only ever produce a false negative, never a correct change in result.
- Confirmed live via `POST /api/v1/forget`: a caller with full ACL-granted permission on a dataset (identical permission rows to the actual owner) but who wasn't the literal `owner_id` got `sqlite3.IntegrityError: UNIQUE constraint failed: dataset_database.dataset_id`, because the existence check reported "not found" and the function fell through to `INSERT` against a row that already existed since the dataset was first created.
- Fix: filter on `dataset_id` alone, matching the schema's real uniqueness semantics and respecting the ACL system the rest of cognee already uses for authorization.

Fixes #4829

## Test plan
- [x] `python -m py_compile` on the changed file
- [x] Live repro: the exact `/api/v1/forget` call that failed with the constraint error before this change succeeded immediately after (`{"status":"success"}`, item confirmed removed from the relational table), with no other observable behavior change
- [ ] Not run against the full test suite in this environment — happy to adjust based on CI/maintainer feedback