### PR TITLE
fix: Verify the schema matches the models (SDK-526)

### DIFF
--- a/cognee/modules/migrations/startup.py
+++ b/cognee/modules/migrations/startup.py
@@ -242,6 +242,113 @@ async def _relational_schema_exists() -> bool:
     return "users" in tables or "alembic_version" in tables
 
 
+_SCHEMA_CHECK_MODES = ("strict", "warn", "off")
+
+
+def _schema_check_mode() -> str:
+    """Read ``MIGRATION_SCHEMA_CHECK`` dynamically (same contract as
+    ``ENABLE_AUTO_MIGRATIONS``): ``strict`` raises on drift, ``warn`` logs it,
+    ``off`` skips the comparison entirely."""
+    mode = os.getenv("MIGRATION_SCHEMA_CHECK", "warn").strip().lower()
+    if mode not in _SCHEMA_CHECK_MODES:
+        logger.warning(
+            "Unknown MIGRATION_SCHEMA_CHECK=%r; using 'warn'. Valid values: %s.",
+            mode,
+            ", ".join(_SCHEMA_CHECK_MODES),
+        )
+        return "warn"
+    return mode
+
+
+async def _collect_relational_schema_drift() -> list[str]:
+    """Tables and columns ``Base.metadata`` declares that the live database lacks.
+
+    Compares against the SAME metadata ``create_database`` builds from, so this
+    answers the question the stamp only assumes: does the schema actually match
+    the revision we recorded? Extra tables/columns in the database are ignored —
+    Alembic bookkeeping and older columns are not drift.
+
+    Returns an empty list when the database cannot be inspected: this is a safety
+    net, and it must never become a new way for startup to fail.
+    """
+    from sqlalchemy import inspect
+
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.infrastructure.databases.relational.ModelBase import Base
+
+    expected = Base.metadata.sorted_tables
+    if not expected:
+        # Models not imported in this process — nothing to compare against.
+        return []
+
+    def _reflect(sync_connection):
+        inspector = inspect(sync_connection)
+        present = {
+            schema: set(inspector.get_table_names(schema=schema))
+            for schema in {table.schema for table in expected}
+        }
+        columns = {
+            (table.schema, table.name): {
+                column["name"] for column in inspector.get_columns(table.name, schema=table.schema)
+            }
+            for table in expected
+            if table.name in present[table.schema]
+        }
+        return present, columns
+
+    try:
+        async with get_relational_engine().engine.connect() as connection:
+            present, actual_columns = await connection.run_sync(_reflect)
+    except Exception as error:
+        logger.warning("Could not verify the relational schema against the models: %s", error)
+        return []
+
+    drift = []
+    for table in expected:
+        if table.name not in present[table.schema]:
+            drift.append(f"missing table '{table.name}'")
+            continue
+        missing = sorted(
+            {column.name for column in table.columns} - actual_columns[(table.schema, table.name)]
+        )
+        if missing:
+            drift.append(f"table '{table.name}' is missing column(s): {', '.join(missing)}")
+    return drift
+
+
+async def verify_relational_schema() -> list[str]:
+    """Assert the relational schema matches the ORM models, and report what does not.
+
+    The fresh-database path STAMPS Alembic head after ``create_all`` instead of
+    replaying history, which asserts that the models and the head describe the
+    same schema. Nothing verified that assertion, so when a deployment shipped an
+    Alembic tree ahead of its bundled models, tenants were provisioned with a
+    schema that silently disagreed with the revision they were stamped at — and
+    every signal (exit code, ``alembic current``, the logs) still read healthy.
+
+    Returns the drift descriptions (empty when the schema matches).
+    """
+    mode = _schema_check_mode()
+    if mode == "off":
+        return []
+
+    drift = await _collect_relational_schema_drift()
+    if not drift:
+        return []
+
+    message = (
+        f"Relational schema does not match the ORM models: {'; '.join(drift)}. "
+        "The database is stamped at an Alembic revision whose schema it does not "
+        "actually have; reads and writes against the missing columns will fail at "
+        "runtime. Repair with a migration that adds them (set "
+        "MIGRATION_SCHEMA_CHECK=warn to downgrade this to a log line)."
+    )
+    if mode == "strict":
+        raise MigrationError(message)
+    logger.error(message)
+    return drift
+
+
 # Alembic revisions that CREATE the cognee data-migration bookkeeping (the
 # dataset_database tracking columns and the global_database_version table). The
 # data-migration system reads/writes these, so the relational schema must not be
