### PR TITLE
feat: Add opt-in ONTOLOGY_MODE=strict entity grounding (COG-6279)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -253,6 +253,15 @@ VECTOR_DATASET_DATABASE_HANDLER="lancedb"
 #ONTOLOGY_RESOLVER=rdflib
 #MATCHING_STRATEGY=fuzzy
 #ONTOLOGY_FILE_PATH=YOUR_FULL_FILE_PATH
+# strict drops extracted entities with no grounding in the ontology (and their edges).
+# An entity is grounded when EITHER its type matches an ontology class OR its name
+# matches an individual — so unknown entities with a recognized type are kept.
+# Entity-grounding only, no OWL constraint reasoning. Strict expects an ontology that
+# covers the corpus's vocabulary; a small ontology will drop most extracted entities
+# (the run logs an aggregate dropped/retained count). Strict prunes only the graph:
+# chunk text is still stored, embedded, and retrievable via CHUNKS/RAG_COMPLETION.
+# With strict on, an empty or missing ontology file is a hard error.
+#ONTOLOGY_MODE=annotate
 
 ################################################################################
 #  Database Adapter Caching

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -591,7 +591,10 @@ Configuration:
 ONTOLOGY_RESOLVER=rdflib  # Default: uses rdflib and OWL files
 MATCHING_STRATEGY=fuzzy   # Default: fuzzy matching with 80% similarity
 ONTOLOGY_FILE_PATH=/path/to/your/ontology.owl  # Full path to ontology file
