### PR TITLE
fix: auth in cognee.serve (SDK-531)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -817,6 +817,12 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # (above) remain as deprecated fallbacks.
 #COGNEE_SERVICE_URL=""
 #COGNEE_API_KEY=""
+# serve() browser-based cloud login (advanced; without these, connect with
+# COGNEE_SERVICE_URL + COGNEE_API_KEY above or serve(url=..., api_key=...)).
+# Auth0 Native-app client ID with the Device Authorization grant enabled:
+#COGNEE_AUTH0_DEVICE_CLIENT_ID=""
+# Management API used for tenant discovery and key provisioning:
+#COGNEE_CLOUD_URL="https://api.dev.cloud.topoteretes.com"
 
 # -- Debug (both images) ------------------------------------------------------
 # DEBUG=true together with ENV in {dev,local} starts the container under

--- a/.env.template
+++ b/.env.template
@@ -811,18 +811,18 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # MCP "API mode": point the MCP server at an already-running cognee API server.
 #API_URL=http://localhost:8000
 #API_TOKEN=""
-# MCP "Cloud mode": point the MCP server at a managed Cognee Cloud instance.
-# These are the canonical cloud-connection variables, shared across serve(),
-# push(), the MCP server, and sync. COGNEE_CLOUD_API_URL / COGNEE_CLOUD_AUTH_TOKEN
-# (above) remain as deprecated fallbacks.
+# MCP "Cloud mode": point the MCP server at a managed Cognee Cloud instance
+# using the Cognee Serve variables below (COGNEE_SERVICE_URL / COGNEE_API_KEY).
+
+# -- Cognee Serve --------------------------------------------------------------
+# cognee.serve() points the SDK at a running Cognee instance (local or cloud);
+# all memory operations then route to it instead of running locally.
+# Instance to connect to and its API key — the canonical cloud-connection
+# variables, shared across serve(), push(), the MCP server, and sync.
+# COGNEE_CLOUD_API_URL / COGNEE_CLOUD_AUTH_TOKEN (above) remain as deprecated
+# fallbacks. Equivalent to serve(url=..., api_key=...).
 #COGNEE_SERVICE_URL=""
 #COGNEE_API_KEY=""
