### PR TITLE
docs(examples): add fact validity guide example script

### DIFF
--- a/examples/guides/fact_validity.py
+++ b/examples/guides/fact_validity.py
@@ -1,0 +1,34 @@
+import asyncio
+
+import cognee
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.modules.engine.models import Entity
+
+# close_node and is_valid are not re-exported from cognee.tasks.storage,
+# so import them from their module.
+from cognee.tasks.storage.close_node import close_node, is_valid
+
+
+async def main():
+    # Step 1: start clean and remember the original fact.
+    await cognee.forget(everything=True)
+    await cognee.remember("Alice works at Acme.", dataset_name="employment_facts")
+
+    # Step 2: entity node ids are deterministic — derive Acme's id from its name.
+    acme_id = Entity.id_for("Acme")
+
+    # Step 3: Alice changes jobs — close the old fact instead of deleting it.
+    closed = await close_node(acme_id)
+    print("closed:", closed)  # True — the node existed and valid_to was stamped
+
+    # Step 4: remember the replacement fact.
+    await cognee.remember("Alice works at Globex.", dataset_name="employment_facts")
+
+    # Step 5: the closed node is still in the graph, just stale.
+    graph = await get_graph_engine()
+    node = await graph.get_node(str(acme_id))
+    print("is_valid:", is_valid(node))  # False — the fact was superseded
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds `examples/guides/fact_validity.py`, a runnable example for the SDK-200 fact-validity surface shipped in v1.5.0 (#4105): `DataPoint.valid_to`, `close_node()`, and `is_valid()`.

The script supersedes a fact instead of deleting it — it remembers "Alice works at Acme", derives the entity node id with `Entity.id_for("Acme")`, closes the node, remembers the replacement fact, and shows `is_valid()` returning `False` for the superseded node.

## Why

The [Fact Validity guide](https://docs.cognee.ai/guides/fact-validity) (cognee-docs #1208) embeds this exact script as its Code in Action block, and the docs test suite runs a verbatim copy at `tests/guides/fact_validity.py`. Every other guide points its examples registry entry at an upstream `examples/guides/` script; fact validity was the only one with no upstream source. This PR adds it so the registry can track drift against the canonical copy.

## Notes

- Verbatim copy of the script tested in cognee-docs CI (`guide_tests.yml`), which runs against the released `cognee` package.
- Requires the default Ladybug graph store — the only backend where `close_node()` can persist `valid_to` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)