@@ -301,6 +408,11 @@ async def apply_all_migrations(
             logger.info("Fresh database: creating schema and stamping at head.")
             await get_relational_engine().create_database()
             await run_relational_stamp("head", script_location)
+
+        # Both branches above only ASSERT that the schema is now at
+        # ``relational_target`` — the stamp records it, the upgrade assumes it.
+        # Verify it before the graph/vector chain reads those tables.
+        await verify_relational_schema()
 
         return await run_database_migrations(data_target)
 

--- a/cognee/tests/unit/modules/migrations/test_relational_schema_verification.py
+++ b/cognee/tests/unit/modules/migrations/test_relational_schema_verification.py
@@ -1,0 +1,277 @@
+"""The relational schema must actually match the models it is stamped against.
+
+``apply_all_migrations`` either upgrades an existing database or, for a fresh
+one, runs ``create_all`` and STAMPS Alembic head. Both paths only *assert* the
+schema is at the target — the stamp records a revision without running it, and
+the upgrade assumes every revision did what it claimed. When a deployment ships
+an Alembic tree ahead of its bundled ORM models, a tenant is provisioned with a
+schema that disagrees with its stamp while every signal (exit code,
+``alembic current``, the logs) still reads healthy.
+
+These tests reflect a REAL SQLite database rather than mocking the inspector, so
+a change that stops detecting drift fails here.
+"""
+
+import asyncio
+import importlib
+import os
+import tempfile
+import unittest
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from sqlalchemy import Column, Integer, MetaData, String, Table
+from sqlalchemy.ext.asyncio import create_async_engine
+
+startup = importlib.import_module("cognee.modules.migrations.startup")
+
+
+@asynccontextmanager
+async def _null_async_cm(*args, **kwargs):
+    yield
+
+
+def _metadata(with_extra_column: bool, with_second_table: bool) -> MetaData:
+    """Declare what the models expect: one table (optionally with a column the
+    database will not have) plus an optional second table."""
+    metadata = MetaData()
+    columns = [Column("id", Integer, primary_key=True), Column("name", String)]
+    if with_extra_column:
+        columns.append(Column("user_id", String))
+    Table("widgets", metadata, *columns)
+    if with_second_table:
+        Table("gadgets", metadata, Column("id", Integer, primary_key=True))
+    return metadata
+
+
+class _EngineHolder:
+    """Stands in for the relational engine wrapper (`.engine` is the AsyncEngine)."""
+
+    def __init__(self, engine):
+        self.engine = engine
+
+
+class TestSchemaDriftDetection(unittest.IsolatedAsyncioTestCase):
+    """`_collect_relational_schema_drift` against a real database."""
+
+    async def asyncSetUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
+        self._tmp.close()
+        self.engine = create_async_engine(f"sqlite+aiosqlite:///{self._tmp.name}")
+        # The database only ever gets the two-column `widgets` table: this is the
+        # tenant provisioned by an older model set.
+        on_disk = MetaData()
+        Table(
+            "widgets",
+            on_disk,
+            Column("id", Integer, primary_key=True),
+            Column("name", String),
+        )
+        async with self.engine.begin() as connection:
+            await connection.run_sync(on_disk.create_all)
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        os.unlink(self._tmp.name)
+
+    def _patch_for(self, metadata):
+        base = MagicMock()
+        base.metadata = metadata
+        return (
+            patch(
+                "cognee.infrastructure.databases.relational.get_relational_engine",
+                return_value=_EngineHolder(self.engine),
+            ),
+            patch(
+                "cognee.infrastructure.databases.relational.ModelBase.Base",
+                base,
+            ),
+        )
+
+    async def test_reports_a_column_the_database_lacks(self):
+        """The August failure: the model gained `user_id`, the tenant's table did not."""
+        engine_patch, base_patch = self._patch_for(_metadata(True, False))
+        with engine_patch, base_patch:
+            drift = await startup._collect_relational_schema_drift()
+
+        self.assertEqual(len(drift), 1, drift)
+        self.assertIn("widgets", drift[0])
+        self.assertIn("user_id", drift[0])
+
+    async def test_reports_a_table_the_database_lacks(self):
+        engine_patch, base_patch = self._patch_for(_metadata(False, True))
+        with engine_patch, base_patch:
+            drift = await startup._collect_relational_schema_drift()
+
+        self.assertEqual(drift, ["missing table 'gadgets'"])
+
+    async def test_matching_schema_reports_nothing(self):
+        engine_patch, base_patch = self._patch_for(_metadata(False, False))
+        with engine_patch, base_patch:
+            drift = await startup._collect_relational_schema_drift()
+
+        self.assertEqual(drift, [])
+
+    async def test_extra_database_columns_are_not_drift(self):
+        """Alembic bookkeeping and retired columns live in the database without
+        being declared; only what the models NEED is checked."""
+        async with self.engine.begin() as connection:
+            extra = MetaData()
+            Table("leftovers", extra, Column("id", Integer, primary_key=True))
+            await connection.run_sync(extra.create_all)
+
+        engine_patch, base_patch = self._patch_for(_metadata(False, False))
+        with engine_patch, base_patch:
+            drift = await startup._collect_relational_schema_drift()
+
+        self.assertEqual(drift, [])
+
+    async def test_uninspectable_database_is_not_a_failure(self):
+        """The check is a safety net; it must never become a new way to fail."""
+        broken = MagicMock()
+        broken.engine.connect.side_effect = RuntimeError("no route to host")
+        with (
+            patch(
+                "cognee.infrastructure.databases.relational.get_relational_engine",
+                return_value=broken,
+            ),
+            patch(
+                "cognee.infrastructure.databases.relational.ModelBase.Base",
+                MagicMock(metadata=_metadata(True, True)),
+            ),
+        ):
+            drift = await startup._collect_relational_schema_drift()
+
+        self.assertEqual(drift, [])
+
+
+class TestSchemaCheckModes(unittest.IsolatedAsyncioTestCase):
+    """`verify_relational_schema` honours MIGRATION_SCHEMA_CHECK."""
+
+    def setUp(self):
+        self._saved = os.environ.get("MIGRATION_SCHEMA_CHECK")
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("MIGRATION_SCHEMA_CHECK", None)
+        else:
+            os.environ["MIGRATION_SCHEMA_CHECK"] = self._saved
+
+    async def test_strict_raises_with_the_drift_in_the_message(self):
+        os.environ["MIGRATION_SCHEMA_CHECK"] = "strict"
+        with patch.object(
+            startup,
+            "_collect_relational_schema_drift",
+            new=AsyncMock(return_value=["table 'pipeline_runs' is missing column(s): user_id"]),
+        ):
+            with self.assertRaises(startup.MigrationError) as caught:
+                await startup.verify_relational_schema()
+
+        self.assertIn("pipeline_runs", str(caught.exception))
+        self.assertIn("user_id", str(caught.exception))
+
+    async def test_warn_returns_drift_without_raising(self):
+        os.environ["MIGRATION_SCHEMA_CHECK"] = "warn"
+        with patch.object(
+            startup,
+            "_collect_relational_schema_drift",
+            new=AsyncMock(return_value=["missing table 'gadgets'"]),
+        ):
+            drift = await startup.verify_relational_schema()
+
+        self.assertEqual(drift, ["missing table 'gadgets'"])
+
+    async def test_off_skips_the_comparison_entirely(self):
+        os.environ["MIGRATION_SCHEMA_CHECK"] = "off"
+        collect = AsyncMock(return_value=["missing table 'gadgets'"])
+        with patch.object(startup, "_collect_relational_schema_drift", new=collect):
+            drift = await startup.verify_relational_schema()
+
+        self.assertEqual(drift, [])
+        collect.assert_not_awaited()
+
+    async def test_unknown_mode_falls_back_to_warn(self):
+        os.environ["MIGRATION_SCHEMA_CHECK"] = "nonsense"
+        with patch.object(
+            startup,
+            "_collect_relational_schema_drift",
+            new=AsyncMock(return_value=["missing table 'gadgets'"]),
+        ):
+            drift = await startup.verify_relational_schema()
+
+        self.assertEqual(drift, ["missing table 'gadgets'"])
+
+    async def test_default_mode_is_warn(self):
+        os.environ.pop("MIGRATION_SCHEMA_CHECK", None)
+        self.assertEqual(startup._schema_check_mode(), "warn")
+
+
+class TestVerificationRunsOnBothMigrationPaths(unittest.TestCase):
+    """The check must run after the fresh-database stamp AND after an upgrade —
+    a stamp is exactly where the assertion goes unverified."""
+
+    def setUp(self):
+        runner = importlib.import_module("cognee.modules.migrations.runner")
+        self._lock_patch = patch.object(runner, "_migration_lock", _null_async_cm)
+        self._lock_patch.start()
+
+    def tearDown(self):
+        self._lock_patch.stop()
+
+    def _run(self, schema_exists):
+        verify = AsyncMock(return_value=[])
+        db_engine = MagicMock()
+        db_engine.create_database = AsyncMock()
+        with (
+            patch.object(
+                startup, "_relational_schema_exists", new=AsyncMock(return_value=schema_exists)
+            ),
+            patch.object(startup, "run_relational_migrations", new=AsyncMock()),
+            patch.object(startup, "run_relational_stamp", new=AsyncMock()),
+            patch.object(startup, "verify_relational_schema", verify),
+            patch(
+                "cognee.infrastructure.databases.relational.get_relational_engine",
+                return_value=db_engine,
+            ),
+            patch(
+                "cognee.modules.migrations.runner.run_database_migrations",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            asyncio.run(startup.apply_all_migrations("head"))
+        return verify
+
+    def test_runs_after_fresh_database_stamp(self):
+        self._run(schema_exists=False).assert_awaited_once()
+
+    def test_runs_after_existing_database_upgrade(self):
+        self._run(schema_exists=True).assert_awaited_once()
+
+    def test_strict_failure_stops_the_data_migrations(self):
+        """Drift means the tables the graph/vector chain reads are wrong — it must
+        not proceed on a schema we know is broken."""
+        data_migrations = AsyncMock(return_value=[])
+        db_engine = MagicMock()
+        db_engine.create_database = AsyncMock()
+        with (
+            patch.object(startup, "_relational_schema_exists", new=AsyncMock(return_value=False)),
+            patch.object(startup, "run_relational_stamp", new=AsyncMock()),
+            patch.object(
+                startup,
+                "verify_relational_schema",
+                new=AsyncMock(side_effect=startup.MigrationError("drift")),
+            ),
+            patch(
+                "cognee.infrastructure.databases.relational.get_relational_engine",
+                return_value=db_engine,
+            ),
+            patch("cognee.modules.migrations.runner.run_database_migrations", new=data_migrations),
+        ):
+            with self.assertRaises(startup.MigrationError):
+                asyncio.run(startup.apply_all_migrations("head"))
+
+        data_migrations.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Both migration paths only **assert** the schema reached the target — neither verifies it.

```python
if await _relational_schema_exists():
    await run_relational_migrations(...)     # upgrade, assumes each revision did its job
else:
    await get_relational_engine().create_database()   # create_all from the ORM models
    await run_relational_stamp("head", ...)           # records the chain, runs NOTHING
```

The fresh-database shortcut is sound *provided the models and the Alembic head describe the same schema*. Nothing checks that.

In cognee cloud they diverged for nine days. The Alembic tree had gained `a7f3c9e1b5d2` (14 columns on `pipeline_runs`) while the image still bundled a cognee whose `PipelineRun` model had 8. **148 tenant databases** were provisioned with an 8-column table stamped at head — a schema Alembic will never migrate again, because it considers that revision applied.

Every signal read healthy the whole time: initContainer `exit 0`, `alembic current` = head, logs saying `Relational migrations applied (target head)`. It surfaced eleven days later as `column pipeline_runs.user_id does not exist` in a customer's `cognify` call.

## Change

`verify_relational_schema()` compares the live schema against the same `Base.metadata` that `create_database` builds from, and reports the tables and columns the models declare that the database lacks. It runs on **both** paths, before the graph/vector chain reads those tables.

`MIGRATION_SCHEMA_CHECK` selects behaviour: `strict` raises, `warn` (default) logs, `off` skips.

## Two deliberate defaults, both open to challenge

**Default is `warn`, not `strict`.** A fleet that already carries drift would fail closed on every affected tenant the moment this lands — turning a latent problem into an outage. `warn` surfaces the drift immediately (it would light up all 148 today) and the flip to `strict` is a one-line change once a fleet is clean. If you'd rather ship fail-closed from the start, say so and I'll flip it.

**Inspection failures are swallowed**, logged as a warning and treated as "no drift". A safety net must not become a new way for startup to fail — that lesson is fresh: adding embedding credentials to the migrations initContainer converted a crash into an unbounded hang.

## Testing

13 new tests reflecting a **real SQLite database** rather than mocking the inspector, so a change that stops detecting drift fails here.

Mutation-checked — each of these turns the suite red:
| Mutation | Result |
|---|---|
| drift detection always returns `[]` | 2 failed |
| remove the call from `apply_all_migrations` | 3 failed |
| `strict` no longer raises | 1 failed |

Existing suites: 64 migration tests pass; `cognee/tests/unit` shows no new failures (the 15 in a full-suite run are pre-existing event-loop pollution — `modules/retrieval` passes 518/518 in isolation on both this branch and `dev`).