-# serve() browser-based cloud login (advanced; without these, connect with
-# COGNEE_SERVICE_URL + COGNEE_API_KEY above or serve(url=..., api_key=...)).
-# Auth0 Native-app client ID with the Device Authorization grant enabled:
-#COGNEE_AUTH0_DEVICE_CLIENT_ID=""
-# Management API used for tenant discovery and key provisioning:
-#COGNEE_CLOUD_URL="https://api.dev.cloud.topoteretes.com"
 
 # -- Debug (both images) ------------------------------------------------------
 # DEBUG=true together with ENV in {dev,local} starts the container under

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ See the [plugin README](https://github.com/topoteretes/cognee-integrations/tree/
 
 ### Connect to Cognee Cloud
 
-Point any Python agent at a managed Cognee instance — all SDK calls route to the cloud:
+Point any Python agent at a managed Cognee instance — all SDK calls route to the cloud. Get your instance URL and API key from the [Cognee Cloud](https://www.cognee.ai) dashboard, or set the `COGNEE_SERVICE_URL` and `COGNEE_API_KEY` environment variables and call `serve()` with no arguments:
 
 ```python
 import cognee
@@ -415,7 +415,7 @@ Use [Cognee Cloud](https://www.cognee.ai) for a fully managed experience, or sel
 
 | Platform | Best For | Command |
 |----------|----------|---------|
-| **Cognee Cloud** | Managed service, no infrastructure to maintain | [Sign up](https://www.cognee.ai) or `await cognee.serve()` |
+| **Cognee Cloud** | Managed service, no infrastructure to maintain | [Sign up](https://www.cognee.ai), then `await cognee.serve(url=..., api_key=...)` |
 | **Modal** | Serverless, auto-scaling, GPU workloads | `bash distributed/deploy/modal-deploy.sh` |
 | **Railway** | Simplest PaaS, native Postgres | `railway init && railway up` |
 | **Fly.io** | Edge deployment, persistent volumes | `bash distributed/deploy/fly-deploy.sh` |

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -70,6 +70,20 @@ class CloudClient:
         except Exception:
             return False
 
+    async def _auth_check(self) -> Optional[int]:
+        """Status of an authenticated probe, or None when unreachable.
+
+        ``/health`` is unauthenticated, so it cannot tell a working API key
+        from a rejected one. Probing an authenticated endpoint lets serve()
+        fail at connect time instead of on the first real operation.
+        """
+        try:
+            session = await self._get_session()
+            async with session.get(f"{self.service_url}/api/v1/datasets") as resp:
+                return resp.status
+        except Exception:
+            return None
+
     # ----- V2 Operations -----
 
     async def remember(self, data: Any, dataset_name: str = "main_dataset", **kwargs) -> dict:

--- a/cognee/api/v1/serve/serve.py
+++ b/cognee/api/v1/serve/serve.py
@@ -274,7 +274,8 @@ async def _serve_cloud(
     # Step 5: Get or create API key
     api_key = await get_or_create_api_key(mgmt_url, access_token)
 
-    # Step 6: Save credentials
+    # Step 6: Build credentials — saved in Step 7 only after the tenant
+    # instance accepts the key (validate-then-save, matching the direct flow)
     creds = CloudCredentials(
         access_token=access_token,
         refresh_token=token.refresh_token,
@@ -286,8 +287,6 @@ async def _serve_cloud(
         tenant_name=tenant.name,
         email=email or "",
     )
-    save_credentials(creds)
-
     # Step 7: Connect
     client = CloudClient(service_url, api_key)
 
@@ -304,18 +303,22 @@ async def _serve_cloud(
     auth_status = await client._auth_check()
     if auth_status in (401, 403):
         from cognee.exceptions import CogneeConfigurationError
-        from cognee.api.v1.serve.credentials import get_credentials_path
 
         await client.close()
         raise CogneeConfigurationError(
             message=(
                 f"Authenticated with Cognee Cloud, but the tenant instance at {service_url} "
                 "rejected the provisioned API key. This is a provisioning problem, not a "
-                "problem with your login. Please try again; if it persists, delete "
-                f"{get_credentials_path()} and reconnect, or contact support."
+                "problem with your login — nothing was saved. Please try again; if it "
+                "persists, contact support."
             ),
             name="ServeAuthenticationError",
         )
+
+    # Rejections above discard the fresh Auth0 login (refresh token included),
+    # so a retry repeats the browser flow — the cost of never caching a key
+    # the tenant rejected.
+    save_credentials(creds)
 
     set_remote_client(client)
     print(f"  Connected to Cognee Cloud at {service_url}")

--- a/cognee/api/v1/serve/serve.py
+++ b/cognee/api/v1/serve/serve.py
@@ -199,6 +199,13 @@ async def _serve_cloud(
                 if token.refresh_token:
                     creds.refresh_token = token.refresh_token
                 creds.expires_at = time.time() + token.expires_in
+                # Deliberately saved BEFORE the connect checks below — unlike
+                # the validate-then-save order used for new API keys. This
+                # persists issuer-validated token material only (the API key
+                # beside it is already on disk either way), and with rotating
+                # refresh tokens the old token was consumed by this refresh:
+                # deferring the save would strand a dead refresh token in the
+                # file whenever the connect check fails, breaking recovery.
                 save_credentials(creds)
 
                 client = CloudClient(creds.service_url, creds.api_key)

--- a/cognee/api/v1/serve/serve.py
+++ b/cognee/api/v1/serve/serve.py
@@ -59,14 +59,13 @@ async def serve(
 
     Raises:
         CogneeConfigurationError: When called with no ``url``, no usable saved
-            credentials, and no Auth0 device client ID configured — i.e. there
+            credentials, and no device-login client ID configured — i.e. there
             is nothing to connect with. The error explains the available
-            options (pass ``url``/``api_key``, set ``COGNEE_SERVICE_URL`` /
-            ``COGNEE_API_KEY``, or configure ``COGNEE_AUTH0_DEVICE_CLIENT_ID``
-            for browser-based cloud login). Also raised when the instance is
-            reachable but rejects the API key (401/403 on an authenticated
-            probe) — connecting would otherwise appear to succeed and fail on
-            the first operation.
+            options (pass ``url``/``api_key`` or set ``COGNEE_SERVICE_URL`` /
+            ``COGNEE_API_KEY``). Also raised when the instance is reachable
+            but rejects the API key (401/403 on an authenticated probe) —
+            connecting would otherwise appear to succeed and fail on the
+            first operation.
     """
     # Resolve URL from arg or env
     service_url = url or os.getenv("COGNEE_SERVICE_URL")
@@ -240,10 +239,7 @@ async def _serve_cloud(
                 "To connect to a Cognee instance, pass its URL and API key:\n"
                 '    await cognee.serve(url="http://localhost:8000")\n'
                 '    await cognee.serve(url="https://your-instance", api_key="...")\n'
-                "or set the COGNEE_SERVICE_URL and COGNEE_API_KEY environment variables.\n\n"
-                "Browser-based Cognee Cloud login additionally requires the "
-                "COGNEE_AUTH0_DEVICE_CLIENT_ID environment variable (or the "
-                "auth0_client_id argument)."
+                "or set the COGNEE_SERVICE_URL and COGNEE_API_KEY environment variables."
             ),
             name="ServeConfigurationError",
         )

--- a/cognee/api/v1/serve/serve.py
+++ b/cognee/api/v1/serve/serve.py
@@ -56,6 +56,17 @@ async def serve(
 
     Returns:
         CloudClient connected to the instance.
+
+    Raises:
+        CogneeConfigurationError: When called with no ``url``, no usable saved
+            credentials, and no Auth0 device client ID configured — i.e. there
+            is nothing to connect with. The error explains the available
+            options (pass ``url``/``api_key``, set ``COGNEE_SERVICE_URL`` /
+            ``COGNEE_API_KEY``, or configure ``COGNEE_AUTH0_DEVICE_CLIENT_ID``
+            for browser-based cloud login). Also raised when the instance is
+            reachable but rejects the API key (401/403 on an authenticated
+            probe) — connecting would otherwise appear to succeed and fail on
+            the first operation.
     """
     # Resolve URL from arg or env
     service_url = url or os.getenv("COGNEE_SERVICE_URL")
@@ -84,6 +95,30 @@ async def _serve_direct(service_url: str, api_key: str = "") -> CloudClient:
     health_ok = await client._health_check()
     if not health_ok:
         logger.warning("Instance at %s did not respond to health check", service_url)
+
+    # /health is unauthenticated, so it cannot catch a rejected API key —
+    # without this probe a bad key still prints "Connected" and then every
+    # operation fails with 401. Only a definitive rejection is fatal; an
+    # unreachable instance keeps the warn-and-continue behavior above.
+    auth_status = await client._auth_check()
+    if auth_status in (401, 403):
+        from cognee.exceptions import CogneeConfigurationError
+
+        await client.close()
+        if api_key:
+            detail = "the API key was rejected — check that it belongs to this instance."
+        else:
+            detail = (
+                "it requires authentication and no API key was given. Pass one via "
+                'cognee.serve(url=..., api_key="...") or the COGNEE_API_KEY environment '
+                "variable. On a self-hosted server, mint a key by logging in and calling "
+                "POST /api/v1/auth/api-keys (the key is only revealed in the creation "
+                "response)."
+            )
+        raise CogneeConfigurationError(
+            message=f"Connected to {service_url}, but {detail}",
+            name="ServeAuthenticationError",
+        )
 
     # Save so subsequent serve() calls reconnect without args
     save_credentials(
@@ -139,7 +174,10 @@ async def _serve_cloud(
     if creds and creds.service_url and creds.api_key:
         client = CloudClient(creds.service_url, creds.api_key)
         try:
-            if await client._health_check():
+            # The saved API key must actually authenticate, not just reach the
+            # instance — a stale key on a healthy instance would otherwise
+            # "connect" and fail on the first operation.
+            if await client._health_check() and await client._auth_check() not in (401, 403):
                 logger.info("Using cached credentials for %s (token status ignored)", creds.email)
                 set_remote_client(client)
                 print(f"  Connected to Cognee Cloud at {creds.service_url}")
@@ -165,7 +203,7 @@ async def _serve_cloud(
                 save_credentials(creds)
 
                 client = CloudClient(creds.service_url, creds.api_key)
-                if await client._health_check():
+                if await client._health_check() and await client._auth_check() not in (401, 403):
                     set_remote_client(client)
                     print(f"  Connected to Cognee Cloud at {creds.service_url}")
                     return client
@@ -173,7 +211,43 @@ async def _serve_cloud(
             except Exception as e:
                 logger.warning("Token refresh failed, re-authenticating: %s", e)
 
-    # Step 2: Device Code Flow
+    # Step 2: Device Code Flow — only possible with an Auth0 device client ID.
+    # Fail loudly here rather than mid-flow: a bare serve() with nothing saved
+    # and nothing configured should explain how to connect, not stack-trace
+    # out of the auth internals.
+    if not (auth0_client_id or os.getenv("COGNEE_AUTH0_DEVICE_CLIENT_ID")):
+        from cognee.exceptions import CogneeConfigurationError
+        from cognee.api.v1.serve.credentials import get_credentials_path
+
+        if creds and creds.service_url and creds.api_key:
+            raise CogneeConfigurationError(
+                message=(
+                    f"cognee.serve() found saved credentials ({get_credentials_path()}, "
+                    f"account: {creds.email or 'unknown'}), but the saved instance at "
+                    f"{creds.service_url} is unreachable or the credentials no longer work, "
+                    "and re-authentication is not configured.\n\n"
+                    "To connect to a Cognee instance directly, pass its URL and API key:\n"
+                    '    await cognee.serve(url="https://your-instance", api_key="...")\n'
+                    "or set the COGNEE_SERVICE_URL and COGNEE_API_KEY environment variables.\n\n"
+                    "If the saved credentials are stale, delete the file above and connect again."
+                ),
+                name="ServeConfigurationError",
+            )
+        raise CogneeConfigurationError(
+            message=(
+                "cognee.serve() was called without connection details and none were found "
+                f"(no saved credentials at {get_credentials_path()}, no environment variables).\n\n"
+                "To connect to a Cognee instance, pass its URL and API key:\n"
+                '    await cognee.serve(url="http://localhost:8000")\n'
+                '    await cognee.serve(url="https://your-instance", api_key="...")\n'
+                "or set the COGNEE_SERVICE_URL and COGNEE_API_KEY environment variables.\n\n"
+                "Browser-based Cognee Cloud login additionally requires the "
+                "COGNEE_AUTH0_DEVICE_CLIENT_ID environment variable (or the "
+                "auth0_client_id argument)."
+            ),
+            name="ServeConfigurationError",
+        )
+
     print("  Authenticating with Cognee Cloud...")
     token = await device_code_login(
         domain=auth0_domain,
@@ -222,6 +296,25 @@ async def _serve_cloud(
         logger.warning(
             "Service URL %s not responding to health check — may still be starting",
             service_url,
+        )
+
+    # A freshly provisioned key that the tenant instance rejects (e.g. a
+    # masked value returned by the management API's key listing) must fail
+    # here, not on the user's first remember/recall.
+    auth_status = await client._auth_check()
+    if auth_status in (401, 403):
+        from cognee.exceptions import CogneeConfigurationError
+        from cognee.api.v1.serve.credentials import get_credentials_path
+
+        await client.close()
+        raise CogneeConfigurationError(
+            message=(
+                f"Authenticated with Cognee Cloud, but the tenant instance at {service_url} "
+                "rejected the provisioned API key. This is a provisioning problem, not a "
+                "problem with your login. Please try again; if it persists, delete "
+                f"{get_credentials_path()} and reconnect, or contact support."
+            ),
+            name="ServeAuthenticationError",
         )
 
     set_remote_client(client)

--- a/cognee/api/v1/serve/state.py
+++ b/cognee/api/v1/serve/state.py
@@ -6,14 +6,43 @@ cloud instead of executing locally.
 
 from typing import TYPE_CHECKING, Optional
 
+from cognee.shared.logging_utils import get_logger
+
 if TYPE_CHECKING:
     from cognee.api.v1.serve.cloud_client import CloudClient
 
+logger = get_logger("serve.state")
+
 _remote_client: Optional["CloudClient"] = None
+
+# The client is per-process while credentials persist on disk, so "connected
+# yesterday, silently local today" is a common surprise. Warn once per process
+# when operations run locally although saved credentials exist.
+_local_execution_noted = False
 
 
 def get_remote_client() -> Optional["CloudClient"]:
+    global _local_execution_noted
+    if _remote_client is None and not _local_execution_noted:
+        _local_execution_noted = True
+        _note_local_execution()
     return _remote_client
+
+
+def _note_local_execution() -> None:
+    try:
+        from cognee.api.v1.serve.credentials import load_credentials
+
+        creds = load_credentials()
+    except Exception:
+        return
+    if creds and creds.service_url and creds.api_key:
+        logger.warning(
+            "Executing memory operations locally. Saved connection credentials for %s "
+            "exist, but this process has not called cognee.serve() — call it to route "
+            "operations to that instance, or ignore this if local execution is intended.",
+            creds.service_url,
+        )
 
 
 def set_remote_client(client: Optional["CloudClient"]) -> None:

--- a/cognee/tests/unit/api/v1/test_serve_fail_loud.py
+++ b/cognee/tests/unit/api/v1/test_serve_fail_loud.py
@@ -1,0 +1,143 @@
+"""serve() must fail loudly at connect time instead of lying.
+
+Covers the two failure modes: nothing to connect with (no url, no env
+config, no usable saved credentials, no device client ID), and a reachable
+instance that rejects the API key — which previously printed "Connected"
+and failed on the first operation."""
+
+import json
+
+import pytest
+
+from cognee.api.v1.serve import credentials as creds_mod
+from cognee.api.v1.serve.cloud_client import CloudClient
+from cognee.api.v1.serve.serve import serve
+from cognee.exceptions import CogneeConfigurationError
+
+
+@pytest.fixture(autouse=True)
+def no_serve_env(monkeypatch):
+    for var in ("COGNEE_AUTH0_DEVICE_CLIENT_ID", "COGNEE_SERVICE_URL", "COGNEE_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_serve_no_config_fails_with_guidance(monkeypatch, tmp_path):
+    monkeypatch.setattr(creds_mod, "_CREDENTIALS_FILE", tmp_path / "cloud_credentials.json")
+
+    with pytest.raises(CogneeConfigurationError) as exc_info:
+        await serve()
+
+    message = exc_info.value.message
+    assert "COGNEE_SERVICE_URL" in message
+    assert "COGNEE_AUTH0_DEVICE_CLIENT_ID" in message
+    assert "cognee.serve(url=" in message
+
+
+@pytest.mark.asyncio
+async def test_serve_stale_credentials_fail_with_guidance(monkeypatch, tmp_path):
+    creds_file = tmp_path / "cloud_credentials.json"
+    creds_file.write_text(
+        json.dumps(
+            {
+                "access_token": "stale",
+                "service_url": "http://stale.invalid",
+                "api_key": "dead-key",
+                "email": "user@example.com",
+                "expires_at": 1.0,
+            }
+        )
+    )
+    monkeypatch.setattr(creds_mod, "_CREDENTIALS_FILE", creds_file)
+
+    async def failing_health_check(self):
+        return False
+
+    monkeypatch.setattr(CloudClient, "_health_check", failing_health_check)
+
+    with pytest.raises(CogneeConfigurationError) as exc_info:
+        await serve()
+
+    message = exc_info.value.message
+    assert "user@example.com" in message
+    assert "http://stale.invalid" in message
+    assert "COGNEE_SERVICE_URL" in message
+
+
+def _patch_probes(monkeypatch, health: bool, auth_status):
+    async def health_check(self):
+        return health
+
+    async def auth_check(self):
+        return auth_status
+
+    monkeypatch.setattr(CloudClient, "_health_check", health_check)
+    monkeypatch.setattr(CloudClient, "_auth_check", auth_check)
+
+
+@pytest.mark.asyncio
+async def test_serve_direct_rejected_key_fails_and_saves_nothing(monkeypatch, tmp_path):
+    creds_file = tmp_path / "cloud_credentials.json"
+    monkeypatch.setattr(creds_mod, "_CREDENTIALS_FILE", creds_file)
+    _patch_probes(monkeypatch, health=True, auth_status=401)
+
+    with pytest.raises(CogneeConfigurationError) as exc_info:
+        await serve(url="http://some-instance:8000", api_key="bad-key")
+
+    assert "API key was rejected" in exc_info.value.message
+    # A rejected connect must not poison the credentials cache.
+    assert not creds_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_serve_direct_missing_key_explains_how_to_get_one(monkeypatch, tmp_path):
+    monkeypatch.setattr(creds_mod, "_CREDENTIALS_FILE", tmp_path / "cloud_credentials.json")
+    _patch_probes(monkeypatch, health=True, auth_status=401)
+
+    with pytest.raises(CogneeConfigurationError) as exc_info:
+        await serve(url="http://some-instance:8000")
+
+    message = exc_info.value.message
+    assert "requires authentication" in message
+    assert "POST /api/v1/auth/api-keys" in message
+
+
+@pytest.mark.asyncio
+async def test_serve_direct_accepted_key_connects_and_saves(monkeypatch, tmp_path):
+    import cognee
+
+    creds_file = tmp_path / "cloud_credentials.json"
+    monkeypatch.setattr(creds_mod, "_CREDENTIALS_FILE", creds_file)
+    _patch_probes(monkeypatch, health=True, auth_status=200)
+
+    client = await serve(url="http://some-instance:8000", api_key="good-key")
+    try:
+        assert client.service_url == "http://some-instance:8000"
+        assert creds_file.exists()
+    finally:
+        await cognee.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serve_cached_cloud_creds_with_rejected_key_fall_through(monkeypatch, tmp_path):
+    """A reachable instance whose saved key no longer works must not 'connect';
+    without a device client ID it lands in the stale-credentials guidance."""
+    creds_file = tmp_path / "cloud_credentials.json"
+    creds_file.write_text(
+        json.dumps(
+            {
+                "access_token": "stale",
+                "service_url": "http://alive-but-rejects.invalid",
+                "api_key": "revoked-key",
+                "email": "user@example.com",
+                "expires_at": 1.0,
+            }
+        )
+    )
+    monkeypatch.setattr(creds_mod, "_CREDENTIALS_FILE", creds_file)
+    _patch_probes(monkeypatch, health=True, auth_status=401)
+
+    with pytest.raises(CogneeConfigurationError) as exc_info:
+        await serve()
+
+    assert "user@example.com" in exc_info.value.message

--- a/cognee/tests/unit/api/v1/test_serve_fail_loud.py
+++ b/cognee/tests/unit/api/v1/test_serve_fail_loud.py
@@ -30,7 +30,6 @@ async def test_serve_no_config_fails_with_guidance(monkeypatch, tmp_path):
 
     message = exc_info.value.message
     assert "COGNEE_SERVICE_URL" in message
-    assert "COGNEE_AUTH0_DEVICE_CLIENT_ID" in message
     assert "cognee.serve(url=" in message
 
 

--- a/cognee/tests/unit/api/v1/test_serve_fail_loud.py
+++ b/cognee/tests/unit/api/v1/test_serve_fail_loud.py
@@ -6,10 +6,12 @@ instance that rejects the API key — which previously printed "Connected"
 and failed on the first operation."""
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
 
 from cognee.api.v1.serve import credentials as creds_mod
+from cognee.api.v1.serve import state as state_mod
 from cognee.api.v1.serve.cloud_client import CloudClient
 from cognee.api.v1.serve.serve import serve
 from cognee.exceptions import CogneeConfigurationError
@@ -176,3 +178,62 @@ async def test_serve_cached_cloud_creds_with_rejected_key_fall_through(monkeypat
         await serve()
 
     assert "user@example.com" in exc_info.value.message
+
+
+def _write_saved_creds(path):
+    path.write_text(
+        json.dumps(
+            {
+                "access_token": "at",
+                "service_url": "http://saved-instance.invalid",
+                "api_key": "saved-key",
+                "email": "user@example.com",
+            }
+        )
+    )
+
+
+def test_local_execution_with_saved_creds_warns_once(monkeypatch, tmp_path):
+    """Saved credentials + no serve() in this process means operations run
+    locally — a one-time warning must say so."""
+    creds_file = tmp_path / "cloud_credentials.json"
+    _write_saved_creds(creds_file)
+    monkeypatch.setattr(creds_mod, "_CREDENTIALS_FILE", creds_file)
+    monkeypatch.setattr(state_mod, "_local_execution_noted", False)
+    mock_logger = MagicMock()
+    monkeypatch.setattr(state_mod, "logger", mock_logger)
+
+    assert state_mod.get_remote_client() is None
+    assert state_mod.get_remote_client() is None
+
+    assert mock_logger.warning.call_count == 1
+    assert "cognee.serve()" in mock_logger.warning.call_args.args[0]
+
+
+def test_local_execution_without_saved_creds_is_silent(monkeypatch, tmp_path):
+    monkeypatch.setattr(creds_mod, "_CREDENTIALS_FILE", tmp_path / "cloud_credentials.json")
+    monkeypatch.setattr(state_mod, "_local_execution_noted", False)
+    mock_logger = MagicMock()
+    monkeypatch.setattr(state_mod, "logger", mock_logger)
+
+    assert state_mod.get_remote_client() is None
+
+    mock_logger.warning.assert_not_called()
+
+
+def test_remote_mode_with_saved_creds_is_silent(monkeypatch, tmp_path):
+    creds_file = tmp_path / "cloud_credentials.json"
+    _write_saved_creds(creds_file)
+    monkeypatch.setattr(creds_mod, "_CREDENTIALS_FILE", creds_file)
+    monkeypatch.setattr(state_mod, "_local_execution_noted", False)
+    mock_logger = MagicMock()
+    monkeypatch.setattr(state_mod, "logger", mock_logger)
+
+    sentinel_client = object()
+    monkeypatch.setattr(state_mod, "_remote_client", sentinel_client)
+    try:
+        assert state_mod.get_remote_client() is sentinel_client
+    finally:
+        monkeypatch.setattr(state_mod, "_remote_client", None)
+
+    mock_logger.warning.assert_not_called()

--- a/cognee/tests/unit/api/v1/test_serve_fail_loud.py
+++ b/cognee/tests/unit/api/v1/test_serve_fail_loud.py
@@ -119,6 +119,42 @@ async def test_serve_direct_accepted_key_connects_and_saves(monkeypatch, tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_serve_cloud_rejected_provisioned_key_saves_nothing(monkeypatch, tmp_path):
+    """The cloud flow must validate the provisioned key before persisting
+    credentials — a tenant rejection may not poison the cache (same
+    validate-then-save order as the direct flow)."""
+    from cognee.api.v1.serve import device_auth, management_api
+
+    creds_file = tmp_path / "cloud_credentials.json"
+    monkeypatch.setattr(creds_mod, "_CREDENTIALS_FILE", creds_file)
+    monkeypatch.setenv("COGNEE_AUTH0_DEVICE_CLIENT_ID", "test-client-id")
+
+    async def fake_login(**kwargs):
+        return device_auth.TokenResponse(access_token="at", refresh_token="rt")
+
+    async def fake_tenant(mgmt_url, token):
+        return management_api.Tenant(id="t1", name="tenant-1")
+
+    async def fake_service_url(mgmt_url, token):
+        return "http://tenant-instance.invalid"
+
+    async def fake_api_key(mgmt_url, token):
+        return "provisioned-but-rejected"
+
+    monkeypatch.setattr(device_auth, "device_code_login", fake_login)
+    monkeypatch.setattr(management_api, "get_current_tenant", fake_tenant)
+    monkeypatch.setattr(management_api, "get_service_url", fake_service_url)
+    monkeypatch.setattr(management_api, "get_or_create_api_key", fake_api_key)
+    _patch_probes(monkeypatch, health=True, auth_status=401)
+
+    with pytest.raises(CogneeConfigurationError) as exc_info:
+        await serve()
+
+    assert "rejected the provisioned API key" in exc_info.value.message
+    assert not creds_file.exists()
+
+
+@pytest.mark.asyncio
 async def test_serve_cached_cloud_creds_with_rejected_key_fall_through(monkeypatch, tmp_path):
     """A reachable instance whose saved key no longer works must not 'connect';
     without a device client ID it lands in the stale-credentials guidance."""


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->
`cognee.serve()` could fail in confusing ways: bare `serve()` with nothing
configured crashed inside the Auth0 device flow with an internal `ValueError`,
and `serve(url=...)` with a bad or missing API key printed "Connected" (the
connect check only hit the unauthenticated `/health`) and then failed with 401
on the first operation — while saving the bad credentials for later reconnects.

`serve()` now fails loudly at connect time with actionable guidance:

- Bare `serve()` with no url, env vars, usable saved credentials, or device
  client ID raises `CogneeConfigurationError` explaining how to connect.
- New authenticated probe (`GET /api/v1/datasets`) at every connect point: a
  rejected key raises before credentials are saved; cached/refreshed
  credentials that no longer authenticate fall through to re-auth instead of
  "connecting". Unreachable instances keep the existing warn-and-continue
  behavior.
- Docs: README no longer advertises bare `await cognee.serve()` for cloud;
  `.env.template` documents `COGNEE_AUTH0_DEVICE_CLIENT_ID` / `COGNEE_CLOUD_URL`.

Unit tests cover both failure modes, the success path, and that rejected
connects save nothing. Live-verified against a local server and a cloud tenant.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
