### PR TITLE
COG-6482 fix: Rearm jest fetch mocking and guard server config

### DIFF
--- a/cognee-frontend/.env.template
+++ b/cognee-frontend/.env.template
@@ -3,7 +3,7 @@
 # Read at run time, so the same built image (and the published
 # cognee/cognee-ui container) can be pointed anywhere:
 #
-#   docker run -e COGNEE_BACKEND_URL=http://cognee:8000 cognee/cognee-ui
+#   docker run -e COGNEE_BACKEND_URL=https://cognee.example.com cognee/cognee-ui
 #
 # Leave it unset for the usual localhost setup: the browser then derives the
 # backend host from the address the UI was loaded from, on port 8000.

--- a/cognee-frontend/jest.config.mjs
+++ b/cognee-frontend/jest.config.mjs
@@ -1,12 +1,17 @@
 import nextJest from "next/jest.js";
 
-// next/jest wires up SWC, CSS/asset stubs and the tsconfig "paths" aliases, so
-// tests compile through the same pipeline the app does.
+// next/jest wires up SWC and the CSS/asset stubs, so tests compile through the
+// same pipeline the app does. It does not carry the tsconfig paths across; see
+// moduleNameMapper below.
 const createJestConfig = nextJest({ dir: "./" });
 
 /** @type {import('jest').Config} */
 const config = {
   testEnvironment: "jest-environment-jsdom",
+  // `output: "standalone"` emits .next/standalone/package.json with the same
+  // name as the root one, which trips a haste collision warning on every run
+  // after a build.
+  modulePathIgnorePatterns: ["<rootDir>/.next/"],
   // next/jest does not carry the tsconfig "paths" aliases across, so map
   // them here. Without this, every "@/..." import fails to resolve.
   moduleNameMapper: {

--- a/cognee-frontend/jest.setup.ts
+++ b/cognee-frontend/jest.setup.ts
@@ -2,9 +2,15 @@
 import "@testing-library/jest-dom";
 
 // jsdom ships no fetch API, so suites that construct a Response fail with
-// "Response is not defined". jest-fetch-mock installs the whole family
-// (fetch/Response/Headers/Request) and leaves real fetch mocked per test.
+// "Response is not defined". enableMocks() installs the whole family
+// (fetch/Response/Headers/Request) and makes global fetch the mock, which is
+// what lets a test call fetchMock.mockResponseOnce(...).
+//
+// Do not add dontMock() here. It sets the library's isMocking predicate to a
+// permanent false, and mockResponseOnce and friends only swap the
+// implementation without flipping it back, so the stubbing API would be
+// silently dead repo-wide and unstubbed calls would hit the real network.
+// src/__tests__/fetchMocking.test.ts guards both halves of this.
 import fetchMock from "jest-fetch-mock";
 
 fetchMock.enableMocks();
-fetchMock.dontMock();

--- a/cognee-frontend/package-lock.json
+++ b/cognee-frontend/package-lock.json
@@ -29,6 +29,7 @@
         "react-error-boundary": "^6.0.0",
         "react-force-graph-2d": "^1.29.0",
         "react-markdown": "^10.1.0",
+        "server-only": "^0.0.1",
         "uuid": "^11.1.0",
         "valibot": "^1.2.0"
       },
@@ -11166,6 +11167,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/cognee-frontend/package.json
+++ b/cognee-frontend/package.json
@@ -32,6 +32,7 @@
     "react-error-boundary": "^6.0.0",
     "react-force-graph-2d": "^1.29.0",
     "react-markdown": "^10.1.0",
+    "server-only": "^0.0.1",
     "uuid": "^11.1.0",
     "valibot": "^1.2.0"
   },

--- a/cognee-frontend/src/__tests__/fetchMocking.test.ts
+++ b/cognee-frontend/src/__tests__/fetchMocking.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Guards the jest fetch setup itself.
+ *
+ * jest.setup.ts previously called `enableMocks()` followed by `dontMock()`,
+ * which leaves jest-fetch-mock's isMocking predicate permanently false. The
+ * stubbing API still appeared to work, but every `mockResponseOnce` was a no-op
+ * and the call fell through to a real network request. These two tests fail if
+ * that combination ever comes back.
+ */
+import fetchMock from "jest-fetch-mock";
+
+describe("jest fetch setup", () => {
+  it("provides the fetch API classes jsdom lacks", () => {
+    expect(typeof Response).toBe("function");
+    expect(typeof Headers).toBe("function");
+    expect(typeof Request).toBe("function");
+  });
+
+  it("lets a test stub fetch instead of reaching the network", async () => {
+    fetchMock.resetMocks();
+    fetchMock.mockResponseOnce(JSON.stringify({ stubbed: true }));
+
+    const response = await fetch("http://backend.invalid/api/v1/datasets");
+
+    expect(await response.json()).toEqual({ stubbed: true });
+    expect(fetchMock).toHaveBeenCalledWith("http://backend.invalid/api/v1/datasets");
+  });
+});

