### PR TITLE
fix(embeddings): recover from Vertex per-model batch-size rejections in embed_text

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -41,8 +41,15 @@ logger = get_logger("LiteLLMEmbeddingEngine")
 # BadRequestError (e.g. OpenAI 400 "maximum input length is 8192 tokens"). Match
 # those by message so the split/pool recovery below can handle them too. Kept
 # narrow to length/token-limit phrasings so genuinely-bad requests still fail fast.
+# Vertex reports oversized batches two ways depending on which limit is hit:
+# the per-prediction instance cap ("2048 instance(s) is allowed per prediction")
+# and the per-model batch cap ("a batchSize value of 1234 but the supported
+# range is from 1 (inclusive) to 251 (exclusive)" -- "too many instances").
 _EMBED_LENGTH_ERROR_RE = re.compile(
-    r"maximum\s+input\s+length|instance\(s\)\s+is\s+allowed\s+per\s+prediction",
+    r"maximum\s+input\s+length"
+    r"|instance\(s\)\s+is\s+allowed\s+per\s+prediction"
+    r"|too\s+many\s+instances"
+    r"|batchsize\s+value\s+of",
     re.IGNORECASE,
 )
 
@@ -262,9 +269,13 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
             # ContextWindowExceededError subclasses BadRequestError. litellm raises
             # it for chat context-length errors, but the embeddings API returns a
             # plain BadRequestError for over-length input (OpenAI 400: "maximum input
-            # length is 8192 tokens"; Vertex AI 400: "2048 instance(s) is allowed per
-            # prediction"). Recover (split + pool) for both; re-raise any
-            # other BadRequest unchanged so genuinely bad requests still fail fast.
+            # length is 8192 tokens"). Vertex words batch-limit 400s differently
+            # depending on which cap is hit: the per-prediction instance cap
+            # ("2048 instance(s) is allowed per prediction") or the per-model
+            # batch cap ("too many instances" / "batchSize value of 1234 but the
+            # supported range is ... to 251 (exclusive)"). Recover (split + pool)
+            # for all of these; re-raise any other BadRequest unchanged so
+            # genuinely bad requests still fail fast.
             if not (
                 isinstance(error, litellm.exceptions.ContextWindowExceededError)
                 or _EMBED_LENGTH_ERROR_RE.search(str(error))

--- a/cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py
+++ b/cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py
@@ -222,3 +222,46 @@ async def test_litellm_embedding_splits_batch_on_vertex_instance_limit_error():
 
     assert result == [[1.0, 1.0]] * 4
     assert embed_mock.await_count > 1
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedding_splits_batch_on_vertex_model_batch_limit_error():
+    import litellm
+
+    with patch(
+        "cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine."
+        "LiteLLMEmbeddingEngine.get_tokenizer",
+        return_value=Mock(),
+    ):
+        from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine import (
+            LiteLLMEmbeddingEngine,
+        )
+
+        engine = LiteLLMEmbeddingEngine(model="test-model", dimensions=2)
+
+    # Verbatim phrasing of Vertex's per-model batch cap (distinct from the
+    # per-prediction instance cap covered above): once a request is under the
+    # 2048-instance prediction limit, Vertex enforces a much smaller
+    # per-model batchSize cap (e.g. 250 for gemini-embedding-001).
+    batch_limit_error = litellm.exceptions.BadRequestError(
+        message=(
+            "Unable to submit request because it included too many instances. "
+            "Reduce the number of instances and try again. "
+            "Unable to submit request because it has a batchSize value of 1234 "
+            "but the supported range is from 1 (inclusive) to 251 (exclusive). "
+            "Update the value and try again."
+        ),
+        model="test-model",
+        llm_provider="vertex_ai",
+    )
+
+    async def fake_aembedding(**kwargs):
+        if len(kwargs["input"]) > 2:
+            raise batch_limit_error
+        return Mock(data=[{"embedding": [1.0, 1.0]} for _ in kwargs["input"]])
+
+    with patch("litellm.aembedding", AsyncMock(side_effect=fake_aembedding)) as embed_mock:
+        result = await engine.embed_text(["a", "b", "c", "d"])
+
+    assert result == [[1.0, 1.0]] * 4
+    assert embed_mock.await_count > 1


### PR DESCRIPTION
## Description

Follow-up to #4569. While testing that fix against a real Vertex deployment, we found Vertex enforces two separate batch limits, and each rejects with its own error message:

- the per-prediction instance cap: `2048 instance(s) is allowed per prediction. Actual: 4777`, already recovered by #4569
- the per-model batchSize cap: `Unable to submit request because it included too many instances. ... a batchSize value of 1234 but the supported range is from 1 (inclusive) to 251 (exclusive).` — **not** recovered

A batch under the first cap but over the second (e.g. 1,234 names against `gemini-embedding-001`'s 250 limit) fell through the recovery path and was re-raised, so `embed_text` still crashed on large graphs even with #4569 applied.

This widens `_EMBED_LENGTH_ERROR_RE` to also match the second phrasing, so the existing recursive split lands the request under whichever cap is binding. No behavior change for any other BadRequest.

## Acceptance Criteria

- A batch-size rejection phrased the per-model way (the verbatim QA error text) is recovered by the existing split-and-retry path instead of re-raised.
- The per-prediction phrasing from #4569 and the OpenAI phrasing keep working (existing tests cover both).
- Genuinely bad requests still fail fast (narrow alternation added; nothing else widened).
- New unit test fails without the fix and passes with it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

**Unit tests** (`test_embedding_context_window_fallbacks.py`, including the new `test_litellm_embedding_splits_batch_on_vertex_model_batch_limit_error`):

![unit tests passing](https://raw.githubusercontent.com/lallenlowe/cognee/pr-assets-2/1-unit-tests.png)

**Integration test** (1,234 entity names, the exact batch size that failed on our QA deployment, embedded through Vertex `gemini-embedding-001` via a LiteLLM-compatible gateway, exit 0):

![integration test passing](https://raw.githubusercontent.com/lallenlowe/cognee/pr-assets-2/2-integration-test.png)

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style
- [x] I have added tests that prove my fix is effective or that it works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
