### PR TITLE
ci: Keep docs work that overshoots the turn cap (RES-30)

### DIFF
--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -199,6 +199,7 @@ jobs:
       - name: Plan docs changes with Claude
         if: ${{ steps.assessment.outputs.needs_update == 'true' }}
         id: claude_scope
+        continue-on-error: true
         uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678  # v1.0.201
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -217,6 +218,29 @@ jobs:
             - **Prepared documentation edit scope** (`./${{ steps.branch_paths.outputs.docs_edit_scope_markdown }}`): Curated source files, docs candidates, assessment summary, and out-of-scope files.
             - **Prepared documentation edit scope JSON** (`./${{ steps.branch_paths.outputs.docs_edit_scope_json }}`): Machine-readable copy of the prepared scope.
           claude_args: "--allowed-tools Read,Write,Glob,Grep --max-turns 35"
+
+      # The action fails a step whose reported turn count overshoots the cap even
+      # when the agent finished cleanly, which throws away completed work. So judge
+      # from the agent's own result: a clean finish carries on, a genuinely
+      # truncated run (error_max_turns) still fails here rather than opening a PR
+      # from a half-written plan.
+      - name: Check the planning agent finished
+        if: ${{ steps.assessment.outputs.needs_update == 'true' }}
+        env:
+          CLAUDE_CONCLUSION: ${{ steps.claude_scope.outputs.conclusion }}
+          EXECUTION_FILE: ${{ steps.claude_scope.outputs.execution_file }}
+        run: |
+          set -euo pipefail
+
+          if [ "${CLAUDE_CONCLUSION:-}" != "success" ]; then
+            if [ -z "${EXECUTION_FILE:-}" ] || [ ! -s "${EXECUTION_FILE}" ] || \
+               ! jq -e '[.. | objects | select(has("is_error"))] | last | .is_error == false' \
+                    "${EXECUTION_FILE}" >/dev/null 2>&1; then
+              echo "The planning agent did not finish (conclusion=${CLAUDE_CONCLUSION:-unknown})."
+              exit 1
+            fi
+            echo "The action failed on the turn count but the planning agent finished cleanly - keeping the work."
+          fi
 
       - name: Validate docs scope plan
         if: ${{ steps.assessment.outputs.needs_update == 'true' }}
@@ -256,6 +280,7 @@ jobs:
       - name: Generate docs changes with Claude
         if: ${{ steps.assessment.outputs.needs_update == 'true' && steps.scope_plan.outputs.docs_needed == 'true' }}
         id: claude
+        continue-on-error: true
         uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678  # v1.0.201
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -278,6 +303,29 @@ jobs:
             - **Branch notes** (`./${{ steps.branch_paths.outputs.notes_markdown }}`)
             - **Documentation assessment** (`./${{ steps.branch_paths.outputs.assessment_markdown }}`)
           claude_args: "--allowed-tools Read,Edit,Write,Glob,Grep,Bash --max-turns 50"
+
+      # The action fails a step whose reported turn count overshoots the cap even
+      # when the agent finished cleanly, which throws away completed work. So judge
+      # from the agent's own result: a clean finish carries on, a genuinely
+      # truncated run (error_max_turns) still fails here rather than opening a PR
+      # containing a half-written page.
+      - name: Check the editing agent finished
+        if: ${{ steps.assessment.outputs.needs_update == 'true' && steps.scope_plan.outputs.docs_needed == 'true' }}
+        env:
+          CLAUDE_CONCLUSION: ${{ steps.claude.outputs.conclusion }}
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        run: |
+          set -euo pipefail
+
+          if [ "${CLAUDE_CONCLUSION:-}" != "success" ]; then
+            if [ -z "${EXECUTION_FILE:-}" ] || [ ! -s "${EXECUTION_FILE}" ] || \
+               ! jq -e '[.. | objects | select(has("is_error"))] | last | .is_error == false' \
+                    "${EXECUTION_FILE}" >/dev/null 2>&1; then
+              echo "The editing agent did not finish (conclusion=${CLAUDE_CONCLUSION:-unknown})."
+              exit 1
+            fi
+            echo "The action failed on the turn count but the editing agent finished cleanly - keeping the work."
+          fi
 
       - name: Prepare docs PR content
         if: ${{ steps.assessment.outputs.needs_update == 'true' && steps.scope_plan.outputs.docs_needed == 'true' }}