+ONTOLOGY_MODE=annotate    # Default: enrich only. strict drops entities with no ontology grounding
 ```
+
+`ONTOLOGY_MODE=strict` keeps an entity when either its type matches an ontology class or its name matches an individual, and drops the rest (plus their edges). It prunes only the graph — chunk text stays stored/embedded, so CHUNKS/RAG_COMPLETION can still surface dropped entities. It expects an ontology covering the corpus's vocabulary (a small ontology drops most entities; an aggregate dropped/retained count is logged), and an empty/missing ontology file with strict on is a hard error. The mode can also be set per call via `config={"ontology_config": {"ontology_mode": "strict", ...}}`.
 
 Implementation: `cognee/modules/ontology/`
 

--- a/catalog/entries/use-cases/custom-ontology.yaml
+++ b/catalog/entries/use-cases/custom-ontology.yaml
@@ -7,7 +7,7 @@ tags:
   - owl
   - domain-vocabulary
   - entity-extraction
-summary: Ground extracted entities in a domain ontology (OWL or similar) — matched entities are canonicalized and enriched with its class hierarchy; unmatched entities are retained as extracted (unless ONTOLOGY_MODE=strict, which drops entities with neither a class match on their type nor an individual match on their name — note strict prunes only the graph, chunk text stays stored and retrievable via chunk-based search).
+summary: Ground extracted entities in a domain ontology (OWL or similar) — matched entities are canonicalized and enriched with its class hierarchy; unmatched ones are kept, or dropped by ONTOLOGY_MODE=strict (graph-only; chunks stay searchable).
 what_youll_build: A cognify run configured with a custom ontology file where matched entity names and types are canonicalized to the ontology's terms and enriched with its class hierarchy, and recall answers use the domain's terminology.
 quickstart: |
   git clone https://github.com/topoteretes/cognee.git

--- a/catalog/entries/use-cases/custom-ontology.yaml
+++ b/catalog/entries/use-cases/custom-ontology.yaml
@@ -7,8 +7,8 @@ tags:
   - owl
   - domain-vocabulary
   - entity-extraction
-summary: Constrain cognee's entity extraction to a domain ontology (OWL or similar) so the graph reflects your vocabulary, not the LLM's guesses.
-what_youll_build: A cognify run configured with a custom ontology file where entity types and relationships come from the ontology, and recall answers respect the domain's terminology.
+summary: Ground extracted entities in a domain ontology (OWL or similar) — matched entities are canonicalized and enriched with its class hierarchy; unmatched entities are retained as extracted (unless ONTOLOGY_MODE=strict, which drops entities with neither a class match on their type nor an individual match on their name — note strict prunes only the graph, chunk text stays stored and retrievable via chunk-based search).
+what_youll_build: A cognify run configured with a custom ontology file where matched entity names and types are canonicalized to the ontology's terms and enriched with its class hierarchy, and recall answers use the domain's terminology.
 quickstart: |
   git clone https://github.com/topoteretes/cognee.git
   cd cognee

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -18,7 +18,10 @@ from cognee.infrastructure.databases.vector.embeddings.config import EmbeddingCo
 from cognee.infrastructure.llm.config import LLMConfig
 from cognee.modules.chunking.TextChunker import TextChunker
 from cognee.modules.ontology.ontology_config import Config
-from cognee.modules.ontology.get_default_ontology_resolver import get_configured_ontology_resolver
+from cognee.modules.ontology.get_default_ontology_resolver import (
+    get_configured_ontology_mode,
+    get_configured_ontology_resolver,
+)
 from cognee.modules.users.models import User
 
 from cognee.tasks.documents import (
@@ -296,7 +299,13 @@ async def cognify(
         await run_migrations_and_block(datasets, user)
 
         resolved_resolver = get_configured_ontology_resolver(config)
-        config = {"ontology_config": {"ontology_resolver": resolved_resolver}}
+        resolved_ontology_mode = get_configured_ontology_mode(config)
+        config = {
+            "ontology_config": {
+                "ontology_resolver": resolved_resolver,
+                "ontology_mode": resolved_ontology_mode,
+            }
+        }
 
         if dry_run:
             if temporal_cognify:

--- a/cognee/modules/ontology/construct_data_points_and_edges_with_ontology.py
+++ b/cognee/modules/ontology/construct_data_points_and_edges_with_ontology.py
@@ -9,8 +9,16 @@ from cognee.modules.engine.models import Entity, EntityType
 from cognee.modules.engine.utils import generate_edge_name, generate_node_name
 from cognee.modules.graph.utils.expand_with_nodes_and_edges import construct_data_points_and_edges
 from cognee.modules.ontology.base_ontology_resolver import BaseOntologyResolver
+from cognee.modules.ontology.exceptions import EmptyOntologyInStrictModeError
 from cognee.modules.ontology.models import AttachedOntologyNode
+from cognee.modules.ontology.ontology_env_config import (
+    get_ontology_env_config,
+    normalize_ontology_mode,
+)
 from cognee.shared.data_models import KnowledgeGraph, Node
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
 
 _ONTOLOGY_CLASS_CATEGORY = "classes"
 _ONTOLOGY_INDIVIDUAL_CATEGORY = "individuals"
@@ -27,6 +35,33 @@ class OntologyMatch:
 
 
 OntologyMatchLookup = dict[tuple[str, str], Optional[OntologyMatch]]
+
+
+@dataclass
+class _StrictModeDropCounts:
+    total_nodes: int = 0
+    dropped_nodes: int = 0
+    total_edges: int = 0
+    dropped_edges: int = 0
+
+    def add(self, other: "_StrictModeDropCounts") -> None:
+        self.total_nodes += other.total_nodes
+        self.dropped_nodes += other.dropped_nodes
+        self.total_edges += other.total_edges
+        self.dropped_edges += other.dropped_edges
+
+
+def ensure_ontology_usable_in_strict_mode(ontology_resolver: BaseOntologyResolver) -> None:
+    """Refuse strict mode when the resolver holds no ontology entries at all.
+
+    An empty lookup — typically a mistyped ONTOLOGY_FILE_PATH, which the resolver
+    only warns about — is indistinguishable from "the ontology rejected everything"
+    once matching starts, so strict mode would silently drop the entire graph.
+    Resolvers without a ``lookup`` dict (custom implementations) are not checked.
+    """
+    lookup = getattr(ontology_resolver, "lookup", None)
+    if isinstance(lookup, dict) and not any(lookup.values()):
+        raise EmptyOntologyInStrictModeError()
 
 
 def _find_ontology_match(
@@ -98,8 +133,16 @@ def _get_ontology_match(
 def _canonicalize_extracted_graph(
     extracted_graph: KnowledgeGraph,
     ontology_match_lookup: OntologyMatchLookup,
-) -> None:
-    """Canonicalize one graph and collapse nodes matched to the same ontology entity."""
+    strict: bool = False,
+) -> _StrictModeDropCounts:
+    """Canonicalize one graph and collapse nodes matched to the same ontology entity.
+
+    Strict mode is entity-grounding only: a node is retained when the ontology matched
+    EITHER its type against a class OR its name against an individual — an unknown
+    entity with a recognized type survives. Nodes with neither match are dropped along
+    with their edges. There is no domain/range/cardinality/disjointness reasoning, and
+    relationship names are not checked against the ontology.
+    """
     extracted_node_ids: set[str] = set()
     for node in extracted_graph.nodes:
         if node.id in extracted_node_ids:
@@ -107,6 +150,7 @@ def _canonicalize_extracted_graph(
         extracted_node_ids.add(node.id)
 
     retained_nodes: list[Node] = []
+    dropped_node_ids: set[str] = set()
     surviving_node_id_by_entity_id: dict[UUID, str] = {}
     surviving_node_id_by_collapsed_node_id: dict[str, str] = {}
 
@@ -125,7 +169,10 @@ def _canonicalize_extracted_graph(
             node.name,
         )
         if entity_match is None:
-            retained_nodes.append(node)
+            if strict and entity_type_match is None:
+                dropped_node_ids.add(node.id)
+            else:
+                retained_nodes.append(node)
             continue
 
         node.name = entity_match.canonical_name
@@ -138,10 +185,17 @@ def _canonicalize_extracted_graph(
 
         surviving_node_id_by_collapsed_node_id[node.id] = surviving_node_id
 
-    extracted_graph.nodes = retained_nodes
-    if not surviving_node_id_by_collapsed_node_id:
-        return
+    drop_counts = _StrictModeDropCounts(
+        total_nodes=len(extracted_node_ids),
+        dropped_nodes=len(dropped_node_ids),
+        total_edges=len(extracted_graph.edges),
+    )
 
+    extracted_graph.nodes = retained_nodes
+    if not surviving_node_id_by_collapsed_node_id and not dropped_node_ids:
+        return drop_counts
+
+    retained_edges = []
     for edge in extracted_graph.edges:
         edge.source_node_id = surviving_node_id_by_collapsed_node_id.get(
             edge.source_node_id,
@@ -151,23 +205,59 @@ def _canonicalize_extracted_graph(
             edge.target_node_id,
             edge.target_node_id,
         )
+        if edge.source_node_id in dropped_node_ids or edge.target_node_id in dropped_node_ids:
+            continue
+        retained_edges.append(edge)
+
+    drop_counts.dropped_edges = len(extracted_graph.edges) - len(retained_edges)
+    extracted_graph.edges = retained_edges
+    return drop_counts
 
 
 def canonicalize_extracted_graphs(
     data_chunks: list[DocumentChunk],
     extracted_graphs: list[KnowledgeGraph],
     ontology_resolver: BaseOntologyResolver,
+    strict: bool = False,
 ) -> tuple[list[KnowledgeGraph], OntologyMatchLookup]:
-    """Canonicalize ontology matches in place before ordinary graph construction."""
+    """Canonicalize ontology matches in place before ordinary graph construction.
+
+    Strict mode prunes only the extracted graph: chunks were already stored and
+    embedded earlier in the pipeline, so chunk-based search types (CHUNKS,
+    CHUNKS_LEXICAL, RAG_COMPLETION) still retrieve text mentioning dropped entities.
+    Only graph-based search types see the pruned view.
+    """
+    if strict:
+        ensure_ontology_usable_in_strict_mode(ontology_resolver)
+
     ontology_match_lookup = _find_ontology_matches_for_extracted_graphs(
         data_chunks,
         extracted_graphs,
         ontology_resolver,
     )
 
+    run_drop_counts = _StrictModeDropCounts()
     for extracted_graph in extracted_graphs:
         if extracted_graph:
-            _canonicalize_extracted_graph(extracted_graph, ontology_match_lookup)
+            run_drop_counts.add(
+                _canonicalize_extracted_graph(extracted_graph, ontology_match_lookup, strict=strict)
+            )
+
+    if strict and (run_drop_counts.dropped_nodes or run_drop_counts.dropped_edges):
+        retained_nodes = run_drop_counts.total_nodes - run_drop_counts.dropped_nodes
+        logger.warning(
+            "Strict ontology mode dropped %s of %s extracted node(s) (%.0f%% retained) "
+            "and %s of %s edge(s) across %s graph(s). A high drop ratio usually means "
+            "the ontology does not cover the corpus's vocabulary.",
+            run_drop_counts.dropped_nodes,
+            run_drop_counts.total_nodes,
+            100.0 * retained_nodes / run_drop_counts.total_nodes
+            if run_drop_counts.total_nodes
+            else 0.0,
+            run_drop_counts.dropped_edges,
+            run_drop_counts.total_edges,
+            len(extracted_graphs),
+        )
 
     return extracted_graphs, ontology_match_lookup
 
@@ -319,12 +409,21 @@ def construct_data_points_and_edges_with_ontology(
     data_chunks: list[DocumentChunk],
     extracted_graphs: list[KnowledgeGraph],
     ontology_resolver: BaseOntologyResolver,
+    ontology_mode: Optional[str] = None,
 ) -> tuple[dict[str, Entity | EntityType], dict[EdgeIdentity, Edge]]:
-    """Canonicalize, construct, and enrich extracted graphs with ontology data."""
+    """Canonicalize, construct, and enrich extracted graphs with ontology data.
+
+    ``ontology_mode`` overrides the ONTOLOGY_MODE environment value for this call;
+    when None, the environment value applies.
+    """
+    if ontology_mode is None:
+        ontology_mode = get_ontology_env_config().ontology_mode
+    strict = normalize_ontology_mode(ontology_mode) == "strict"
     canonicalized_graphs, ontology_match_lookup = canonicalize_extracted_graphs(
         data_chunks,
         extracted_graphs,
         ontology_resolver,
+        strict=strict,
     )
     data_points_by_id, edges_by_identity = construct_data_points_and_edges(
         data_chunks,

--- a/cognee/modules/ontology/exceptions/__init__.py
+++ b/cognee/modules/ontology/exceptions/__init__.py
@@ -4,4 +4,9 @@ Custom exceptions for the Cognee API.
 This module defines a set of exceptions for handling various data errors
 """
 
-from .exceptions import OntologyInitializationError, FindClosestMatchError, GetSubgraphError
+from .exceptions import (
+    OntologyInitializationError,
+    FindClosestMatchError,
+    GetSubgraphError,
+    EmptyOntologyInStrictModeError,
+)

--- a/cognee/modules/ontology/exceptions/exceptions.py
+++ b/cognee/modules/ontology/exceptions/exceptions.py
@@ -22,6 +22,21 @@ class FindClosestMatchError(CogneeSystemError):
         super().__init__(message, name, status_code)
 
 
+class EmptyOntologyInStrictModeError(CogneeSystemError):
+    def __init__(
+        self,
+        message: str = (
+            "ONTOLOGY_MODE=strict requires an ontology with at least one class or "
+            "individual, but the configured ontology is empty (often a mistyped "
+            "ONTOLOGY_FILE_PATH). Strict mode would drop every extracted entity, "
+            "so the run is refused instead."
+        ),
+        name: str = "EmptyOntologyInStrictModeError",
+        status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR,
+    ):
+        super().__init__(message, name, status_code)
+
+
 class GetSubgraphError(CogneeSystemError):
     def __init__(
         self,

--- a/cognee/modules/ontology/get_default_ontology_resolver.py
+++ b/cognee/modules/ontology/get_default_ontology_resolver.py
@@ -1,8 +1,14 @@
 from typing import Optional
 
 from cognee.modules.ontology.base_ontology_resolver import BaseOntologyResolver
+from cognee.modules.ontology.construct_data_points_and_edges_with_ontology import (
+    ensure_ontology_usable_in_strict_mode,
+)
 from cognee.modules.ontology.ontology_config import Config
-from cognee.modules.ontology.ontology_env_config import get_ontology_env_config
+from cognee.modules.ontology.ontology_env_config import (
+    get_ontology_env_config,
+    normalize_ontology_mode,
+)
 from cognee.modules.ontology.rdf_xml.RDFLibOntologyResolver import RDFLibOntologyResolver
 from cognee.modules.ontology.matching_strategies import FuzzyMatchingStrategy
 
@@ -27,8 +33,27 @@ def get_configured_ontology_resolver(
         and ontology_config.ontology_resolver
         and ontology_config.matching_strategy
     ):
-        return get_ontology_resolver_from_env(**ontology_config.to_dict())
+        resolver = get_ontology_resolver_from_env(**ontology_config.to_dict())
+        if ontology_config.ontology_mode == "strict":
+            # Fail before any pipeline work: a mistyped ONTOLOGY_FILE_PATH yields an
+            # empty resolver, and strict mode over an empty ontology drops everything.
+            ensure_ontology_usable_in_strict_mode(resolver)
+        return resolver
     return None
+
+
+def get_configured_ontology_mode(config: Optional[Config] = None) -> str:
+    """Resolve the ontology mode from an explicit config or the environment.
+
+    A per-call ``ontology_mode`` in the config wins; otherwise the ONTOLOGY_MODE
+    environment value applies. The result is always a normalized, valid mode.
+    """
+    if config is not None:
+        ontology_config = config.get("ontology_config")
+        if isinstance(ontology_config, dict) and ontology_config.get("ontology_mode") is not None:
+            return normalize_ontology_mode(ontology_config["ontology_mode"])
+
+    return get_ontology_env_config().ontology_mode
 
 
 def get_ontology_resolver_from_env(

--- a/cognee/modules/ontology/ontology_config.py
+++ b/cognee/modules/ontology/ontology_config.py
@@ -9,9 +9,14 @@ class OntologyConfig(TypedDict, total=False):
 
     Attributes:
         ontology_resolver: The ontology resolver instance to use
+        ontology_mode: How strictly to apply the ontology for this call —
+            "annotate" (enrich only, the default) or "strict" (drop extracted
+            entities with no ontology grounding). Falls back to the
+            ONTOLOGY_MODE environment value when omitted.
     """
 
     ontology_resolver: Optional[BaseOntologyResolver]
+    ontology_mode: Optional[str]
 
 
 class Config(TypedDict, total=False):

--- a/cognee/modules/ontology/ontology_env_config.py
+++ b/cognee/modules/ontology/ontology_env_config.py
@@ -1,7 +1,34 @@
 """This module contains the configuration for ontology handling."""
 
 from functools import lru_cache
+
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("ontology_env_config")
+
+VALID_ONTOLOGY_MODES: frozenset[str] = frozenset({"annotate", "strict"})
+DEFAULT_ONTOLOGY_MODE = "annotate"
+
+
+def normalize_ontology_mode(mode: "str | None") -> str:
+    """Normalize an ontology mode value, falling back to the default with a warning.
+
+    An unknown value must never break a cognify run (the config is constructed even
+    for runs with no ontology at all), so this warns and falls back instead of raising.
+    """
+    normalized_mode = str(mode).strip().lower()
+    if normalized_mode not in VALID_ONTOLOGY_MODES:
+        logger.warning(
+            "Unknown ONTOLOGY_MODE=%r — falling back to %r. Valid values: %s",
+            mode,
+            DEFAULT_ONTOLOGY_MODE,
+            ", ".join(sorted(VALID_ONTOLOGY_MODES)),
+        )
+        return DEFAULT_ONTOLOGY_MODE
+    return normalized_mode
 
 
 class OntologyEnvConfig(BaseSettings):
@@ -16,18 +43,29 @@ class OntologyEnvConfig(BaseSettings):
     - ontology_resolver
     - ontology_matching
     - ontology_file_path
+    - ontology_mode
     - model_config
     """
 
     ontology_resolver: str = "rdflib"
     matching_strategy: str = "fuzzy"
     ontology_file_path: str = ""
+    ontology_mode: str = DEFAULT_ONTOLOGY_MODE
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow", populate_by_name=True)
 
+    @field_validator("ontology_mode", mode="before")
+    @classmethod
+    def _normalize_ontology_mode(cls, value) -> str:
+        return normalize_ontology_mode(value)
+
     def to_dict(self) -> dict:
         """
-        Return the configuration as a dictionary.
+        Return the resolver-factory keyword arguments as a dictionary.
+
+        Note: this dict is splatted into ``get_ontology_resolver_from_env`` — it must
+        contain exactly that function's parameters. ``ontology_mode`` deliberately does
+        not belong here; it is read separately via ``get_configured_ontology_mode``.
         """
         return {
             "ontology_resolver": self.ontology_resolver,

--- a/cognee/tasks/graph/extract_graph_from_data.py
+++ b/cognee/tasks/graph/extract_graph_from_data.py
@@ -5,7 +5,10 @@ from pydantic import BaseModel
 
 from cognee.modules.pipelines.tasks.task import task_summary
 from cognee.modules.ontology.ontology_config import Config
-from cognee.modules.ontology.get_default_ontology_resolver import get_configured_ontology_resolver
+from cognee.modules.ontology.get_default_ontology_resolver import (
+    get_configured_ontology_mode,
+    get_configured_ontology_resolver,
+)
 from cognee.modules.ontology.base_ontology_resolver import BaseOntologyResolver
 from cognee.modules.ontology.construct_data_points_and_edges_with_ontology import (
     construct_data_points_and_edges_with_ontology,
@@ -87,6 +90,7 @@ async def integrate_chunk_graphs(
     chunk_attachment: Optional[Literal["direct", "all"]] = None,
     pipeline_name: str = None,
     task_name: str = None,
+    ontology_mode: Optional[str] = None,
     **kwargs,
 ) -> List[DocumentChunk]:
     """Convert extracted graphs into linked data points for later storage.
@@ -103,6 +107,8 @@ async def integrate_chunk_graphs(
         chunk_attachment: How widely each chunk links into its extracted graph.
             ``"all"`` links it to every stored node; omitted and ``"direct"``
             keep the single-root linkage. Custom DataPoint models only.
+        ontology_mode: Per-call ontology mode ("annotate" or "strict"); None
+            falls back to the ONTOLOGY_MODE environment value.
 
     Returns:
         The input chunks, updated with their extracted entities
@@ -147,6 +153,7 @@ async def integrate_chunk_graphs(
             data_chunks,
             chunk_graphs,
             ontology_resolver,
+            ontology_mode=ontology_mode,
         )
 
     existing_edge_identities = await find_existing_edge_identities(edges_by_identity.keys())
@@ -214,6 +221,7 @@ async def extract_graph_from_data(
             await callback_result
 
     ontology_resolver = get_configured_ontology_resolver(config)
+    ontology_mode = get_configured_ontology_mode(config)
 
     task_name = "extract_graph_from_data"
 
@@ -225,6 +233,7 @@ async def extract_graph_from_data(
         chunk_attachment=chunk_attachment,
         pipeline_name=pipeline_name,
         task_name=task_name,
+        ontology_mode=ontology_mode,
         **kwargs,
     )
 

--- a/cognee/tasks/graph/extract_graph_from_data_v2.py
+++ b/cognee/tasks/graph/extract_graph_from_data_v2.py
@@ -31,7 +31,9 @@ async def extract_graph_from_data(
     Args:
         data_chunks: List of document chunks to process
         n_rounds: Number of extraction rounds to perform (default: 2)
-        ontology_resolver: Resolver for validating entities against ontology
+        ontology_resolver: Resolver for matching and enriching extracted entities
+            from the ontology (annotation only by default; ONTOLOGY_MODE=strict drops
+            entities with no ontology grounding)
 
     Returns:
         List of updated DocumentChunk objects with extracted graph data

--- a/cognee/tests/unit/api/v1/cognify/test_cognify_ontology_resolution.py
+++ b/cognee/tests/unit/api/v1/cognify/test_cognify_ontology_resolution.py
@@ -15,9 +15,11 @@ serve_state_module = importlib.import_module("cognee.api.v1.serve.state")
 @patch.object(cognify_module, "get_pipeline_executor")
 @patch.object(cognify_module, "get_default_tasks", new_callable=AsyncMock)
 @patch("cognee.modules.migrations.startup.run_migrations_and_block", new_callable=AsyncMock)
+@patch.object(cognify_module, "get_configured_ontology_mode", return_value="annotate")
 @patch.object(cognify_module, "get_configured_ontology_resolver")
 async def test_cognify_normalizes_skip_config(
     mock_get_resolver,
+    mock_get_mode,
     mock_migrations,
     mock_get_default_tasks,
     mock_get_pipeline_executor,
@@ -31,9 +33,12 @@ async def test_cognify_normalizes_skip_config(
     await cognify_module.cognify(config=input_config)
 
     mock_get_resolver.assert_called_once_with(input_config)
+    mock_get_mode.assert_called_once_with(input_config)
     mock_get_default_tasks.assert_awaited_once()
     passed_config = mock_get_default_tasks.await_args.kwargs["config"]
-    assert passed_config == {"ontology_config": {"ontology_resolver": None}}
+    assert passed_config == {
+        "ontology_config": {"ontology_resolver": None, "ontology_mode": "annotate"}
+    }
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/ontology/test_construct_data_points_and_edges_with_ontology.py
+++ b/cognee/tests/unit/modules/ontology/test_construct_data_points_and_edges_with_ontology.py
@@ -1,6 +1,9 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+
+import cognee.modules.ontology.construct_data_points_and_edges_with_ontology as ontology_module
 
 from cognee.modules.engine.models import Entity, EntityType
 from cognee.modules.ontology.base_ontology_resolver import BaseOntologyResolver
@@ -9,6 +12,7 @@ from cognee.modules.ontology.construct_data_points_and_edges_with_ontology impor
     canonicalize_extracted_graphs,
     construct_data_points_and_edges_with_ontology,
 )
+from cognee.modules.ontology.exceptions import EmptyOntologyInStrictModeError
 from cognee.modules.ontology.models import AttachedOntologyNode
 from cognee.shared.data_models import Edge as KGEdge
 from cognee.shared.data_models import KnowledgeGraph, Node
@@ -184,3 +188,117 @@ def test_construct_data_points_and_edges_with_ontology_uses_the_pure_constructor
     assert widget.is_a is gadget
     assert widget.ontology_valid is True
     assert gadget.ontology_valid is True
+
+
+def _make_graph_with_ungrounded_node():
+    return KnowledgeGraph(
+        nodes=[
+            Node(id="typed-1", name="Nomatch", type="Gadget", description="class match"),
+            Node(id="named-1", name="Widget", type="Unmatched", description="individual match"),
+            Node(id="ghost-1", name="Ghost", type="Phantom", description="ungrounded"),
+        ],
+        edges=[
+            KGEdge(
+                source_node_id="named-1",
+                target_node_id="ghost-1",
+                relationship_name="haunted_by",
+            )
+        ],
+    )
+
+
+def test_strict_mode_drops_ungrounded_nodes_and_their_edges():
+    graph = _make_graph_with_ungrounded_node()
+
+    canonicalize_extracted_graphs([_make_chunk()], [graph], _StubResolver(), strict=True)
+
+    assert [node.id for node in graph.nodes] == ["typed-1", "named-1"]
+    assert graph.edges == []
+
+
+def test_annotate_mode_retains_ungrounded_nodes_and_their_edges():
+    graph = _make_graph_with_ungrounded_node()
+
+    canonicalize_extracted_graphs([_make_chunk()], [graph], _StubResolver())
+
+    assert [node.id for node in graph.nodes] == ["typed-1", "named-1", "ghost-1"]
+    assert len(graph.edges) == 1
+    assert graph.edges[0].target_node_id == "ghost-1"
+
+
+def test_construct_data_points_and_edges_with_ontology_reads_strict_mode_from_config(monkeypatch):
+    monkeypatch.setattr(
+        ontology_module,
+        "get_ontology_env_config",
+        lambda: SimpleNamespace(ontology_mode="strict"),
+    )
+    chunk = _make_chunk()
+    chunk.contains = None
+    graph = _make_graph_with_ungrounded_node()
+
+    data_points_by_id, _ = construct_data_points_and_edges_with_ontology(
+        [chunk],
+        [graph],
+        _StubResolver(),
+    )
+
+    assert str(Entity.id_for("widget_canonical")) in data_points_by_id
+    assert str(Entity.id_for("ghost")) not in data_points_by_id
+    assert [node.id for node in graph.nodes] == ["typed-1", "named-1"]
+
+
+def test_per_call_ontology_mode_overrides_env(monkeypatch):
+    monkeypatch.setattr(
+        ontology_module,
+        "get_ontology_env_config",
+        lambda: SimpleNamespace(ontology_mode="annotate"),
+    )
+    chunk = _make_chunk()
+    chunk.contains = None
+    graph = _make_graph_with_ungrounded_node()
+
+    construct_data_points_and_edges_with_ontology(
+        [chunk],
+        [graph],
+        _StubResolver(),
+        ontology_mode="strict",
+    )
+
+    assert [node.id for node in graph.nodes] == ["typed-1", "named-1"]
+
+
+class _EmptyLookupResolver(_StubResolver):
+    def __init__(self):
+        super().__init__()
+        self.lookup = {"classes": {}, "individuals": {}}
+
+
+def test_strict_mode_with_empty_ontology_lookup_raises():
+    resolver = _EmptyLookupResolver()
+    graph = _make_graph_with_ungrounded_node()
+
+    with pytest.raises(EmptyOntologyInStrictModeError):
+        canonicalize_extracted_graphs([_make_chunk()], [graph], resolver, strict=True)
+
+    # Annotate mode over the same empty resolver must keep working.
+    canonicalize_extracted_graphs([_make_chunk()], [graph], resolver)
+    assert len(graph.nodes) == 3
+
+
+def test_strict_mode_logs_one_aggregate_drop_summary(monkeypatch):
+    mock_logger = MagicMock()
+    monkeypatch.setattr(ontology_module, "logger", mock_logger)
+    graphs = [_make_graph_with_ungrounded_node(), _make_graph()]
+
+    canonicalize_extracted_graphs(
+        [_make_chunk(), _make_chunk()],
+        graphs,
+        _StubResolver(),
+        strict=True,
+    )
+
+    assert mock_logger.warning.call_count == 1
+    warning_args = mock_logger.warning.call_args[0]
+    # 1 of 4 nodes dropped, 1 of 1 edges dropped, across 2 graphs.
+    assert warning_args[1:3] == (1, 4)
+    assert warning_args[4:7] == (1, 1, 2)

--- a/cognee/tests/unit/modules/ontology/test_get_configured_ontology_resolver.py
+++ b/cognee/tests/unit/modules/ontology/test_get_configured_ontology_resolver.py
@@ -2,7 +2,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cognee.modules.ontology.get_default_ontology_resolver import get_configured_ontology_resolver
+from cognee.modules.ontology.exceptions import EmptyOntologyInStrictModeError
+from cognee.modules.ontology.get_default_ontology_resolver import (
+    get_configured_ontology_mode,
+    get_configured_ontology_resolver,
+)
+from cognee.modules.ontology.ontology_env_config import OntologyEnvConfig
 
 
 def _mock_resolver():
@@ -53,3 +58,67 @@ def test_none_config_without_env_returns_none(mock_env_config):
     mock_env_config.return_value.matching_strategy = "fuzzy"
 
     assert get_configured_ontology_resolver(None) is None
+
+
+@patch("cognee.modules.ontology.get_default_ontology_resolver.RDFLibOntologyResolver")
+@patch("cognee.modules.ontology.get_default_ontology_resolver.get_ontology_env_config")
+def test_none_config_splats_real_to_dict_into_real_factory(mock_env_config, mock_resolver_class):
+    """The real env config's to_dict() must match the real factory's signature.
+
+    Regression test: a key added to to_dict() that the factory does not accept
+    breaks every env-configured cognify run with a TypeError. Only the resolver
+    class itself is stubbed here — config and factory bodies run for real.
+    """
+    mock_env_config.return_value = OntologyEnvConfig(
+        _env_file=None,
+        ontology_resolver="rdflib",
+        matching_strategy="fuzzy",
+        ontology_file_path="ontology.owl",
+    )
+    resolver = _mock_resolver()
+    resolver.lookup = {"classes": {"car": object()}, "individuals": {}}
+    mock_resolver_class.return_value = resolver
+
+    assert get_configured_ontology_resolver(None) is resolver
+
+
+@patch("cognee.modules.ontology.get_default_ontology_resolver.RDFLibOntologyResolver")
+@patch("cognee.modules.ontology.get_default_ontology_resolver.get_ontology_env_config")
+def test_env_strict_mode_with_empty_ontology_fails_fast(mock_env_config, mock_resolver_class):
+    mock_env_config.return_value = OntologyEnvConfig(
+        _env_file=None,
+        ontology_file_path="/typo/does_not_exist.owl",
+        ontology_mode="strict",
+    )
+    empty_resolver = _mock_resolver()
+    empty_resolver.lookup = {"classes": {}, "individuals": {}}
+    mock_resolver_class.return_value = empty_resolver
+
+    with pytest.raises(EmptyOntologyInStrictModeError):
+        get_configured_ontology_resolver(None)
+
+
+@patch("cognee.modules.ontology.get_default_ontology_resolver.get_ontology_env_config")
+def test_ontology_mode_from_config_overrides_env(mock_env_config):
+    mock_env_config.return_value.ontology_mode = "annotate"
+
+    config = {"ontology_config": {"ontology_resolver": _mock_resolver(), "ontology_mode": "strict"}}
+    assert get_configured_ontology_mode(config) == "strict"
+
+
+@patch("cognee.modules.ontology.get_default_ontology_resolver.get_ontology_env_config")
+def test_ontology_mode_falls_back_to_env(mock_env_config):
+    mock_env_config.return_value.ontology_mode = "strict"
+
+    assert get_configured_ontology_mode(None) == "strict"
+    assert (
+        get_configured_ontology_mode({"ontology_config": {"ontology_resolver": None}}) == "strict"
+    )
+
+
+@patch("cognee.modules.ontology.get_default_ontology_resolver.get_ontology_env_config")
+def test_invalid_per_call_ontology_mode_falls_back_to_default(mock_env_config):
+    mock_env_config.return_value.ontology_mode = "annotate"
+
+    config = {"ontology_config": {"ontology_resolver": None, "ontology_mode": "bogus"}}
+    assert get_configured_ontology_mode(config) == "annotate"

--- a/cognee/tests/unit/modules/ontology/test_ontology_env_config.py
+++ b/cognee/tests/unit/modules/ontology/test_ontology_env_config.py
@@ -1,0 +1,36 @@
+import inspect
+
+from cognee.modules.ontology.get_default_ontology_resolver import get_ontology_resolver_from_env
+from cognee.modules.ontology.ontology_env_config import (
+    OntologyEnvConfig,
+    normalize_ontology_mode,
+)
+
+
+def test_to_dict_matches_resolver_factory_signature():
+    """to_dict() is splatted into get_ontology_resolver_from_env — every key must
+    be a parameter of that factory, or env-configured cognify runs die in a TypeError."""
+    factory_parameters = set(inspect.signature(get_ontology_resolver_from_env).parameters)
+
+    config_keys = set(OntologyEnvConfig(_env_file=None).to_dict())
+
+    assert config_keys <= factory_parameters
+
+
+def test_ontology_mode_is_case_insensitive():
+    config = OntologyEnvConfig(_env_file=None, ontology_mode="Strict")
+    assert config.ontology_mode == "strict"
+
+    config = OntologyEnvConfig(_env_file=None, ontology_mode=" ANNOTATE ")
+    assert config.ontology_mode == "annotate"
+
+
+def test_unknown_ontology_mode_falls_back_to_annotate():
+    config = OntologyEnvConfig(_env_file=None, ontology_mode="bogus")
+    assert config.ontology_mode == "annotate"
+
+
+def test_normalize_ontology_mode_never_raises():
+    assert normalize_ontology_mode("strict") == "strict"
+    assert normalize_ontology_mode("Bogus") == "annotate"
+    assert normalize_ontology_mode(None) == "annotate"

--- a/cognee/tests/unit/tasks/graph/test_extract_graph_from_data.py
+++ b/cognee/tests/unit/tasks/graph/test_extract_graph_from_data.py
@@ -265,7 +265,9 @@ async def test_integrate_chunk_graphs_selects_the_ontology_constructor(
     await integrate_chunk_graphs([chunk], [graph], KnowledgeGraph, resolver)
 
     mock_construct.assert_not_called()
-    mock_construct_with_ontology.assert_called_once_with([chunk], [graph], resolver)
+    mock_construct_with_ontology.assert_called_once_with(
+        [chunk], [graph], resolver, ontology_mode=None
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Split out of #4628 (ontology part only, taken first per review). Adds the opt-in `ONTOLOGY_MODE=strict` entity-grounding mode, with the review findings on that PR fixed.

### Feature

The ontology pass has always been annotation-only — matched entities are canonicalized and enriched, unmatched entities retained verbatim, nothing rejected. `ONTOLOGY_MODE=strict` (default `annotate`; default pipeline byte-identical) drops extracted entities with **neither** a class match on their type **nor** an individual match on their name, filters edges touching dropped nodes, and logs one aggregate dropped/retained summary per run. Scope is entity grounding only: no domain/range/cardinality/disjointness reasoning; relationship names are not checked.

### Review fixes folded in

- **High — env-configured cognify crash**: `ontology_mode` is no longer in `OntologyEnvConfig.to_dict()`. That dict is splatted into `get_ontology_resolver_from_env` (exactly three params, no `**kwargs`), so the extra key gave every user with `ONTOLOGY_FILE_PATH` set a `TypeError` out of `cognify()`. A regression test now checks the **real** `to_dict()` against the **real** factory signature (the old test mocked both halves).
- **Validation**: `ontology_mode` is a plain `str`, normalized case-insensitively; unknown values warn and fall back to `annotate` (same pattern as `get_provenance_config`) instead of a pydantic `ValidationError` killing runs that use no ontology at all.
- **Medium — strict over an empty ontology is a hard error**: a mistyped `ONTOLOGY_FILE_PATH` produces a resolver with an empty lookup (the resolver only warns), which strict mode would previously turn into a silently empty graph on a run that reports success. Now `EmptyOntologyInStrictModeError` is raised — fail-fast at resolver configuration on the env path, and at canonicalization for per-call resolvers.
- **Medium — drop visibility**: the per-chunk warning is replaced by one aggregate per run: dropped/total nodes, retained %, dropped/total edges, graph count, plus a hint that a high ratio means the ontology doesn't cover the corpus vocabulary.
- **Low — per-call mode**: `ontology_mode` is now an optional field of the `OntologyConfig` TypedDict (`config={"ontology_config": {"ontology_mode": "strict", ...}}`), resolved per call like the resolver; env is the fallback. The env read is gone from deep inside the construct module's default path when a mode is passed.
- **Low — documented design choices**: the either-match grounding rule (a known type lets an unknown entity through — stated, deliberate), and that strict prunes **only the graph**: chunk text stays stored/embedded, so CHUNKS/CHUNKS_LEXICAL/RAG_COMPLETION can still surface dropped entities. Documented in `.env.template`, the catalog entry, CLAUDE.md, and docstrings.

### Not in this PR

The assertion-authority/supersession commits stay in #4628 (superseded-tag write-back on re-assertion, `supersession_reason` wording, and PR-description corrections are handled there).

### Tests

- `to_dict()` ↔ factory signature regression test (real config, real factory body, only the resolver class stubbed)
- mode normalization + unknown-value fallback
- strict + empty lookup raises (env path and canonicalization path)
- per-call `ontology_mode` overrides env; config → env fallback; invalid per-call value falls back
- aggregate drop summary logged once with correct counts
- existing strict/annotate behavior tests from the original commit retained

`pytest cognee/tests/unit/modules/ontology cognee/tests/unit/api cognee/tests/unit/tasks/graph cognee/tests/unit/modules/cognify` — all passing; `pre-commit run` clean.

Linear: COG-6279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
