### PR TITLE
COG-6491 fix: Stop mangling Turso dataset path

### DIFF
--- a/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
@@ -30,11 +30,21 @@ class TursoGraphDatasetDatabaseHandler:
 
         base_config = get_base_config()
         databases_dir = os.path.join(base_config.system_root_directory, "databases")
+
+        # This is delete_dataset's own os.path.isabs guard, evaluated at
+        # creation time: a non-absolute path would be silently skipped there
+        # (and by prune_system, which routes through it), leaving a file
+        # nothing can remove. Runs before makedirs so a non-local root such as
+        # an s3:// one creates no local directory on the way out.
+        if not os.path.isabs(databases_dir):
+            raise EnvironmentError(
+                "Turso per-dataset graph databases need an absolute local path; set "
+                f"SYSTEM_ROOT_DIRECTORY to one (got {base_config.system_root_directory!r})."
+            )
+
         os.makedirs(databases_dir, exist_ok=True)
 
-        db_file = os.path.join(databases_dir, f"graph_{dataset_id}.db")
-        # sqlite+aiosqlite:/// needs three slashes for absolute path
-        dataset_url = f"/{db_file}" if not db_file.startswith("/") else db_file
+        dataset_url = os.path.join(databases_dir, f"graph_{dataset_id}.db")
 
         engine = create_graph_engine(
             graph_database_provider="turso",

--- a/cognee/tests/unit/infrastructure/databases/graph/test_turso_graph_dataset_database_handler.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_turso_graph_dataset_database_handler.py
@@ -1,7 +1,7 @@
-"""Tests for TursoGraphDatasetDatabaseHandler.delete_dataset (Finding 5,
-COG-6335 review).
+"""Tests for TursoGraphDatasetDatabaseHandler (delete_dataset from Finding 5,
+COG-6335 review; create_dataset from COG-6491).
 
-Covers:
+delete_dataset covers:
 - eviction is by database name (aevict_for_database), matching the generic
   key ensure_graph_memory_cleared's get_graph_engine() resolves, instead of
   the old narrower exact-key evict() that could miss the live cache entry
@@ -9,21 +9,37 @@ Covers:
   removed
 - a dataset with no graph_database_name never calls the cache at all
   (nothing to evict by)
+- -wal/-shm companions absent (clean checkpointed close) does not raise
+- eviction completes before the file is removed, not just both happening
 - delete_dataset actually removes the file at the URL create_dataset itself
-  produces, on the OS the test runs on -- not a hand-built clean path. On
-  POSIX, create_dataset's URL equals os.path.join's result verbatim; on
-  Windows, os.path.join returns a backslash drive-letter path that does not
-  start with "/", so create_dataset prepends one ("sqlite+aiosqlite:///
-  needs three slashes for absolute path"), and delete_dataset must still
-  find and remove the resulting file. Round-tripping through the real
-  create_dataset (mocking only get_base_config/get_graph_config/
-  create_graph_engine, not the path construction itself) is what lets
-  Windows CI -- not a POSIX dev machine -- be the actual judge of whether
-  the absolute-path check in delete_dataset works for what create_dataset
-  really produces on that platform.
+  produces, on the OS the test runs on -- not a hand-built clean path.
+  Round-tripping through the real create_dataset (mocking only
+  get_base_config/get_graph_config/create_graph_engine, not the path
+  construction itself) is what lets Windows CI -- not a POSIX dev machine --
+  judge whether delete_dataset's absolute-path check works for what
+  create_dataset really produces on that platform.
+
+create_dataset covers:
+- the URL is os.path.join's result verbatim, with no added prefix
+- the same holds for a Windows-shaped path, asserted on any OS
+- a non-absolute system root is rejected, and rejected before makedirs
+- the dataset opens for real: a live engine round trip leaves a file at the
+  URL, which on windows-latest is a real drive-letter path
+
+COG-6491: an earlier create_dataset appended a leading "/" whenever the
+joined path did not already start with one. On Windows that produced
+"/C:\\...", which ntpath.isabs() rejects on Python 3.13 (on 3.12 isabs
+passed and os.path.exists failed instead -- same silent no-op, different
+route), so delete_dataset cleaned up nothing. It also fired on POSIX for any
+system root not starting with "/" -- an s3:// one, or a relative one --
+where the extra "/" was in fact what made sqlite refuse the path outright.
+Dropping it alone would have turned that loud failure into an accepted,
+CWD-relative file that the isabs() guard makes undeletable, so create_dataset
+now rejects those roots instead.
 """
 
 import importlib
+import ntpath
 import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -64,6 +80,89 @@ async def _create_real_dataset_url(tmp_path, dataset_id="dataset-id"):
         info = await TursoGraphDatasetDatabaseHandler.create_dataset(dataset_id, None)
 
     return info["graph_database_url"]
+
+
+async def _create_dataset_url_for_root(system_root, fake_os=None):
+    """create_dataset against an arbitrary system root, with the engine
+    stubbed so only path construction runs. fake_os replaces the handler's
+    own os global -- patching handler_module.os's attributes would mutate the
+    stdlib process-wide, since handler_module.os *is* os."""
+    fake_engine = MagicMock()
+    fake_engine.initialize = AsyncMock()
+
+    with (
+        patch.object(
+            handler_module,
+            "get_graph_config",
+            return_value=SimpleNamespace(graph_database_provider="turso"),
+        ),
+        patch.object(
+            handler_module,
+            "get_base_config",
+            return_value=SimpleNamespace(system_root_directory=system_root),
+        ),
+        patch.object(handler_module, "create_graph_engine", return_value=fake_engine),
+        patch.object(
+            handler_module, "os", fake_os or SimpleNamespace(path=os.path, makedirs=MagicMock())
+        ),
+    ):
+        info = await TursoGraphDatasetDatabaseHandler.create_dataset("dataset-id", None)
+
+    return info["graph_database_url"]
+
+
+async def test_create_dataset_url_is_the_plain_join(tmp_path):
+    """The URL is os.path.join's result verbatim -- no added prefix."""
+    dataset_url = await _create_dataset_url_for_root(str(tmp_path))
+
+    assert dataset_url == os.path.join(str(tmp_path), "databases", "graph_dataset-id.db")
+    assert os.path.isabs(dataset_url)
+
+
+async def test_create_dataset_does_not_prefix_windows_style_path():
+    """Platform-independent guard for the COG-6491 mangling.
+
+    On POSIX the old and new expressions are byte-identical, since
+    os.path.join already yields a leading "/" -- so a POSIX run cannot catch
+    a reintroduction on its own and only windows-latest would. Handing the
+    handler an os whose path is ntpath reproduces the Windows string
+    arithmetic here: the old code turned this into "/C:\\fake\\databases\\...",
+    which ntpath.isabs rejects and delete_dataset therefore never cleans up."""
+    dataset_url = await _create_dataset_url_for_root(
+        r"C:\fake", fake_os=SimpleNamespace(path=ntpath, makedirs=MagicMock())
+    )
+
+    assert dataset_url == r"C:\fake\databases\graph_dataset-id.db"
+    assert ntpath.isabs(dataset_url)
+    assert not dataset_url.startswith("/")
+
+
+@pytest.mark.parametrize(
+    "system_root",
+    ["s3://bucket/cognee/system", "relative/system/root"],
+    ids=["s3_root", "relative_root"],
+)
+async def test_create_dataset_rejects_non_absolute_system_root(system_root):
+    """A libSQL dataset is a local file, and delete_dataset's os.path.isabs
+    guard silently skips a non-absolute one, so such a database could never
+    be removed. Both roots are reachable: ensure_absolute_path passes s3://
+    through untouched, and cognee.config.system_root_directory assigns a
+    relative path without revalidating. sqlite accepts both (creating a file
+    relative to the CWD), so without this check they would be orphans."""
+    with pytest.raises(EnvironmentError, match="absolute local path"):
+        await _create_dataset_url_for_root(system_root)
+
+
+async def test_create_dataset_makes_no_directory_for_non_absolute_root():
+    """The check runs before makedirs, so a non-local root leaves no local
+    directory tree behind -- an s3:// root would otherwise have os.makedirs
+    build a literal "./s3:/bucket/cognee/system/databases"."""
+    fake_os = SimpleNamespace(path=os.path, makedirs=MagicMock())
+
+    with pytest.raises(EnvironmentError):
+        await _create_dataset_url_for_root("s3://bucket/cognee/system", fake_os=fake_os)
+
+    fake_os.makedirs.assert_not_called()
 
 
 async def test_delete_dataset_evicts_by_database_name(monkeypatch, tmp_path):
@@ -177,10 +276,53 @@ async def test_delete_dataset_evicts_before_removing_file(monkeypatch, tmp_path)
     monkeypatch.setattr(
         handler_module, "graph_engine_cache", SimpleNamespace(aevict_for_database=fake_aevict)
     )
-    monkeypatch.setattr(handler_module.os, "remove", tracking_remove)
+    # Replace the module's os global, not os.remove itself -- handler_module.os
+    # *is* os, so setting an attribute on it would swap the stdlib's remove
+    # process-wide for the duration of the test.
+    monkeypatch.setattr(handler_module, "os", SimpleNamespace(path=os.path, remove=tracking_remove))
 
     await TursoGraphDatasetDatabaseHandler.delete_dataset(
         _dataset_database(str(db_path), graph_db_name="dataset-id")
     )
 
     assert call_order == ["evict", "remove"]
+
+
+async def test_create_dataset_opens_a_real_graph(tmp_path):
+    """The other half of COG-6491: cleanup was the visible failure, but the
+    same value also builds the connection string, interpolated into
+    "sqlite+aiosqlite:///". Nothing else here lets the real engine run, so
+    nothing else would notice a URL sqlite cannot open.
+
+    create_graph_engine is deliberately NOT patched: this drives create_dataset
+    end to end and asserts a file exists at the URL it returned. On
+    windows-latest tmp_path is a real drive-letter path, which makes this the
+    acceptance test for "a per-dataset Turso graph opens on Windows"; on POSIX
+    it is an ordinary sqlite round trip."""
+    kwargs = dict(
+        graph_database_provider="turso",
+        graph_file_path="",
+        graph_database_key="",
+    )
+
+    with (
+        patch.object(
+            handler_module,
+            "get_graph_config",
+            return_value=SimpleNamespace(graph_database_provider="turso"),
+        ),
+        patch.object(
+            handler_module,
+            "get_base_config",
+            return_value=SimpleNamespace(system_root_directory=str(tmp_path)),
+        ),
+    ):
+        info = await TursoGraphDatasetDatabaseHandler.create_dataset("dataset-id", None)
+
+    dataset_url = info["graph_database_url"]
+    try:
+        assert os.path.exists(dataset_url)
+    finally:
+        # create_graph_engine is closing_lru_cache-wrapped; without this the
+        # adapter stays cached under a tmp_path key that is gone next test.
+        handler_module.graph_engine_cache.evict(graph_database_url=dataset_url, **kwargs)


### PR DESCRIPTION
## Description

`TursoGraphDatasetDatabaseHandler.create_dataset` built the per-dataset libSQL
path with:

    dataset_url = f"/{db_file}" if not db_file.startswith("/") else db_file

On Windows, `os.path.join` returns a backslash drive-letter path like
`C:\...\databases\graph_<id>.db`, which does not start with `/`, so this
prepended one and produced `/C:\...`. `ntpath.isabs()` rejects that on
Python 3.13, so `delete_dataset`'s own `os.path.isabs` guard silently
skipped removing the file (and its `-wal`/`-shm` companions) instead of
deleting it, and the same mangled value also broke the SQLAlchemy connection
string. This is what has kept the `windows-latest` unit job red on `dev`.

Dropping the leading slash unconditionally would have regressed two other
cases that reach the same code path: an `s3://` system root (passed through
untouched by `ensure_absolute_path`) and a relative root set via
`cognee.config.system_root_directory` (not revalidated by pydantic on
assignment). For those, sqlite would silently accept a CWD-relative file
that `delete_dataset`/`prune_system` could never clean up — a silent orphan
instead of a loud failure.

Fix: stop mangling the path (`dataset_url` is now `os.path.join`'s result,
verbatim), and reject a non-absolute `system_root_directory` up front in
`create_dataset`, before any directory is created. This is
`delete_dataset`'s own `os.path.isabs` guard, evaluated at creation time
instead of at deletion time.

## Acceptance Criteria

- `create_dataset`'s URL is `os.path.join`'s result with no added prefix, on
  every OS.
- A Windows-shaped path (via `ntpath`) is not prefixed with `/` and stays
  `ntpath.isabs`.
- A non-absolute `system_root_directory` (`s3://...`, or a relative path)
  raises `EnvironmentError` before `os.makedirs` runs — no local directory
  is created for a non-local root.
- `delete_dataset` removes the exact file `create_dataset` produces on the
  OS the test runs on (round-tripped through the real `create_dataset`, not
  a hand-built path), including on Windows.
- A live `create_graph_engine` round trip actually opens a file at the
  returned URL.

Proof: `cognee/tests/unit/infrastructure/databases/graph/test_turso_graph_dataset_database_handler.py`
covers all of the above; `windows-latest` was the only CI lane that could
catch the original bug, since POSIX's `os.path.join` already starts with
`/` and never exercised the mangling branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.