### PR DESCRIPTION
## Description

Closes RES-30.

The daily `automation | Draft Docs PRs For Previous Day Dev PRs` workflow calls Claude twice per merged dev PR — `Plan docs changes with Claude` (`--max-turns 35`) and `Generate docs changes with Claude` (`--max-turns 50`). When either step fails, the matrix job aborts before `Create or update docs pull request` and that PR silently gets no docs draft.

`claude-code-action` fails those steps in two different ways, and only one is a real problem:

- **`error_max_turns`** — the agent was genuinely cut off mid-task.
- **"Claude reported a successful result after N turns, exceeding the configured maximum of M"** — the agent finished cleanly and the action failed it afterwards. `base-action/src/run-claude-sdk.ts` throws when the SDK returns `subtype: "success"` and `num_turns > maxTurns`, but `num_turns` is not the counter the cap is enforced against, so it reads high and the check is a false positive by construction. RES-24 established this from source and a local repro.

Four jobs hit this across three recent runs, and none of the four cognee PRs has a docs PR today:

| cognee PR | Step | Failure | Fixed here? |
| -- | -- | -- | -- |
| #4608 | Generate | successful result after 57 turns, cap 50 | ✅ false positive |
| #4645 | Plan | successful result after 37 turns, cap 35 | ✅ false positive |
| #4611 | Generate | `error_max_turns`, cap 50 | ❌ real truncation |
| #4654 | Plan | `error_max_turns`, cap 35 | ❌ real truncation |

## Changes

Ports the fix [cognee-docs#1561](https://github.com/topoteretes/cognee-docs/pull/1561) already made to `docs-improvement-from-chatbot.yml`:

- `continue-on-error: true` on both Claude steps, so the action's exit status no longer decides the job.
- A gate step after each — `Check the planning agent finished` and `Check the editing agent finished` — that passes on conclusion `success`, and otherwise keeps the work only when the execution file's last `is_error` is `false`. A genuine truncation still exits non-zero, so a half-written plan or page never reaches a PR.

Downstream `if:` conditions are untouched: `Validate docs scope plan` still guards on the scope plan file existing.

## Notes for the reviewer

- This recovers the two false-positive jobs only. `#4611` and `#4654` really did run out of turns; raising the caps or narrowing `.github/prompts/docs_scope_plan.md` and `docs_edit.md` is deliberately out of scope and needs its own issue.
- The same pattern merged in cognee-docs at 2026-09-01 14:02 UTC, after that workflow's last scheduled run, so it has not yet been exercised by a real scheduled run in either repo. Worth a `workflow_dispatch` with `anchor_date` before relying on it.
- The four docs PRs lost to these failures were created by hand rather than back-filled by a re-run; they are linked from RES-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Why the planning step needs a gate too

It looks like the step that never fails; it is in fact the one that fails most. Across all 9 failed runs of this workflow:

| Claude step | Failed jobs | Of which recoverable overshoots |
| -- | -- | -- |
| `Plan docs changes with Claude` | 8 | ≥3 — #4645 (37/35), #4426 (37/35), #4061 (38/35) |
| `Generate docs changes with Claude` | 6 | ≥2 — #4608 (57/50), #4377 (54/50) |

(Six further Claude-step failures in run 29709518191 can't be classified — its annotations have expired. Non-Claude failures are excluded: 11 `Generate branch notes` failures in run 30411018845 and 2 `Prepare docs edit scope` failures in 29075294346.)

Planning fails more often for a structural reason: it runs on **every** PR the assessment marks `needs_update=true`, while generate only runs on the subset whose plan then says `docs_needed=true` — more executions against a tighter cap (35 vs 50).

The gate is also what makes `continue-on-error` safe on that step. `Validate docs scope plan` only checks the plan file is non-empty (`test -s`), so without the gate a genuinely truncated plan — #4654 and #4481 were both `error_max_turns` at 35 — would pass validation and drive a real docs edit.
