### PR TITLE
Fix/lancedb periodic compaction

### DIFF
--- a/cognee/infrastructure/databases/vector/config.py
+++ b/cognee/infrastructure/databases/vector/config.py
@@ -36,6 +36,14 @@ class VectorConfig(BaseSettings):
     vector_db_host: str = ""
     vector_db_subprocess_enabled: bool = True
     vector_pool_args: Union[str, None] = None
+    # Writes-per-table threshold at which accumulated LanceDB fragments/
+    # versions are folded back down via `optimize()`. Every `merge_insert`
+    # mints a new table version *and* a new data fragment, and LanceDB never
+    # compacts on its own -- left unbounded this inflates storage, query
+    # cost and process memory without limit on a long-lived deployment
+    # (see https://github.com/topoteretes/cognee/issues/4684). Ignored by
+    # backends other than LanceDB. `0` disables background compaction.
+    vector_db_compaction_write_interval: int = 25
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
@@ -113,6 +121,7 @@ class VectorConfig(BaseSettings):
             "vector_db_password": self.vector_db_password,
             "vector_db_host": self.vector_db_host,
             "vector_db_subprocess_enabled": self.vector_db_subprocess_enabled,
+            "vector_db_compaction_write_interval": self.vector_db_compaction_write_interval,
         }
 
 

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -3,6 +3,7 @@ import copy
 import inspect
 import threading
 import types
+from datetime import timedelta
 from collections import OrderedDict
 from os import path
 from uuid import UUID
@@ -13,6 +14,7 @@ from lancedb.pydantic import LanceModel, Vector
 from typing import List, Optional, Union, get_args, get_origin, get_type_hints
 
 from cognee.infrastructure.databases.exceptions import MissingQueryParameterError
+from cognee.infrastructure.databases.vector.config import get_vectordb_config
 from cognee.infrastructure.engine import DataPoint
 from cognee.infrastructure.engine.utils import parse_id
 from cognee.infrastructure.files.storage import get_file_storage
@@ -200,6 +202,10 @@ class LanceDBAdapter(VectorDBInterface):
         #   (*,     True)  — closed, not reusable in either mode
         self._subprocess_mode = session is not None
         self._permanently_closed = False
