### PR TITLE
fix(ci): Drop the /v1 suffix from the Ollama endpoint (CLO-594)

### DIFF
--- a/.github/workflows/test_ollama.yml
+++ b/.github/workflows/test_ollama.yml
@@ -98,7 +98,10 @@ jobs:
           PYTHONFAULTHANDLER: 1
           LLM_PROVIDER: "ollama"
           LLM_API_KEY: "ollama"
-          LLM_ENDPOINT: "http://localhost:11434/v1/"
+          # No /v1 suffix: LLM_PROVIDER=ollama makes litellm qualify the model
+          # as "ollama/phi4" and take its native route, which appends
+          # /api/generate to this base. A /v1/ here yields /v1/api/generate -> 404.
+          LLM_ENDPOINT: "http://localhost:11434"
           LLM_MODEL: "phi4"
           EMBEDDING_PROVIDER: "ollama"
           EMBEDDING_MODEL: "qwen3-embedding:latest"

--- a/.github/workflows/test_ollama.yml
+++ b/.github/workflows/test_ollama.yml
@@ -98,9 +98,6 @@ jobs:
           PYTHONFAULTHANDLER: 1
           LLM_PROVIDER: "ollama"
           LLM_API_KEY: "ollama"
-          # No /v1 suffix: LLM_PROVIDER=ollama makes litellm qualify the model
-          # as "ollama/phi4" and take its native route, which appends
-          # /api/generate to this base. A /v1/ here yields /v1/api/generate -> 404.
           LLM_ENDPOINT: "http://localhost:11434"
           LLM_MODEL: "phi4"
           EMBEDDING_PROVIDER: "ollama"


### PR DESCRIPTION
## Description

The Ollama nightly has failed **every night since 2026-08-22** (last green Aug 21), always with the same 404 before any useful work happens:

```
MaskedHTTPStatusError: Client error '404 Not Found' for url
  'http://localhost:11434/v1/api/generate'
litellm.APIConnectionError: OllamaException - 404 page not found
```

`LLM_ENDPOINT` has carried a `/v1/` suffix since 2025-10-31 and was correct for most of that time: under the `instructor` framework litellm received a bare `phi4` and dispatched over the OpenAI-compatible API, where `/v1/` is exactly right.

`ee7f784a1` (CLO-594) then qualified the model with its provider to fix a `LLM Provider NOT provided` routing error. That qualification is what breaks this — `ollama/phi4` moves litellm onto its **native Ollama route**, which appends `/api/generate` to `api_base`, so a `/v1/` base resolves to `/v1/api/generate`, a path Ollama does not serve. CLO-594 fixed one error and uncovered the next, which is why the nightly went red the same night it merged.

## Evidence

Reproduced locally against a real Ollama (`phi4` + `qwen3-embedding:latest`). The failure matches CI's log exactly; dropping the suffix takes the job to a clean pass:

```
kind='graph_completion' search_type='GRAPH_COMPLETION'
text='Natural language processing (NLP) is an interdisciplinary subfield of
computer science and information retrieval...'
```

Isolated from cognee entirely:

| `api_base` | `ollama/phi4` | `ollama_chat/phi4` |
|---|---|---|
| `http://localhost:11434/v1/` | ❌ 404 | ❌ 404 |
| `http://localhost:11434` | ✅ | ✅ |

`EMBEDDING_ENDPOINT` is deliberately unchanged — it is consumed by cognee's own `OllamaEmbeddingEngine` over httpx and never reaches litellm. It worked throughout.

## Verification

Draft pending a `workflow_dispatch` run of Nightly Tests on this branch.

Note the local pass ran native Ollama on Metal, while CI runs it CPU-only in a container on `ubuntu-22.04`, where the job's own TODO says phi4 wants 32 GB. This change makes the *configuration* correct; it does not by itself prove the job fits the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)