### PR TITLE
fix: Emit oversized trailing chunk run (SDK-527)

### DIFF
--- a/cognee/tasks/chunks/chunk_by_sentence.py
+++ b/cognee/tasks/chunks/chunk_by_sentence.py
@@ -2,6 +2,9 @@ from uuid import uuid4, UUID
 from typing import Optional, Iterator, Tuple
 from .chunk_by_word import chunk_by_word
 from cognee.infrastructure.databases.vector.embeddings import get_embedding_engine
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger(__name__)
 
 
 def get_word_size(word: str) -> int:
@@ -90,10 +93,21 @@ def chunk_by_sentence(
             sentence_size += word_size
 
     if len(sentence) > 0:
-        if maximum_size and sentence_size > maximum_size:
-            raise ValueError(f"Input word {word} longer than chunking size {maximum_size}.")
-
         section_end = "sentence_cut" if word_type_state == "word" else word_type_state
+
+        if maximum_size and sentence_size > maximum_size:
+            # A trailing run with no sentence or paragraph boundary (a protein sequence, a
+            # base64 blob, a glyph run left by PDF extraction) can exceed the chunk size. An
+            # oversized run in the middle of a document is already emitted as a single chunk;
+            # raising only when it is the last one made the whole document unprocessable, and
+            # with no partial-commit mode that failed the entire pipeline run.
+            logger.warning(
+                "Trailing run of %d tokens exceeds the chunk size of %d; "
+                "emitting it as a single oversized chunk.",
+                sentence_size,
+                maximum_size,
+            )
+
         yield (
             paragraph_id,
             sentence,

--- a/cognee/tests/unit/processing/chunks/chunk_by_sentence_test.py
+++ b/cognee/tests/unit/processing/chunks/chunk_by_sentence_test.py
@@ -55,5 +55,16 @@ def test_paragraph_chunk_length(input_text, maximum_length):
     ),
 )
 def test_paragraph_chunk_long_input(input_text, maximum_length):
-    with pytest.raises(ValueError):
-        list(chunk_by_sentence(input_text, maximum_length))
+    """A run longer than the chunk size that reaches the end of the text is emitted, not raised on.
+
+    Before the fix this asserted ``ValueError``. A single such run made the whole document
+    unprocessable, and with no partial-commit mode that failed the entire pipeline run. The
+    chunker's existing contract is that an oversized run becomes one oversized chunk (see
+    ``test_oversized_paragraph_gets_emitted_as_a_single_chunk``); the trailing run now follows
+    the same rule, so no text is lost.
+    """
+    chunks = list(chunk_by_sentence(input_text, maximum_length))
+
+    assert chunks, "an oversized trailing run must still produce a chunk"
+    reconstructed_text = "".join(chunk[1] for chunk in chunks)
+    assert reconstructed_text == input_text, "no text may be lost"

--- a/cognee/tests/unit/processing/chunks/test_input.py
+++ b/cognee/tests/unit/processing/chunks/test_input.py
@@ -283,5 +283,15 @@ Which would but lead me to a worse relapse [ 100 ]""",
 }
 
 INPUT_TEXTS_LONGWORDS = {
+    # Each of these contains a run no sentence or paragraph boundary can break. The first two
+    # are the shapes that failed in production: a protein sequence at the end of a paper and
+    # a LaTeX matrix brace extracted as a run of private-use glyphs.
+    "protein_sequence_tail": (
+        "This paper studies the folding kinetics of the protein. The full sequence follows.\n"
+        + "GKITFYEDRGFQGHCYECSSDCPNLQPYFSRCNSIRVDSGCWMLYERPNYQGHQYFLRRGDYPDYQQWMGFNDSIRSCRLIPQHTGTFR"
+        * 12
+    ),
+    "private_use_glyph_run": "29\n" + "\uf8ec" * 400,
+    "single_giant_token": "A" * 5000,
     "chinese_text": """在这个繁华的城市里，藏着一个古老的小巷，名叫杨柳巷。巷子两旁的青石板路已经被无数行人的脚步磨得发亮，斑驳的老墙上爬满了常青藤，给这个充满历史气息的小巷增添了一抹生机。每天清晨，巷子里都会飘出阵阵香气，那是张婆婆家的早点铺子散发出的包子和豆浆的味道。老店门前经常排着长队，有步履匆匆的上班族，也有悠闲散步的老人。巷子深处有一家传统的茶馆，古色古香的木桌椅上总是坐满了品茶聊天的街坊邻里。傍晚时分，夕阳的余晖洒在石板路上，为这个充满生活气息的小巷染上一层温暖的金色。街角的老榕树下，常常有卖唱的艺人在这里驻足，用沧桑的嗓音讲述着这座城市的故事。偶尔，还能看到三三两两的游客举着相机，试图捕捉这里独特的市井风情。这条看似普通的小巷，承载着太多市民的回忆和岁月的痕迹，它就像是这座城市的一个缩影，悄悄地诉说着曾经的故事。""",
 }


### PR DESCRIPTION
## Description
`chunk_by_sentence` raises `ValueError` when the text remaining after its loop exceeds `maximum_size` — i.e. when a document *ends* in a long run with no sentence-ending punctuation (protein/DNA sequences, base64 blobs, long URLs, private-use glyph runs from PDF extraction). The message blames an "input word", but the guard tests the accumulated trailing sentence.

The same run in the *middle* of a document is already emitted as one oversized chunk (contract pinned by `test_oversized_paragraph_gets_emitted_as_a_single_chunk`). Only the trailing position raised — and since one failed item fails the whole pipeline run, one such document rolled back everything the run had processed. Field data from a 10 GB arXiv ingest: 2 documents in 24,000 (`1101.5641v1`, `1406.4373v1`), each destroying a completed 2,000-document wave (340 and 974 min of rework); zero occurrences in the 140,000+ documents processed after patching this in the run's image.

The fix emits the trailing run exactly as a mid-document one, with a `logger.warning` carrying the token count and limit. Deliberately **not** included: splitting oversized runs to respect `maximum_size` — that would change the pinned TextChunker contract and is left to a separate proposal (see the Excluded section of SDK-527).

Linear: [SDK-527](https://linear.app/cognee/issue/SDK-527/chunker-emit-an-oversized-trailing-run-instead-of-raising-and-killing)

## Acceptance Criteria
* Documents ending in an unbreakable run chunk without raising; joined chunks are byte-identical to the input — covered by the inverted `test_paragraph_chunk_long_input` plus three new fixtures (protein tail, glyph run, single giant token).
* No behavior change for normal input: all 36 `(text, maximum_size)` combos over the existing `INPUT_TEXTS` produce byte-identical output to `dev` (verified by running both versions side by side).
* The oversized-paragraph contract is untouched: `tests/unit/modules/chunking` passes unchanged.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
```
$ pytest cognee/tests/unit/processing/chunks cognee/tests/unit/modules/chunking -q
330 passed, 1 skipped in 0.37s

old (dev) vs new on the long-run fixtures, maximum_size=64:
  protein_sequence_tail    old=RAISES  new=4 chunks,  text preserved=True
  private_use_glyph_run    old=RAISES  new=2 chunks,  text preserved=True
  single_giant_token       old=RAISES  new=2 chunks,  text preserved=True
  chinese_text             old=RAISES  new=10 chunks, text preserved=True
normal INPUT_TEXTS: 36/36 combos byte-identical to dev
```

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqYNHtL3zqaXmaLfcNpVCv