--- a/cognee-frontend/src/app/(app)/api-keys/ApiKeysPage.tsx
+++ b/cognee-frontend/src/app/(app)/api-keys/ApiKeysPage.tsx
@@ -12,7 +12,6 @@ import getMyUserId from "@/modules/apiKeys/getMyUserId";
 import { TrackPageView, trackEvent } from "@/modules/analytics";
 import { isCloudEnvironment } from "@/utils";
 import { notifications } from "@mantine/notifications";
-import { getLocalApiUrl } from "@/modules/users/getLocalApiUrl";
 
 function StatusDot({ label, ready }: { label: string; ready: boolean }) {
   return (
@@ -54,7 +53,7 @@ export default function ApiKeysPage() {
   const isCloud = isCloudEnvironment();
   // In cloud, never fall back to localhost — show the real tenant URL when known,
   // otherwise treat as provisioning. Only local/OSS mode uses localApiUrl.
-  const baseUrl = isCloud ? serviceUrl : (serviceUrl || getLocalApiUrl());
+  const baseUrl = serviceUrl;
   const urlProvisioning = isCloud && !serviceUrl;
   const [keys, setKeys] = useState<ApiKey[]>([]);
   const [loading, setLoading] = useState(true);

--- a/cognee-frontend/src/modules/config/runtimeConfig.ts
+++ b/cognee-frontend/src/modules/config/runtimeConfig.ts
@@ -51,7 +51,7 @@ export function normalizeBackendUrl(
   // problem tells the operator nothing about what to type instead.
   if (!/^https?:\/\//i.test(value)) {
     throw new Error(
-      `${source} must be an absolute http(s) URL, got "${value}". Expected something like "http://cognee:8000".`,
+      `${source} must be an absolute http(s) URL, got "${value}". Expected something like "http://localhost:8000".`,
     );
   }
 

--- a/cognee-frontend/src/modules/config/serverRuntimeConfig.ts
+++ b/cognee-frontend/src/modules/config/serverRuntimeConfig.ts
@@ -1,3 +1,9 @@
+// Server-side only. Without this guard, a client component importing this
+// module would get process.env.COGNEE_BACKEND_URL replaced with undefined at
+// build time and silently fall back to localhost. next/jest maps this to an
+// empty mock, so tests are unaffected.
+import "server-only";
+
 import { normalizeBackendUrl, type RuntimeConfig } from "./runtimeConfig";
 
 /**


### PR DESCRIPTION
## Description

Follow-ups from a review pass over COG-6342 and COG-6343, both already in the 6319 feature branch. Nothing here is broken at runtime; two of them are traps.

`jest.setup.ts` had `enableMocks()` followed by `dontMock()`. `dontMock()` kills the isMocking predicate for good, and `mockResponseOnce` only swaps the implementation without turning it back on, so stubbing was dead repo-wide and any unstubbed call went to the real network. `enableMocks()` alone is what works. Dropping to a bare import is not enough either, it gives you `Response` and friends but leaves global fetch unmocked. There is a new test that reaches for an unroutable host so neither half can regress quietly.

`serverRuntimeConfig.ts` gets `import "server-only"`. Without it, pulling that module into a client component makes Next replace `COGNEE_BACKEND_URL` with undefined at build time and the module silently returns the localhost default, no error anywhere. The package was not installed, so it is added as a dependency: package.json +1 line, lockfile +7, nothing else moved.

Smaller stuff: `modulePathIgnorePatterns` so the standalone output stops colliding with the root package in jest's haste map, a jest.config comment that contradicted the mapping right below it, two examples recommending a backend URL the browser cannot resolve, and a dead fallback in ApiKeysPage whose import was the only thing keeping it alive.

Three modules the COG-6342 deletions orphaned (`switchTenant`, `workspaceCreationLock`, `getUserAppState`) stay for now. Verified they have no importers, but cognee-frontend is synced from cognee-saas, so deleting only here just invites the sync to put them back. Same reasoning as COG-6480. Left open on the ticket.

Base is the 6319 feature branch, not `dev`.

## Acceptance Criteria

* `fetchMock.mockResponseOnce(...)` actually intercepts, covered by a test
* Importing `serverRuntimeConfig` from a client component fails the build
* No haste collision warning after a build
* No example anywhere recommends a URL the browser cannot resolve
* Existing suite still green

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

```
$ npx tsc --noEmit -p tsconfig.json
(no output)

$ npx jest
Test Suites: 15 passed, 15 total
Tests:       126 passed, 126 total

$ npm run build
✓ Compiled successfully

$ pre-commit run --all-files
6 hooks passed
```

Also built the image with this branch applied on top of the 6319 packaging commit, since `server-only` is a new dependency and the two had never been built together: `docker build` passes, `npm ci` picks it up, and the container still refuses to start on a malformed `COGNEE_BACKEND_URL`, serves the right one, and reports healthy. Full round trip against a real backend container works, login and dashboard, all API calls 200.

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.