### PR TITLE
fix(ingestion): keep the WHERE clause for aliased tables, fail loudly for alias refs and JOINs

### DIFF
--- a/cognee/tasks/ingestion/create_dlt_source.py
+++ b/cognee/tasks/ingestion/create_dlt_source.py
@@ -126,14 +126,54 @@ def _parse_sql_query(query: str) -> tuple:
     Table names may be schema-qualified (``public.users``). ``\\w+`` alone
     stops at the first dot, which used to drop both the schema and the WHERE
     clause.
+
+    A table alias (``users u`` / ``users AS u``) is allowed as long as the
+    WHERE clause qualifies columns with the table name, not the alias: dlt's
+    select is built on the bare table, so an alias reference (``u.age``)
+    cannot be replayed and raises instead of silently ingesting the whole
+    table. JOIN queries raise for the same reason — their WHERE spans tables
+    the single-table source cannot express.
     """
+    # Words that can follow a table name without being an alias.
+    _RESERVED_AFTER_TABLE = (
+        "WHERE",
+        "JOIN",
+        "INNER",
+        "LEFT",
+        "RIGHT",
+        "FULL",
+        "CROSS",
+        "ORDER",
+        "GROUP",
+        "LIMIT",
+        "UNION",
+        "OFFSET",
+        "HAVING",
+    )
+    alias_pattern = "|".join(_RESERVED_AFTER_TABLE)
     match = re.match(
-        r"SELECT\s+.+?\s+FROM\s+(\w+(?:\.\w+)*)(?:\s+WHERE\s+(.+))?",
+        r"SELECT\s+.+?\s+FROM\s+"
+        r"(?P<table>\w+(?:\.\w+)*)"
+        rf"(?:\s+(?:AS\s+)?(?!(?:{alias_pattern})\b)(?P<alias>\w+))?"
+        rf"(?P<join>\s+(?:(?:INNER|LEFT|RIGHT|FULL|CROSS)\s+)?JOIN\b)?"
+        r"(?:\s+WHERE\s+(?P<where>.+))?",
         query.strip(),
         re.IGNORECASE | re.DOTALL,
     )
     if not match:
         raise ValueError(f"Cannot parse SQL query: {query}")
-    table_name = match.group(1)
-    where_clause = match.group(2) or "1=1"
+    if match.group("join"):
+        raise ValueError(
+            "JOIN queries are not supported for filtered ingestion (the WHERE clause spans "
+            f"tables this source cannot express): {query}. Ingest the table without a filter, "
+            "or create a view and ingest that."
+        )
+    table_name = match.group("table")
+    where_clause = match.group("where") or "1=1"
+    alias = match.group("alias")
+    if alias and re.search(rf"\b{re.escape(alias)}\.\w+", where_clause, re.IGNORECASE):
+        raise ValueError(
+            f"WHERE clause references the table alias '{alias}', but the filter is replayed against "
+            f"the bare table '{table_name}'. Qualify columns with the table name instead: {query}"
+        )
     return table_name, where_clause

--- a/cognee/tests/unit/tasks/ingestion/test_parse_sql_query.py
+++ b/cognee/tests/unit/tasks/ingestion/test_parse_sql_query.py
@@ -41,6 +41,24 @@ from cognee.tasks.ingestion.create_dlt_source import (
             "SELECT a, b FROM reporting.fact_orders WHERE status = 'open'",
             ("reporting.fact_orders", "status = 'open'"),
         ),
+        # A table alias must not break WHERE adjacency (#4839): the alias
+        # segment used to defeat the WHERE group, silently falling back to 1=1
+        # and ingesting the whole table.
+        (
+            "SELECT * FROM users AS u WHERE age > 18",
+            ("users", "age > 18"),
+        ),
+        ("SELECT * FROM users u WHERE age > 18", ("users", "age > 18")),
+        ("SELECT * FROM users u", ("users", "1=1")),
+        (
+            "SELECT * FROM public.users AS u WHERE age > 18",
+            ("public.users", "age > 18"),
+        ),
+        # An alias named like a clause keyword is a clause keyword, not an alias.
+        (
+            "SELECT * FROM users ORDER BY age LIMIT 5",
+            ("users", "1=1"),
+        ),
     ],
 )
 def test_parse_sql_query(query, expected):
@@ -50,6 +68,22 @@ def test_parse_sql_query(query, expected):
 def test_parse_sql_query_rejects_non_select():
     with pytest.raises(ValueError, match="Cannot parse SQL query"):
         _parse_sql_query("DELETE FROM users")
+
+
+def test_parse_sql_query_rejects_alias_qualified_where():
+    """dlt replays the filter against the bare table, so an alias reference cannot work."""
+    with pytest.raises(ValueError, match="references the table alias 'u'"):
+        _parse_sql_query("SELECT * FROM users u WHERE u.age > 18")
+
+
+def test_parse_sql_query_rejects_joins():
+    """A JOIN query's WHERE spans tables the single-table source cannot express."""
+    with pytest.raises(ValueError, match="JOIN queries are not supported"):
+        _parse_sql_query(
+            "SELECT o.id FROM orders o JOIN customers c ON o.cid = c.id WHERE c.age > 18"
+        )
+    with pytest.raises(ValueError, match="JOIN queries are not supported"):
+        _parse_sql_query("SELECT * FROM users LEFT JOIN roles r ON users.rid = r.id")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #4839

## What Problem This Solves

`_parse_sql_query`'s WHERE group required `WHERE` to sit immediately after the captured table name, so any **alias** segment (`users u`, `users AS u`) or **JOIN** broke the adjacency and the clause silently fell back to `1=1` — the whole table was ingested instead of the filtered rows. Same silent-over-ingestion class as #3663, for the query shapes #4687's schema-qualification fix left:

```python
_parse_sql_query("SELECT * FROM users AS u WHERE age > 18")   # ('users', '1=1')  <- before
_parse_sql_query("SELECT * FROM users u WHERE age > 18")      # ('users', '1=1')  <- before
_parse_sql_query("SELECT o.id FROM orders o JOIN customers c ON o.cid = c.id WHERE c.age > 18")
                                                              # ('orders', '1=1')  <- before
```

Reachable from the public API: `add(data=["postgresql://..."], query="SELECT * FROM users AS u WHERE age > 18")`.

## Why This Change Was Made

- The optional table-alias is now part of the match (with a keyword lookahead so `WHERE`/`JOIN`/`ORDER`… are never mistaken for an alias), so an unqualified WHERE next to an alias is applied as written.
- Two shapes cannot be replayed against dlt's bare-table select, so they now **raise `ValueError` with guidance** instead of silently ingesting everything:
  - a WHERE that references the alias (`u.age > 18`) — dlt builds the select on the bare table, so the alias doesn't exist downstream;
  - JOIN queries — their WHERE spans tables the single-table source cannot express (suggested alternatives in the message: ingest unfiltered, or ingest a view).

## Testing

`cognee/tests/unit/tasks/ingestion/test_parse_sql_query.py` gains: alias with/without `AS` (bare and schema-qualified) keeping the WHERE; alias with no WHERE; a keyword-follows-table case; the two new `ValueError` paths; plus a no-`WHERE` `ORDER BY/LIMIT` regression case. All 21 tests in the file pass; the wider `tests/unit/tasks/ingestion/` directory shows the same 7 pre-existing failures with and without this change (verified by stashing), and 85 pass with it (78 without).

Note: `ruff check` flags 3 pre-existing `UP045` findings in this file (lines 46/49/85, untouched by this diff) — left alone to keep the change single-purpose.
