### PR TITLE
ci: Pin actions/checkout to v6.1.0 in container jobs

### DIFF
--- a/.github/workflows/docker_compose.yml
+++ b/.github/workflows/docker_compose.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089  # master
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -794,7 +794,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out
-        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089  # master
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Cognee Setup
         uses: ./.github/actions/cognee_setup
@@ -857,7 +857,7 @@ jobs:
     container: ${{ inputs.ci-image != '' && fromJSON(format('{{"image":"{0}","credentials":{{"username":"{1}","password":"{2}"}}}}', inputs.ci-image, github.actor, github.token)) || null }}
     steps:
       - name: Check out
-        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089  # master
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Cognee Setup
         uses: ./.github/actions/cognee_setup
@@ -883,7 +883,7 @@ jobs:
     container: ${{ inputs.ci-image != '' && fromJSON(format('{{"image":"{0}","credentials":{{"username":"{1}","password":"{2}"}}}}', inputs.ci-image, github.actor, github.token)) || null }}
     steps:
       - name: Check out
-        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089  # master
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Cognee Setup
         uses: ./.github/actions/cognee_setup
@@ -908,7 +908,7 @@ jobs:
     container: ${{ inputs.ci-image != '' && fromJSON(format('{{"image":"{0}","credentials":{{"username":"{1}","password":"{2}"}}}}', inputs.ci-image, github.actor, github.token)) || null }}
     steps:
       - name: Check out
-        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089  # master
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Cognee Setup
         uses: ./.github/actions/cognee_setup
@@ -933,7 +933,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out
-        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089  # master
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Cognee Setup
         uses: ./.github/actions/cognee_setup
@@ -1364,7 +1364,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out
-        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089  # master
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Cognee Setup
         uses: ./.github/actions/cognee_setup
@@ -1478,7 +1478,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Check out
-        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089  # master
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Cognee Setup
         uses: ./.github/actions/cognee_setup
@@ -2142,7 +2142,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089  # master
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Cognee Setup
         uses: ./.github/actions/cognee_setup


### PR DESCRIPTION
## Description

The three containerized delete E2E jobs — **Delete data from two users operating on different datasets**, **Delete data from two users operating on same dataset**, and **Delete dataset in Kuzu graph case** — fail deterministically on every branch, **including dev** (run 33366867584), since GitHub's forced Node 20 → 24 runner migration rolled out. Reruns fail identically; no test code ever executes.

### Root cause

Eight checkout steps in `e2e_tests.yml` (plus one in `docker_compose.yml`) were pinned to a stale `actions/checkout` **master** SHA (`61b9e37...`) that predates the action's automatic `safe.directory` handling. In jobs that run inside the CI container, the workspace `/__w/cognee/cognee` is owned by a different UID than the container user, so git 2.39.5 aborts during checkout:

```
fatal: detected dubious ownership in repository at '/__w/cognee/cognee'
##[error]The process '/usr/bin/git' failed with exit code 128
```

The same stale pin in the non-container jobs (Neo4j, performance) survives only because there is no UID mismatch on the plain runner. It worked until this week because the old action ran on Node 20; the runners now force Node 24 (the job logs warn about exactly this).

### Fix

Replace the stale SHA with the `v6.1.0` pin (`d23441a...`) already used by every other checkout step in the same file — v6 configures `safe.directory` automatically.

## Testing

- `grep` confirms zero remaining `61b9e37...` pins in `.github/`.
- The E2E suite on this PR is the real test: the three delete jobs should get past checkout and actually run.

Refs COG-6292 — follow-up PR #4844 is currently blocked on these required checks, as is dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)