+        # Per-collection write counter driving periodic compaction (see
+        # `_maybe_compact`). Instance-level, not class-level: it must not be
+        # shared across adapters pointed at different LanceDB stores.
+        self._compaction_write_counts: dict[str, int] = {}
 
     async def get_connection(self):
         """
@@ -405,6 +411,56 @@ class LanceDBAdapter(VectorDBInterface):
         connection = await self.get_connection()
         return await connection.open_table(collection_name)
 
+    async def _maybe_compact(self, collection_name: str, collection) -> None:
+        """Best-effort LanceDB compaction, run periodically as a table is written.
+
+        Every `merge_insert` mints a new table version *and* a new data
+        fragment, and LanceDB never compacts on its own:
+        https://github.com/topoteretes/cognee/issues/4684. Left alone this
+        grows without bound on a long-lived deployment -- one real-world
+        store reached 6,592 versions / 6,557 fragments across 20 tables
+        (937 MB for a 2,461-node graph) before an offline `optimize()` cut
+        it to 48 / 27 / 411 MB with identical row counts.
+
+        Runs `optimize()` every `vector_db_compaction_write_interval` writes
+        to a given table (tracked per collection, per adapter instance)
+        rather than after every write, so the cost is amortized instead of
+        paid on the hot path each time. Mirrors the same best-effort
+        compaction already used after re-keying in
+        `cognee/modules/migrations/versions/_vector_rekey.py`.
+
+        Compaction is hygiene, not correctness: any failure -- including
+        subprocess-proxy handles that don't expose `optimize` -- is
+        swallowed so it can never fail, or slow down the caller's view of,
+        the write that already succeeded.
+        """
+        interval = get_vectordb_config().vector_db_compaction_write_interval
+        if interval <= 0:
+            return
+
+        count = self._compaction_write_counts.get(collection_name, 0) + 1
+        self._compaction_write_counts[collection_name] = count
+        if count % interval != 0:
+            return
+
+        optimize = getattr(collection, "optimize", None)
+        if optimize is None:
+            return
+
+        try:
+            # cleanup_older_than=timedelta(seconds=0) forces immediate
+            # removal of old fragment files. Without it, optimize() merges
+            # fragments but keeps the old ones on disk under LanceDB's
+            # default retention window -- which defeats the point here,
+            # since the goal is to actually shrink storage now.
+            await optimize(cleanup_older_than=timedelta(seconds=0))
+        except Exception as exc:  # noqa: BLE001 - compaction is an optimization, not correctness
+            logger.warning(
+                "Periodic compaction skipped for collection '%s': %s",
+                collection_name,
+                exc,
+            )
+
     async def create_data_points(self, collection_name: str, data_points: list[DataPoint]):
         """Upsert DataPoints into `collection_name`, merging belongs_to_set with any prior rows."""
         payload_schema = type(data_points[0])
@@ -534,6 +590,7 @@ class LanceDBAdapter(VectorDBInterface):
             #      schema now requires to be non-null. Raised from the Rust side
             #      (lance-file writer) when an old-schema row is upserted against
             #      a newer schema with a non-null field and no default in storage.
+
             err = str(e)
             if "not found in target schema" not in err and "contained null values" not in err:
                 raise
@@ -545,6 +602,11 @@ class LanceDBAdapter(VectorDBInterface):
             await self._migrate_collection_schema(
                 collection_name, collection, payload_schema, lance_data_points
             )
+        else:
+            # Only on the plain (non-migration) success path: the migration
+            # path already rebuilds the table from scratch, so it starts
+            # fragment-free and needs no extra compaction here.
+            await self._maybe_compact(collection_name, collection)
 
     async def upsert_raw_vectors(
         self,
@@ -601,6 +663,7 @@ class LanceDBAdapter(VectorDBInterface):
                 .when_not_matched_insert_all()
                 .execute(self._records_for_write(raw_points))
             )
+        await self._maybe_compact(collection_name, collection)
 
     async def _migrate_collection_schema(
         self,

--- a/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_compaction.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_compaction.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from pydantic import BaseModel
+
+try:
+    from cognee.infrastructure.databases.vector.config import get_vectordb_config
+    from cognee.infrastructure.databases.vector.lancedb.LanceDBAdapter import LanceDBAdapter
+
+    HAS_LANCEDB = True
+except ModuleNotFoundError:
+    HAS_LANCEDB = False
+
+
+class _FakeEmbeddingEngine:
+    def get_vector_size(self):
+        return 3
+
+    def get_batch_size(self):
+        return 100
+
+    async def embed_text(self, texts):
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+
+class _Payload(BaseModel):
+    slot: int
+    label: str
+
+
+def _fragment_count(db_path: str, collection_name: str) -> int:
+    """Count on-disk data fragment files for a table.
+
+    Mirrors the reproduction command from
+    https://github.com/topoteretes/cognee/issues/4684:
+    `find ... -path "*.lance/data/*" -type f | wc -l`
+    -- counting files directly rather than depending on a specific
+    lancedb version's stats API.
+    """
+    data_dir = Path(db_path) / f"{collection_name}.lance" / "data"
+    if not data_dir.exists():
+        return 0
+    return len(list(data_dir.iterdir()))
+
+
+async def _write_n_points(adapter: LanceDBAdapter, collection: str, n: int) -> None:
+    for i in range(n):
+        await adapter.upsert_raw_vectors(
+            collection,
+            [
+                {
+                    "id": uuid4(),
+                    "vector": [0.1, 0.2, 0.3],
+                    "payload": {"slot": i, "label": f"row-{i}"},
+                }
+            ],
+            payload_schema=_Payload,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_lancedb_compacts_after_configured_write_interval(tmp_path, monkeypatch):
+    """Fragments must be folded back down once the configured write count is hit."""
+    monkeypatch.setenv("VECTOR_DB_COMPACTION_WRITE_INTERVAL", "3")
+    get_vectordb_config.cache_clear()
+    try:
+        db_path = str(tmp_path / "db")
+        adapter = LanceDBAdapter(
+            url=db_path, api_key=None, embedding_engine=_FakeEmbeddingEngine()
+        )
+        collection = "CompactionTarget_label"
+
+        await _write_n_points(adapter, collection, 3)
+
+        # Without compaction this would be 3 fragments (one per upsert, per
+        # the issue's own measurement). optimize() should have folded them
+        # into (at most) one on the 3rd write.
+        assert _fragment_count(db_path, collection) <= 1
+    finally:
+        get_vectordb_config.cache_clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_lancedb_compaction_disabled_when_interval_is_zero(tmp_path, monkeypatch):
+    """Interval 0 must restore today's uncompacted behaviour exactly."""
+    monkeypatch.setenv("VECTOR_DB_COMPACTION_WRITE_INTERVAL", "0")
+    get_vectordb_config.cache_clear()
+    try:
+        db_path = str(tmp_path / "db")
+        adapter = LanceDBAdapter(
+            url=db_path, api_key=None, embedding_engine=_FakeEmbeddingEngine()
+        )
+        collection = "NoCompactionTarget_label"
+
+        await _write_n_points(adapter, collection, 6)
+
+        # One fragment per upsert, never compacted -- today's behaviour,
+        # preserved for anyone who opts out.
+        assert _fragment_count(db_path, collection) == 6
+    finally:
+        get_vectordb_config.cache_clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_lancedb_compaction_does_not_lose_rows(tmp_path, monkeypatch):
+    """Compaction must never change row counts or retrievable data (core safety property)."""
+    monkeypatch.setenv("VECTOR_DB_COMPACTION_WRITE_INTERVAL", "2")
+    get_vectordb_config.cache_clear()
+    try:
+        db_path = str(tmp_path / "db")
+        adapter = LanceDBAdapter(
+            url=db_path, api_key=None, embedding_engine=_FakeEmbeddingEngine()
+        )
+        collection = "RowSafetyTarget_label"
+        ids = [uuid4() for _ in range(5)]
+
+        for i, point_id in enumerate(ids):
+            await adapter.upsert_raw_vectors(
+                collection,
+                [
+                    {
+                        "id": point_id,
+                        "vector": [0.1, 0.2, 0.3],
+                        "payload": {"slot": i, "label": f"row-{i}"},
+                    }
+                ],
+                payload_schema=_Payload,
+            )
+
+        table = await adapter.get_collection(collection)
+        assert await table.count_rows() == 5
+
+        retrieved = await adapter.retrieve(collection, [str(pid) for pid in ids])
+        assert len(retrieved) == 5
+    finally:
+        get_vectordb_config.cache_clear()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!--

