### PR TITLE
fix(migrations): stop treating a failed schema inspection as an empty database [SDK-519]

### DIFF
--- a/cognee/modules/migrations/startup.py
+++ b/cognee/modules/migrations/startup.py
@@ -227,18 +227,37 @@ async def _relational_schema_exists() -> bool:
         restructured in the future.
     Only when NEITHER exists is the database genuinely empty — the one state
     where create_all + stamp head is safe.
+
+    A failed inspection RAISES instead of answering: "cannot inspect" is not
+    "empty". Guessing "empty" would send a populated-but-unreachable database
+    (a server still starting up, a transient connection failure) into the
+    create_all + stamp-head bootstrap — create_all silently skips the existing
+    tables and the stamp then marks every pending migration as applied without
+    running it, leaving the database permanently mis-stamped at head. The one
+    genuinely-fresh case that used to surface as an exception (a local SQLite
+    database whose file does not exist yet) is decided as the filesystem fact
+    it is, before connecting.
     """
     from sqlalchemy import inspect
 
     from cognee.infrastructure.databases.relational import get_relational_engine
 
-    try:
-        async with get_relational_engine().engine.connect() as connection:
-            tables = await connection.run_sync(
-                lambda sync_conn: inspect(sync_conn).get_table_names()
-            )
-    except Exception:
-        return False  # cannot inspect (e.g. brand-new SQLite file) -> treat as empty
+    engine = get_relational_engine()
+
+    # Brand-new local SQLite database: the file is not there yet
+    # (create_database() creates the directory and file). S3-backed SQLite is
+    # excluded — its engine connects to a local temp file that always exists,
+    # and a fresh S3 database reports empty through the inspection below.
+    if (
+        engine.engine.dialect.name == "sqlite"
+        and engine.db_path
+        and "s3://" not in engine.db_path
+        and not os.path.exists(engine.db_path)
+    ):
+        return False
+
+    async with engine.engine.connect() as connection:
+        tables = await connection.run_sync(lambda sync_conn: inspect(sync_conn).get_table_names())
     return "users" in tables or "alembic_version" in tables
 
 

--- a/cognee/tests/integration/infrastructure/relational/test_relational_schema_probe.py
+++ b/cognee/tests/integration/infrastructure/relational/test_relational_schema_probe.py
@@ -1,0 +1,90 @@
+"""Integration tests for ``_relational_schema_exists`` against REAL SQLite stores.
+
+The probe decides which bootstrap branch a database takes: *exists* ->
+``alembic upgrade head`` (migration bodies run), *empty* -> ``create_all`` +
+``stamp head`` (no bodies run). These tests lock in its tri-state contract:
+
+- a missing local SQLite file is FRESH, decided from the filesystem without
+  ever connecting (the probe must not create the file as a side effect);
+- a reachable database with no cognee tables is FRESH via inspection;
+- a database holding ``users`` or ``alembic_version`` EXISTS;
+- an uninspectable database RAISES — "cannot inspect" must never be answered
+  as "empty", because that answer sends a populated database into the
+  create_all + stamp-head bootstrap and mis-stamps it at head with no
+  migration having run.
+
+Only the relational engine is touched: the adapter is built directly on a tmp
+path and injected by patching ``get_relational_engine`` — no config, LLM, or
+graph/vector stores involved.
+"""
+
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DatabaseError
+
+from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter import (
+    SQLAlchemyAdapter,
+)
+from cognee.modules.migrations.startup import _relational_schema_exists
+
+_GET_ENGINE = "cognee.infrastructure.databases.relational.get_relational_engine"
+
+
+def _probe_with(adapter: SQLAlchemyAdapter) -> bool:
+    async def _run():
+        with patch(_GET_ENGINE, return_value=adapter):
+            try:
+                return await _relational_schema_exists()
+            finally:
+                await adapter.engine.dispose()
+
+    return asyncio.run(_run())
+
+
+def _adapter_for(db_path) -> SQLAlchemyAdapter:
+    return SQLAlchemyAdapter(f"sqlite+aiosqlite:///{db_path}")
+
+
+def test_missing_sqlite_file_is_fresh_and_probe_does_not_create_it(tmp_path):
+    db_path = tmp_path / "not_created_yet.db"
+
+    assert _probe_with(_adapter_for(db_path)) is False
+    # Decided from the filesystem, not by connecting: an aiosqlite connect
+    # would have created the file.
+    assert not os.path.exists(db_path)
+
+
+def test_reachable_empty_database_is_fresh_via_inspection(tmp_path):
+    db_path = tmp_path / "empty.db"
+    db_path.touch()  # existing zero-byte file is a valid empty SQLite database
+
+    assert _probe_with(_adapter_for(db_path)) is False
+    assert os.path.exists(db_path)
+
+
+@pytest.mark.parametrize("marker_table", ["users", "alembic_version"])
+def test_database_with_either_marker_table_exists(tmp_path, marker_table):
+    db_path = tmp_path / "populated.db"
+    seed = _adapter_for(db_path)
+
+    async def _seed():
+        async with seed.engine.begin() as connection:
+            await connection.execute(text(f"CREATE TABLE {marker_table} (id INTEGER PRIMARY KEY)"))
+        await seed.engine.dispose()
+
+    asyncio.run(_seed())
+
+    assert _probe_with(_adapter_for(db_path)) is True
+
+
+def test_uninspectable_database_raises_instead_of_reporting_fresh(tmp_path):
+    db_path = tmp_path / "corrupt.db"
+    db_path.write_bytes(b"this is not a sqlite database, inspection must fail")
+
+    adapter = _adapter_for(db_path)
+    with pytest.raises(DatabaseError):
+        _probe_with(adapter)


### PR DESCRIPTION
## Problem

`_relational_schema_exists()` decides which bootstrap branch a database takes: **exists** → `alembic upgrade head` (bodies run), **empty** → `create_all()` + `alembic stamp head` (no bodies run). It swallowed every inspection failure and answered *empty*:

```python
except Exception:
    return False  # cannot inspect (e.g. brand-new SQLite file) -> treat as empty
```

That maps "cannot determine" onto the one answer that authorizes the stamp. A populated database that is merely unreachable at probe time (Postgres/Neon still starting up, a transient connection failure at container start) goes down the fresh path: `create_all(checkfirst)` silently skips the existing tables, then `stamp head` marks every pending migration as applied **without running any of them**. The database comes out permanently mis-stamped at head — `alembic upgrade head` can never repair it because nothing is pending — and the run reports success, so there is zero log evidence.

We hit this failure class in cognee cloud: tenant DBs stamped at/past `a7f3c9e1b5d2` with the `pipeline_runs` operation-record columns missing, failing every pipeline run with `UndefinedColumn: pipeline_runs.user_id`.

## Change

The only genuinely-fresh case the broad `except` covered is a **local SQLite database whose file does not exist yet** — a filesystem fact, not an exception to interpret. Decide it with `os.path.exists` before connecting; every other inspection failure now propagates, so startup fails loudly and retries instead of silently poisoning `alembic_version`.

- Local SQLite, file missing → `False` (fresh) without connecting — also no longer creates a stray empty file as a probe side effect.
- S3-backed SQLite excluded from the precondition: its engine connects to a local temp file that always exists, and a fresh S3 database reports empty through the normal inspection.
- Postgres needs no exception mapping at all: a genuinely fresh database is still *reachable* (provisioned, zero tables), so "fresh" is detected by a successful inspection returning no tables — anything that throws is by definition "cannot determine".

## Behavior matrix (Postgres)

| DB state at probe time | Before | After |
|---|---|---|
| Existing, reachable | upgrade runs | unchanged |
| Fresh (provisioned, empty) | create_all + stamp | unchanged |
| Unreachable (cold start, blip, auth) | silently treated as empty → **wrong stamp** | raises → visible crash-loop, retried |

No retry logic added on purpose: the caller side (server lifespan / init containers / next SDK call) already re-runs migrations, and a crash-looping start is recoverable where a mis-stamped database is not.

## Testing

- `uv run ruff check` / `format` clean (pre-commit passed).
- Existing unit tests mock `_relational_schema_exists` by return value and are unaffected; the exception path had no test coverage before or after.


## Linear
SDK-519 — https://linear.app/cognee/issue/SDK-519/failed-relational-schema-inspection-must-raise-not-mis-stamp-the
