### PR TITLE
feat: register the macOS desktop app as a known plugin

### DIFF
--- a/cognee/modules/integrations/plugins.py
+++ b/cognee/modules/integrations/plugins.py
@@ -16,6 +16,7 @@ pre-migration installs; ``None`` means the plugin never had one.
 
 KNOWN_PLUGINS: dict[str, dict] = {
     "claude-code": {"label": "Claude Code", "session_prefix": "cc_"},
+    "desktop": {"label": "Cognee Desktop", "session_prefix": None},
     "codex": {"label": "Codex", "session_prefix": "codex_"},
     "opencode": {"label": "OpenCode", "session_prefix": "opencode_"},
     "openclaw": {"label": "Openclaw", "session_prefix": None},


### PR DESCRIPTION
## Description
Adds a `desktop` entry to `KNOWN_PLUGINS` so the macOS desktop app (`integrations/desktop` in cognee-integrations) can provision its own agent identity via `POST /api/v1/integrations/plugins/desktop/provision`, exactly like the coding-agent plugins — instead of authenticating with the raw tenant key.

No legacy `session_prefix` — the desktop app never had one, so pre-migration detection doesn't apply. It registers as a generic `sdk` connection in the agent-connection registry (no native `AgentConnectionType` needed).

## Verified end-to-end
Against a local dev server (this branch):
- provision minted the agent sub-user + labeled API key (idempotent on re-run)
- the desktop app indexed and searched using that key
- `GET /integrations/status` reports `desktop: connected` (`identity` from the parent's view; `registry` when the agent introspects itself — see note)

## Note for reviewers
When the plugin itself calls `/integrations/status` with its own key, `identity_plugin_statuses` finds nothing (it scans the caller's *children*), so the row surfaces via the registry source. Accurate but slightly surprising; if self-views should also read `identity`, a follow-up could special-case a caller whose own email parses as a plugin identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)