Fixes #4684
I was looking at issue #4684. The problem is that LanceDB writes a new
version + a new fragment file every time cognee saves data
(merge_insert), and nothing in normal operation ever cleans those up.
The issue reporter measured a real deployment where 5.3 MB of actual
data turned into 937 MB on disk because of this, and one table alone
had 1,451 leftover fragments.

I checked the codebase and found there's already an optimize() call
used for compaction in one place — a one-off migration script
(_vector_rekey.py) — but it's never called during normal writes. So my
fix reuses that same pattern instead of inventing something new.

What I did:
- Added a config setting `vector_db_compaction_write_interval`
  (default 25, set to 0 to disable) so operators can control how often
  compaction runs.
- Added a `_maybe_compact()` method on the LanceDB adapter that counts
  writes per table, and calls `table.optimize()` once the count hits
  the interval.
- I initially just called `optimize()` with no arguments, tested it,
  and found the fragment count didn't actually drop — turns out
  LanceDB keeps old fragment files around by default even after
  compaction, unless you tell it not to. So I added
  `cleanup_older_than=timedelta(seconds=0)` to force it to actually
  remove the old files, matching what the issue's own workaround did.
- Hooked this into the two real write paths that use merge_insert:
  create_data_points and upsert_raw_vectors.
- Made it fail-safe: if optimize() throws for any reason, it's caught
  and logged as a warning, never raised. Compaction should never be
  able to break a write that already succeeded.
-->

## Acceptance Criteria
<!--
- Fragments actually get compacted after N writes to a table, where N
  is configurable.
- Setting the interval to 0 keeps today's behavior exactly (no
  compaction at all), for anyone who doesn't want this.
- Compaction never loses or changes row data.
- No existing tests break.
-->

## Type of Change
<!-- Please check the relevant option -->
- [ x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->
<img width="1092" height="891" alt="1" src="https://github.com/user-attachments/assets/50c99596-a3aa-4201-a949-92c8931b172d" />
<img width="1077" height="880" alt="2" src="https://github.com/user-attachments/assets/5ace7221-bf88-4889-9b20-d612996606d5" />


## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ x ] **This PR contains minimal changes necessary to address the issue/feature**
- [ x ] My code follows the project's coding standards and style guidelines
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ x] All new and existing tests pass
- [ x ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ x ] I have linked any relevant issues in the description
- [  x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
