### PR TITLE
fix(dashboard): render operation-level activity rows without crashing

### DIFF
--- a/cognee-frontend/src/ui/elements/AgentActivityTerminal.tsx
+++ b/cognee-frontend/src/ui/elements/AgentActivityTerminal.tsx
@@ -15,7 +15,9 @@ import { SEARCH_SESSION_PREFIX } from "@/modules/sessions/getSessions";
 export interface PipelineRun {
   id: string;
   pipeline_name: string | null;
-  status: string;
+  // The activity API serializes status as null when run.status is unset
+  // (get_activity_router.py), so every .includes(...) read must coalesce.
+  status: string | null;
   dataset_id: string | null;
   dataset_name: string | null;
   owner_id: string | null;
@@ -422,7 +424,7 @@ export function AgentActivityTerminal({
       return ev.kind === "agentQuery";
     }
     if (termFilter === "errors") {
-      if (ev.kind === "run") return ev.r.status.includes("ERRORED");
+      if (ev.kind === "run") return (ev.r.status ?? "").includes("ERRORED");
       if (ev.kind === "session") return ev.s.effective_status === "failed" || ev.s.error_count > 0;
       return false;
     }
@@ -836,8 +838,8 @@ export function AgentActivityTerminal({
               // ── Operational pipeline run: a compact, non-expandable marker ──
               if (ev.kind === "run") {
                 const r = ev.r;
-                const isError = r.status.includes("ERRORED");
-                const isRunning = r.status.includes("STARTED") || r.status.includes("INITIATED");
+                const isError = (r.status ?? "").includes("ERRORED");
+                const isRunning = (r.status ?? "").includes("STARTED") || (r.status ?? "").includes("INITIATED");
                 const outcome: Outcome = isRunning ? "running" : isError ? "error" : "done";
                 // Defensive fallback only — the push above already guarantees
                 // pipeline_name is set for every "run" event reaching here.


### PR DESCRIPTION
## Summary

Operation-level `PipelineRun` rows (recall, remember, search, ...) are deliberately stored with `pipeline_name = null` and `operation_name` populated (`record_operation._write_operation_row`). The API already returns `operation_name` on `dev`, but `AgentActivityTerminal` still types `pipeline_name` as a required string and calls `.toLowerCase()` on it unconditionally, so the first operation-level row renders the error boundary (`Cannot read properties of null (reading 'toLowerCase')`). This PR fixes the frontend half.

## Changes

- `cognee-frontend/src/ui/elements/runPipelineName.ts` (new, pure module): `runPipelineName(r) = r.pipeline_name ?? r.operation_name ?? ""` plus `pipelineLabel` moved next to it.
- `AgentActivityTerminal.tsx`: `pipeline_name` typed `string | null`, `operation_name` added; the event filter and the label now derive the display name via `runPipelineName`. Operation rows are labeled like their pipeline counterparts (`cognee.recall`, `cognee.search`) and survive the search/recall filter instead of being dropped.
- `cognee-frontend/jest.config.json` (new, minimal): the repo ships `__tests__` suites and jest dev-dependencies but no jest config, so the new test was not runnable; this wires `ts-jest` + the `@/` alias. Nothing else runs jest today, so it changes no existing pipeline.
- `cognee-frontend/src/ui/elements/__tests__/runPipelineName.test.ts`: regression tests (null fallback, both-null, no-crash on `.toLowerCase()`, label parity).

## How was this tested?

- `npx jest --config jest.config.json` → 5/5 passed (scoped to the new suite).
- `npx tsc --noEmit` → 27 pre-existing project errors both with and without this change; zero errors reference the touched files.
- Backend change is a serialized-field addition (`operation_name` exists on the model, `PipelineRun.py:48`); `ast.parse` clean. No backend unit suite covers this router (none exists).

Fixes #4834

## Additional context

A null-guard that only dropped these rows would also hide recall/search operation activity from the terminal; falling back to `operation_name` keeps it visible, matching the issue's suggested direction. Commit is DCO-signed.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin