### PR TITLE
feat(observability): Add opt-in eval capture telemetry (SDK-529)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -543,6 +543,27 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # Add extra resource attributes (useful for Kubernetes, multi-instance deployments)
 # OTEL_RESOURCE_ATTRIBUTES="service.namespace=my-team,service.version=1.0"
 
+################################################################################
+#  Eval capture (SDK-529)
+################################################################################
+
+# -- Capture what the pipeline produces and chooses (per-chunk graphs, merge
+#    decisions, summaries, retrieval candidate pools, run manifests) for offline
+#    evals. Off by default and free when off; when on, artifacts land as gzip'd
+#    JSONL under COGNEE_CAPTURE_DIR (default: <DATA_ROOT_DIRECTORY>/capture). ---
+# COGNEE_CAPTURE_ENABLED=false
+# COGNEE_CAPTURE_DIR=
+
+# Buffered events before the newest are dropped; events per sink write (also the
+# flush trigger); background flush tick when quiet, in seconds.
+# COGNEE_CAPTURE_QUEUE_SIZE=512
+# COGNEE_CAPTURE_BATCH_SIZE=64
+# COGNEE_CAPTURE_FLUSH_INTERVAL_S=2.0
+
+# Per-run sampling of retrieval.* events, in [0, 1]; bound on a single sink write.
+# COGNEE_CAPTURE_SAMPLE_RATE=1.0
+# COGNEE_CAPTURE_SINK_TIMEOUT_S=30.0
+
 # -- Langfuse rides the same OTLP pipeline (no separate SDK). Setting these keys
 #    builds the OTLP endpoint + Basic-auth header and turns tracing on; LLM calls
 #    show up as generations. Optional and off by default. Requires cognee[tracing]. --

--- a/.env.template
+++ b/.env.template
@@ -586,8 +586,11 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # Per-run sampling of retrieval.* event payloads, in [0, 1]. Only retrieval.* is
 # sampled; every other kind (and every run manifest) is always captured.
 # COGNEE_CAPTURE_SINK_TIMEOUT_S bounds a single sink write, in seconds.
+# COGNEE_CAPTURE_DRAIN_TIMEOUT_S bounds the flush wait added at every pipeline
+# completion while capture is on (leftovers stay with the background flusher).
 # COGNEE_CAPTURE_SAMPLE_RATE=1.0
 # COGNEE_CAPTURE_SINK_TIMEOUT_S=30.0
+# COGNEE_CAPTURE_DRAIN_TIMEOUT_S=5.0
 
 
 ################################################################################

--- a/.env.template
+++ b/.env.template
@@ -543,27 +543,6 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # Add extra resource attributes (useful for Kubernetes, multi-instance deployments)
 # OTEL_RESOURCE_ATTRIBUTES="service.namespace=my-team,service.version=1.0"
 
-################################################################################
-#  Eval capture (SDK-529)
-################################################################################
-
-# -- Capture what the pipeline produces and chooses (per-chunk graphs, merge
-#    decisions, summaries, retrieval candidate pools, run manifests) for offline
-#    evals. Off by default and free when off; when on, artifacts land as gzip'd
-#    JSONL under COGNEE_CAPTURE_DIR (default: <DATA_ROOT_DIRECTORY>/capture). ---
-# COGNEE_CAPTURE_ENABLED=false
-# COGNEE_CAPTURE_DIR=
-
-# Buffered events before the newest are dropped; events per sink write (also the
-# flush trigger); background flush tick when quiet, in seconds.
-# COGNEE_CAPTURE_QUEUE_SIZE=512
-# COGNEE_CAPTURE_BATCH_SIZE=64
-# COGNEE_CAPTURE_FLUSH_INTERVAL_S=2.0
-
-# Per-run sampling of retrieval.* events, in [0, 1]; bound on a single sink write.
-# COGNEE_CAPTURE_SAMPLE_RATE=1.0
-# COGNEE_CAPTURE_SINK_TIMEOUT_S=30.0
-
 # -- Langfuse rides the same OTLP pipeline (no separate SDK). Setting these keys
 #    builds the OTLP endpoint + Basic-auth header and turns tracing on; LLM calls
 #    show up as generations. Optional and off by default. Requires cognee[tracing]. --
@@ -586,6 +565,29 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # CACHE_DB_URL=postgresql+asyncpg://cognee:cognee@localhost:5432/cognee_db
 # Minimum seconds between global TTL purge sweeps (sqlite/postgres backends)
 # CACHE_PURGE_INTERVAL_SECONDS=900
+
+################################################################################
+#  Eval capture
+################################################################################
+
+# -- Capture what the pipeline produces and chooses (per-chunk graphs, merge
+#    decisions, summaries, retrieval candidate pools, run manifests) for offline
+#    evals. Off by default and free when off; when on, artifacts land as gzip'd
+#    JSONL under COGNEE_CAPTURE_DIR (default: <DATA_ROOT_DIRECTORY>/capture). ---
+# COGNEE_CAPTURE_ENABLED=false
+# COGNEE_CAPTURE_DIR=
+
+# Buffered events before the newest are dropped; events per sink write (also the
+# flush trigger); background flush tick when quiet, in seconds.
+# COGNEE_CAPTURE_QUEUE_SIZE=512
+# COGNEE_CAPTURE_BATCH_SIZE=64
+# COGNEE_CAPTURE_FLUSH_INTERVAL_S=2.0
+
+# Per-run sampling of retrieval.* event payloads, in [0, 1]. Only retrieval.* is
+# sampled; every other kind (and every run manifest) is always captured.
+# COGNEE_CAPTURE_SINK_TIMEOUT_S bounds a single sink write, in seconds.
+# COGNEE_CAPTURE_SAMPLE_RATE=1.0
+# COGNEE_CAPTURE_SINK_TIMEOUT_S=30.0
 
 
 ################################################################################

--- a/.env.template
+++ b/.env.template
@@ -573,7 +573,13 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # -- Capture what the pipeline produces and chooses (per-chunk graphs, merge
 #    decisions, summaries, retrieval candidate pools, run manifests) for offline
 #    evals. Off by default and free when off; when on, artifacts land as gzip'd
-#    JSONL under COGNEE_CAPTURE_DIR (default: <DATA_ROOT_DIRECTORY>/capture). ---
+#    JSONL under COGNEE_CAPTURE_DIR (default: <DATA_ROOT_DIRECTORY>/capture).
+#    NOTE: those artifacts are derived user content — the raw extracted graphs
+#    carry entity names, descriptions and relationships verbatim — filed per
+#    dataset and run, inheriting the directory's permissions, and NOT removed
+#    when a dataset is forgotten. Enabling capture means owning the same
+#    retention and access-control obligations for that directory as for the
+#    data root. Must be an absolute path (or s3://). ---
 # COGNEE_CAPTURE_ENABLED=false
 # COGNEE_CAPTURE_DIR=
 
@@ -585,12 +591,13 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # COGNEE_CAPTURE_BATCH_SIZE=64
 # COGNEE_CAPTURE_FLUSH_INTERVAL_S=2.0
 
-# Per-run sampling of retrieval.* event payloads, in [0, 1]. Only retrieval.* is
-# sampled; every other kind (and every run manifest) is always captured.
+# Per-run sampling of retrieval.* event payloads only, in [0, 1] — the knob is
+# named for what it samples: every extraction kind and every run manifest is
+# always captured in full while capture is on.
 # COGNEE_CAPTURE_SINK_TIMEOUT_S bounds a single sink write, in seconds.
 # COGNEE_CAPTURE_DRAIN_TIMEOUT_S bounds the flush wait added at every pipeline
 # completion while capture is on (leftovers stay with the background flusher).
-# COGNEE_CAPTURE_SAMPLE_RATE=1.0
+# COGNEE_CAPTURE_RETRIEVAL_SAMPLE_RATE=1.0
 # COGNEE_CAPTURE_SINK_TIMEOUT_S=30.0
 # COGNEE_CAPTURE_DRAIN_TIMEOUT_S=5.0
 

--- a/.env.template
+++ b/.env.template
@@ -578,8 +578,10 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # COGNEE_CAPTURE_DIR=
 
 # Buffered events before the newest are dropped; events per sink write (also the
-# flush trigger); background flush tick when quiet, in seconds.
-# COGNEE_CAPTURE_QUEUE_SIZE=512
+# flush trigger); background flush tick when quiet, in seconds. Keep QUEUE_SIZE
+# at or above cognify's chunks_per_batch (default 2000): the per-chunk emit
+# points run over a whole task batch, and anything past the bound is dropped.
+# COGNEE_CAPTURE_QUEUE_SIZE=2048
 # COGNEE_CAPTURE_BATCH_SIZE=64
 # COGNEE_CAPTURE_FLUSH_INTERVAL_S=2.0
 

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -104,6 +104,15 @@ async def lifespan(app: FastAPI):
 
     await recover_stale_cognify_runs_on_startup()
 
+    # Eval capture (SDK-529): resolve the capture config (and, when enabled, the
+    # storage sink) once here, so the first request of the process does not pay
+    # that one-time initialization on its awaited path. Lazy import: ``import
+    # cognee`` must not load the capture package. Never raises; a failed
+    # initialization just leaves capture disabled.
+    from cognee.modules.observability import capture as eval_capture
+
+    eval_capture.is_active()
+
     # Emit a clear startup message for docker logs
     logger.info("Backend server has started")
 

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -128,6 +128,15 @@ async def lifespan(app: FastAPI):
 
     await close_telemetry_session()
 
+    # Flush buffered eval-capture events (SDK-529) and stop the flusher on the
+    # loop that owns it, rather than leaving the last requests' records to the
+    # atexit hook. Lazy import: ``import cognee`` must not load the capture
+    # package; is_active() keeps this a no-op when capture is off.
+    from cognee.modules.observability import capture as eval_capture
+
+    if eval_capture.is_active():
+        await eval_capture.shutdown()
+
 
 app = FastAPI(debug=app_environment != "prod", lifespan=lifespan)
 

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -365,7 +365,11 @@ async def cognify(
         }
 
         def resolve_cognify_tasks(data_item):
-            return tasks_by_route[cognify_route_for(data_item)]
+            item_tasks = tasks_by_route[cognify_route_for(data_item)]
+            # Eval capture (SDK-529): the resolver runs inside the pipeline's run
+            # scope, which the task lists above were built outside of.
+            _note_chunking_config(item_tasks)
+            return item_tasks
 
         result = await pipeline_executor_func(
             pipeline=run_pipeline,
@@ -395,6 +399,33 @@ async def cognify(
         record_operation_duration(_duration_ms, _attrs)
 
         return result
+
+
+def _note_chunking_config(tasks: list[Task]) -> None:
+    """Record the chunker and chunk size a task list runs with on the eval-capture manifest.
+
+    SDK-529. Called from the per-item task resolver rather than at task construction:
+    the pipeline run scope only exists inside ``run_tasks``, so a note taken while the
+    task lists are built would land on no scope. Both values are read off the list's
+    ``extract_chunks_from_documents`` task (present in the standard, temporal and DLT
+    lists; absent from the code lists, which chunk nothing). The lazy import keeps
+    ``import cognee`` free of the capture package; a no-op while capture is off.
+    """
+    from cognee.modules.observability import capture as eval_capture
+
+    if not eval_capture.is_active():
+        return
+
+    for task in tasks:
+        if task.executable is extract_chunks_from_documents:
+            params = task.default_params["kwargs"]
+            chunker = params.get("chunker")
+            eval_capture.note(
+                "chunking.chunker",
+                None if chunker is None else getattr(chunker, "__name__", type(chunker).__name__),
+            )
+            eval_capture.note("chunking.chunk_size", params.get("max_chunk_size"))
+            return
 
 
 async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's comment)

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -47,8 +47,6 @@ from cognee.modules.observability import (
     MEMORY_SYSTEM,
     MEMORY_OPERATION,
     record_operation_duration,
-    increment_graph_edges,
-    increment_graph_nodes,
 )
 
 

--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -662,6 +662,18 @@ async def recall(
                     if not search_dataset_ids:
                         raise DatasetNotFoundError(message="No datasets found.")
 
+                # Bind the dataset on the operation record as soon as it is
+                # known, mirroring search(): with exactly one target the row and
+                # the eval-capture manifest (SDK-529) file under it instead of
+                # under ``nodataset/``.
+                if (
+                    current_operation is not None
+                    and search_dataset_ids
+                    and len(search_dataset_ids) == 1
+                    and isinstance(search_dataset_ids[0], UUID)
+                ):
+                    current_operation.set_dataset(search_dataset_ids[0])
+
                 from cognee.modules.recall.config import get_recall_config
 
                 # Warm-up short-circuit. Config errors fail open (skip the

--- a/cognee/infrastructure/llm/extraction/extract_summary.py
+++ b/cognee/infrastructure/llm/extraction/extract_summary.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 from instructor.core import InstructorRetryException
 from pydantic import BaseModel
@@ -29,10 +30,12 @@ def get_mock_summarized_code() -> SummarizedCode:
 
 async def extract_summary_with_provenance(
     content: str, response_model: type[BaseModel]
-) -> tuple[BaseModel, str, str]:
+) -> tuple[Any, str, str]:
     """``extract_summary`` plus what eval capture records about the call (SDK-529).
 
-    Returns ``(llm_output, prompt_text, model_name)``. The prompt text is the
+    Returns ``(llm_output, prompt_text, model_name)``. ``llm_output`` is an instance
+    of ``response_model`` (typed ``Any``: callers read model-specific fields such as
+    ``.summary`` off it). The prompt text is the
     system prompt that was sent — already read for the call, so returning it
     costs nothing extra — and the model name is the model id the active LLM
     context config routes the call to (inside ``pipeline_stage("summarization")``

--- a/cognee/infrastructure/llm/extraction/extract_summary.py
+++ b/cognee/infrastructure/llm/extraction/extract_summary.py
@@ -44,6 +44,8 @@ async def extract_summary_with_provenance(
     single-value contract for every other caller.
     """
     system_prompt = read_query_prompt(SUMMARY_PROMPT_FILE) or ""
+    # One ContextVar read (falling back to the lru_cached global config), so
+    # every extract_summary caller can pay it, capture on or off.
     model_name = get_llm_context_config().llm_model
 
     llm_output = await LLMGateway.acreate_structured_output(content, system_prompt, response_model)

--- a/cognee/infrastructure/llm/extraction/extract_summary.py
+++ b/cognee/infrastructure/llm/extraction/extract_summary.py
@@ -4,11 +4,14 @@ from instructor.core import InstructorRetryException
 from pydantic import BaseModel
 
 from cognee.infrastructure.llm.LLMGateway import LLMGateway
+from cognee.infrastructure.llm.config import get_llm_context_config
 from cognee.infrastructure.llm.prompts import read_query_prompt
 from cognee.shared.data_models import SummarizedCode
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("extract_summary")
+
+SUMMARY_PROMPT_FILE = "summarize_content.txt"
 
 
 def get_mock_summarized_code() -> SummarizedCode:
@@ -24,10 +27,31 @@ def get_mock_summarized_code() -> SummarizedCode:
     )
 
 
-async def extract_summary(content: str, response_model: type[BaseModel]):
-    system_prompt = read_query_prompt("summarize_content.txt") or ""
+async def extract_summary_with_provenance(
+    content: str, response_model: type[BaseModel]
+) -> tuple[BaseModel, str, str]:
+    """``extract_summary`` plus what eval capture records about the call (SDK-529).
+
+    Returns ``(llm_output, prompt_text, model_name)``. The prompt text is the
+    system prompt that was sent — already read for the call, so returning it
+    costs nothing extra — and the model name is the model id the active LLM
+    context config routes the call to (inside ``pipeline_stage("summarization")``
+    that is the summarization-stage model; the same id the session usage
+    tracker records). Used by ``summarize_text``; ``extract_summary`` keeps its
+    single-value contract for every other caller.
+    """
+    system_prompt = read_query_prompt(SUMMARY_PROMPT_FILE) or ""
+    model_name = get_llm_context_config().llm_model
 
     llm_output = await LLMGateway.acreate_structured_output(content, system_prompt, response_model)
+
+    return llm_output, system_prompt, model_name
+
+
+async def extract_summary(content: str, response_model: type[BaseModel]):
+    llm_output, _prompt_text, _model_name = await extract_summary_with_provenance(
+        content, response_model
+    )
 
     return llm_output
 

--- a/cognee/infrastructure/llm/extraction/knowledge_graph/extract_content_graph.py
+++ b/cognee/infrastructure/llm/extraction/knowledge_graph/extract_content_graph.py
@@ -1,4 +1,5 @@
 import os
+from functools import lru_cache
 from typing import Any
 
 from pydantic import BaseModel
@@ -21,16 +22,29 @@ def _note_extraction_config(system_prompt: str) -> None:
     or the global config outside a stage — resolved exactly as ``LLMGateway`` resolves
     it. The import is lazy so ``import cognee`` never loads the capture package, and
     the fingerprint (a sha256 over the rendered prompt) is only computed while capture
-    is active; ``note()`` itself is a no-op without a run scope.
+    is active - and once per distinct prompt, not once per chunk; ``note()`` itself is
+    a no-op without a run scope.
     """
     from cognee.modules.observability import capture as eval_capture
 
     if not eval_capture.is_active():
         return
     eval_capture.note("extraction.model", get_llm_context_config().llm_model)
-    eval_capture.note(
-        "extraction.prompt_fingerprint", eval_capture.prompt_fingerprint(system_prompt)
-    )
+    eval_capture.note("extraction.prompt_fingerprint", _prompt_fingerprint(system_prompt))
+
+
+@lru_cache(maxsize=8)
+def _prompt_fingerprint(system_prompt: str) -> str:
+    """Fingerprint of one rendered extraction prompt, memoized per distinct prompt text.
+
+    ``extract_content_graph`` runs once per chunk and every chunk of a batch renders
+    the same prompt, so the sha256 is paid once per prompt rather than once per chunk
+    (the economy ``summarize_text`` applies to its prompt). Only reached while capture
+    is active; a ``custom_prompt`` gets its own entry.
+    """
+    from cognee.modules.observability import capture as eval_capture
+
+    return eval_capture.prompt_fingerprint(system_prompt)
 
 
 async def extract_content_graph(

--- a/cognee/infrastructure/llm/extraction/knowledge_graph/extract_content_graph.py
+++ b/cognee/infrastructure/llm/extraction/knowledge_graph/extract_content_graph.py
@@ -1,5 +1,4 @@
 import os
-from functools import lru_cache
 from typing import Any
 
 from pydantic import BaseModel
@@ -20,31 +19,22 @@ def _note_extraction_config(system_prompt: str) -> None:
     Eval capture (SDK-529). The model is the one every LLM call in this context is
     routed to — the stage-merged config that ``pipeline_stage("extraction")`` bound,
     or the global config outside a stage — resolved exactly as ``LLMGateway`` resolves
-    it. The import is lazy so ``import cognee`` never loads the capture package, and
-    the fingerprint (a sha256 over the rendered prompt) is only computed while capture
-    is active - and once per distinct prompt, not once per chunk; ``note()`` itself is
-    a no-op without a run scope.
+    it. The import is lazy so ``import cognee`` never loads the capture package.
+
+    The fingerprint (a sha256 over the rendered prompt; ~2.5 us for the 2.4 KB default
+    prompt) is computed per call, and only while capture is active AND a run scope is
+    open — without a scope ``note()`` would discard it, so nothing is hashed. It is
+    deliberately not memoized: a process-wide cache outlives runs (and tests), so a
+    regressed ``is_active()`` guard would go unnoticed for any prompt seen before.
     """
     from cognee.modules.observability import capture as eval_capture
 
-    if not eval_capture.is_active():
+    if not eval_capture.is_active() or eval_capture.current_scope() is None:
         return
     eval_capture.note("extraction.model", get_llm_context_config().llm_model)
-    eval_capture.note("extraction.prompt_fingerprint", _prompt_fingerprint(system_prompt))
-
-
-@lru_cache(maxsize=8)
-def _prompt_fingerprint(system_prompt: str) -> str:
-    """Fingerprint of one rendered extraction prompt, memoized per distinct prompt text.
-
-    ``extract_content_graph`` runs once per chunk and every chunk of a batch renders
-    the same prompt, so the sha256 is paid once per prompt rather than once per chunk
-    (the economy ``summarize_text`` applies to its prompt). Only reached while capture
-    is active; a ``custom_prompt`` gets its own entry.
-    """
-    from cognee.modules.observability import capture as eval_capture
-
-    return eval_capture.prompt_fingerprint(system_prompt)
+    eval_capture.note(
+        "extraction.prompt_fingerprint", eval_capture.prompt_fingerprint(system_prompt)
+    )
 
 
 async def extract_content_graph(

--- a/cognee/infrastructure/llm/extraction/knowledge_graph/extract_content_graph.py
+++ b/cognee/infrastructure/llm/extraction/knowledge_graph/extract_content_graph.py
@@ -6,10 +6,31 @@ from pydantic import BaseModel
 from cognee.infrastructure.engine import DataPoint
 from cognee.infrastructure.llm.config import (
     get_llm_config,
+    get_llm_context_config,
 )
 from cognee.infrastructure.llm.LLMGateway import LLMGateway
 from cognee.infrastructure.llm.prompts import render_prompt
 from cognee.shared.graph_model_utils import datapoint_model_to_basemodel
+
+
+def _note_extraction_config(system_prompt: str) -> None:
+    """Record the effective extraction model and prompt fingerprint on the run manifest.
+
+    Eval capture (SDK-529). The model is the one every LLM call in this context is
+    routed to — the stage-merged config that ``pipeline_stage("extraction")`` bound,
+    or the global config outside a stage — resolved exactly as ``LLMGateway`` resolves
+    it. The import is lazy so ``import cognee`` never loads the capture package, and
+    the fingerprint (a sha256 over the rendered prompt) is only computed while capture
+    is active; ``note()`` itself is a no-op without a run scope.
+    """
+    from cognee.modules.observability import capture as eval_capture
+
+    if not eval_capture.is_active():
+        return
+    eval_capture.note("extraction.model", get_llm_context_config().llm_model)
+    eval_capture.note(
+        "extraction.prompt_fingerprint", eval_capture.prompt_fingerprint(system_prompt)
+    )
 
 
 async def extract_content_graph(
@@ -31,6 +52,8 @@ async def extract_content_graph(
             base_directory = None
 
         system_prompt = render_prompt(prompt_path, {}, base_directory=base_directory)
+
+    _note_extraction_config(system_prompt)
 
     simplified_response_model = response_model
     if isinstance(response_model, type) and issubclass(response_model, DataPoint):

--- a/cognee/modules/graph/cognee_graph/CogneeGraph.py
+++ b/cognee/modules/graph/cognee_graph/CogneeGraph.py
@@ -17,6 +17,11 @@ import heapq
 
 logger = get_logger("CogneeGraph")
 
+# Distance assigned to a projected node or edge the vector search did not score,
+# and the default for every ``triplet_distance_penalty`` parameter up the stack
+# (projection, brute-force search, the retrievers, the capture payload).
+DEFAULT_TRIPLET_DISTANCE_PENALTY = 6.5
+
 
 class CogneeGraph(CogneeAbstractGraph):
     """
@@ -39,7 +44,7 @@ class CogneeGraph(CogneeAbstractGraph):
         self.edges = []
         self.edges_by_distance_key = {}
         self.directed = directed
-        self.triplet_distance_penalty = 6.5
+        self.triplet_distance_penalty = DEFAULT_TRIPLET_DISTANCE_PENALTY
         self.feedback_influence = get_base_config().default_feedback_influence
         self.personal_influence = get_base_config().personalization_influence
 
@@ -242,7 +247,7 @@ class CogneeGraph(CogneeAbstractGraph):
         node_name: Optional[List[str]] = None,
         node_name_filter_operator: str = "OR",
         relevant_ids_to_filter: Optional[List[str]] = None,
-        triplet_distance_penalty: float = 6.5,
+        triplet_distance_penalty: float = DEFAULT_TRIPLET_DISTANCE_PENALTY,
         feedback_influence: float = get_base_config().default_feedback_influence,
     ) -> None:
         if node_dimension < 1 or edge_dimension < 1:
@@ -291,7 +296,7 @@ class CogneeGraph(CogneeAbstractGraph):
         directed: bool = True,
         node_dimension: int = 1,
         edge_dimension: int = 1,
-        triplet_distance_penalty: float = 6.5,
+        triplet_distance_penalty: float = DEFAULT_TRIPLET_DISTANCE_PENALTY,
         feedback_influence: float = get_base_config().default_feedback_influence,
     ) -> None:
         """

--- a/cognee/modules/observability/capture/__init__.py
+++ b/cognee/modules/observability/capture/__init__.py
@@ -45,7 +45,7 @@ from .events import (
 )
 from .hook import drain, emit, is_active, register_capture_sink, should_capture, shutdown
 from .manifest import RunScope, bump, current_scope, note, run_scope
-from .prompt_hash import prompt_file_fingerprint, prompt_fingerprint
+from .prompt_hash import prompt_fingerprint
 from .sinks import CaptureSink, StorageSink
 
 __all__ = [
@@ -69,7 +69,6 @@ __all__ = [
     "get_capture_config",
     "is_active",
     "note",
-    "prompt_file_fingerprint",
     "prompt_fingerprint",
     "register_capture_sink",
     "run_scope",

--- a/cognee/modules/observability/capture/__init__.py
+++ b/cognee/modules/observability/capture/__init__.py
@@ -1,0 +1,65 @@
+"""Eval capture — non-blocking capture of pipeline output for offline evals (SDK-529).
+
+Public surface is this package only. It is deliberately NOT re-exported from
+``cognee.modules.observability`` (import cycle with ``cognee/base_config.py``
+and import cost of ``import cognee``). Nothing under ``cognee_db_workers/``
+imports it; emit points live on the adapter side in ``cognee/``.
+
+Typical use::
+
+    from cognee.modules.observability import capture
+
+    if capture.is_active() and capture.should_capture(capture.KIND_EXTRACTION_CHUNK_GRAPH):
+        capture.emit(
+            capture.KIND_EXTRACTION_CHUNK_GRAPH,
+            graph.model_dump(mode="json"),   # snapshot: the graph is mutated afterwards
+            payload_kind="json",
+            stage="extract_graph_from_data",
+        )
+"""
+
+from .config import CaptureConfig, get_capture_config
+from .events import (
+    KIND_EXTRACTION_CHUNK_GRAPH,
+    KIND_EXTRACTION_DROPPED_DUPLICATES,
+    KIND_EXTRACTION_FUZZY_MATCH,
+    KIND_RETRIEVAL_CANDIDATES,
+    KIND_RUN_MANIFEST,
+    KIND_STORAGE_DELTA,
+    KIND_SUMMARY_GENERATED,
+    RETRIEVAL_KIND_PREFIX,
+    CaptureEvent,
+)
+from .hook import drain, emit, is_active, register_capture_sink, should_capture, shutdown
+from .manifest import RunScope, bump, current_scope, note, run_scope
+from .prompt_hash import prompt_file_fingerprint, prompt_fingerprint
+from .sinks import CaptureSink, StorageSink
+
+__all__ = [
+    "CaptureConfig",
+    "CaptureEvent",
+    "CaptureSink",
+    "KIND_EXTRACTION_CHUNK_GRAPH",
+    "KIND_EXTRACTION_DROPPED_DUPLICATES",
+    "KIND_EXTRACTION_FUZZY_MATCH",
+    "KIND_RETRIEVAL_CANDIDATES",
+    "KIND_RUN_MANIFEST",
+    "KIND_STORAGE_DELTA",
+    "KIND_SUMMARY_GENERATED",
+    "RETRIEVAL_KIND_PREFIX",
+    "RunScope",
+    "StorageSink",
+    "bump",
+    "current_scope",
+    "drain",
+    "emit",
+    "get_capture_config",
+    "is_active",
+    "note",
+    "prompt_file_fingerprint",
+    "prompt_fingerprint",
+    "register_capture_sink",
+    "run_scope",
+    "should_capture",
+    "shutdown",
+]

--- a/cognee/modules/observability/capture/__init__.py
+++ b/cognee/modules/observability/capture/__init__.py
@@ -5,17 +5,30 @@ Public surface is this package only. It is deliberately NOT re-exported from
 and import cost of ``import cognee``). Nothing under ``cognee_db_workers/``
 imports it; emit points live on the adapter side in ``cognee/``.
 
-Typical use::
+Typical use - the ``extraction.chunk_graph`` emit point in ``extract_graph_from_data``
+(``should_capture`` only gates the sampled ``retrieval.*`` kinds; it is True for the
+rest, so pipeline emit points check ``is_active()`` alone)::
 
     from cognee.modules.observability import capture
 
-    if capture.is_active() and capture.should_capture(capture.KIND_EXTRACTION_CHUNK_GRAPH):
+    if capture.is_active():
         capture.emit(
             capture.KIND_EXTRACTION_CHUNK_GRAPH,
-            graph.model_dump(mode="json"),   # snapshot: the graph is mutated afterwards
+            {
+                "chunk_id": str(chunk.id),
+                "chunk_index": chunk_index,
+                "chunk_size_chars": len(chunk.text),
+                # A snapshot taken now, never the live object or a model_copy:
+                # the graph is mutated (dedup, canonicalization) afterwards.
+                "graph": graph.model_dump(mode="json"),
+            },
             payload_kind="json",
             stage="extract_graph_from_data",
         )
+
+Payloads are plain JSON (dicts/lists of scalars) or back-reference-free pydantic
+models - never graph elements, scored results or DataPoint instances. Consumers
+read the chunk graph at ``payload["graph"]`` next to its join keys.
 """
 
 from .config import CaptureConfig, get_capture_config

--- a/cognee/modules/observability/capture/__init__.py
+++ b/cognee/modules/observability/capture/__init__.py
@@ -43,7 +43,16 @@ from .events import (
     RETRIEVAL_KIND_PREFIX,
     CaptureEvent,
 )
-from .hook import drain, emit, is_active, register_capture_sink, should_capture, shutdown
+from .hook import (
+    drain,
+    emit,
+    emit_lazy,
+    has_room,
+    is_active,
+    register_capture_sink,
+    should_capture,
+    shutdown,
+)
 from .manifest import RunScope, bump, current_scope, note, run_scope
 from .prompt_hash import prompt_fingerprint
 from .sinks import CaptureSink, StorageSink
@@ -66,7 +75,9 @@ __all__ = [
     "current_scope",
     "drain",
     "emit",
+    "emit_lazy",
     "get_capture_config",
+    "has_room",
     "is_active",
     "note",
     "prompt_fingerprint",

--- a/cognee/modules/observability/capture/__init__.py
+++ b/cognee/modules/observability/capture/__init__.py
@@ -29,6 +29,23 @@ rest, so pipeline emit points check ``is_active()`` alone)::
 Payloads are plain JSON (dicts/lists of scalars) or back-reference-free pydantic
 models - never graph elements, scored results or DataPoint instances. Consumers
 read the chunk graph at ``payload["graph"]`` next to its join keys.
+
+What lands on disk, and who may read it
+----------------------------------------
+Capture writes derived user content, not just metrics. ``extraction.chunk_graph``
+carries the raw per-chunk graph verbatim - entity names, types, descriptions and
+relationship labels the LLM extracted from the user's documents; ``extraction.
+fuzzy_match`` carries the extracted names it looked up; ``retrieval.candidates``
+carries candidate ids and scores (not the query text, which ``record_operation``
+already logs elsewhere); ``summary.generated`` carries hashes and sizes only.
+Everything is filed under ``<COGNEE_CAPTURE_DIR>/<dataset_id>/<run_id>/`` so it can
+be retained, exported or deleted per dataset, and inherits the permissions of
+that directory (``<DATA_ROOT_DIRECTORY>/capture`` by default: the same protection
+as the ingested files themselves). A deployment that enables capture takes on
+the same retention and access-control obligations for this directory as for the
+data root - in particular, forgetting a dataset does not remove its capture
+files. ``COGNEE_CAPTURE_RETRIEVAL_SAMPLE_RATE`` samples only ``retrieval.*``
+payloads; the extraction kinds are always captured in full while capture is on.
 """
 
 from .config import CaptureConfig, get_capture_config

--- a/cognee/modules/observability/capture/config.py
+++ b/cognee/modules/observability/capture/config.py
@@ -31,6 +31,9 @@ class CaptureConfig(BaseSettings):
     cognee_capture_batch_size: int = 64
     cognee_capture_flush_interval_s: float = 2.0
     cognee_capture_sample_rate: float = 1.0
+    # Upper bound on one sink write; a wedged sink (S3 under partition) must not
+    # pin the flusher and every later drain().
+    cognee_capture_sink_timeout_s: float = 30.0
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
@@ -40,6 +43,11 @@ class CaptureConfig(BaseSettings):
             raise ValueError(
                 "COGNEE_CAPTURE_SAMPLE_RATE must be in [0, 1], "
                 f"got {self.cognee_capture_sample_rate}"
+            )
+        if self.cognee_capture_sink_timeout_s <= 0:
+            raise ValueError(
+                "COGNEE_CAPTURE_SINK_TIMEOUT_S must be positive, "
+                f"got {self.cognee_capture_sink_timeout_s}"
             )
 
         if not self.cognee_capture_dir:
@@ -60,6 +68,7 @@ class CaptureConfig(BaseSettings):
             "cognee_capture_batch_size": self.cognee_capture_batch_size,
             "cognee_capture_flush_interval_s": self.cognee_capture_flush_interval_s,
             "cognee_capture_sample_rate": self.cognee_capture_sample_rate,
+            "cognee_capture_sink_timeout_s": self.cognee_capture_sink_timeout_s,
         }
 
 

--- a/cognee/modules/observability/capture/config.py
+++ b/cognee/modules/observability/capture/config.py
@@ -49,6 +49,21 @@ class CaptureConfig(BaseSettings):
                 "COGNEE_CAPTURE_SINK_TIMEOUT_S must be positive, "
                 f"got {self.cognee_capture_sink_timeout_s}"
             )
+        # A batch size of 0 would make every flush pop nothing — and a flusher
+        # that pops nothing without suspending monopolises its event loop.
+        if self.cognee_capture_queue_size < 1:
+            raise ValueError(
+                f"COGNEE_CAPTURE_QUEUE_SIZE must be at least 1, got {self.cognee_capture_queue_size}"
+            )
+        if self.cognee_capture_batch_size < 1:
+            raise ValueError(
+                f"COGNEE_CAPTURE_BATCH_SIZE must be at least 1, got {self.cognee_capture_batch_size}"
+            )
+        if self.cognee_capture_flush_interval_s <= 0:
+            raise ValueError(
+                "COGNEE_CAPTURE_FLUSH_INTERVAL_S must be positive, "
+                f"got {self.cognee_capture_flush_interval_s}"
+            )
 
         if not self.cognee_capture_dir:
             # Lazy on purpose — see the module docstring.

--- a/cognee/modules/observability/capture/config.py
+++ b/cognee/modules/observability/capture/config.py
@@ -34,6 +34,11 @@ class CaptureConfig(BaseSettings):
     # Upper bound on one sink write; a wedged sink (S3 under partition) must not
     # pin the flusher and every later drain().
     cognee_capture_sink_timeout_s: float = 30.0
+    # Default budget for drain() when the caller passes no timeout — the wait the
+    # pipeline wiring adds at every run completion while capture is on. Lower it
+    # when that tail latency matters more than losing a slow sink's last batch
+    # to the atexit hook.
+    cognee_capture_drain_timeout_s: float = 5.0
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
@@ -48,6 +53,11 @@ class CaptureConfig(BaseSettings):
             raise ValueError(
                 "COGNEE_CAPTURE_SINK_TIMEOUT_S must be positive, "
                 f"got {self.cognee_capture_sink_timeout_s}"
+            )
+        if self.cognee_capture_drain_timeout_s <= 0:
+            raise ValueError(
+                "COGNEE_CAPTURE_DRAIN_TIMEOUT_S must be positive, "
+                f"got {self.cognee_capture_drain_timeout_s}"
             )
         # A batch size of 0 would make every flush pop nothing — and a flusher
         # that pops nothing without suspending monopolises its event loop.
@@ -84,6 +94,7 @@ class CaptureConfig(BaseSettings):
             "cognee_capture_flush_interval_s": self.cognee_capture_flush_interval_s,
             "cognee_capture_sample_rate": self.cognee_capture_sample_rate,
             "cognee_capture_sink_timeout_s": self.cognee_capture_sink_timeout_s,
+            "cognee_capture_drain_timeout_s": self.cognee_capture_drain_timeout_s,
         }
 
 

--- a/cognee/modules/observability/capture/config.py
+++ b/cognee/modules/observability/capture/config.py
@@ -1,0 +1,73 @@
+"""Configuration for eval capture (SDK-529).
+
+Fields are named after the full environment variables (repo convention — no
+``env_prefix``). The ``COGNEE_`` prefix follows ``COGNEE_TRACING_ENABLED``;
+unprefixed ``CAPTURE_*`` would be ambiguous.
+
+The base config is read lazily inside the validator: ``cognee/base_config.py``
+imports the observability package, so a module-level ``get_base_config`` import
+here would create a partially-initialized-module cycle, and a class-time default
+would freeze ``DATA_ROOT_DIRECTORY`` and break monkeypatching in tests.
+"""
+
+import os
+from functools import lru_cache
+
+import pydantic
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class CaptureConfig(BaseSettings):
+    """Knobs for the non-blocking eval capture hook.
+
+    Read once per process by ``hook._ensure_initialized()``; never on the emit
+    path. Directory defaults to ``<data_root>/capture`` (not ``evals``, which
+    collides with ``cognee/eval_framework`` artifacts).
+    """
+
+    cognee_capture_enabled: bool = False
+    cognee_capture_dir: str | None = None
+    cognee_capture_queue_size: int = 512
+    cognee_capture_batch_size: int = 64
+    cognee_capture_flush_interval_s: float = 2.0
+    cognee_capture_sample_rate: float = 1.0
+
+    model_config = SettingsConfigDict(env_file=".env", extra="allow")
+
+    @pydantic.model_validator(mode="after")
+    def fill_derived(self):
+        if not 0.0 <= self.cognee_capture_sample_rate <= 1.0:
+            raise ValueError(
+                "COGNEE_CAPTURE_SAMPLE_RATE must be in [0, 1], "
+                f"got {self.cognee_capture_sample_rate}"
+            )
+
+        if not self.cognee_capture_dir:
+            # Lazy on purpose — see the module docstring.
+            from cognee.base_config import get_base_config
+
+            base_config = get_base_config()
+            self.cognee_capture_dir = os.path.join(base_config.data_root_directory, "capture")
+
+        return self
+
+    def to_dict(self) -> dict:
+        """Return the configuration as a dictionary."""
+        return {
+            "cognee_capture_enabled": self.cognee_capture_enabled,
+            "cognee_capture_dir": self.cognee_capture_dir,
+            "cognee_capture_queue_size": self.cognee_capture_queue_size,
+            "cognee_capture_batch_size": self.cognee_capture_batch_size,
+            "cognee_capture_flush_interval_s": self.cognee_capture_flush_interval_s,
+            "cognee_capture_sample_rate": self.cognee_capture_sample_rate,
+        }
+
+
+@lru_cache
+def get_capture_config() -> CaptureConfig:
+    """Return the cached capture configuration.
+
+    Tests that change the environment call ``get_capture_config.cache_clear()``
+    (``hook._reset_for_tests()`` does it too).
+    """
+    return CaptureConfig()

--- a/cognee/modules/observability/capture/config.py
+++ b/cognee/modules/observability/capture/config.py
@@ -26,6 +26,15 @@ class CaptureConfig(BaseSettings):
     Read once per process by ``hook._ensure_initialized()``; never on the emit
     path. Directory defaults to ``<data_root>/capture`` (not ``evals``, which
     collides with ``cognee/eval_framework`` artifacts).
+
+    Enabling capture writes derived user content to that directory: the raw
+    per-chunk graphs (extracted entity names, descriptions, relationships),
+    the names looked up against the ontology, and retrieval candidate ids —
+    filed per dataset and run. It inherits the directory's permissions and is
+    not removed when a dataset is forgotten, so a deployment that turns it on
+    owns the same retention and access-control obligations for it as for the
+    data root. ``COGNEE_CAPTURE_RETRIEVAL_SAMPLE_RATE`` samples only the
+    ``retrieval.*`` payloads; the extraction kinds are always captured in full.
     """
 
     cognee_capture_enabled: bool = False
@@ -37,7 +46,7 @@ class CaptureConfig(BaseSettings):
     cognee_capture_queue_size: int = 2048
     cognee_capture_batch_size: int = 64
     cognee_capture_flush_interval_s: float = 2.0
-    cognee_capture_sample_rate: float = 1.0
+    cognee_capture_retrieval_sample_rate: float = 1.0
     # Upper bound on one sink write; a wedged sink (S3 under partition) must not
     # pin the flusher and every later drain().
     cognee_capture_sink_timeout_s: float = 30.0
@@ -51,10 +60,10 @@ class CaptureConfig(BaseSettings):
 
     @pydantic.model_validator(mode="after")
     def fill_derived(self):
-        if not 0.0 <= self.cognee_capture_sample_rate <= 1.0:
+        if not 0.0 <= self.cognee_capture_retrieval_sample_rate <= 1.0:
             raise ValueError(
-                "COGNEE_CAPTURE_SAMPLE_RATE must be in [0, 1], "
-                f"got {self.cognee_capture_sample_rate}"
+                "COGNEE_CAPTURE_RETRIEVAL_SAMPLE_RATE must be in [0, 1], "
+                f"got {self.cognee_capture_retrieval_sample_rate}"
             )
         if self.cognee_capture_sink_timeout_s <= 0:
             raise ValueError(
@@ -106,7 +115,7 @@ class CaptureConfig(BaseSettings):
             "cognee_capture_queue_size": self.cognee_capture_queue_size,
             "cognee_capture_batch_size": self.cognee_capture_batch_size,
             "cognee_capture_flush_interval_s": self.cognee_capture_flush_interval_s,
-            "cognee_capture_sample_rate": self.cognee_capture_sample_rate,
+            "cognee_capture_retrieval_sample_rate": self.cognee_capture_retrieval_sample_rate,
             "cognee_capture_sink_timeout_s": self.cognee_capture_sink_timeout_s,
             "cognee_capture_drain_timeout_s": self.cognee_capture_drain_timeout_s,
         }

--- a/cognee/modules/observability/capture/config.py
+++ b/cognee/modules/observability/capture/config.py
@@ -16,6 +16,9 @@ from functools import lru_cache
 import pydantic
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+# A leaf module (no cognee imports), so unlike base_config it is safe here.
+from cognee.root_dir import ensure_absolute_path
+
 
 class CaptureConfig(BaseSettings):
     """Knobs for the non-blocking eval capture hook.
@@ -27,7 +30,11 @@ class CaptureConfig(BaseSettings):
 
     cognee_capture_enabled: bool = False
     cognee_capture_dir: str | None = None
-    cognee_capture_queue_size: int = 512
+    # Must not be a fraction of cognify's default ``chunks_per_batch`` (2000):
+    # the per-chunk emit points run over a whole task batch, and a burst past
+    # this bound is dropped newest-first. 2048 covers the default batch with the
+    # flusher draining alongside (``capture_chunk_graphs`` yields every 64).
+    cognee_capture_queue_size: int = 2048
     cognee_capture_batch_size: int = 64
     cognee_capture_flush_interval_s: float = 2.0
     cognee_capture_sample_rate: float = 1.0
@@ -81,6 +88,13 @@ class CaptureConfig(BaseSettings):
 
             base_config = get_base_config()
             self.cognee_capture_dir = os.path.join(base_config.data_root_directory, "capture")
+
+        # Same rule as every other storage root (BaseConfig.validate_paths): a
+        # relative value would resolve against the process CWD and scatter
+        # gzip'd chunk graphs — verbatim entity names — wherever the server or
+        # CLI happened to start, the repo working tree included. Loud at
+        # startup instead; s3:// is absolute by definition.
+        self.cognee_capture_dir = ensure_absolute_path(self.cognee_capture_dir)
 
         return self
 

--- a/cognee/modules/observability/capture/events.py
+++ b/cognee/modules/observability/capture/events.py
@@ -1,0 +1,55 @@
+"""Capture event record and kind constants (SDK-529).
+
+A ``CaptureEvent`` is what ``emit()`` appends to the buffer: an object
+reference (or a snapshot, see the snapshot rule in ``hook.py``) plus the
+attribution needed to place it later. Nothing here serializes — the flusher
+turns events into the record shape handed to sinks::
+
+    {"kind", "run_id": str|None, "dataset_id": str|None, "stage", "ts", "payload"}
+
+where ``payload`` is ``model_dump(mode="json")`` for ``payload_kind="pydantic"``,
+the object as-is for ``"json"`` (must be JSON-serializable; sinks apply
+``json.dumps(default=str)``), and the str as-is for ``"text"``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from .manifest import RunScope
+
+KIND_EXTRACTION_CHUNK_GRAPH = "extraction.chunk_graph"
+KIND_EXTRACTION_DROPPED_DUPLICATES = "extraction.dropped_duplicates"
+KIND_EXTRACTION_FUZZY_MATCH = "extraction.fuzzy_match"
+KIND_STORAGE_DELTA = "storage.delta"
+KIND_SUMMARY_GENERATED = "summary.generated"
+KIND_RETRIEVAL_CANDIDATES = "retrieval.candidates"
+KIND_RUN_MANIFEST = "run.manifest"
+
+# Retrieval kinds are the ones subject to per-run sampling (see should_capture).
+RETRIEVAL_KIND_PREFIX = "retrieval."
+
+
+@dataclass(slots=True)
+class CaptureEvent:
+    """One buffered observation; serialized later by the flusher, never at emit."""
+
+    kind: str
+    # Object reference (or snapshot per the snapshot rule).
+    payload: Any
+    # "pydantic" | "json" | "text"
+    payload_kind: str
+    # Explicit overrides — raw at emit, str()-coerced by the flusher.
+    run_id: UUID | str | None
+    dataset_id: UUID | str | None
+    # The active manifest scope at emit time. The flusher resolves
+    # ``run_id = event.run_id or scope.run_id`` (same for dataset_id) AT
+    # SERIALIZATION TIME, so a dataset bound late via ``RunScope.set_dataset()``
+    # shows up on events that were already buffered.
+    scope: RunScope | None
+    stage: str | None
+    # time.time() at emit.
+    ts: float

--- a/cognee/modules/observability/capture/events.py
+++ b/cognee/modules/observability/capture/events.py
@@ -5,11 +5,20 @@ reference (or a snapshot, see the snapshot rule in ``hook.py``) plus the
 attribution needed to place it later. Nothing here serializes — the flusher
 turns events into the record shape handed to sinks::
 
-    {"kind", "run_id": str|None, "dataset_id": str|None, "stage", "ts", "payload"}
+    {
+        "schema_version": int,           # CAPTURE_SCHEMA_VERSION
+        "event_id": str,                 # "<process>-<seq>", stable across redelivery
+        "kind", "run_id": str|None, "dataset_id": str|None, "stage", "ts", "payload",
+    }
 
 where ``payload`` is ``model_dump(mode="json")`` for ``payload_kind="pydantic"``,
 the object as-is for ``"json"`` (must be JSON-serializable; sinks apply
 ``json.dumps(default=str)``), and the str as-is for ``"text"``.
+
+``event_id`` is assigned at emit, not at serialization: delivery is
+at-least-once (a flush cut off mid-write is re-buffered and written again),
+and an id minted while serializing would differ between the two copies,
+defeating the deduplication it exists for.
 """
 
 from __future__ import annotations
@@ -20,6 +29,12 @@ from uuid import UUID
 
 if TYPE_CHECKING:
     from .manifest import RunScope
+
+# Version of the record envelope and the payload shapes under each kind. Bump
+# on any change a consumer of the persisted files could not absorb silently:
+# a renamed or re-typed envelope key, a payload key changing meaning, a kind
+# being split. Additive payload keys do not need a bump.
+CAPTURE_SCHEMA_VERSION = 1
 
 KIND_EXTRACTION_CHUNK_GRAPH = "extraction.chunk_graph"
 KIND_EXTRACTION_DROPPED_DUPLICATES = "extraction.dropped_duplicates"
@@ -53,3 +68,10 @@ class CaptureEvent:
     stage: str | None
     # time.time() at emit.
     ts: float
+    # Position in this process's emit sequence; with the per-process prefix it
+    # forms ``event_id``. Assigned at emit so a requeued event keeps its id.
+    seq: int
+    # Set by the flusher on the first sink acknowledgement, so a run's
+    # ``events_delivered`` credits an event once even if at-least-once delivery
+    # writes it twice.
+    delivered: bool = False

--- a/cognee/modules/observability/capture/hook.py
+++ b/cognee/modules/observability/capture/hook.py
@@ -119,6 +119,7 @@ BATCH_SIZE: int = _FIELDS["cognee_capture_batch_size"].default
 FLUSH_INTERVAL_S: float = _FIELDS["cognee_capture_flush_interval_s"].default
 SAMPLE_RATE: float = _FIELDS["cognee_capture_sample_rate"].default
 SINK_TIMEOUT_S: float = _FIELDS["cognee_capture_sink_timeout_s"].default
+DRAIN_TIMEOUT_S: float = _FIELDS["cognee_capture_drain_timeout_s"].default
 # Floor for the interval tick: a non-positive interval would spin the flusher.
 _MIN_FLUSH_INTERVAL_S: float = 0.01
 # How long shutdown() / _reset_for_tests() wait for a cancelled flusher to
@@ -194,6 +195,7 @@ def _configure(
     flush_interval_s: float | None = None,
     sample_rate: float | None = None,
     sink_timeout_s: float | None = None,
+    drain_timeout_s: float | None = None,
 ) -> None:
     """Set the cached knobs (from the config once per process, or from tests).
 
@@ -202,7 +204,7 @@ def _configure(
     nothing without ever suspending would monopolise its event loop; a
     non-positive interval would spin the flusher.
     """
-    global QUEUE_SIZE, BATCH_SIZE, FLUSH_INTERVAL_S, SAMPLE_RATE, SINK_TIMEOUT_S
+    global QUEUE_SIZE, BATCH_SIZE, FLUSH_INTERVAL_S, SAMPLE_RATE, SINK_TIMEOUT_S, DRAIN_TIMEOUT_S
     if queue_size is not None:
         QUEUE_SIZE = max(1, queue_size)
     if batch_size is not None:
@@ -213,6 +215,8 @@ def _configure(
         SAMPLE_RATE = sample_rate
     if sink_timeout_s is not None:
         SINK_TIMEOUT_S = sink_timeout_s
+    if drain_timeout_s is not None:
+        DRAIN_TIMEOUT_S = drain_timeout_s
 
 
 def _load_knobs(config: CaptureConfig) -> None:
@@ -222,6 +226,7 @@ def _load_knobs(config: CaptureConfig) -> None:
         flush_interval_s=config.cognee_capture_flush_interval_s,
         sample_rate=config.cognee_capture_sample_rate,
         sink_timeout_s=config.cognee_capture_sink_timeout_s,
+        drain_timeout_s=config.cognee_capture_drain_timeout_s,
     )
 
 
@@ -321,15 +326,22 @@ def register_capture_sink(sink: CaptureSink | None) -> None:
     tuning knobs (``COGNEE_CAPTURE_QUEUE_SIZE`` etc.) still come from the
     environment.
     Registering a sink re-arms flushing on loops ``shutdown()`` stopped.
+
+    Runs under ``_init_lock``: a registration racing ``_ensure_initialized()``
+    (a startup thread calling ``is_active()`` while another registers) must not
+    interleave with the env auto-registration, or the explicit sink could be
+    overwritten by the ``StorageSink`` — last-wins only holds when the two
+    writers are serialized.
     """
     global _sink, _initialized
-    if not _initialized:
-        _initialized = True
-        try:
-            _load_knobs(get_capture_config())
-        except Exception as exc:
-            logger.debug("capture config unavailable, keeping default knobs (%s)", exc)
-    _sink = sink
+    with _init_lock:
+        if not _initialized:
+            _initialized = True
+            try:
+                _load_knobs(get_capture_config())
+            except Exception as exc:
+                logger.debug("capture config unavailable, keeping default knobs (%s)", exc)
+        _sink = sink
     if sink is not None:
         _forget_stopped_flushers()
         _register_atexit()
@@ -863,8 +875,12 @@ async def _drain_until(deadline: float) -> None:
         await asyncio.sleep(0.01)
 
 
-async def drain(timeout: float = 5.0) -> None:
+async def drain(timeout: float | None = None) -> None:
     """Flush the events buffered so far, then wait for in-flight batches.
+
+    ``timeout=None`` (the default) means the configured budget:
+    ``COGNEE_CAPTURE_DRAIN_TIMEOUT_S``, 5 s unless overridden — this is the
+    wait the pipeline wiring adds at every run completion while capture is on.
 
     Never requires a flusher to exist, never raises (a cancellation of the
     caller propagates, as it must), and returns within about ``timeout`` — the
@@ -875,6 +891,8 @@ async def drain(timeout: float = 5.0) -> None:
     that does not let that cancel land is abandoned after the grace rather than
     waited on forever.
     """
+    if timeout is None:
+        timeout = DRAIN_TIMEOUT_S
     try:
         await _drain_until(time.monotonic() + timeout)
     except Exception as exc:
@@ -980,5 +998,6 @@ def _reset_for_tests() -> None:
         flush_interval_s=_FIELDS["cognee_capture_flush_interval_s"].default,
         sample_rate=_FIELDS["cognee_capture_sample_rate"].default,
         sink_timeout_s=_FIELDS["cognee_capture_sink_timeout_s"].default,
+        drain_timeout_s=_FIELDS["cognee_capture_drain_timeout_s"].default,
     )
     get_capture_config.cache_clear()

--- a/cognee/modules/observability/capture/hook.py
+++ b/cognee/modules/observability/capture/hook.py
@@ -91,6 +91,7 @@ import asyncio
 import atexit
 import collections
 import random
+import threading
 import time
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -127,6 +128,12 @@ _CANCEL_GRACE_S: float = 1.0
 # Module state.
 _sink: CaptureSink | None = None
 _initialized: bool = False
+# Serializes the one-time initialization only. is_active() reads _initialized
+# BEFORE taking it, so the warm path stays a plain global read with no locking.
+# Reentrant + _initializing: initialization imports the storage chain, and a
+# re-entrant is_active() from inside it must read "off", never deadlock.
+_init_lock = threading.RLock()
+_initializing: bool = False
 _buffer: collections.deque[CaptureEvent] = collections.deque()
 # Process-global, monotonic, approximate (lock-free on the emit path). Reported
 # once per manifest as a delta, never logged per drop.
@@ -266,22 +273,38 @@ def _ensure_initialized() -> None:
     ``is_active()`` — never from ``emit()``. A failing initialization (bad
     env, unreachable storage) logs once and leaves capture off: capture must
     never break the operation it observes.
-    """
-    global _initialized, _sink
-    if _initialized:
-        return
-    _initialized = True
-    try:
-        config = get_capture_config()
-        _load_knobs(config)
-        if config.cognee_capture_enabled and _sink is None:
-            # Lazy: keeps this module free of the storage/base_config import chain.
-            from cognee.infrastructure.files.storage import get_file_storage
 
-            _sink = StorageSink(get_file_storage(config.cognee_capture_dir))
-            _register_atexit()
-    except Exception as exc:
-        logger.warning("eval capture disabled: initialization failed (%s)", exc)
+    Runs under ``_init_lock`` and publishes ``_initialized`` only once ``_sink``
+    is installed. cognee reaches ``is_active()`` from ``to_thread`` workers and
+    the dataset-queue thread, and this body imports the storage chain (hundreds
+    of ms cold); publishing the flag first would make every concurrent caller
+    in that window see capture as OFF and silently skip a run's early events.
+    """
+    global _initialized, _sink, _initializing
+    with _init_lock:
+        # Re-check under the lock: a thread that waited here while another did
+        # the work must not redo it. _initializing catches the re-entrant case,
+        # which the RLock would otherwise let recurse.
+        if _initialized or _initializing:
+            return
+        _initializing = True
+        try:
+            config = get_capture_config()
+            _load_knobs(config)
+            if config.cognee_capture_enabled and _sink is None:
+                # Lazy: keeps this module free of the storage/base_config import chain.
+                from cognee.infrastructure.files.storage import get_file_storage
+
+                _sink = StorageSink(get_file_storage(config.cognee_capture_dir))
+                _register_atexit()
+        except Exception as exc:
+            logger.warning("eval capture disabled: initialization failed (%s)", exc)
+        finally:
+            # Set LAST, and inside the lock: a concurrent is_active() must never
+            # see _initialized True while _sink is still None, or it would skip
+            # capture for the whole (import-chain-long) initialization window.
+            _initialized = True
+            _initializing = False
 
 
 def is_active() -> bool:
@@ -294,9 +317,9 @@ def is_active() -> bool:
 def register_capture_sink(sink: CaptureSink | None) -> None:
     """Process-wide sink registration; last wins, ``None`` clears.
 
-    An explicit registration overrides env auto-registration of the SINK
-    (mirrors ``register_activity_sink`` semantics); the tuning knobs
-    (``COGNEE_CAPTURE_QUEUE_SIZE`` etc.) still come from the environment.
+    An explicit registration overrides env auto-registration of the SINK; the
+    tuning knobs (``COGNEE_CAPTURE_QUEUE_SIZE`` etc.) still come from the
+    environment.
     Registering a sink re-arms flushing on loops ``shutdown()`` stopped.
     """
     global _sink, _initialized
@@ -585,6 +608,15 @@ async def _wait_bounded(awaitable: Awaitable[T], timeout: float | None) -> T:
     cancellation straight through. Like ``wait_for``, a timeout cancels the
     inner awaitable and waits for that cancellation to land before raising
     ``asyncio.TimeoutError``, so the inner is never left running.
+
+    Unlike ``wait_for``, that post-cancel wait is itself bounded by
+    ``_CANCEL_GRACE_S``. A sink that swallows ``CancelledError`` (out of
+    contract, but ``register_capture_sink`` is public API) would otherwise pin
+    the flusher forever and blow every ``drain()`` budget without limit — and
+    because the same wait sits on the ``CancelledError`` branch, no outer
+    ``wait_for`` could rescue the caller either. Giving up on the cancel leaves
+    the inner running, so the caller must treat the batch as undelivered
+    (``_flush_one_batch`` re-buffers it).
     """
     future = asyncio.ensure_future(awaitable)
     if timeout is None:
@@ -598,11 +630,11 @@ async def _wait_bounded(awaitable: Awaitable[T], timeout: float | None) -> T:
         # wait_for — do not return while it may still be running.
         if not future.done():
             future.cancel()
-            await asyncio.wait({future})
+            await asyncio.wait({future}, timeout=_CANCEL_GRACE_S)
         raise
     if not done:
         future.cancel()
-        await asyncio.wait({future})
+        await asyncio.wait({future}, timeout=_CANCEL_GRACE_S)
         raise asyncio.TimeoutError
     return future.result()
 
@@ -763,9 +795,17 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
                 except asyncio.TimeoutError as exc:
                     if deadline is not None and time.monotonic() >= deadline:
                         break  # the caller's budget ran out, not the sink's: retry later
-                    logger.debug("capture sink failed (%s)", exc)
+                    # The sink blew SINK_TIMEOUT_S; its write was cancelled and
+                    # the slots are blanked below, so these events are gone.
+                    # Account for the loss instead of hiding it: a run whose sink
+                    # is wedged must not report dropped_events = 0.
+                    _dropped += len(indexes)
+                    logger.debug(
+                        "capture sink timed out, %d event(s) dropped (%s)", len(indexes), exc
+                    )
                 except Exception as exc:
-                    logger.debug("capture sink failed (%s)", exc)
+                    _dropped += len(indexes)
+                    logger.debug("capture sink failed, %d event(s) dropped (%s)", len(indexes), exc)
                 for index in indexes:
                     pending[index] = None
                 # Let other coroutines interleave between sink writes.
@@ -781,8 +821,9 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
         logger.debug("capture flush failed, %d event(s) dropped (%s)", lost, exc)
     except BaseException:
         # Cancellation (asyncio.run teardown, uvicorn shutdown, a cancelled
-        # drain() caller) or a KeyboardInterrupt/SystemExit escaping a sink:
-        # do not lose the popped batch.
+        # drain() caller) or a custom BaseException escaping a sink: do not lose
+        # the popped batch. KeyboardInterrupt/SystemExit from a sink do NOT
+        # reach here - asyncio re-raises those out of the loop itself.
         _requeue(pending)
         raise
     finally:
@@ -829,7 +870,10 @@ async def drain(timeout: float = 5.0) -> None:
     caller propagates, as it must), and returns within about ``timeout`` — the
     budget is enforced inside a batch too, per sink write — even under a
     continuous producer or a wedged sink (leftovers stay with the flusher /
-    the atexit hook).
+    the atexit hook). "About" is ``timeout`` plus at most one
+    ``_CANCEL_GRACE_S``: a write cut off by the budget is cancelled, and a sink
+    that does not let that cancel land is abandoned after the grace rather than
+    waited on forever.
     """
     try:
         await _drain_until(time.monotonic() + timeout)

--- a/cognee/modules/observability/capture/hook.py
+++ b/cognee/modules/observability/capture/hook.py
@@ -30,16 +30,25 @@ thread-agnostic — emit is reached from ``to_thread``'d sync code, run_sync's
 thread, the dataset-queue reaper thread, and across ``asyncio.run``
 boundaries. ``asyncio.Queue`` is loop-bound and its ``put_nowait`` from a
 foreign thread wakes getters via loop-owned futures, so it is rejected. The
-``len() >= QUEUE_SIZE`` check is a soft bound across threads (harmless).
+``len() >= QUEUE_SIZE`` check is a soft bound across threads (harmless). Run
+manifests bypass the bound (``_emit_unbounded``): the manifest is the record
+that carries ``dropped_events``, so drop-newest must never eat it; the number
+of manifests in flight is bounded by the number of concurrent runs.
 
 Flushing
 --------
-One flusher task per event loop, started lazily by the first on-loop emit and
-woken either by the ``FLUSH_INTERVAL_S`` tick or by ``emit()`` when the buffer
-reaches ``BATCH_SIZE`` (``call_soon_threadsafe`` — the only loop primitive safe
-from any thread/loop). Serialization runs in ``asyncio.to_thread`` because it
-is pure CPU (~15 ms per 64-graph batch) and would otherwise freeze concurrent
-recall coroutines. A cancelled flush pushes its popped batch back so
+One flusher task per event loop, started by the first on-loop emit or eagerly
+at ``run_scope`` entry (so worker-thread emits during a run are picked up by
+the interval tick even when nothing emits on-loop), and woken either by the
+``FLUSH_INTERVAL_S`` tick or by ``emit()`` when the buffer reaches
+``BATCH_SIZE`` (``call_soon_threadsafe`` — the only loop primitive safe from
+any thread/loop). Serialization runs in a worker thread because it is pure CPU
+(~15 ms per 64-graph batch) and would otherwise freeze concurrent recall
+coroutines; inside atexit handlers the executor is gone and it runs inline.
+``_in_flight`` counts batches from pop to delivery, so ``drain()`` waits for a
+batch the flusher is still serializing. Each sink write is bounded by
+``SINK_TIMEOUT_S`` so a wedged sink cannot pin the flusher (and every later
+``drain()``) forever. A cancelled flush pushes its popped batch back so
 ``asyncio.run`` teardown loses nothing; the atexit hook or next ``drain()``
 picks it up. Known limitation: a loop closed WITHOUT cancelling (pytest-asyncio
 0.21) loses an in-flight batch — tests drain explicitly.
@@ -53,7 +62,7 @@ import collections
 import random
 import time
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -61,20 +70,21 @@ from cognee.shared.logging_utils import get_logger
 
 from .config import CaptureConfig, get_capture_config
 from .events import RETRIEVAL_KIND_PREFIX, CaptureEvent
-from .sinks import CaptureSink, StorageSink
+from .sinks import CaptureSink, StorageSink, run_off_loop
 
 if TYPE_CHECKING:
     from .manifest import RunScope
 
 logger = get_logger("eval_capture")
 
-# Knobs. Defaults mirror CaptureConfig; _ensure_initialized() overwrites them
-# from the environment once per process, _configure() from tests.
+# Knobs. Defaults mirror CaptureConfig; _load_knobs() overwrites them from the
+# environment once per process, _configure() from tests.
 _FIELDS = CaptureConfig.model_fields
 QUEUE_SIZE: int = _FIELDS["cognee_capture_queue_size"].default
 BATCH_SIZE: int = _FIELDS["cognee_capture_batch_size"].default
 FLUSH_INTERVAL_S: float = _FIELDS["cognee_capture_flush_interval_s"].default
 SAMPLE_RATE: float = _FIELDS["cognee_capture_sample_rate"].default
+SINK_TIMEOUT_S: float = _FIELDS["cognee_capture_sink_timeout_s"].default
 
 # Module state.
 _sink: CaptureSink | None = None
@@ -82,7 +92,8 @@ _initialized: bool = False
 _buffer: collections.deque[CaptureEvent] = collections.deque()
 # Process-global, monotonic. Reported once per manifest as a delta, never logged per drop.
 _dropped: int = 0
-# Sink writes currently awaited, on any loop.
+# Batches popped from the buffer but not yet delivered (serializing or awaiting
+# the sink), on any loop. drain() waits on it.
 _in_flight: int = 0
 _atexit_registered: bool = False
 
@@ -93,9 +104,14 @@ _current_scope: ContextVar[RunScope | None] = ContextVar("cognee_capture_scope",
 
 @dataclass(slots=True)
 class _Flusher:
-    task: asyncio.Task
     loop: asyncio.AbstractEventLoop
     wake: asyncio.Event
+    # True from the moment a wake.set() is scheduled until the flusher has
+    # consumed it, so a synchronous burst past BATCH_SIZE schedules ONE loop
+    # callback instead of one per emit.
+    wake_pending: bool = False
+    # Bound right after creation: the flush task needs the flusher, the flusher the task.
+    task: asyncio.Task = field(init=False)
 
 
 _flushers: dict[asyncio.AbstractEventLoop, _Flusher] = {}
@@ -137,9 +153,20 @@ def _flush_at_exit() -> None:
     if _get_running_loop() is not None:
         return
     try:
+        # threading._shutdown() has already run here, so the default executor
+        # refuses new work; run_off_loop() falls back to inline serialization.
         asyncio.run(drain(1.0))
     except Exception:
         pass
+
+
+def _load_knobs(config: CaptureConfig) -> None:
+    global QUEUE_SIZE, BATCH_SIZE, FLUSH_INTERVAL_S, SAMPLE_RATE, SINK_TIMEOUT_S
+    QUEUE_SIZE = config.cognee_capture_queue_size
+    BATCH_SIZE = config.cognee_capture_batch_size
+    FLUSH_INTERVAL_S = config.cognee_capture_flush_interval_s
+    SAMPLE_RATE = config.cognee_capture_sample_rate
+    SINK_TIMEOUT_S = config.cognee_capture_sink_timeout_s
 
 
 def _ensure_initialized() -> None:
@@ -151,16 +178,13 @@ def _ensure_initialized() -> None:
     env, unreachable storage) logs once and leaves capture off: capture must
     never break the operation it observes.
     """
-    global _initialized, _sink, QUEUE_SIZE, BATCH_SIZE, FLUSH_INTERVAL_S, SAMPLE_RATE
+    global _initialized, _sink
     if _initialized:
         return
     _initialized = True
     try:
         config = get_capture_config()
-        QUEUE_SIZE = config.cognee_capture_queue_size
-        BATCH_SIZE = config.cognee_capture_batch_size
-        FLUSH_INTERVAL_S = config.cognee_capture_flush_interval_s
-        SAMPLE_RATE = config.cognee_capture_sample_rate
+        _load_knobs(config)
         if config.cognee_capture_enabled and _sink is None:
             # Lazy: keeps this module free of the storage/base_config import chain.
             from cognee.infrastructure.files.storage import get_file_storage
@@ -181,12 +205,18 @@ def is_active() -> bool:
 def register_capture_sink(sink: CaptureSink | None) -> None:
     """Process-wide sink registration; last wins, ``None`` clears.
 
-    An explicit registration overrides env auto-registration (mirrors
-    ``register_activity_sink`` semantics).
+    An explicit registration overrides env auto-registration of the SINK
+    (mirrors ``register_activity_sink`` semantics); the tuning knobs
+    (``COGNEE_CAPTURE_QUEUE_SIZE`` etc.) still come from the environment.
     """
     global _sink, _initialized
+    if not _initialized:
+        _initialized = True
+        try:
+            _load_knobs(get_capture_config())
+        except Exception as exc:
+            logger.debug("capture config unavailable, keeping default knobs (%s)", exc)
     _sink = sink
-    _initialized = True
     if sink is not None:
         _register_atexit()
 
@@ -217,14 +247,13 @@ def emit(
     if sink is None:
         return
 
-    buffer = _buffer
-    if len(buffer) >= QUEUE_SIZE:
+    if len(_buffer) >= QUEUE_SIZE:
         # Drop-NEWEST: the buffer is a bounded observation window, not a queue
         # the pipeline waits on.
         _dropped += 1
         return
 
-    buffer.append(
+    _enqueue(
         CaptureEvent(
             kind=kind,
             payload=payload,
@@ -237,24 +266,83 @@ def emit(
         )
     )
 
+
+def _emit_unbounded(
+    kind: str,
+    payload: Any,
+    *,
+    payload_kind: str,
+    run_id: UUID | str | None,
+    dataset_id: UUID | str | None,
+) -> None:
+    """``emit()`` without the ``QUEUE_SIZE`` bound — for run manifests only.
+
+    A run that overflowed the buffer must still land its manifest: it is the
+    record carrying ``dropped_events`` and the authoritative dataset
+    attribution, so drop-newest applying to it would make overflow
+    unobservable offline. Bounded by the number of concurrent runs.
+    """
+    if _sink is None:
+        return
+    _enqueue(
+        CaptureEvent(
+            kind=kind,
+            payload=payload,
+            payload_kind=payload_kind,
+            run_id=run_id,
+            dataset_id=dataset_id,
+            scope=_current_scope.get(),
+            stage=None,
+            ts=time.time(),
+        )
+    )
+
+
+def _enqueue(event: CaptureEvent) -> None:
+    """Append, make sure this loop has a flusher, fire the BATCH_SIZE wake."""
+    buffer = _buffer
+    buffer.append(event)
+
     loop = _get_running_loop()
-    flusher: _Flusher | None = None
-    if loop is not None:
-        flusher = _flushers.get(loop)
-        if flusher is None or flusher.task.done():
-            # A done() flusher (crashed, cancelled) is treated as absent.
-            flusher = _start_flusher(loop)
+    flusher = _ensure_flusher(loop) if loop is not None else None
     # else: a worker-thread emit; the deque is picked up by whichever flusher runs next.
 
     if len(buffer) >= BATCH_SIZE:
         if flusher is None:
             flusher = _any_live_flusher()
-        if flusher is not None and not flusher.loop.is_closed() and not flusher.wake.is_set():
-            # is_set() pre-check: fires at most once per batch (~100 ns on-loop).
+        if flusher is not None and not flusher.wake_pending and not flusher.loop.is_closed():
+            # wake_pending: one callback per batch, even in a synchronous burst
+            # where the scheduled wake.set() has not run yet.
+            flusher.wake_pending = True
             try:
                 flusher.loop.call_soon_threadsafe(flusher.wake.set)
             except RuntimeError:
-                pass  # loop closing
+                flusher.wake_pending = False  # loop closing
+
+
+def _ensure_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
+    """Return this loop's live flusher, starting one if absent or done()."""
+    flusher = _flushers.get(loop)
+    if flusher is None or flusher.task.done():
+        # A done() flusher (crashed, cancelled) is treated as absent.
+        flusher = _start_flusher(loop)
+    return flusher
+
+
+def ensure_flusher() -> None:
+    """Start the running loop's flusher eagerly (called at ``run_scope`` entry).
+
+    Emits from plain threads cannot start a flusher (no running loop in the
+    emitting thread), so a run whose emit points all execute in worker threads
+    would otherwise accumulate events until QUEUE_SIZE and drop the rest. Both
+    wirings open their scope on-loop at run start, so this gives every run a
+    live flusher before its first worker-thread emit. Off the hot path.
+    """
+    if _sink is None:
+        return
+    loop = _get_running_loop()
+    if loop is not None:
+        _ensure_flusher(loop)
 
 
 def _start_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
@@ -264,23 +352,22 @@ def _start_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
         if stale_loop.is_closed() or stale.task.done():
             _flushers.pop(stale_loop, None)
 
-    wake = asyncio.Event()
-    flush_coroutine = _flush_loop(wake)
+    flusher = _Flusher(loop=loop, wake=asyncio.Event())
+    flush_coroutine = _flush_loop(flusher)
     try:
-        task = loop.create_task(flush_coroutine)
+        flusher.task = loop.create_task(flush_coroutine)
     except RuntimeError:
         # Loop closing — same posture as _TELEMETRY_TASKS in cognee/shared/utils.py.
         flush_coroutine.close()
         return None
 
-    flusher = _Flusher(task, loop, wake)
     _flushers[loop] = flusher
 
     def _discard(_task: asyncio.Task) -> None:
         if _flushers.get(loop) is flusher:
             _flushers.pop(loop, None)
 
-    task.add_done_callback(_discard)
+    flusher.task.add_done_callback(_discard)
     return flusher
 
 
@@ -296,7 +383,8 @@ def _any_live_flusher() -> _Flusher | None:
 # ---------------------------------------------------------------------------
 
 
-async def _flush_loop(wake: asyncio.Event) -> None:
+async def _flush_loop(flusher: _Flusher) -> None:
+    wake = flusher.wake
     while True:
         try:
             try:
@@ -304,6 +392,8 @@ async def _flush_loop(wake: asyncio.Event) -> None:
             except asyncio.TimeoutError:
                 pass  # interval tick
             wake.clear()
+            # Re-arm BEFORE flushing so an emit that lands mid-flush can wake us again.
+            flusher.wake_pending = False
             # Burst absorption: after a full batch keep flushing until the buffer
             # is below the threshold; sleep only when quiet.
             while _buffer:
@@ -353,9 +443,14 @@ def _serialize_batch(batch: list[CaptureEvent]) -> list[dict]:
     return records
 
 
-async def _flush_one_batch() -> None:
-    """Pop up to BATCH_SIZE events, serialize off-loop, hand groups to the sink."""
-    global _in_flight
+async def _flush_one_batch() -> int:
+    """Pop up to BATCH_SIZE events, serialize off-loop, hand groups to the sink.
+
+    Returns the number of events popped. ``_in_flight`` is held for the whole
+    pop→deliver window so ``drain()`` can wait for a batch that another
+    consumer (the flusher) is still serializing.
+    """
+    global _in_flight, _dropped
     buffer = _buffer
     batch: list[CaptureEvent] = []
     try:
@@ -364,16 +459,17 @@ async def _flush_one_batch() -> None:
     except IndexError:
         pass  # raced with another consumer (drain + flusher split the work)
     if not batch:
-        return
+        return 0
 
     sink = _sink
     if sink is None:
-        return  # sink cleared after these were queued: nothing to deliver to
+        return len(batch)  # sink cleared after these were queued: nothing to deliver to
 
     # Events not yet handed to the sink; on cancellation these go back.
     pending: list[CaptureEvent | None] = list(batch)
+    _in_flight += 1
     try:
-        records = await asyncio.to_thread(_serialize_batch, batch)
+        records = await run_off_loop(_serialize_batch, batch)
 
         groups: dict[tuple[str | None, str], list[int]] = {}
         for index, record in enumerate(records):
@@ -381,13 +477,12 @@ async def _flush_one_batch() -> None:
 
         for indexes in groups.values():
             group = [records[index] for index in indexes]
-            _in_flight += 1
             try:
-                await sink(group)
+                # Bounded: a wedged sink (S3 under partition) must not pin the
+                # flusher — and every later drain() — forever.
+                await asyncio.wait_for(sink(group), SINK_TIMEOUT_S)
             except Exception as exc:
                 logger.debug("capture sink failed (%s)", exc)
-            finally:
-                _in_flight -= 1
             for index in indexes:
                 pending[index] = None
             # Let other coroutines interleave between sink writes.
@@ -396,6 +491,15 @@ async def _flush_one_batch() -> None:
         # asyncio.run teardown / uvicorn shutdown: do not lose the popped batch.
         buffer.extendleft(reversed([event for event in pending if event is not None]))
         raise
+    except Exception as exc:
+        # Not re-queued: a deterministic failure would pin the head of the
+        # buffer forever. Account for the loss instead of hiding it.
+        lost = sum(1 for event in pending if event is not None)
+        _dropped += lost
+        logger.debug("capture flush failed, %d event(s) dropped (%s)", lost, exc)
+    finally:
+        _in_flight -= 1
+    return len(batch)
 
 
 # ---------------------------------------------------------------------------
@@ -403,25 +507,40 @@ async def _flush_one_batch() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def drain(timeout: float = 5.0) -> None:
-    """Flush the buffer inline on the calling loop, then wait for in-flight writes.
+async def _drain_until(deadline: float) -> None:
+    # (a) Inline on the calling loop: flush what is buffered NOW. The deque is
+    # the coordination point — popleft is atomic, so a concurrently running
+    # flusher and this drain simply split the work (blob names are
+    # collision-free). Budgeted by the entry count so a producer faster than
+    # the sink cannot pin the caller: the flusher owns whatever arrives later.
+    budget = len(_buffer)
+    while budget > 0 and _buffer and time.monotonic() < deadline:
+        budget -= await _flush_one_batch()
+    # (b) Wait for batches other consumers hold (popped, serializing or
+    # awaiting their sink): a plain int counter, no foreign-loop futures.
+    while _in_flight > 0 and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
 
-    Never requires a flusher to exist and never raises. The deque is the
-    coordination point: a concurrently running flusher and a drain simply
-    split the work (blob names are collision-free).
+
+async def drain(timeout: float = 5.0) -> None:
+    """Flush the events buffered so far, then wait for in-flight batches.
+
+    Never requires a flusher to exist, never raises, and returns within about
+    ``timeout`` even under a continuous producer (leftovers stay with the
+    flusher / the atexit hook).
     """
     try:
-        while _buffer:
-            await _flush_one_batch()
-        deadline = time.monotonic() + timeout
-        while _in_flight > 0 and time.monotonic() < deadline:
-            await asyncio.sleep(0.01)
+        await _drain_until(time.monotonic() + timeout)
     except Exception as exc:
         logger.debug("capture drain failed (%s)", exc)
 
 
 async def shutdown(timeout: float = 5.0) -> None:
-    """Drain, then stop every flusher. For process teardown, not the request path."""
+    """Drain, stop every flusher, then deliver anything a cancelled flush put back.
+
+    For process teardown (FastAPI lifespan, tests), not the request path.
+    """
+    deadline = time.monotonic() + timeout
     await drain(timeout)
     current_loop = _get_running_loop()
     same_loop_tasks: list[asyncio.Task] = []
@@ -432,6 +551,13 @@ async def shutdown(timeout: float = 5.0) -> None:
     _flushers.clear()
     if same_loop_tasks:
         await asyncio.gather(*same_loop_tasks, return_exceptions=True)
+    # A flusher cancelled mid-batch re-buffered it; no flusher is left to pick
+    # it up, so deliver it here rather than leaving it to the atexit hook.
+    if _buffer:
+        try:
+            await _drain_until(max(deadline, time.monotonic() + min(timeout, 1.0)))
+        except Exception as exc:
+            logger.debug("capture drain failed (%s)", exc)
 
 
 async def _await_cancelled(task: asyncio.Task) -> None:
@@ -492,9 +618,10 @@ def _configure(
     batch_size: int | None = None,
     flush_interval_s: float | None = None,
     sample_rate: float | None = None,
+    sink_timeout_s: float | None = None,
 ) -> None:
     """Override the cached knobs without going through the environment (tests)."""
-    global QUEUE_SIZE, BATCH_SIZE, FLUSH_INTERVAL_S, SAMPLE_RATE
+    global QUEUE_SIZE, BATCH_SIZE, FLUSH_INTERVAL_S, SAMPLE_RATE, SINK_TIMEOUT_S
     if queue_size is not None:
         QUEUE_SIZE = queue_size
     if batch_size is not None:
@@ -503,6 +630,8 @@ def _configure(
         FLUSH_INTERVAL_S = flush_interval_s
     if sample_rate is not None:
         SAMPLE_RATE = sample_rate
+    if sink_timeout_s is not None:
+        SINK_TIMEOUT_S = sink_timeout_s
 
 
 def _reset_for_tests() -> None:
@@ -527,5 +656,6 @@ def _reset_for_tests() -> None:
         batch_size=_FIELDS["cognee_capture_batch_size"].default,
         flush_interval_s=_FIELDS["cognee_capture_flush_interval_s"].default,
         sample_rate=_FIELDS["cognee_capture_sample_rate"].default,
+        sink_timeout_s=_FIELDS["cognee_capture_sink_timeout_s"].default,
     )
     get_capture_config.cache_clear()

--- a/cognee/modules/observability/capture/hook.py
+++ b/cognee/modules/observability/capture/hook.py
@@ -50,19 +50,39 @@ otherwise freeze concurrent recall coroutines; inside atexit handlers the
 executor is gone and it runs inline. Each sink write is bounded by
 ``SINK_TIMEOUT_S`` so a wedged sink cannot pin the flusher forever.
 
-``_in_flight`` counts popped-but-undelivered events per loop, so ``drain()``
-waits for a batch the flusher is still serializing — but only on loops that
-are running: a batch stranded on a loop that stopped, or was closed without
-cancelling its tasks (pytest-asyncio 0.21), can never complete and must not
-turn every later ``drain()`` into a full timeout. ``drain(timeout)`` is
-authoritative inside a batch too: sink writes are bounded by what is left of
-the budget and whatever could not be delivered goes back to the head of the
-buffer for the flusher / the atexit hook.
+Every timed wait on the flusher and drain paths goes through ``_wait_bounded``,
+never ``asyncio.wait_for``: on CPython < 3.12 ``wait_for`` swallows a
+cancellation that lands in the same loop iteration as the inner awaitable's
+completion (bpo-42130), and a flusher that loses its cancel never leaves its
+``while True`` — ``asyncio.run()``'s teardown and ``shutdown()`` then wait for
+it forever, and a caller cancelled mid-``drain()`` runs on past its own
+cancellation.
+
+A flusher cancelled from outside — ``asyncio.run`` / uvicorn tearing the loop
+down, ``shutdown()`` — stays in ``_flushers`` as a tombstone: its loop is going
+away, so no replacement is started on it. A late emit there (a ``run_tasks``
+generator finalized by ``shutdown_asyncgens()`` after the runner cancelled all
+tasks, a ``record_operation`` ``finally`` on a cancelled main task) would
+otherwise start a fresh flusher that the closing loop destroys mid-batch; the
+event stays in the deque for the next ``drain()`` or the atexit hook instead.
+
+``_in_flight`` holds the batches popped but not yet delivered, per loop, so
+``drain()`` can wait for a batch the flusher is still serializing — but only on
+loops that are running: a batch on a loop that stopped can never complete
+while it is stopped and must not turn every later ``drain()`` into a full
+timeout. A batch stranded on a loop that was CLOSED without cancelling its
+tasks (pytest-asyncio 0.21, a ``run_until_complete`` driver that never resumed)
+goes back to the head of the buffer when the loop is pruned, so it reaches the
+next drain / the atexit hook instead of vanishing with the dead task.
+``drain(timeout)`` is authoritative inside a batch too: sink writes are bounded
+by what is left of the budget and whatever could not be delivered goes back to
+the head of the buffer for the flusher / the atexit hook.
 
 Delivery is at-least-once: a cancelled flush (``asyncio.run`` teardown, uvicorn
-shutdown) or a drain whose budget ran out mid-write re-buffers the group that
-was being written along with the rest, so a consumer may see the same record
-twice. Blob names are collision-free, so nothing is overwritten.
+shutdown), a drain whose budget ran out mid-write, or a batch recovered from a
+dead loop re-buffers the group that was being written along with the rest, so
+a consumer may see the same record twice. Blob names are collision-free, so
+nothing is overwritten.
 """
 
 from __future__ import annotations
@@ -74,7 +94,7 @@ import random
 import time
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Awaitable, TypeVar
 from uuid import UUID
 
 from cognee.shared.logging_utils import get_logger
@@ -88,6 +108,8 @@ if TYPE_CHECKING:
 
 logger = get_logger("eval_capture")
 
+T = TypeVar("T")
+
 # Knobs. Defaults mirror CaptureConfig; _load_knobs() overwrites them from the
 # environment once per process, _configure() from tests.
 _FIELDS = CaptureConfig.model_fields
@@ -98,6 +120,9 @@ SAMPLE_RATE: float = _FIELDS["cognee_capture_sample_rate"].default
 SINK_TIMEOUT_S: float = _FIELDS["cognee_capture_sink_timeout_s"].default
 # Floor for the interval tick: a non-positive interval would spin the flusher.
 _MIN_FLUSH_INTERVAL_S: float = 0.01
+# How long shutdown() / _reset_for_tests() wait for a cancelled flusher to
+# finish: a regression that loses the cancel must fail a test, not hang it.
+_CANCEL_GRACE_S: float = 1.0
 
 # Module state.
 _sink: CaptureSink | None = None
@@ -106,11 +131,15 @@ _buffer: collections.deque[CaptureEvent] = collections.deque()
 # Process-global, monotonic, approximate (lock-free on the emit path). Reported
 # once per manifest as a delta, never logged per drop.
 _dropped: int = 0
-# Events popped from the buffer but not yet delivered (serializing or awaiting
-# the sink), keyed by the loop doing the work. A loop runs in one thread at a
-# time, so each key is only ever mutated by its owner thread — no lock needed.
-# drain() waits on the RUNNING loops' counts only (see _in_flight_live()).
-_in_flight: dict[asyncio.AbstractEventLoop, int] = {}
+# Batches popped from the buffer but not yet delivered (serializing or awaiting
+# the sink), keyed by the loop doing the work. Each entry is the batch's slot
+# list — an event until its group is acknowledged, None afterwards — so the
+# undelivered remainder is always reachable from here, not only from the frame
+# of the task doing the flush. A loop runs in one thread at a time, so each
+# key is only ever mutated by its owner thread; other threads only read, or
+# pop the key of a CLOSED loop (which no thread runs any more). drain() waits
+# on the RUNNING loops' counts only (see _in_flight_live()).
+_in_flight: dict[asyncio.AbstractEventLoop, list[list[CaptureEvent | None]]] = {}
 _atexit_registered: bool = False
 
 # The active manifest scope (owned here so manifest.py can import it without a
@@ -127,6 +156,8 @@ class _Flusher:
     # callback instead of one per emit.
     wake_pending: bool = False
     # Bound right after creation: the flush task needs the flusher, the flusher the task.
+    # A task that ended cancelled turns this entry into a tombstone for its
+    # loop (see _ensure_flusher).
     task: asyncio.Task = field(init=False)
 
 
@@ -207,10 +238,15 @@ def _register_atexit() -> None:
 
 
 def _flush_at_exit() -> None:
+    if _sink is None:
+        return
+    # Batches stranded on loops that were closed without cancelling their tasks
+    # go back to the buffer first, so they are part of what gets persisted.
+    _prune_closed_loops()
     # Only batches on a loop that is still running (a daemon thread's) can
-    # complete here; anything stranded on a stopped or closed loop cannot, and
-    # waiting for it would just add a full timeout to every interpreter exit.
-    if _sink is None or not (_buffer or _in_flight_live()):
+    # complete here; anything on a stopped loop cannot, and waiting for it
+    # would just add a full timeout to every interpreter exit.
+    if not (_buffer or _in_flight_live()):
         return
     if _get_running_loop() is not None:
         return
@@ -261,6 +297,7 @@ def register_capture_sink(sink: CaptureSink | None) -> None:
     An explicit registration overrides env auto-registration of the SINK
     (mirrors ``register_activity_sink`` semantics); the tuning knobs
     (``COGNEE_CAPTURE_QUEUE_SIZE`` etc.) still come from the environment.
+    Registering a sink re-arms flushing on loops ``shutdown()`` stopped.
     """
     global _sink, _initialized
     if not _initialized:
@@ -271,6 +308,7 @@ def register_capture_sink(sink: CaptureSink | None) -> None:
             logger.debug("capture config unavailable, keeping default knobs (%s)", exc)
     _sink = sink
     if sink is not None:
+        _forget_stopped_flushers()
         _register_atexit()
 
 
@@ -382,12 +420,22 @@ def _enqueue(event: CaptureEvent) -> None:
 
 
 def _ensure_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
-    """Return this loop's live flusher, starting one if absent or done()."""
+    """Return this loop's live flusher, starting one if absent or crashed.
+
+    ``None`` for a loop whose flusher was CANCELLED: that is the runner tearing
+    the loop down (``asyncio.run``, uvicorn) or ``shutdown()``, and a fresh
+    flusher started on a closing loop is destroyed with its popped batch. The
+    cancelled entry stays as a tombstone until the loop is closed and pruned,
+    or a sink is (re)registered. A flusher that CRASHED is replaced.
+    """
     flusher = _flushers.get(loop)
-    if flusher is None or flusher.task.done():
-        # A done() flusher (crashed, cancelled) is treated as absent.
-        flusher = _start_flusher(loop)
-    return flusher
+    if flusher is not None:
+        task = flusher.task
+        if not task.done():
+            return flusher
+        if task.cancelled():
+            return None
+    return _start_flusher(loop)
 
 
 def ensure_flusher() -> None:
@@ -420,33 +468,55 @@ def _start_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
 
     _flushers[loop] = flusher
 
-    def _discard(_task: asyncio.Task) -> None:
-        if _flushers.get(loop) is flusher:
-            _flushers.pop(loop, None)
+    def _on_done(task: asyncio.Task) -> None:
+        if _flushers.get(loop) is not flusher:
+            return
+        if task.cancelled():
+            # Keep the entry as a tombstone (see _ensure_flusher): the loop
+            # is going away, no replacement is started on it.
+            return
+        _flushers.pop(loop, None)
+        # A crash (a BaseException out of a sink) ended the task; retrieving
+        # the exception here keeps asyncio's "Task exception was never
+        # retrieved" ERROR out of the logs. The next emit starts a replacement.
+        exc = task.exception()
+        if exc is not None:
+            logger.debug("capture flusher stopped (%r)", exc)
 
-    flusher.task.add_done_callback(_discard)
+    flusher.task.add_done_callback(_on_done)
     return flusher
 
 
 def _prune_closed_loops() -> None:
-    """Forget flushers and in-flight batches stranded on closed loops.
+    """Forget flushers on closed loops; re-buffer the batches stranded there.
 
     Explicit because ``add_done_callback`` never fires for a task parked on a
-    closed loop. The events such a task had popped can never be delivered (the
-    task was destroyed with its loop), so they are counted as dropped. A loop
-    that merely stopped keeps its entries: it may run again (a driver calling
-    ``run_until_complete`` repeatedly) and its task is still cancellable by
-    ``shutdown()`` / ``_reset_for_tests()``; ``_any_live_flusher()`` and
-    ``_in_flight_live()`` skip it while it is not running.
+    closed loop. A batch such a task had popped can never be acknowledged (the
+    task died with its loop), so its undelivered slots go back to the head of
+    the buffer for the next drain / the atexit hook — at-least-once: a group
+    whose sink write completed but whose acknowledgement never ran is written
+    again. A loop that merely stopped keeps its entries: it may run again (a
+    driver calling ``run_until_complete`` repeatedly) and its task is still
+    cancellable by ``shutdown()`` / ``_reset_for_tests()``;
+    ``_any_live_flusher()`` and ``_in_flight_live()`` skip it while it is not
+    running.
     """
-    global _dropped
-    # Snapshot the items — another thread may be mutating the dicts.
-    for stale_loop, stale in list(_flushers.items()):
-        if stale_loop.is_closed() or stale.task.done():
+    # Snapshot the keys — another thread may be mutating the dicts. Only a
+    # closed loop's entries are touched, and no thread runs a closed loop.
+    for stale_loop in list(_flushers):
+        if stale_loop.is_closed():
             _flushers.pop(stale_loop, None)
     for stale_loop in list(_in_flight):
         if stale_loop.is_closed():
-            _dropped += _in_flight.pop(stale_loop, 0)
+            for pending in _in_flight.pop(stale_loop, ()):
+                _requeue(pending)
+
+
+def _forget_stopped_flushers() -> None:
+    """Drop tombstones so flushing can resume on their loops (sink re-registered)."""
+    for loop, flusher in list(_flushers.items()):
+        if flusher.task.done():
+            _flushers.pop(loop, None)
 
 
 def _any_live_flusher() -> _Flusher | None:
@@ -467,23 +537,37 @@ def _any_live_flusher() -> _Flusher | None:
 # ---------------------------------------------------------------------------
 
 
-def _in_flight_add(loop: asyncio.AbstractEventLoop, count: int) -> None:
+def _track_in_flight(loop: asyncio.AbstractEventLoop, pending: list[CaptureEvent | None]) -> None:
     # Only ever called from ``loop``'s own thread (see _in_flight).
-    total = _in_flight.get(loop, 0) + count
-    if total > 0:
-        _in_flight[loop] = total
-    else:
+    _in_flight.setdefault(loop, []).append(pending)
+
+
+def _untrack_in_flight(loop: asyncio.AbstractEventLoop, pending: list[CaptureEvent | None]) -> None:
+    batches = _in_flight.get(loop)
+    if batches is None:
+        return  # already recovered by _prune_closed_loops (loop closed under us)
+    for index, candidate in enumerate(batches):
+        if candidate is pending:
+            del batches[index]
+            break
+    if not batches:
         _in_flight.pop(loop, None)
+
+
+def _count_pending(batches: list[list[CaptureEvent | None]]) -> int:
+    return sum(1 for pending in list(batches) for event in pending if event is not None)
 
 
 def _in_flight_total() -> int:
     """Popped-but-undelivered events on every loop (tests, diagnostics)."""
-    return sum(list(_in_flight.values()))
+    return sum(_count_pending(batches) for batches in list(_in_flight.values()))
 
 
 def _in_flight_live() -> int:
     """Popped-but-undelivered events on loops that can still deliver them."""
-    return sum(count for loop, count in list(_in_flight.items()) if loop.is_running())
+    return sum(
+        _count_pending(batches) for loop, batches in list(_in_flight.items()) if loop.is_running()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -491,12 +575,44 @@ def _in_flight_live() -> int:
 # ---------------------------------------------------------------------------
 
 
+async def _wait_bounded(awaitable: Awaitable[T], timeout: float | None) -> T:
+    """``asyncio.wait_for`` that cannot swallow the caller's cancellation.
+
+    On CPython < 3.12 ``wait_for`` returns the inner result instead of raising
+    when the cancel lands in the same loop iteration as the inner completion
+    (bpo-42130): ``Task.cancel()`` consumed the request and it is lost. Here
+    the caller parks on ``asyncio.wait``, whose waiter future carries the
+    cancellation straight through. Like ``wait_for``, a timeout cancels the
+    inner awaitable and waits for that cancellation to land before raising
+    ``asyncio.TimeoutError``, so the inner is never left running.
+    """
+    future = asyncio.ensure_future(awaitable)
+    if timeout is None:
+        # A direct await propagates a racing cancel correctly (it is wait_for's
+        # `if fut.done(): return fut.result()` that does not).
+        return await future
+    try:
+        done, _pending = await asyncio.wait({future}, timeout=timeout)
+    except asyncio.CancelledError:
+        # The caller was cancelled: take the inner down with it, and — like
+        # wait_for — do not return while it may still be running.
+        if not future.done():
+            future.cancel()
+            await asyncio.wait({future})
+        raise
+    if not done:
+        future.cancel()
+        await asyncio.wait({future})
+        raise asyncio.TimeoutError
+    return future.result()
+
+
 async def _flush_loop(flusher: _Flusher) -> None:
     wake = flusher.wake
     while True:
         try:
             try:
-                await asyncio.wait_for(wake.wait(), FLUSH_INTERVAL_S)
+                await _wait_bounded(wake.wait(), FLUSH_INTERVAL_S)
             except asyncio.TimeoutError:
                 pass  # interval tick
             wake.clear()
@@ -540,7 +656,11 @@ def _serialize_batch(batch: list[CaptureEvent]) -> list[dict]:
 
         scope = event.scope
         run_id = event.run_id or (scope.run_id if scope is not None else None)
-        dataset_id = event.dataset_id or (scope.dataset_id if scope is not None else None)
+        # A scope without a dataset of its own (an operation recorded inside a
+        # pipeline task) is attributed to the enclosing run's dataset.
+        dataset_id = event.dataset_id or (
+            scope.resolved_dataset_id() if scope is not None else None
+        )
         records.append(
             {
                 "kind": event.kind,
@@ -555,10 +675,17 @@ def _serialize_batch(batch: list[CaptureEvent]) -> list[dict]:
 
 
 def _requeue(pending: list[CaptureEvent | None]) -> None:
-    """Put the not-yet-delivered events back at the head of the buffer, in order."""
+    """Put the not-yet-delivered events back at the head of the buffer, in order.
+
+    The slots are blanked so the batch counts as nothing in flight afterwards:
+    an event is always in exactly one of the buffer, a tracked batch, the sink,
+    or ``_dropped``.
+    """
     leftovers = [event for event in pending if event is not None]
     if leftovers:
         _buffer.extendleft(reversed(leftovers))
+        for index in range(len(pending)):
+            pending[index] = None
 
 
 def _remaining(deadline: float | None) -> float | None:
@@ -578,9 +705,10 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
     buffer for the flusher / the atexit hook (at-least-once, see the module
     docstring). The flusher passes no deadline.
 
-    The popped events are counted in ``_in_flight`` for this loop from pop to
+    The popped events are tracked in ``_in_flight`` for this loop from pop to
     delivery so ``drain()`` can wait for a batch another consumer is still
-    serializing.
+    serializing, and so ``_prune_closed_loops`` can recover the batch if the
+    loop dies under it.
     """
     global _dropped
     buffer = _buffer
@@ -602,16 +730,16 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
         return len(batch)
 
     loop = asyncio.get_running_loop()
-    # Events not yet handed to the sink; on cancellation or a spent deadline these go back.
+    # One slot per event, blanked as its group is acknowledged; on cancellation
+    # or a spent deadline the rest goes back to the buffer.
     pending: list[CaptureEvent | None] = list(batch)
-    outstanding = len(batch)
-    _in_flight_add(loop, outstanding)
+    _track_in_flight(loop, pending)
     try:
         records: list[dict] | None = None
         remaining = _remaining(deadline)
         if remaining is None or remaining > 0:
             try:
-                records = await asyncio.wait_for(run_off_loop(_serialize_batch, batch), remaining)
+                records = await _wait_bounded(run_off_loop(_serialize_batch, batch), remaining)
             except asyncio.TimeoutError:
                 pass  # budget spent while serializing: the whole batch goes back
 
@@ -631,7 +759,7 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
                     bound = min(bound, remaining)
                 group = [records[index] for index in indexes]
                 try:
-                    await asyncio.wait_for(sink(group), bound)
+                    await _wait_bounded(sink(group), bound)
                 except asyncio.TimeoutError as exc:
                     if deadline is not None and time.monotonic() >= deadline:
                         break  # the caller's budget ran out, not the sink's: retry later
@@ -640,27 +768,27 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
                     logger.debug("capture sink failed (%s)", exc)
                 for index in indexes:
                     pending[index] = None
-                outstanding -= len(indexes)
-                _in_flight_add(loop, -len(indexes))
                 # Let other coroutines interleave between sink writes.
                 await asyncio.sleep(0)
 
         # Deadline leftovers (never any for the flusher, which has no deadline).
         _requeue(pending)
-    except asyncio.CancelledError:
-        # asyncio.run teardown / uvicorn shutdown: do not lose the popped batch.
-        _requeue(pending)
-        raise
     except Exception as exc:
         # Not re-queued: a deterministic failure would pin the head of the
         # buffer forever. Account for the loss instead of hiding it.
         lost = sum(1 for event in pending if event is not None)
         _dropped += lost
         logger.debug("capture flush failed, %d event(s) dropped (%s)", lost, exc)
+    except BaseException:
+        # Cancellation (asyncio.run teardown, uvicorn shutdown, a cancelled
+        # drain() caller) or a KeyboardInterrupt/SystemExit escaping a sink:
+        # do not lose the popped batch.
+        _requeue(pending)
+        raise
     finally:
         # Whatever was not delivered is either back in the buffer or dropped:
         # in no case is it still in flight.
-        _in_flight_add(loop, -outstanding)
+        _untrack_in_flight(loop, pending)
     return len(batch)
 
 
@@ -670,6 +798,9 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
 
 
 async def _drain_until(deadline: float) -> None:
+    # Batches stranded on loops closed since the last pass go back to the
+    # buffer first, so this drain covers them too.
+    _prune_closed_loops()
     # (a) Inline on the calling loop: flush what is buffered NOW. The deque is
     # the coordination point — popleft is atomic, so a concurrently running
     # flusher and this drain simply split the work (blob names are
@@ -683,11 +814,10 @@ async def _drain_until(deadline: float) -> None:
             break  # the flusher took the rest; never spin
         budget -= popped
     # (b) Wait for batches other consumers hold (popped, serializing or
-    # awaiting their sink): plain int counters, no foreign-loop futures — and
-    # only on loops that are running. A batch stranded on a stopped or closed
-    # loop can never complete; waiting for it would turn every later drain()
-    # in the process into a full timeout.
-    _prune_closed_loops()
+    # awaiting their sink): plain counters, no foreign-loop futures — and only
+    # on loops that are running. A batch on a stopped loop cannot complete
+    # while it is stopped; waiting for it would turn every later drain() in
+    # the process into a full timeout.
     while _in_flight_live() > 0 and time.monotonic() < deadline:
         await asyncio.sleep(0.01)
 
@@ -695,10 +825,11 @@ async def _drain_until(deadline: float) -> None:
 async def drain(timeout: float = 5.0) -> None:
     """Flush the events buffered so far, then wait for in-flight batches.
 
-    Never requires a flusher to exist, never raises, and returns within about
-    ``timeout`` — the budget is enforced inside a batch too, per sink write —
-    even under a continuous producer or a wedged sink (leftovers stay with the
-    flusher / the atexit hook).
+    Never requires a flusher to exist, never raises (a cancellation of the
+    caller propagates, as it must), and returns within about ``timeout`` — the
+    budget is enforced inside a batch too, per sink write — even under a
+    continuous producer or a wedged sink (leftovers stay with the flusher /
+    the atexit hook).
     """
     try:
         await _drain_until(time.monotonic() + timeout)
@@ -709,9 +840,13 @@ async def drain(timeout: float = 5.0) -> None:
 async def shutdown(timeout: float = 5.0) -> None:
     """Drain, stop every flusher, then deliver anything a cancelled flush put back.
 
-    For process teardown (FastAPI lifespan, tests), not the request path.
+    For process teardown (FastAPI lifespan, tests), not the request path. The
+    stopped flushers stay registered as tombstones, so an emit that arrives
+    after shutdown (one more request during a lifespan shutdown) does not
+    start a new flusher: it stays in the deque for the atexit hook.
     """
     deadline = time.monotonic() + timeout
+    grace = min(timeout, _CANCEL_GRACE_S)
     await drain(timeout)
     current_loop = _get_running_loop()
     same_loop_tasks: list[asyncio.Task] = []
@@ -719,23 +854,16 @@ async def shutdown(timeout: float = 5.0) -> None:
         if flusher.loop is current_loop and not flusher.task.done():
             same_loop_tasks.append(flusher.task)
         _cancel_flusher(flusher, wait=False)
-    _flushers.clear()
     if same_loop_tasks:
-        await asyncio.gather(*same_loop_tasks, return_exceptions=True)
+        # Bounded: a flusher that failed to honour its cancel must not hang teardown.
+        await asyncio.wait(same_loop_tasks, timeout=grace)
     # A flusher cancelled mid-batch re-buffered it; no flusher is left to pick
     # it up, so deliver it here rather than leaving it to the atexit hook.
     if _buffer:
         try:
-            await _drain_until(max(deadline, time.monotonic() + min(timeout, 1.0)))
+            await _drain_until(max(deadline, time.monotonic() + grace))
         except Exception as exc:
             logger.debug("capture drain failed (%s)", exc)
-
-
-async def _await_cancelled(task: asyncio.Task) -> None:
-    try:
-        await task
-    except (asyncio.CancelledError, Exception):
-        pass
 
 
 def _cancel_flusher(flusher: _Flusher, *, wait: bool) -> None:
@@ -752,9 +880,11 @@ def _cancel_flusher(flusher: _Flusher, *, wait: bool) -> None:
     else:
         flusher.task.cancel()
         if wait:
-            # Deliver the cancellation so the task is not destroyed while pending.
+            # Deliver the cancellation so the task is not destroyed while
+            # pending. Bounded: a regression that loses the cancel must fail a
+            # test, not hang the suite.
             try:
-                loop.run_until_complete(_await_cancelled(flusher.task))
+                loop.run_until_complete(asyncio.wait({flusher.task}, timeout=_CANCEL_GRACE_S))
             except Exception:
                 pass
 

--- a/cognee/modules/observability/capture/hook.py
+++ b/cognee/modules/observability/capture/hook.py
@@ -1,0 +1,531 @@
+"""Non-blocking eval capture hook (SDK-529).
+
+Captures what the pipeline produces and chooses (per-chunk graphs, merge
+decisions, summaries, retrieval candidate pools, run manifests) for offline
+evals, at ZERO cost when disabled and near-zero on the hot path when enabled.
+Capture never breaks, slows (beyond the snapshot cost), or blocks the
+operation it observes.
+
+Hot-path contract
+-----------------
+* ``emit()`` starts with ``sink = _sink; if sink is None: return`` — the OFF
+  cost is one global read, no allocation. Only after that is the
+  ``CaptureEvent`` built and appended to the deque. On a full buffer the
+  newest event is dropped and ``_dropped`` incremented. No serialization, no
+  I/O, no await, no logging, no config read, no exception path — ever.
+* ``is_active()`` is one global read in steady state (a flag-guarded one-time
+  ``_ensure_initialized()`` on first call). Callers hoist it out of loops.
+* Sinks run only from the background flusher or ``drain()``/``shutdown()``.
+* Snapshot rule: ``emit()`` never serializes, so an emit point whose payload is
+  mutated afterwards MUST pass a snapshot — for pydantic graphs
+  ``payload=graph.model_dump(mode="json"), payload_kind="json"`` (~32 µs per
+  40n/60e KnowledgeGraph). Not ``model_copy(deep=True)`` (8x slower) and not a
+  shallow ``model_copy`` (shares Node instances). Immutable payloads may be
+  passed by reference.
+
+Buffering
+---------
+``collections.deque``: append/popleft are atomic under the GIL and loop- and
+thread-agnostic — emit is reached from ``to_thread``'d sync code, run_sync's
+thread, the dataset-queue reaper thread, and across ``asyncio.run``
+boundaries. ``asyncio.Queue`` is loop-bound and its ``put_nowait`` from a
+foreign thread wakes getters via loop-owned futures, so it is rejected. The
+``len() >= QUEUE_SIZE`` check is a soft bound across threads (harmless).
+
+Flushing
+--------
+One flusher task per event loop, started lazily by the first on-loop emit and
+woken either by the ``FLUSH_INTERVAL_S`` tick or by ``emit()`` when the buffer
+reaches ``BATCH_SIZE`` (``call_soon_threadsafe`` — the only loop primitive safe
+from any thread/loop). Serialization runs in ``asyncio.to_thread`` because it
+is pure CPU (~15 ms per 64-graph batch) and would otherwise freeze concurrent
+recall coroutines. A cancelled flush pushes its popped batch back so
+``asyncio.run`` teardown loses nothing; the atexit hook or next ``drain()``
+picks it up. Known limitation: a loop closed WITHOUT cancelling (pytest-asyncio
+0.21) loses an in-flight batch — tests drain explicitly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import collections
+import random
+import time
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from cognee.shared.logging_utils import get_logger
+
+from .config import CaptureConfig, get_capture_config
+from .events import RETRIEVAL_KIND_PREFIX, CaptureEvent
+from .sinks import CaptureSink, StorageSink
+
+if TYPE_CHECKING:
+    from .manifest import RunScope
+
+logger = get_logger("eval_capture")
+
+# Knobs. Defaults mirror CaptureConfig; _ensure_initialized() overwrites them
+# from the environment once per process, _configure() from tests.
+_FIELDS = CaptureConfig.model_fields
+QUEUE_SIZE: int = _FIELDS["cognee_capture_queue_size"].default
+BATCH_SIZE: int = _FIELDS["cognee_capture_batch_size"].default
+FLUSH_INTERVAL_S: float = _FIELDS["cognee_capture_flush_interval_s"].default
+SAMPLE_RATE: float = _FIELDS["cognee_capture_sample_rate"].default
+
+# Module state.
+_sink: CaptureSink | None = None
+_initialized: bool = False
+_buffer: collections.deque[CaptureEvent] = collections.deque()
+# Process-global, monotonic. Reported once per manifest as a delta, never logged per drop.
+_dropped: int = 0
+# Sink writes currently awaited, on any loop.
+_in_flight: int = 0
+_atexit_registered: bool = False
+
+# The active manifest scope (owned here so manifest.py can import it without a
+# runtime cycle; manifest.py owns RunScope and run_scope()).
+_current_scope: ContextVar[RunScope | None] = ContextVar("cognee_capture_scope", default=None)
+
+
+@dataclass(slots=True)
+class _Flusher:
+    task: asyncio.Task
+    loop: asyncio.AbstractEventLoop
+    wake: asyncio.Event
+
+
+_flushers: dict[asyncio.AbstractEventLoop, _Flusher] = {}
+
+
+def _running_loop_fallback() -> asyncio.AbstractEventLoop | None:
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+
+
+# asyncio._get_running_loop returns None instead of raising: no exception path per emit.
+_get_running_loop = getattr(asyncio, "_get_running_loop", _running_loop_fallback)
+
+
+# ---------------------------------------------------------------------------
+# Initialization and registration
+# ---------------------------------------------------------------------------
+
+
+def _register_atexit() -> None:
+    """Flush leftovers at interpreter exit (mirrors ``_register_telemetry_session_atexit``).
+
+    Covers the CLI (``asyncio.run`` per command cancels the flusher, the
+    cancelled batch is pushed back, atexit flushes it) and uvicorn (loop closed
+    before interpreter exit).
+    """
+    global _atexit_registered
+    if _atexit_registered:
+        return
+    _atexit_registered = True
+    atexit.register(_flush_at_exit)
+
+
+def _flush_at_exit() -> None:
+    if _sink is None or not (_buffer or _in_flight):
+        return
+    if _get_running_loop() is not None:
+        return
+    try:
+        asyncio.run(drain(1.0))
+    except Exception:
+        pass
+
+
+def _ensure_initialized() -> None:
+    """Read the config once per process and auto-register the storage sink.
+
+    Guarded by ``_initialized`` (NOT by ``_sink``). This is the ONLY place
+    ``get_capture_config()`` is consulted at runtime, and it is reached from
+    ``is_active()`` — never from ``emit()``. A failing initialization (bad
+    env, unreachable storage) logs once and leaves capture off: capture must
+    never break the operation it observes.
+    """
+    global _initialized, _sink, QUEUE_SIZE, BATCH_SIZE, FLUSH_INTERVAL_S, SAMPLE_RATE
+    if _initialized:
+        return
+    _initialized = True
+    try:
+        config = get_capture_config()
+        QUEUE_SIZE = config.cognee_capture_queue_size
+        BATCH_SIZE = config.cognee_capture_batch_size
+        FLUSH_INTERVAL_S = config.cognee_capture_flush_interval_s
+        SAMPLE_RATE = config.cognee_capture_sample_rate
+        if config.cognee_capture_enabled and _sink is None:
+            # Lazy: keeps this module free of the storage/base_config import chain.
+            from cognee.infrastructure.files.storage import get_file_storage
+
+            _sink = StorageSink(get_file_storage(config.cognee_capture_dir))
+            _register_atexit()
+    except Exception as exc:
+        logger.warning("eval capture disabled: initialization failed (%s)", exc)
+
+
+def is_active() -> bool:
+    """True when a sink is registered. Hoist out of per-node loops."""
+    if not _initialized:
+        _ensure_initialized()
+    return _sink is not None
+
+
+def register_capture_sink(sink: CaptureSink | None) -> None:
+    """Process-wide sink registration; last wins, ``None`` clears.
+
+    An explicit registration overrides env auto-registration (mirrors
+    ``register_activity_sink`` semantics).
+    """
+    global _sink, _initialized
+    _sink = sink
+    _initialized = True
+    if sink is not None:
+        _register_atexit()
+
+
+# ---------------------------------------------------------------------------
+# Emit (hot path)
+# ---------------------------------------------------------------------------
+
+
+def emit(
+    kind: str,
+    payload: Any,
+    *,
+    payload_kind: str = "pydantic",
+    stage: str | None = None,
+    run_id: UUID | str | None = None,
+    dataset_id: UUID | str | None = None,
+) -> None:
+    """Buffer one observation. Never serializes, awaits, logs, or blocks.
+
+    ``payload`` is kept by reference — see the snapshot rule in the module
+    docstring for payloads mutated after emit. ``run_id``/``dataset_id`` are
+    explicit overrides; unset values are resolved from the active
+    ``run_scope`` at serialization time.
+    """
+    global _dropped
+    sink = _sink
+    if sink is None:
+        return
+
+    buffer = _buffer
+    if len(buffer) >= QUEUE_SIZE:
+        # Drop-NEWEST: the buffer is a bounded observation window, not a queue
+        # the pipeline waits on.
+        _dropped += 1
+        return
+
+    buffer.append(
+        CaptureEvent(
+            kind=kind,
+            payload=payload,
+            payload_kind=payload_kind,
+            run_id=run_id,
+            dataset_id=dataset_id,
+            scope=_current_scope.get(),
+            stage=stage,
+            ts=time.time(),
+        )
+    )
+
+    loop = _get_running_loop()
+    flusher: _Flusher | None = None
+    if loop is not None:
+        flusher = _flushers.get(loop)
+        if flusher is None or flusher.task.done():
+            # A done() flusher (crashed, cancelled) is treated as absent.
+            flusher = _start_flusher(loop)
+    # else: a worker-thread emit; the deque is picked up by whichever flusher runs next.
+
+    if len(buffer) >= BATCH_SIZE:
+        if flusher is None:
+            flusher = _any_live_flusher()
+        if flusher is not None and not flusher.loop.is_closed() and not flusher.wake.is_set():
+            # is_set() pre-check: fires at most once per batch (~100 ns on-loop).
+            try:
+                flusher.loop.call_soon_threadsafe(flusher.wake.set)
+            except RuntimeError:
+                pass  # loop closing
+
+
+def _start_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
+    # Prune explicitly: add_done_callback never fires for a task parked on a
+    # closed loop. Snapshot the items — another thread may be mutating the dict.
+    for stale_loop, stale in list(_flushers.items()):
+        if stale_loop.is_closed() or stale.task.done():
+            _flushers.pop(stale_loop, None)
+
+    wake = asyncio.Event()
+    flush_coroutine = _flush_loop(wake)
+    try:
+        task = loop.create_task(flush_coroutine)
+    except RuntimeError:
+        # Loop closing — same posture as _TELEMETRY_TASKS in cognee/shared/utils.py.
+        flush_coroutine.close()
+        return None
+
+    flusher = _Flusher(task, loop, wake)
+    _flushers[loop] = flusher
+
+    def _discard(_task: asyncio.Task) -> None:
+        if _flushers.get(loop) is flusher:
+            _flushers.pop(loop, None)
+
+    task.add_done_callback(_discard)
+    return flusher
+
+
+def _any_live_flusher() -> _Flusher | None:
+    for flusher in list(_flushers.values()):
+        if not flusher.loop.is_closed() and not flusher.task.done():
+            return flusher
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Flusher
+# ---------------------------------------------------------------------------
+
+
+async def _flush_loop(wake: asyncio.Event) -> None:
+    while True:
+        try:
+            try:
+                await asyncio.wait_for(wake.wait(), FLUSH_INTERVAL_S)
+            except asyncio.TimeoutError:
+                pass  # interval tick
+            wake.clear()
+            # Burst absorption: after a full batch keep flushing until the buffer
+            # is below the threshold; sleep only when quiet.
+            while _buffer:
+                await _flush_one_batch()
+                if len(_buffer) < BATCH_SIZE:
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # A bad iteration must never kill the task.
+            logger.debug("capture flusher iteration failed (%s)", exc)
+
+
+def _serialize_payload(event: CaptureEvent) -> Any:
+    payload_kind = event.payload_kind
+    if payload_kind == "pydantic":
+        return event.payload.model_dump(mode="json")
+    if payload_kind in ("json", "text"):
+        return event.payload
+    raise ValueError(f"unknown payload_kind {payload_kind!r}")
+
+
+def _serialize_batch(batch: list[CaptureEvent]) -> list[dict]:
+    """Turn events into sink records. Runs in a worker thread (pure CPU)."""
+    records: list[dict] = []
+    for event in batch:
+        try:
+            payload = _serialize_payload(event)
+        except Exception as exc:
+            # Keep the record so the run's event count stays honest.
+            logger.debug("capture payload serialization failed (%s)", exc)
+            payload = {"error": repr(exc)}
+
+        scope = event.scope
+        run_id = event.run_id or (scope.run_id if scope is not None else None)
+        dataset_id = event.dataset_id or (scope.dataset_id if scope is not None else None)
+        records.append(
+            {
+                "kind": event.kind,
+                "run_id": None if run_id is None else str(run_id),
+                "dataset_id": None if dataset_id is None else str(dataset_id),
+                "stage": event.stage,
+                "ts": event.ts,
+                "payload": payload,
+            }
+        )
+    return records
+
+
+async def _flush_one_batch() -> None:
+    """Pop up to BATCH_SIZE events, serialize off-loop, hand groups to the sink."""
+    global _in_flight
+    buffer = _buffer
+    batch: list[CaptureEvent] = []
+    try:
+        while buffer and len(batch) < BATCH_SIZE:
+            batch.append(buffer.popleft())
+    except IndexError:
+        pass  # raced with another consumer (drain + flusher split the work)
+    if not batch:
+        return
+
+    sink = _sink
+    if sink is None:
+        return  # sink cleared after these were queued: nothing to deliver to
+
+    # Events not yet handed to the sink; on cancellation these go back.
+    pending: list[CaptureEvent | None] = list(batch)
+    try:
+        records = await asyncio.to_thread(_serialize_batch, batch)
+
+        groups: dict[tuple[str | None, str], list[int]] = {}
+        for index, record in enumerate(records):
+            groups.setdefault((record["run_id"], record["kind"]), []).append(index)
+
+        for indexes in groups.values():
+            group = [records[index] for index in indexes]
+            _in_flight += 1
+            try:
+                await sink(group)
+            except Exception as exc:
+                logger.debug("capture sink failed (%s)", exc)
+            finally:
+                _in_flight -= 1
+            for index in indexes:
+                pending[index] = None
+            # Let other coroutines interleave between sink writes.
+            await asyncio.sleep(0)
+    except asyncio.CancelledError:
+        # asyncio.run teardown / uvicorn shutdown: do not lose the popped batch.
+        buffer.extendleft(reversed([event for event in pending if event is not None]))
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Drain / shutdown
+# ---------------------------------------------------------------------------
+
+
+async def drain(timeout: float = 5.0) -> None:
+    """Flush the buffer inline on the calling loop, then wait for in-flight writes.
+
+    Never requires a flusher to exist and never raises. The deque is the
+    coordination point: a concurrently running flusher and a drain simply
+    split the work (blob names are collision-free).
+    """
+    try:
+        while _buffer:
+            await _flush_one_batch()
+        deadline = time.monotonic() + timeout
+        while _in_flight > 0 and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+    except Exception as exc:
+        logger.debug("capture drain failed (%s)", exc)
+
+
+async def shutdown(timeout: float = 5.0) -> None:
+    """Drain, then stop every flusher. For process teardown, not the request path."""
+    await drain(timeout)
+    current_loop = _get_running_loop()
+    same_loop_tasks: list[asyncio.Task] = []
+    for flusher in list(_flushers.values()):
+        if flusher.loop is current_loop and not flusher.task.done():
+            same_loop_tasks.append(flusher.task)
+        _cancel_flusher(flusher, wait=False)
+    _flushers.clear()
+    if same_loop_tasks:
+        await asyncio.gather(*same_loop_tasks, return_exceptions=True)
+
+
+async def _await_cancelled(task: asyncio.Task) -> None:
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+def _cancel_flusher(flusher: _Flusher, *, wait: bool) -> None:
+    loop = flusher.loop
+    if loop.is_closed() or flusher.task.done():
+        return
+    if loop is _get_running_loop():
+        flusher.task.cancel()
+    elif loop.is_running():
+        try:
+            loop.call_soon_threadsafe(flusher.task.cancel)
+        except RuntimeError:
+            pass
+    else:
+        flusher.task.cancel()
+        if wait:
+            # Deliver the cancellation so the task is not destroyed while pending.
+            try:
+                loop.run_until_complete(_await_cancelled(flusher.task))
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Sampling
+# ---------------------------------------------------------------------------
+
+
+def should_capture(kind: str) -> bool:
+    """Per-run sampling gate for retrieval kinds; every other kind is captured.
+
+    Inside a ``run_scope`` the decision was made ONCE at scope entry (no
+    per-emit RNG); without a scope fall back to ``SAMPLE_RATE``.
+    """
+    if not kind.startswith(RETRIEVAL_KIND_PREFIX):
+        return True
+    scope = _current_scope.get()
+    if scope is not None:
+        return scope.sampled
+    return random.random() < SAMPLE_RATE
+
+
+# ---------------------------------------------------------------------------
+# Test hooks
+# ---------------------------------------------------------------------------
+
+
+def _configure(
+    *,
+    queue_size: int | None = None,
+    batch_size: int | None = None,
+    flush_interval_s: float | None = None,
+    sample_rate: float | None = None,
+) -> None:
+    """Override the cached knobs without going through the environment (tests)."""
+    global QUEUE_SIZE, BATCH_SIZE, FLUSH_INTERVAL_S, SAMPLE_RATE
+    if queue_size is not None:
+        QUEUE_SIZE = queue_size
+    if batch_size is not None:
+        BATCH_SIZE = batch_size
+    if flush_interval_s is not None:
+        FLUSH_INTERVAL_S = flush_interval_s
+    if sample_rate is not None:
+        SAMPLE_RATE = sample_rate
+
+
+def _reset_for_tests() -> None:
+    """Return the module to its pristine state (sync).
+
+    Cancels flusher tasks whose loop is still open — and, when that loop is not
+    running, runs it until the cancellation is delivered — so pytest-asyncio
+    0.21.x (which closes loops without cancelling tasks) never destroys a
+    pending flusher.
+    """
+    global _sink, _initialized, _dropped, _in_flight
+    for flusher in list(_flushers.values()):
+        _cancel_flusher(flusher, wait=True)
+    _flushers.clear()
+    _buffer.clear()
+    _dropped = 0
+    _in_flight = 0
+    _sink = None
+    _initialized = False
+    _configure(
+        queue_size=_FIELDS["cognee_capture_queue_size"].default,
+        batch_size=_FIELDS["cognee_capture_batch_size"].default,
+        flush_interval_s=_FIELDS["cognee_capture_flush_interval_s"].default,
+        sample_rate=_FIELDS["cognee_capture_sample_rate"].default,
+    )
+    get_capture_config.cache_clear()

--- a/cognee/modules/observability/capture/hook.py
+++ b/cognee/modules/observability/capture/hook.py
@@ -31,9 +31,10 @@ thread, the dataset-queue reaper thread, and across ``asyncio.run``
 boundaries. ``asyncio.Queue`` is loop-bound and its ``put_nowait`` from a
 foreign thread wakes getters via loop-owned futures, so it is rejected. The
 ``len() >= QUEUE_SIZE`` check is a soft bound across threads (harmless). Run
-manifests bypass the bound (``_emit_unbounded``): the manifest is the record
-that carries ``dropped_events``, so drop-newest must never eat it; the number
-of manifests in flight is bounded by the number of concurrent runs.
+manifests get headroom past the bound (``_emit_manifest``, up to
+``2 * QUEUE_SIZE`` buffered events in total): the manifest is the record that
+carries ``dropped_events``, so drop-newest must not eat it while there is room,
+but the buffer stays finite under a wedged sink.
 
 Flushing
 --------
@@ -42,16 +43,26 @@ at ``run_scope`` entry (so worker-thread emits during a run are picked up by
 the interval tick even when nothing emits on-loop), and woken either by the
 ``FLUSH_INTERVAL_S`` tick or by ``emit()`` when the buffer reaches
 ``BATCH_SIZE`` (``call_soon_threadsafe`` — the only loop primitive safe from
-any thread/loop). Serialization runs in a worker thread because it is pure CPU
-(~15 ms per 64-graph batch) and would otherwise freeze concurrent recall
-coroutines; inside atexit handlers the executor is gone and it runs inline.
-``_in_flight`` counts batches from pop to delivery, so ``drain()`` waits for a
-batch the flusher is still serializing. Each sink write is bounded by
-``SINK_TIMEOUT_S`` so a wedged sink cannot pin the flusher (and every later
-``drain()``) forever. A cancelled flush pushes its popped batch back so
-``asyncio.run`` teardown loses nothing; the atexit hook or next ``drain()``
-picks it up. Known limitation: a loop closed WITHOUT cancelling (pytest-asyncio
-0.21) loses an in-flight batch — tests drain explicitly.
+any thread/loop; a worker-thread emit targets a flusher whose loop is RUNNING,
+since a wake scheduled on a stopped loop would never fire). Serialization runs
+in a worker thread because it is pure CPU (~15 ms per 64-graph batch) and would
+otherwise freeze concurrent recall coroutines; inside atexit handlers the
+executor is gone and it runs inline. Each sink write is bounded by
+``SINK_TIMEOUT_S`` so a wedged sink cannot pin the flusher forever.
+
+``_in_flight`` counts popped-but-undelivered events per loop, so ``drain()``
+waits for a batch the flusher is still serializing — but only on loops that
+are running: a batch stranded on a loop that stopped, or was closed without
+cancelling its tasks (pytest-asyncio 0.21), can never complete and must not
+turn every later ``drain()`` into a full timeout. ``drain(timeout)`` is
+authoritative inside a batch too: sink writes are bounded by what is left of
+the budget and whatever could not be delivered goes back to the head of the
+buffer for the flusher / the atexit hook.
+
+Delivery is at-least-once: a cancelled flush (``asyncio.run`` teardown, uvicorn
+shutdown) or a drain whose budget ran out mid-write re-buffers the group that
+was being written along with the rest, so a consumer may see the same record
+twice. Blob names are collision-free, so nothing is overwritten.
 """
 
 from __future__ import annotations
@@ -85,16 +96,21 @@ BATCH_SIZE: int = _FIELDS["cognee_capture_batch_size"].default
 FLUSH_INTERVAL_S: float = _FIELDS["cognee_capture_flush_interval_s"].default
 SAMPLE_RATE: float = _FIELDS["cognee_capture_sample_rate"].default
 SINK_TIMEOUT_S: float = _FIELDS["cognee_capture_sink_timeout_s"].default
+# Floor for the interval tick: a non-positive interval would spin the flusher.
+_MIN_FLUSH_INTERVAL_S: float = 0.01
 
 # Module state.
 _sink: CaptureSink | None = None
 _initialized: bool = False
 _buffer: collections.deque[CaptureEvent] = collections.deque()
-# Process-global, monotonic. Reported once per manifest as a delta, never logged per drop.
+# Process-global, monotonic, approximate (lock-free on the emit path). Reported
+# once per manifest as a delta, never logged per drop.
 _dropped: int = 0
-# Batches popped from the buffer but not yet delivered (serializing or awaiting
-# the sink), on any loop. drain() waits on it.
-_in_flight: int = 0
+# Events popped from the buffer but not yet delivered (serializing or awaiting
+# the sink), keyed by the loop doing the work. A loop runs in one thread at a
+# time, so each key is only ever mutated by its owner thread — no lock needed.
+# drain() waits on the RUNNING loops' counts only (see _in_flight_live()).
+_in_flight: dict[asyncio.AbstractEventLoop, int] = {}
 _atexit_registered: bool = False
 
 # The active manifest scope (owned here so manifest.py can import it without a
@@ -129,6 +145,49 @@ _get_running_loop = getattr(asyncio, "_get_running_loop", _running_loop_fallback
 
 
 # ---------------------------------------------------------------------------
+# Knobs
+# ---------------------------------------------------------------------------
+
+
+def _configure(
+    *,
+    queue_size: int | None = None,
+    batch_size: int | None = None,
+    flush_interval_s: float | None = None,
+    sample_rate: float | None = None,
+    sink_timeout_s: float | None = None,
+) -> None:
+    """Set the cached knobs (from the config once per process, or from tests).
+
+    Clamped as defence in depth on top of ``CaptureConfig`` validation: a batch
+    size of 0 makes ``_flush_one_batch`` pop nothing, and a consumer that pops
+    nothing without ever suspending would monopolise its event loop; a
+    non-positive interval would spin the flusher.
+    """
+    global QUEUE_SIZE, BATCH_SIZE, FLUSH_INTERVAL_S, SAMPLE_RATE, SINK_TIMEOUT_S
+    if queue_size is not None:
+        QUEUE_SIZE = max(1, queue_size)
+    if batch_size is not None:
+        BATCH_SIZE = max(1, batch_size)
+    if flush_interval_s is not None:
+        FLUSH_INTERVAL_S = max(_MIN_FLUSH_INTERVAL_S, flush_interval_s)
+    if sample_rate is not None:
+        SAMPLE_RATE = sample_rate
+    if sink_timeout_s is not None:
+        SINK_TIMEOUT_S = sink_timeout_s
+
+
+def _load_knobs(config: CaptureConfig) -> None:
+    _configure(
+        queue_size=config.cognee_capture_queue_size,
+        batch_size=config.cognee_capture_batch_size,
+        flush_interval_s=config.cognee_capture_flush_interval_s,
+        sample_rate=config.cognee_capture_sample_rate,
+        sink_timeout_s=config.cognee_capture_sink_timeout_s,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Initialization and registration
 # ---------------------------------------------------------------------------
 
@@ -148,7 +207,10 @@ def _register_atexit() -> None:
 
 
 def _flush_at_exit() -> None:
-    if _sink is None or not (_buffer or _in_flight):
+    # Only batches on a loop that is still running (a daemon thread's) can
+    # complete here; anything stranded on a stopped or closed loop cannot, and
+    # waiting for it would just add a full timeout to every interpreter exit.
+    if _sink is None or not (_buffer or _in_flight_live()):
         return
     if _get_running_loop() is not None:
         return
@@ -158,15 +220,6 @@ def _flush_at_exit() -> None:
         asyncio.run(drain(1.0))
     except Exception:
         pass
-
-
-def _load_knobs(config: CaptureConfig) -> None:
-    global QUEUE_SIZE, BATCH_SIZE, FLUSH_INTERVAL_S, SAMPLE_RATE, SINK_TIMEOUT_S
-    QUEUE_SIZE = config.cognee_capture_queue_size
-    BATCH_SIZE = config.cognee_capture_batch_size
-    FLUSH_INTERVAL_S = config.cognee_capture_flush_interval_s
-    SAMPLE_RATE = config.cognee_capture_sample_rate
-    SINK_TIMEOUT_S = config.cognee_capture_sink_timeout_s
 
 
 def _ensure_initialized() -> None:
@@ -267,7 +320,7 @@ def emit(
     )
 
 
-def _emit_unbounded(
+def _emit_manifest(
     kind: str,
     payload: Any,
     *,
@@ -275,14 +328,22 @@ def _emit_unbounded(
     run_id: UUID | str | None,
     dataset_id: UUID | str | None,
 ) -> None:
-    """``emit()`` without the ``QUEUE_SIZE`` bound — for run manifests only.
+    """``emit()`` with headroom past ``QUEUE_SIZE`` — for run manifests only.
 
     A run that overflowed the buffer must still land its manifest: it is the
     record carrying ``dropped_events`` and the authoritative dataset
-    attribution, so drop-newest applying to it would make overflow
-    unobservable offline. Bounded by the number of concurrent runs.
+    attribution, so plain drop-newest would make overflow unobservable
+    offline. The headroom is a second ``QUEUE_SIZE`` — the buffer never holds
+    more than ``2 * QUEUE_SIZE`` events. Manifests accumulate as fast as runs
+    complete (not as fast as runs are concurrent: a wedged sink, or a sync
+    caller with no loop to flush on, leaves every completed run's manifest
+    buffered), so past the cap they are dropped and counted like any event.
     """
+    global _dropped
     if _sink is None:
+        return
+    if len(_buffer) >= 2 * QUEUE_SIZE:
+        _dropped += 1
         return
     _enqueue(
         CaptureEvent(
@@ -346,11 +407,7 @@ def ensure_flusher() -> None:
 
 
 def _start_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
-    # Prune explicitly: add_done_callback never fires for a task parked on a
-    # closed loop. Snapshot the items — another thread may be mutating the dict.
-    for stale_loop, stale in list(_flushers.items()):
-        if stale_loop.is_closed() or stale.task.done():
-            _flushers.pop(stale_loop, None)
+    _prune_closed_loops()
 
     flusher = _Flusher(loop=loop, wake=asyncio.Event())
     flush_coroutine = _flush_loop(flusher)
@@ -371,11 +428,62 @@ def _start_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
     return flusher
 
 
+def _prune_closed_loops() -> None:
+    """Forget flushers and in-flight batches stranded on closed loops.
+
+    Explicit because ``add_done_callback`` never fires for a task parked on a
+    closed loop. The events such a task had popped can never be delivered (the
+    task was destroyed with its loop), so they are counted as dropped. A loop
+    that merely stopped keeps its entries: it may run again (a driver calling
+    ``run_until_complete`` repeatedly) and its task is still cancellable by
+    ``shutdown()`` / ``_reset_for_tests()``; ``_any_live_flusher()`` and
+    ``_in_flight_live()`` skip it while it is not running.
+    """
+    global _dropped
+    # Snapshot the items — another thread may be mutating the dicts.
+    for stale_loop, stale in list(_flushers.items()):
+        if stale_loop.is_closed() or stale.task.done():
+            _flushers.pop(stale_loop, None)
+    for stale_loop in list(_in_flight):
+        if stale_loop.is_closed():
+            _dropped += _in_flight.pop(stale_loop, 0)
+
+
 def _any_live_flusher() -> _Flusher | None:
+    """A flusher whose loop is RUNNING — the wake target for worker-thread emits.
+
+    A stopped-but-open loop's flusher must not be chosen: ``call_soon_threadsafe``
+    on it succeeds but the callback never runs, ``wake_pending`` sticks, and the
+    live loop's flusher is never woken by thread emits.
+    """
     for flusher in list(_flushers.values()):
-        if not flusher.loop.is_closed() and not flusher.task.done():
+        if flusher.loop.is_running() and not flusher.task.done():
             return flusher
     return None
+
+
+# ---------------------------------------------------------------------------
+# In-flight accounting
+# ---------------------------------------------------------------------------
+
+
+def _in_flight_add(loop: asyncio.AbstractEventLoop, count: int) -> None:
+    # Only ever called from ``loop``'s own thread (see _in_flight).
+    total = _in_flight.get(loop, 0) + count
+    if total > 0:
+        _in_flight[loop] = total
+    else:
+        _in_flight.pop(loop, None)
+
+
+def _in_flight_total() -> int:
+    """Popped-but-undelivered events on every loop (tests, diagnostics)."""
+    return sum(list(_in_flight.values()))
+
+
+def _in_flight_live() -> int:
+    """Popped-but-undelivered events on loops that can still deliver them."""
+    return sum(count for loop, count in list(_in_flight.items()) if loop.is_running())
 
 
 # ---------------------------------------------------------------------------
@@ -397,7 +505,10 @@ async def _flush_loop(flusher: _Flusher) -> None:
             # Burst absorption: after a full batch keep flushing until the buffer
             # is below the threshold; sleep only when quiet.
             while _buffer:
-                await _flush_one_batch()
+                if await _flush_one_batch() == 0:
+                    # Nothing poppable (a drain took it): never spin on an
+                    # await that does not suspend.
+                    break
                 if len(_buffer) < BATCH_SIZE:
                     break
         except asyncio.CancelledError:
@@ -443,14 +554,35 @@ def _serialize_batch(batch: list[CaptureEvent]) -> list[dict]:
     return records
 
 
-async def _flush_one_batch() -> int:
+def _requeue(pending: list[CaptureEvent | None]) -> None:
+    """Put the not-yet-delivered events back at the head of the buffer, in order."""
+    leftovers = [event for event in pending if event is not None]
+    if leftovers:
+        _buffer.extendleft(reversed(leftovers))
+
+
+def _remaining(deadline: float | None) -> float | None:
+    return None if deadline is None else deadline - time.monotonic()
+
+
+async def _flush_one_batch(deadline: float | None = None) -> int:
     """Pop up to BATCH_SIZE events, serialize off-loop, hand groups to the sink.
 
-    Returns the number of events popped. ``_in_flight`` is held for the whole
-    pop→deliver window so ``drain()`` can wait for a batch that another
-    consumer (the flusher) is still serializing.
+    Returns the number of events popped; 0 means there was nothing to pop, and
+    callers stop on it so a batch that pops nothing can never spin.
+
+    ``deadline`` (``time.monotonic()``) is ``drain()``'s budget. It bounds the
+    serialization wait and every sink write (each is also bounded by
+    ``SINK_TIMEOUT_S``); once it is spent, whatever is not yet delivered —
+    including the group that was being written — goes back to the head of the
+    buffer for the flusher / the atexit hook (at-least-once, see the module
+    docstring). The flusher passes no deadline.
+
+    The popped events are counted in ``_in_flight`` for this loop from pop to
+    delivery so ``drain()`` can wait for a batch another consumer is still
+    serializing.
     """
-    global _in_flight, _dropped
+    global _dropped
     buffer = _buffer
     batch: list[CaptureEvent] = []
     try:
@@ -463,33 +595,61 @@ async def _flush_one_batch() -> int:
 
     sink = _sink
     if sink is None:
-        return len(batch)  # sink cleared after these were queued: nothing to deliver to
+        # Sink cleared after these were queued: nothing to deliver to. Account
+        # for the loss instead of hiding it.
+        _dropped += len(batch)
+        logger.debug("capture sink cleared, %d buffered event(s) dropped", len(batch))
+        return len(batch)
 
-    # Events not yet handed to the sink; on cancellation these go back.
+    loop = asyncio.get_running_loop()
+    # Events not yet handed to the sink; on cancellation or a spent deadline these go back.
     pending: list[CaptureEvent | None] = list(batch)
-    _in_flight += 1
+    outstanding = len(batch)
+    _in_flight_add(loop, outstanding)
     try:
-        records = await run_off_loop(_serialize_batch, batch)
-
-        groups: dict[tuple[str | None, str], list[int]] = {}
-        for index, record in enumerate(records):
-            groups.setdefault((record["run_id"], record["kind"]), []).append(index)
-
-        for indexes in groups.values():
-            group = [records[index] for index in indexes]
+        records: list[dict] | None = None
+        remaining = _remaining(deadline)
+        if remaining is None or remaining > 0:
             try:
+                records = await asyncio.wait_for(run_off_loop(_serialize_batch, batch), remaining)
+            except asyncio.TimeoutError:
+                pass  # budget spent while serializing: the whole batch goes back
+
+        if records is not None:
+            groups: dict[tuple[str | None, str], list[int]] = {}
+            for index, record in enumerate(records):
+                groups.setdefault((record["run_id"], record["kind"]), []).append(index)
+
+            for indexes in groups.values():
                 # Bounded: a wedged sink (S3 under partition) must not pin the
-                # flusher — and every later drain() — forever.
-                await asyncio.wait_for(sink(group), SINK_TIMEOUT_S)
-            except Exception as exc:
-                logger.debug("capture sink failed (%s)", exc)
-            for index in indexes:
-                pending[index] = None
-            # Let other coroutines interleave between sink writes.
-            await asyncio.sleep(0)
+                # flusher — nor a drain() past its own budget.
+                bound = SINK_TIMEOUT_S
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    bound = min(bound, remaining)
+                group = [records[index] for index in indexes]
+                try:
+                    await asyncio.wait_for(sink(group), bound)
+                except asyncio.TimeoutError as exc:
+                    if deadline is not None and time.monotonic() >= deadline:
+                        break  # the caller's budget ran out, not the sink's: retry later
+                    logger.debug("capture sink failed (%s)", exc)
+                except Exception as exc:
+                    logger.debug("capture sink failed (%s)", exc)
+                for index in indexes:
+                    pending[index] = None
+                outstanding -= len(indexes)
+                _in_flight_add(loop, -len(indexes))
+                # Let other coroutines interleave between sink writes.
+                await asyncio.sleep(0)
+
+        # Deadline leftovers (never any for the flusher, which has no deadline).
+        _requeue(pending)
     except asyncio.CancelledError:
         # asyncio.run teardown / uvicorn shutdown: do not lose the popped batch.
-        buffer.extendleft(reversed([event for event in pending if event is not None]))
+        _requeue(pending)
         raise
     except Exception as exc:
         # Not re-queued: a deterministic failure would pin the head of the
@@ -498,7 +658,9 @@ async def _flush_one_batch() -> int:
         _dropped += lost
         logger.debug("capture flush failed, %d event(s) dropped (%s)", lost, exc)
     finally:
-        _in_flight -= 1
+        # Whatever was not delivered is either back in the buffer or dropped:
+        # in no case is it still in flight.
+        _in_flight_add(loop, -outstanding)
     return len(batch)
 
 
@@ -512,13 +674,21 @@ async def _drain_until(deadline: float) -> None:
     # the coordination point — popleft is atomic, so a concurrently running
     # flusher and this drain simply split the work (blob names are
     # collision-free). Budgeted by the entry count so a producer faster than
-    # the sink cannot pin the caller: the flusher owns whatever arrives later.
+    # the sink cannot pin the caller (the flusher owns whatever arrives later),
+    # and by the deadline, which _flush_one_batch enforces inside the batch.
     budget = len(_buffer)
     while budget > 0 and _buffer and time.monotonic() < deadline:
-        budget -= await _flush_one_batch()
+        popped = await _flush_one_batch(deadline)
+        if popped == 0:
+            break  # the flusher took the rest; never spin
+        budget -= popped
     # (b) Wait for batches other consumers hold (popped, serializing or
-    # awaiting their sink): a plain int counter, no foreign-loop futures.
-    while _in_flight > 0 and time.monotonic() < deadline:
+    # awaiting their sink): plain int counters, no foreign-loop futures — and
+    # only on loops that are running. A batch stranded on a stopped or closed
+    # loop can never complete; waiting for it would turn every later drain()
+    # in the process into a full timeout.
+    _prune_closed_loops()
+    while _in_flight_live() > 0 and time.monotonic() < deadline:
         await asyncio.sleep(0.01)
 
 
@@ -526,7 +696,8 @@ async def drain(timeout: float = 5.0) -> None:
     """Flush the events buffered so far, then wait for in-flight batches.
 
     Never requires a flusher to exist, never raises, and returns within about
-    ``timeout`` even under a continuous producer (leftovers stay with the
+    ``timeout`` — the budget is enforced inside a batch too, per sink write —
+    even under a continuous producer or a wedged sink (leftovers stay with the
     flusher / the atexit hook).
     """
     try:
@@ -612,28 +783,6 @@ def should_capture(kind: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _configure(
-    *,
-    queue_size: int | None = None,
-    batch_size: int | None = None,
-    flush_interval_s: float | None = None,
-    sample_rate: float | None = None,
-    sink_timeout_s: float | None = None,
-) -> None:
-    """Override the cached knobs without going through the environment (tests)."""
-    global QUEUE_SIZE, BATCH_SIZE, FLUSH_INTERVAL_S, SAMPLE_RATE, SINK_TIMEOUT_S
-    if queue_size is not None:
-        QUEUE_SIZE = queue_size
-    if batch_size is not None:
-        BATCH_SIZE = batch_size
-    if flush_interval_s is not None:
-        FLUSH_INTERVAL_S = flush_interval_s
-    if sample_rate is not None:
-        SAMPLE_RATE = sample_rate
-    if sink_timeout_s is not None:
-        SINK_TIMEOUT_S = sink_timeout_s
-
-
 def _reset_for_tests() -> None:
     """Return the module to its pristine state (sync).
 
@@ -642,13 +791,13 @@ def _reset_for_tests() -> None:
     0.21.x (which closes loops without cancelling tasks) never destroys a
     pending flusher.
     """
-    global _sink, _initialized, _dropped, _in_flight
+    global _sink, _initialized, _dropped
     for flusher in list(_flushers.values()):
         _cancel_flusher(flusher, wait=True)
     _flushers.clear()
     _buffer.clear()
+    _in_flight.clear()
     _dropped = 0
-    _in_flight = 0
     _sink = None
     _initialized = False
     _configure(

--- a/cognee/modules/observability/capture/hook.py
+++ b/cognee/modules/observability/capture/hook.py
@@ -33,7 +33,7 @@ foreign thread wakes getters via loop-owned futures, so it is rejected. The
 ``len() >= QUEUE_SIZE`` check is a soft bound across threads (harmless). Run
 manifests get headroom past the bound (``_emit_manifest``, up to
 ``2 * QUEUE_SIZE`` buffered events in total): the manifest is the record that
-carries ``dropped_events``, so drop-newest must not eat it while there is room,
+carries ``events_dropped``, so drop-newest must not eat it while there is room,
 but the buffer stays finite under a wedged sink.
 
 Flushing
@@ -81,8 +81,20 @@ the head of the buffer for the flusher / the atexit hook.
 Delivery is at-least-once: a cancelled flush (``asyncio.run`` teardown, uvicorn
 shutdown), a drain whose budget ran out mid-write, or a batch recovered from a
 dead loop re-buffers the group that was being written along with the rest, so
-a consumer may see the same record twice. Blob names are collision-free, so
-nothing is overwritten.
+a consumer may see the same record twice — under the same ``event_id``, which
+is assigned at emit and is what consumers dedupe on. Blob names are
+collision-free, so nothing is overwritten.
+
+Accounting
+----------
+Every event is, at any moment, in exactly one of: the buffer, a tracked
+in-flight batch, the sink, or dropped. Drops are counted twice over: on the
+process-wide ``_dropped`` (diagnostics) and on the run the event belongs to
+(``RunScope.dropped``, via ``event.scope``) — the latter from whichever thread
+drops it, the emit path or the flusher — so a manifest's ``events_dropped``
+is that run's own count, not a delta of a shared counter that concurrent runs
+pollute. ``RunScope.delivered`` is credited on the sink's first
+acknowledgement of each event.
 """
 
 from __future__ import annotations
@@ -90,18 +102,19 @@ from __future__ import annotations
 import asyncio
 import atexit
 import collections
+import itertools
 import random
 import threading
 import time
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, TypeVar
-from uuid import UUID
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable, TypeVar
+from uuid import UUID, uuid4
 
 from cognee.shared.logging_utils import get_logger
 
 from .config import CaptureConfig, get_capture_config
-from .events import RETRIEVAL_KIND_PREFIX, CaptureEvent
+from .events import CAPTURE_SCHEMA_VERSION, RETRIEVAL_KIND_PREFIX, CaptureEvent
 from .sinks import CaptureSink, StorageSink, run_off_loop
 
 if TYPE_CHECKING:
@@ -153,6 +166,13 @@ _atexit_registered: bool = False
 # The active manifest scope (owned here so manifest.py can import it without a
 # runtime cycle; manifest.py owns RunScope and run_scope()).
 _current_scope: ContextVar[RunScope | None] = ContextVar("cognee_capture_scope", default=None)
+
+# Event ids: "<process>-<seq>". The prefix is unique per process (and restart),
+# the sequence is an itertools.count — next() is atomic under the GIL and
+# ~40 ns, so a worker-thread emit needs no lock. Formatted at serialization,
+# never on the emit path.
+_PROCESS_ID: str = uuid4().hex
+_event_seq = itertools.count(1)
 
 
 @dataclass(slots=True)
@@ -373,10 +393,13 @@ def emit(
     if sink is None:
         return
 
+    scope = _current_scope.get()
     if len(_buffer) >= QUEUE_SIZE:
         # Drop-NEWEST: the buffer is a bounded observation window, not a queue
-        # the pipeline waits on.
+        # the pipeline waits on. Counted on the run too (see Accounting).
         _dropped += 1
+        if scope is not None:
+            scope.dropped += 1
         return
 
     _enqueue(
@@ -386,11 +409,14 @@ def emit(
             payload_kind=payload_kind,
             run_id=run_id,
             dataset_id=dataset_id,
-            scope=_current_scope.get(),
+            scope=scope,
             stage=stage,
             ts=time.time(),
+            seq=next(_event_seq),
         )
     )
+    if scope is not None:
+        scope.emitted += 1
 
 
 def has_room() -> bool:
@@ -426,8 +452,11 @@ def emit_lazy(
     global _dropped
     if _sink is None:
         return
+    scope = _current_scope.get()
     if len(_buffer) >= QUEUE_SIZE:
         _dropped += 1
+        if scope is not None:
+            scope.dropped += 1
         return
     try:
         payload = build_payload()
@@ -441,11 +470,14 @@ def emit_lazy(
             payload_kind=payload_kind,
             run_id=run_id,
             dataset_id=dataset_id,
-            scope=_current_scope.get(),
+            scope=scope,
             stage=stage,
             ts=time.time(),
+            seq=next(_event_seq),
         )
     )
+    if scope is not None:
+        scope.emitted += 1
 
 
 def _emit_manifest(
@@ -459,7 +491,7 @@ def _emit_manifest(
     """``emit()`` with headroom past ``QUEUE_SIZE`` — for run manifests only.
 
     A run that overflowed the buffer must still land its manifest: it is the
-    record carrying ``dropped_events`` and the authoritative dataset
+    record carrying ``events_dropped`` and the authoritative dataset
     attribution, so plain drop-newest would make overflow unobservable
     offline. The headroom is a second ``QUEUE_SIZE`` — the buffer never holds
     more than ``2 * QUEUE_SIZE`` events. Manifests accumulate as fast as runs
@@ -473,6 +505,8 @@ def _emit_manifest(
     if len(_buffer) >= 2 * QUEUE_SIZE:
         _dropped += 1
         return
+    # Not counted on the run: its manifest is the record carrying the counts,
+    # taken before this call.
     _enqueue(
         CaptureEvent(
             kind=kind,
@@ -483,6 +517,7 @@ def _emit_manifest(
             scope=_current_scope.get(),
             stage=None,
             ts=time.time(),
+            seq=next(_event_seq),
         )
     )
 
@@ -762,6 +797,8 @@ def _serialize_batch(batch: list[CaptureEvent]) -> list[dict]:
         )
         records.append(
             {
+                "schema_version": CAPTURE_SCHEMA_VERSION,
+                "event_id": f"{_PROCESS_ID}-{event.seq}",
                 "kind": event.kind,
                 "run_id": None if run_id is None else str(run_id),
                 "dataset_id": None if dataset_id is None else str(dataset_id),
@@ -771,6 +808,30 @@ def _serialize_batch(batch: list[CaptureEvent]) -> list[dict]:
             }
         )
     return records
+
+
+def _account_dropped(events: Iterable[CaptureEvent | None]) -> int:
+    """Count events as lost — on their run's ``dropped`` — and return how many."""
+    lost = 0
+    for event in events:
+        if event is None:
+            continue
+        lost += 1
+        scope = event.scope
+        if scope is not None:
+            scope.dropped += 1
+    return lost
+
+
+def _account_delivered(events: Iterable[CaptureEvent | None]) -> None:
+    """Credit each event's run once, even when at-least-once delivers it twice."""
+    for event in events:
+        if event is None or event.delivered:
+            continue
+        event.delivered = True
+        scope = event.scope
+        if scope is not None:
+            scope.delivered += 1
 
 
 def _requeue(pending: list[CaptureEvent | None]) -> None:
@@ -824,7 +885,7 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
     if sink is None:
         # Sink cleared after these were queued: nothing to deliver to. Account
         # for the loss instead of hiding it.
-        _dropped += len(batch)
+        _dropped += _account_dropped(batch)
         logger.debug("capture sink cleared, %d buffered event(s) dropped", len(batch))
         return len(batch)
 
@@ -857,22 +918,27 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
                         break
                     bound = min(bound, remaining)
                 group = [records[index] for index in indexes]
+                slots = [pending[index] for index in indexes]
+                delivered = False
                 try:
                     await _wait_bounded(sink(group), bound)
+                    delivered = True
                 except asyncio.TimeoutError as exc:
                     if deadline is not None and time.monotonic() >= deadline:
                         break  # the caller's budget ran out, not the sink's: retry later
                     # The sink blew SINK_TIMEOUT_S; its write was cancelled and
                     # the slots are blanked below, so these events are gone.
                     # Account for the loss instead of hiding it: a run whose sink
-                    # is wedged must not report dropped_events = 0.
-                    _dropped += len(indexes)
+                    # is wedged must not report events_dropped = 0.
+                    _dropped += _account_dropped(slots)
                     logger.debug(
                         "capture sink timed out, %d event(s) dropped (%s)", len(indexes), exc
                     )
                 except Exception as exc:
-                    _dropped += len(indexes)
+                    _dropped += _account_dropped(slots)
                     logger.debug("capture sink failed, %d event(s) dropped (%s)", len(indexes), exc)
+                if delivered:
+                    _account_delivered(slots)
                 for index in indexes:
                     pending[index] = None
                 # Let other coroutines interleave between sink writes.
@@ -883,7 +949,7 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
     except Exception as exc:
         # Not re-queued: a deterministic failure would pin the head of the
         # buffer forever. Account for the loss instead of hiding it.
-        lost = sum(1 for event in pending if event is not None)
+        lost = _account_dropped(pending)
         _dropped += lost
         logger.debug("capture flush failed, %d event(s) dropped (%s)", lost, exc)
     except BaseException:
@@ -905,7 +971,7 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
 # ---------------------------------------------------------------------------
 
 
-async def _drain_until(deadline: float) -> None:
+async def _drain_until(deadline: float) -> bool:
     # Batches stranded on loops closed since the last pass go back to the
     # buffer first, so this drain covers them too.
     _prune_closed_loops()
@@ -928,9 +994,10 @@ async def _drain_until(deadline: float) -> None:
     # the process into a full timeout.
     while _in_flight_live() > 0 and time.monotonic() < deadline:
         await asyncio.sleep(0.01)
+    return not _buffer and _in_flight_live() == 0
 
 
-async def drain(timeout: float | None = None) -> None:
+async def drain(timeout: float | None = None) -> bool:
     """Flush the events buffered so far, then wait for in-flight batches.
 
     ``timeout=None`` (the default) means the configured budget:
@@ -945,13 +1012,20 @@ async def drain(timeout: float | None = None) -> None:
     ``_CANCEL_GRACE_S``: a write cut off by the budget is cancelled, and a sink
     that does not let that cancel land is abandoned after the grace rather than
     waited on forever.
+
+    Returns True when nothing is left buffered or in flight on this process —
+    every event was delivered or accounted as dropped — and False when the
+    budget ran out or a concurrent producer kept the buffer non-empty. The
+    pipeline wiring uses it to decide whether its manifest can be drained
+    inline too.
     """
     if timeout is None:
         timeout = DRAIN_TIMEOUT_S
     try:
-        await _drain_until(time.monotonic() + timeout)
+        return await _drain_until(time.monotonic() + timeout)
     except Exception as exc:
         logger.debug("capture drain failed (%s)", exc)
+        return False
 
 
 async def shutdown(timeout: float = 5.0) -> None:

--- a/cognee/modules/observability/capture/hook.py
+++ b/cognee/modules/observability/capture/hook.py
@@ -95,7 +95,7 @@ import threading
 import time
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Awaitable, TypeVar
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, TypeVar
 from uuid import UUID
 
 from cognee.shared.logging_utils import get_logger
@@ -379,6 +379,61 @@ def emit(
         _dropped += 1
         return
 
+    _enqueue(
+        CaptureEvent(
+            kind=kind,
+            payload=payload,
+            payload_kind=payload_kind,
+            run_id=run_id,
+            dataset_id=dataset_id,
+            scope=_current_scope.get(),
+            stage=stage,
+            ts=time.time(),
+        )
+    )
+
+
+def has_room() -> bool:
+    """True when the next ``emit()`` would be buffered rather than dropped.
+
+    For emit points whose payload is expensive to build (a graph snapshot): a
+    burst past ``QUEUE_SIZE`` would otherwise pay the full build cost for
+    events ``emit()`` discards on arrival. One global read plus a ``len()``;
+    a soft check (another thread may fill the buffer in between), never a
+    reservation.
+    """
+    return _sink is not None and len(_buffer) < QUEUE_SIZE
+
+
+def emit_lazy(
+    kind: str,
+    build_payload: Callable[[], Any],
+    *,
+    payload_kind: str = "json",
+    stage: str | None = None,
+    run_id: UUID | str | None = None,
+    dataset_id: UUID | str | None = None,
+) -> None:
+    """``emit()`` for an expensive payload: build it only if it will be buffered.
+
+    ``build_payload`` is the emit point's sanctioned snapshot cost (a
+    ``model_dump(mode="json")``, a hash) and runs on the caller's thread, but
+    only after the same sink/room checks ``emit()`` makes — so a full buffer
+    costs the drop counter and nothing else, instead of a snapshot per dropped
+    event. Unlike ``emit()`` this has an exception path: a builder that raises
+    costs its own event (logged at debug), never the caller.
+    """
+    global _dropped
+    if _sink is None:
+        return
+    if len(_buffer) >= QUEUE_SIZE:
+        _dropped += 1
+        return
+    try:
+        payload = build_payload()
+    except Exception as exc:
+        logger.debug("capture payload build failed (%s)", exc)
+        return
     _enqueue(
         CaptureEvent(
             kind=kind,

--- a/cognee/modules/observability/capture/hook.py
+++ b/cognee/modules/observability/capture/hook.py
@@ -6,15 +6,29 @@ evals, at ZERO cost when disabled and near-zero on the hot path when enabled.
 Capture never breaks, slows (beyond the snapshot cost), or blocks the
 operation it observes.
 
+State
+-----
+Everything the hook owns lives on one ``CaptureRuntime`` instance,
+``_runtime``: the knobs, the registered sink, the buffer, the per-loop
+flushers and in-flight batches, the drop counter. The module functions —
+``emit()``, ``drain()`` and the rest, the public API — read it. Grouping the
+state makes its ownership explicit and lets ``_reset_for_tests()`` swap in a
+fresh instance instead of clearing a dozen globals, so no test inherits
+another's sink, buffer or flushers. It does not remove the singleton: capture
+is process-wide by design (one buffer shared by every loop and thread), so
+there is exactly one runtime per process.
+
 Hot-path contract
 -----------------
-* ``emit()`` starts with ``sink = _sink; if sink is None: return`` — the OFF
-  cost is one global read, no allocation. Only after that is the
-  ``CaptureEvent`` built and appended to the deque. On a full buffer the
-  newest event is dropped and ``_dropped`` incremented. No serialization, no
-  I/O, no await, no logging, no config read, no exception path — ever.
-* ``is_active()`` is one global read in steady state (a flag-guarded one-time
-  ``_ensure_initialized()`` on first call). Callers hoist it out of loops.
+* ``emit()`` starts with ``sink = _runtime.sink; if sink is None: return`` —
+  the OFF cost is one global read and one attribute read, no allocation. Only
+  after that is the ``CaptureEvent`` built and appended to the deque. On a
+  full buffer the newest event is dropped and ``runtime.dropped`` incremented.
+  No serialization, no I/O, no await, no logging, no config read, no exception
+  path — ever.
+* ``is_active()`` is the same two reads in steady state (a flag-guarded
+  one-time ``_ensure_initialized()`` on first call). Callers hoist it out of
+  loops.
 * Sinks run only from the background flusher or ``drain()``/``shutdown()``.
 * Snapshot rule: ``emit()`` never serializes, so an emit point whose payload is
   mutated afterwards MUST pass a snapshot — for pydantic graphs
@@ -30,9 +44,9 @@ thread-agnostic — emit is reached from ``to_thread``'d sync code, run_sync's
 thread, the dataset-queue reaper thread, and across ``asyncio.run``
 boundaries. ``asyncio.Queue`` is loop-bound and its ``put_nowait`` from a
 foreign thread wakes getters via loop-owned futures, so it is rejected. The
-``len() >= QUEUE_SIZE`` check is a soft bound across threads (harmless). Run
+``len() >= queue_size`` check is a soft bound across threads (harmless). Run
 manifests get headroom past the bound (``_emit_manifest``, up to
-``2 * QUEUE_SIZE`` buffered events in total): the manifest is the record that
+``2 * queue_size`` buffered events in total): the manifest is the record that
 carries ``events_dropped``, so drop-newest must not eat it while there is room,
 but the buffer stays finite under a wedged sink.
 
@@ -41,14 +55,14 @@ Flushing
 One flusher task per event loop, started by the first on-loop emit or eagerly
 at ``run_scope`` entry (so worker-thread emits during a run are picked up by
 the interval tick even when nothing emits on-loop), and woken either by the
-``FLUSH_INTERVAL_S`` tick or by ``emit()`` when the buffer reaches
-``BATCH_SIZE`` (``call_soon_threadsafe`` — the only loop primitive safe from
+``flush_interval_s`` tick or by ``emit()`` when the buffer reaches
+``batch_size`` (``call_soon_threadsafe`` — the only loop primitive safe from
 any thread/loop; a worker-thread emit targets a flusher whose loop is RUNNING,
 since a wake scheduled on a stopped loop would never fire). Serialization runs
 in a worker thread because it is pure CPU (~15 ms per 64-graph batch) and would
 otherwise freeze concurrent recall coroutines; inside atexit handlers the
 executor is gone and it runs inline. Each sink write is bounded by
-``SINK_TIMEOUT_S`` so a wedged sink cannot pin the flusher forever.
+``sink_timeout_s`` so a wedged sink cannot pin the flusher forever.
 
 Every timed wait on the flusher and drain paths goes through ``_wait_bounded``,
 never ``asyncio.wait_for``: on CPython < 3.12 ``wait_for`` swallows a
@@ -59,18 +73,19 @@ it forever, and a caller cancelled mid-``drain()`` runs on past its own
 cancellation.
 
 A flusher cancelled from outside — ``asyncio.run`` / uvicorn tearing the loop
-down, ``shutdown()`` — stays in ``_flushers`` as a tombstone: its loop is going
-away, so no replacement is started on it. A late emit there (a ``run_tasks``
-generator finalized by ``shutdown_asyncgens()`` after the runner cancelled all
-tasks, a ``record_operation`` ``finally`` on a cancelled main task) would
-otherwise start a fresh flusher that the closing loop destroys mid-batch; the
-event stays in the deque for the next ``drain()`` or the atexit hook instead.
+down, ``shutdown()`` — stays in ``runtime.flushers`` as a tombstone: its loop
+is going away, so no replacement is started on it. A late emit there (a
+``run_tasks`` generator finalized by ``shutdown_asyncgens()`` after the runner
+cancelled all tasks, a ``record_operation`` ``finally`` on a cancelled main
+task) would otherwise start a fresh flusher that the closing loop destroys
+mid-batch; the event stays in the deque for the next ``drain()`` or the atexit
+hook instead.
 
-``_in_flight`` holds the batches popped but not yet delivered, per loop, so
-``drain()`` can wait for a batch the flusher is still serializing — but only on
-loops that are running: a batch on a loop that stopped can never complete
-while it is stopped and must not turn every later ``drain()`` into a full
-timeout. A batch stranded on a loop that was CLOSED without cancelling its
+``runtime.in_flight`` holds the batches popped but not yet delivered, per
+loop, so ``drain()`` can wait for a batch the flusher is still serializing —
+but only on loops that are running: a batch on a loop that stopped can never
+complete while it is stopped and must not turn every later ``drain()`` into a
+full timeout. A batch stranded on a loop that was CLOSED without cancelling its
 tasks (pytest-asyncio 0.21, a ``run_until_complete`` driver that never resumed)
 goes back to the head of the buffer when the loop is pruned, so it reaches the
 next drain / the atexit hook instead of vanishing with the dead task.
@@ -89,7 +104,7 @@ Accounting
 ----------
 Every event is, at any moment, in exactly one of: the buffer, a tracked
 in-flight batch, the sink, or dropped. Drops are counted twice over: on the
-process-wide ``_dropped`` (diagnostics) and on the run the event belongs to
+runtime's ``dropped`` (diagnostics) and on the run the event belongs to
 (``RunScope.dropped``, via ``event.scope``) — the latter from whichever thread
 drops it, the emit path or the flusher — so a manifest's ``events_dropped``
 is that run's own count, not a delta of a shared counter that concurrent runs
@@ -124,43 +139,86 @@ logger = get_logger("eval_capture")
 
 T = TypeVar("T")
 
-# Knobs. Defaults mirror CaptureConfig; _load_knobs() overwrites them from the
-# environment once per process, _configure() from tests.
 _FIELDS = CaptureConfig.model_fields
-QUEUE_SIZE: int = _FIELDS["cognee_capture_queue_size"].default
-BATCH_SIZE: int = _FIELDS["cognee_capture_batch_size"].default
-FLUSH_INTERVAL_S: float = _FIELDS["cognee_capture_flush_interval_s"].default
-RETRIEVAL_SAMPLE_RATE: float = _FIELDS["cognee_capture_retrieval_sample_rate"].default
-SINK_TIMEOUT_S: float = _FIELDS["cognee_capture_sink_timeout_s"].default
-DRAIN_TIMEOUT_S: float = _FIELDS["cognee_capture_drain_timeout_s"].default
 # Floor for the interval tick: a non-positive interval would spin the flusher.
 _MIN_FLUSH_INTERVAL_S: float = 0.01
 # How long shutdown() / _reset_for_tests() wait for a cancelled flusher to
 # finish: a regression that loses the cancel must fail a test, not hang it.
 _CANCEL_GRACE_S: float = 1.0
 
-# Module state.
-_sink: CaptureSink | None = None
-_initialized: bool = False
-# Serializes the one-time initialization only. is_active() reads _initialized
-# BEFORE taking it, so the warm path stays a plain global read with no locking.
-# Reentrant + _initializing: initialization imports the storage chain, and a
-# re-entrant is_active() from inside it must read "off", never deadlock.
-_init_lock = threading.RLock()
-_initializing: bool = False
-_buffer: collections.deque[CaptureEvent] = collections.deque()
-# Process-global, monotonic, approximate (lock-free on the emit path). Reported
-# once per manifest as a delta, never logged per drop.
-_dropped: int = 0
-# Batches popped from the buffer but not yet delivered (serializing or awaiting
-# the sink), keyed by the loop doing the work. Each entry is the batch's slot
-# list — an event until its group is acknowledged, None afterwards — so the
-# undelivered remainder is always reachable from here, not only from the frame
-# of the task doing the flush. A loop runs in one thread at a time, so each
-# key is only ever mutated by its owner thread; other threads only read, or
-# pop the key of a CLOSED loop (which no thread runs any more). drain() waits
-# on the RUNNING loops' counts only (see _in_flight_live()).
-_in_flight: dict[asyncio.AbstractEventLoop, list[list[CaptureEvent | None]]] = {}
+
+@dataclass(slots=True)
+class _Flusher:
+    # The runtime this flusher drains — bound at creation rather than read
+    # from the module on every tick, so a flusher that outlives a
+    # ``_reset_for_tests()`` swap (one on a foreign loop, cancelled
+    # asynchronously) keeps draining the state it was started for.
+    runtime: CaptureRuntime
+    loop: asyncio.AbstractEventLoop
+    wake: asyncio.Event
+    # True from the moment a wake.set() is scheduled until the flusher has
+    # consumed it, so a synchronous burst past batch_size schedules ONE loop
+    # callback instead of one per emit.
+    wake_pending: bool = False
+    # Bound right after creation: the flush task needs the flusher, the flusher the task.
+    # A task that ended cancelled turns this entry into a tombstone for its
+    # loop (see _ensure_flusher).
+    task: asyncio.Task = field(init=False)
+
+
+@dataclass(eq=False)
+class CaptureRuntime:
+    """The process-wide capture state, in one place (see the module docstring).
+
+    Deliberately NOT here, because each must survive a runtime swap:
+    the atexit registration flag (one handler per process, or every reset
+    would register another), the ``_current_scope`` contextvar (contextvars
+    live at module level), and the event-id prefix and sequence (an id must
+    stay unique across a reset).
+    """
+
+    # Knobs. Defaults mirror CaptureConfig; _load_knobs() overwrites them from
+    # the environment once per process, _configure() from tests.
+    queue_size: int = _FIELDS["cognee_capture_queue_size"].default
+    batch_size: int = _FIELDS["cognee_capture_batch_size"].default
+    flush_interval_s: float = _FIELDS["cognee_capture_flush_interval_s"].default
+    retrieval_sample_rate: float = _FIELDS["cognee_capture_retrieval_sample_rate"].default
+    sink_timeout_s: float = _FIELDS["cognee_capture_sink_timeout_s"].default
+    drain_timeout_s: float = _FIELDS["cognee_capture_drain_timeout_s"].default
+
+    # Registration.
+    sink: CaptureSink | None = None
+    initialized: bool = False
+    # Serializes the one-time initialization only. is_active() reads
+    # ``initialized`` BEFORE taking it, so the warm path stays plain reads with
+    # no locking. Reentrant + ``initializing``: initialization imports the
+    # storage chain, and a re-entrant is_active() from inside it must read
+    # "off", never deadlock.
+    initializing: bool = False
+    init_lock: threading.RLock = field(default_factory=threading.RLock)
+
+    # Buffering.
+    buffer: collections.deque[CaptureEvent] = field(default_factory=collections.deque)
+    # Process-global, monotonic, approximate (lock-free on the emit path).
+    # Diagnostics only — the per-run counts live on each RunScope.
+    dropped: int = 0
+
+    # Flushing. Batches popped from the buffer but not yet delivered
+    # (serializing or awaiting the sink), keyed by the loop doing the work.
+    # Each entry is the batch's slot list — an event until its group is
+    # acknowledged, None afterwards — so the undelivered remainder is always
+    # reachable from here, not only from the frame of the task doing the
+    # flush. A loop runs in one thread at a time, so each key is only ever
+    # mutated by its owner thread; other threads only read, or pop the key of
+    # a CLOSED loop (which no thread runs any more). drain() waits on the
+    # RUNNING loops' counts only (see _in_flight_live()).
+    in_flight: dict[asyncio.AbstractEventLoop, list[list[CaptureEvent | None]]] = field(
+        default_factory=dict
+    )
+    flushers: dict[asyncio.AbstractEventLoop, _Flusher] = field(default_factory=dict)
+
+
+_runtime: CaptureRuntime = CaptureRuntime()
 _atexit_registered: bool = False
 
 # The active manifest scope (owned here so manifest.py can import it without a
@@ -173,23 +231,6 @@ _current_scope: ContextVar[RunScope | None] = ContextVar("cognee_capture_scope",
 # never on the emit path.
 _PROCESS_ID: str = uuid4().hex
 _event_seq = itertools.count(1)
-
-
-@dataclass(slots=True)
-class _Flusher:
-    loop: asyncio.AbstractEventLoop
-    wake: asyncio.Event
-    # True from the moment a wake.set() is scheduled until the flusher has
-    # consumed it, so a synchronous burst past BATCH_SIZE schedules ONE loop
-    # callback instead of one per emit.
-    wake_pending: bool = False
-    # Bound right after creation: the flush task needs the flusher, the flusher the task.
-    # A task that ended cancelled turns this entry into a tombstone for its
-    # loop (see _ensure_flusher).
-    task: asyncio.Task = field(init=False)
-
-
-_flushers: dict[asyncio.AbstractEventLoop, _Flusher] = {}
 
 
 def _running_loop_fallback() -> asyncio.AbstractEventLoop | None:
@@ -217,32 +258,26 @@ def _configure(
     sink_timeout_s: float | None = None,
     drain_timeout_s: float | None = None,
 ) -> None:
-    """Set the cached knobs (from the config once per process, or from tests).
+    """Set the runtime's knobs (from the config once per process, or from tests).
 
     Clamped as defence in depth on top of ``CaptureConfig`` validation: a batch
     size of 0 makes ``_flush_one_batch`` pop nothing, and a consumer that pops
     nothing without ever suspending would monopolise its event loop; a
     non-positive interval would spin the flusher.
     """
-    global \
-        QUEUE_SIZE, \
-        BATCH_SIZE, \
-        FLUSH_INTERVAL_S, \
-        RETRIEVAL_SAMPLE_RATE, \
-        SINK_TIMEOUT_S, \
-        DRAIN_TIMEOUT_S
+    runtime = _runtime
     if queue_size is not None:
-        QUEUE_SIZE = max(1, queue_size)
+        runtime.queue_size = max(1, queue_size)
     if batch_size is not None:
-        BATCH_SIZE = max(1, batch_size)
+        runtime.batch_size = max(1, batch_size)
     if flush_interval_s is not None:
-        FLUSH_INTERVAL_S = max(_MIN_FLUSH_INTERVAL_S, flush_interval_s)
+        runtime.flush_interval_s = max(_MIN_FLUSH_INTERVAL_S, flush_interval_s)
     if retrieval_sample_rate is not None:
-        RETRIEVAL_SAMPLE_RATE = retrieval_sample_rate
+        runtime.retrieval_sample_rate = retrieval_sample_rate
     if sink_timeout_s is not None:
-        SINK_TIMEOUT_S = sink_timeout_s
+        runtime.sink_timeout_s = sink_timeout_s
     if drain_timeout_s is not None:
-        DRAIN_TIMEOUT_S = drain_timeout_s
+        runtime.drain_timeout_s = drain_timeout_s
 
 
 def _load_knobs(config: CaptureConfig) -> None:
@@ -266,7 +301,8 @@ def _register_atexit() -> None:
 
     Covers the CLI (``asyncio.run`` per command cancels the flusher, the
     cancelled batch is pushed back, atexit flushes it) and uvicorn (loop closed
-    before interpreter exit).
+    before interpreter exit). Once per process, not per runtime: the handler
+    reads whatever ``_runtime`` is at exit.
     """
     global _atexit_registered
     if _atexit_registered:
@@ -276,15 +312,16 @@ def _register_atexit() -> None:
 
 
 def _flush_at_exit() -> None:
-    if _sink is None:
+    runtime = _runtime
+    if runtime.sink is None:
         return
     # Batches stranded on loops that were closed without cancelling their tasks
     # go back to the buffer first, so they are part of what gets persisted.
-    _prune_closed_loops()
+    _prune_closed_loops(runtime)
     # Only batches on a loop that is still running (a daemon thread's) can
     # complete here; anything on a stopped loop cannot, and waiting for it
     # would just add a full timeout to every interpreter exit.
-    if not (_buffer or _in_flight_live()):
+    if not (runtime.buffer or _in_flight_live(runtime)):
         return
     if _get_running_loop() is not None:
         return
@@ -299,50 +336,51 @@ def _flush_at_exit() -> None:
 def _ensure_initialized() -> None:
     """Read the config once per process and auto-register the storage sink.
 
-    Guarded by ``_initialized`` (NOT by ``_sink``). This is the ONLY place
+    Guarded by ``initialized`` (NOT by ``sink``). This is the ONLY place
     ``get_capture_config()`` is consulted at runtime, and it is reached from
     ``is_active()`` — never from ``emit()``. A failing initialization (bad
     env, unreachable storage) logs once and leaves capture off: capture must
     never break the operation it observes.
 
-    Runs under ``_init_lock`` and publishes ``_initialized`` only once ``_sink``
+    Runs under ``init_lock`` and publishes ``initialized`` only once ``sink``
     is installed. cognee reaches ``is_active()`` from ``to_thread`` workers and
     the dataset-queue thread, and this body imports the storage chain (hundreds
     of ms cold); publishing the flag first would make every concurrent caller
     in that window see capture as OFF and silently skip a run's early events.
     """
-    global _initialized, _sink, _initializing
-    with _init_lock:
+    runtime = _runtime
+    with runtime.init_lock:
         # Re-check under the lock: a thread that waited here while another did
-        # the work must not redo it. _initializing catches the re-entrant case,
-        # which the RLock would otherwise let recurse.
-        if _initialized or _initializing:
+        # the work must not redo it. ``initializing`` catches the re-entrant
+        # case, which the RLock would otherwise let recurse.
+        if runtime.initialized or runtime.initializing:
             return
-        _initializing = True
+        runtime.initializing = True
         try:
             config = get_capture_config()
             _load_knobs(config)
-            if config.cognee_capture_enabled and _sink is None:
+            if config.cognee_capture_enabled and runtime.sink is None:
                 # Lazy: keeps this module free of the storage/base_config import chain.
                 from cognee.infrastructure.files.storage import get_file_storage
 
-                _sink = StorageSink(get_file_storage(config.cognee_capture_dir))
+                runtime.sink = StorageSink(get_file_storage(config.cognee_capture_dir))
                 _register_atexit()
         except Exception as exc:
             logger.warning("eval capture disabled: initialization failed (%s)", exc)
         finally:
             # Set LAST, and inside the lock: a concurrent is_active() must never
-            # see _initialized True while _sink is still None, or it would skip
-            # capture for the whole (import-chain-long) initialization window.
-            _initialized = True
-            _initializing = False
+            # see ``initialized`` True while ``sink`` is still None, or it would
+            # skip capture for the whole (import-chain-long) initialization window.
+            runtime.initialized = True
+            runtime.initializing = False
 
 
 def is_active() -> bool:
     """True when a sink is registered. Hoist out of per-node loops."""
-    if not _initialized:
+    runtime = _runtime
+    if not runtime.initialized:
         _ensure_initialized()
-    return _sink is not None
+    return runtime.sink is not None
 
 
 def register_capture_sink(sink: CaptureSink | None) -> None:
@@ -353,23 +391,23 @@ def register_capture_sink(sink: CaptureSink | None) -> None:
     environment.
     Registering a sink re-arms flushing on loops ``shutdown()`` stopped.
 
-    Runs under ``_init_lock``: a registration racing ``_ensure_initialized()``
+    Runs under ``init_lock``: a registration racing ``_ensure_initialized()``
     (a startup thread calling ``is_active()`` while another registers) must not
     interleave with the env auto-registration, or the explicit sink could be
     overwritten by the ``StorageSink`` — last-wins only holds when the two
     writers are serialized.
     """
-    global _sink, _initialized
-    with _init_lock:
-        if not _initialized:
-            _initialized = True
+    runtime = _runtime
+    with runtime.init_lock:
+        if not runtime.initialized:
+            runtime.initialized = True
             try:
                 _load_knobs(get_capture_config())
             except Exception as exc:
                 logger.debug("capture config unavailable, keeping default knobs (%s)", exc)
-        _sink = sink
+        runtime.sink = sink
     if sink is not None:
-        _forget_stopped_flushers()
+        _forget_stopped_flushers(runtime)
         _register_atexit()
 
 
@@ -394,21 +432,22 @@ def emit(
     explicit overrides; unset values are resolved from the active
     ``run_scope`` at serialization time.
     """
-    global _dropped
-    sink = _sink
+    runtime = _runtime
+    sink = runtime.sink
     if sink is None:
         return
 
     scope = _current_scope.get()
-    if len(_buffer) >= QUEUE_SIZE:
+    if len(runtime.buffer) >= runtime.queue_size:
         # Drop-NEWEST: the buffer is a bounded observation window, not a queue
         # the pipeline waits on. Counted on the run too (see Accounting).
-        _dropped += 1
+        runtime.dropped += 1
         if scope is not None:
             scope.dropped += 1
         return
 
     _enqueue(
+        runtime,
         CaptureEvent(
             kind=kind,
             payload=payload,
@@ -419,7 +458,7 @@ def emit(
             stage=stage,
             ts=time.time(),
             seq=next(_event_seq),
-        )
+        ),
     )
     if scope is not None:
         scope.emitted += 1
@@ -429,12 +468,13 @@ def has_room() -> bool:
     """True when the next ``emit()`` would be buffered rather than dropped.
 
     For emit points whose payload is expensive to build (a graph snapshot): a
-    burst past ``QUEUE_SIZE`` would otherwise pay the full build cost for
-    events ``emit()`` discards on arrival. One global read plus a ``len()``;
-    a soft check (another thread may fill the buffer in between), never a
+    burst past ``queue_size`` would otherwise pay the full build cost for
+    events ``emit()`` discards on arrival. Two reads plus a ``len()``; a soft
+    check (another thread may fill the buffer in between), never a
     reservation.
     """
-    return _sink is not None and len(_buffer) < QUEUE_SIZE
+    runtime = _runtime
+    return runtime.sink is not None and len(runtime.buffer) < runtime.queue_size
 
 
 def emit_lazy(
@@ -455,12 +495,12 @@ def emit_lazy(
     event. Unlike ``emit()`` this has an exception path: a builder that raises
     costs its own event (logged at debug), never the caller.
     """
-    global _dropped
-    if _sink is None:
+    runtime = _runtime
+    if runtime.sink is None:
         return
     scope = _current_scope.get()
-    if len(_buffer) >= QUEUE_SIZE:
-        _dropped += 1
+    if len(runtime.buffer) >= runtime.queue_size:
+        runtime.dropped += 1
         if scope is not None:
             scope.dropped += 1
         return
@@ -470,6 +510,7 @@ def emit_lazy(
         logger.debug("capture payload build failed (%s)", exc)
         return
     _enqueue(
+        runtime,
         CaptureEvent(
             kind=kind,
             payload=payload,
@@ -480,7 +521,7 @@ def emit_lazy(
             stage=stage,
             ts=time.time(),
             seq=next(_event_seq),
-        )
+        ),
     )
     if scope is not None:
         scope.emitted += 1
@@ -494,26 +535,27 @@ def _emit_manifest(
     run_id: UUID | str | None,
     dataset_id: UUID | str | None,
 ) -> None:
-    """``emit()`` with headroom past ``QUEUE_SIZE`` — for run manifests only.
+    """``emit()`` with headroom past ``queue_size`` — for run manifests only.
 
     A run that overflowed the buffer must still land its manifest: it is the
     record carrying ``events_dropped`` and the authoritative dataset
     attribution, so plain drop-newest would make overflow unobservable
-    offline. The headroom is a second ``QUEUE_SIZE`` — the buffer never holds
-    more than ``2 * QUEUE_SIZE`` events. Manifests accumulate as fast as runs
+    offline. The headroom is a second ``queue_size`` — the buffer never holds
+    more than ``2 * queue_size`` events. Manifests accumulate as fast as runs
     complete (not as fast as runs are concurrent: a wedged sink, or a sync
     caller with no loop to flush on, leaves every completed run's manifest
     buffered), so past the cap they are dropped and counted like any event.
     """
-    global _dropped
-    if _sink is None:
+    runtime = _runtime
+    if runtime.sink is None:
         return
-    if len(_buffer) >= 2 * QUEUE_SIZE:
-        _dropped += 1
+    if len(runtime.buffer) >= 2 * runtime.queue_size:
+        runtime.dropped += 1
         return
     # Not counted on the run: its manifest is the record carrying the counts,
     # taken before this call.
     _enqueue(
+        runtime,
         CaptureEvent(
             kind=kind,
             payload=payload,
@@ -524,22 +566,22 @@ def _emit_manifest(
             stage=None,
             ts=time.time(),
             seq=next(_event_seq),
-        )
+        ),
     )
 
 
-def _enqueue(event: CaptureEvent) -> None:
-    """Append, make sure this loop has a flusher, fire the BATCH_SIZE wake."""
-    buffer = _buffer
+def _enqueue(runtime: CaptureRuntime, event: CaptureEvent) -> None:
+    """Append, make sure this loop has a flusher, fire the batch_size wake."""
+    buffer = runtime.buffer
     buffer.append(event)
 
     loop = _get_running_loop()
-    flusher = _ensure_flusher(loop) if loop is not None else None
+    flusher = _ensure_flusher(runtime, loop) if loop is not None else None
     # else: a worker-thread emit; the deque is picked up by whichever flusher runs next.
 
-    if len(buffer) >= BATCH_SIZE:
+    if len(buffer) >= runtime.batch_size:
         if flusher is None:
-            flusher = _any_live_flusher()
+            flusher = _any_live_flusher(runtime)
         if flusher is not None and not flusher.wake_pending and not flusher.loop.is_closed():
             # wake_pending: one callback per batch, even in a synchronous burst
             # where the scheduled wake.set() has not run yet.
@@ -550,7 +592,7 @@ def _enqueue(event: CaptureEvent) -> None:
                 flusher.wake_pending = False  # loop closing
 
 
-def _ensure_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
+def _ensure_flusher(runtime: CaptureRuntime, loop: asyncio.AbstractEventLoop) -> _Flusher | None:
     """Return this loop's live flusher, starting one if absent or crashed.
 
     ``None`` for a loop whose flusher was CANCELLED: that is the runner tearing
@@ -559,14 +601,14 @@ def _ensure_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
     cancelled entry stays as a tombstone until the loop is closed and pruned,
     or a sink is (re)registered. A flusher that CRASHED is replaced.
     """
-    flusher = _flushers.get(loop)
+    flusher = runtime.flushers.get(loop)
     if flusher is not None:
         task = flusher.task
         if not task.done():
             return flusher
         if task.cancelled():
             return None
-    return _start_flusher(loop)
+    return _start_flusher(runtime, loop)
 
 
 def ensure_flusher() -> None:
@@ -574,21 +616,22 @@ def ensure_flusher() -> None:
 
     Emits from plain threads cannot start a flusher (no running loop in the
     emitting thread), so a run whose emit points all execute in worker threads
-    would otherwise accumulate events until QUEUE_SIZE and drop the rest. Both
-    wirings open their scope on-loop at run start, so this gives every run a
-    live flusher before its first worker-thread emit. Off the hot path.
+    would otherwise accumulate events until ``queue_size`` and drop the rest.
+    Both wirings open their scope on-loop at run start, so this gives every run
+    a live flusher before its first worker-thread emit. Off the hot path.
     """
-    if _sink is None:
+    runtime = _runtime
+    if runtime.sink is None:
         return
     loop = _get_running_loop()
     if loop is not None:
-        _ensure_flusher(loop)
+        _ensure_flusher(runtime, loop)
 
 
-def _start_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
-    _prune_closed_loops()
+def _start_flusher(runtime: CaptureRuntime, loop: asyncio.AbstractEventLoop) -> _Flusher | None:
+    _prune_closed_loops(runtime)
 
-    flusher = _Flusher(loop=loop, wake=asyncio.Event())
+    flusher = _Flusher(runtime=runtime, loop=loop, wake=asyncio.Event())
     flush_coroutine = _flush_loop(flusher)
     try:
         flusher.task = loop.create_task(flush_coroutine)
@@ -597,16 +640,16 @@ def _start_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
         flush_coroutine.close()
         return None
 
-    _flushers[loop] = flusher
+    runtime.flushers[loop] = flusher
 
     def _on_done(task: asyncio.Task) -> None:
-        if _flushers.get(loop) is not flusher:
+        if runtime.flushers.get(loop) is not flusher:
             return
         if task.cancelled():
             # Keep the entry as a tombstone (see _ensure_flusher): the loop
             # is going away, no replacement is started on it.
             return
-        _flushers.pop(loop, None)
+        runtime.flushers.pop(loop, None)
         # A crash (a BaseException out of a sink) ended the task; retrieving
         # the exception here keeps asyncio's "Task exception was never
         # retrieved" ERROR out of the logs. The next emit starts a replacement.
@@ -618,7 +661,7 @@ def _start_flusher(loop: asyncio.AbstractEventLoop) -> _Flusher | None:
     return flusher
 
 
-def _prune_closed_loops() -> None:
+def _prune_closed_loops(runtime: CaptureRuntime) -> None:
     """Forget flushers on closed loops; re-buffer the batches stranded there.
 
     Explicit because ``add_done_callback`` never fires for a task parked on a
@@ -634,30 +677,32 @@ def _prune_closed_loops() -> None:
     """
     # Snapshot the keys — another thread may be mutating the dicts. Only a
     # closed loop's entries are touched, and no thread runs a closed loop.
-    for stale_loop in list(_flushers):
+    for stale_loop in list(runtime.flushers):
         if stale_loop.is_closed():
-            _flushers.pop(stale_loop, None)
-    for stale_loop in list(_in_flight):
+            runtime.flushers.pop(stale_loop, None)
+    for stale_loop in list(runtime.in_flight):
         if stale_loop.is_closed():
-            for pending in _in_flight.pop(stale_loop, ()):
-                _requeue(pending)
+            for pending in runtime.in_flight.pop(stale_loop, ()):
+                _requeue(runtime, pending)
 
 
-def _forget_stopped_flushers() -> None:
+def _forget_stopped_flushers(runtime: CaptureRuntime) -> None:
     """Drop tombstones so flushing can resume on their loops (sink re-registered)."""
-    for loop, flusher in list(_flushers.items()):
+    for loop, flusher in list(runtime.flushers.items()):
         if flusher.task.done():
-            _flushers.pop(loop, None)
+            runtime.flushers.pop(loop, None)
 
 
-def _any_live_flusher() -> _Flusher | None:
+def _any_live_flusher(runtime: CaptureRuntime | None = None) -> _Flusher | None:
     """A flusher whose loop is RUNNING — the wake target for worker-thread emits.
 
     A stopped-but-open loop's flusher must not be chosen: ``call_soon_threadsafe``
     on it succeeds but the callback never runs, ``wake_pending`` sticks, and the
     live loop's flusher is never woken by thread emits.
     """
-    for flusher in list(_flushers.values()):
+    if runtime is None:
+        runtime = _runtime
+    for flusher in list(runtime.flushers.values()):
         if flusher.loop.is_running() and not flusher.task.done():
             return flusher
     return None
@@ -668,13 +713,21 @@ def _any_live_flusher() -> _Flusher | None:
 # ---------------------------------------------------------------------------
 
 
-def _track_in_flight(loop: asyncio.AbstractEventLoop, pending: list[CaptureEvent | None]) -> None:
-    # Only ever called from ``loop``'s own thread (see _in_flight).
-    _in_flight.setdefault(loop, []).append(pending)
+def _track_in_flight(
+    runtime: CaptureRuntime,
+    loop: asyncio.AbstractEventLoop,
+    pending: list[CaptureEvent | None],
+) -> None:
+    # Only ever called from ``loop``'s own thread (see CaptureRuntime.in_flight).
+    runtime.in_flight.setdefault(loop, []).append(pending)
 
 
-def _untrack_in_flight(loop: asyncio.AbstractEventLoop, pending: list[CaptureEvent | None]) -> None:
-    batches = _in_flight.get(loop)
+def _untrack_in_flight(
+    runtime: CaptureRuntime,
+    loop: asyncio.AbstractEventLoop,
+    pending: list[CaptureEvent | None],
+) -> None:
+    batches = runtime.in_flight.get(loop)
     if batches is None:
         return  # already recovered by _prune_closed_loops (loop closed under us)
     for index, candidate in enumerate(batches):
@@ -682,22 +735,26 @@ def _untrack_in_flight(loop: asyncio.AbstractEventLoop, pending: list[CaptureEve
             del batches[index]
             break
     if not batches:
-        _in_flight.pop(loop, None)
+        runtime.in_flight.pop(loop, None)
 
 
 def _count_pending(batches: list[list[CaptureEvent | None]]) -> int:
     return sum(1 for pending in list(batches) for event in pending if event is not None)
 
 
-def _in_flight_total() -> int:
+def _in_flight_total(runtime: CaptureRuntime | None = None) -> int:
     """Popped-but-undelivered events on every loop (tests, diagnostics)."""
-    return sum(_count_pending(batches) for batches in list(_in_flight.values()))
+    if runtime is None:
+        runtime = _runtime
+    return sum(_count_pending(batches) for batches in list(runtime.in_flight.values()))
 
 
-def _in_flight_live() -> int:
+def _in_flight_live(runtime: CaptureRuntime) -> int:
     """Popped-but-undelivered events on loops that can still deliver them."""
     return sum(
-        _count_pending(batches) for loop, batches in list(_in_flight.items()) if loop.is_running()
+        _count_pending(batches)
+        for loop, batches in list(runtime.in_flight.items())
+        if loop.is_running()
     )
 
 
@@ -748,11 +805,12 @@ async def _wait_bounded(awaitable: Awaitable[T], timeout: float | None) -> T:
 
 
 async def _flush_loop(flusher: _Flusher) -> None:
+    runtime = flusher.runtime
     wake = flusher.wake
     while True:
         try:
             try:
-                await _wait_bounded(wake.wait(), FLUSH_INTERVAL_S)
+                await _wait_bounded(wake.wait(), runtime.flush_interval_s)
             except asyncio.TimeoutError:
                 pass  # interval tick
             wake.clear()
@@ -760,12 +818,12 @@ async def _flush_loop(flusher: _Flusher) -> None:
             flusher.wake_pending = False
             # Burst absorption: after a full batch keep flushing until the buffer
             # is below the threshold; sleep only when quiet.
-            while _buffer:
-                if await _flush_one_batch() == 0:
+            while runtime.buffer:
+                if await _flush_one_batch(runtime) == 0:
                     # Nothing poppable (a drain took it): never spin on an
                     # await that does not suspend.
                     break
-                if len(_buffer) < BATCH_SIZE:
+                if len(runtime.buffer) < runtime.batch_size:
                     break
         except asyncio.CancelledError:
             raise
@@ -840,16 +898,16 @@ def _account_delivered(events: Iterable[CaptureEvent | None]) -> None:
             scope.delivered += 1
 
 
-def _requeue(pending: list[CaptureEvent | None]) -> None:
+def _requeue(runtime: CaptureRuntime, pending: list[CaptureEvent | None]) -> None:
     """Put the not-yet-delivered events back at the head of the buffer, in order.
 
     The slots are blanked so the batch counts as nothing in flight afterwards:
     an event is always in exactly one of the buffer, a tracked batch, the sink,
-    or ``_dropped``.
+    or dropped.
     """
     leftovers = [event for event in pending if event is not None]
     if leftovers:
-        _buffer.extendleft(reversed(leftovers))
+        runtime.buffer.extendleft(reversed(leftovers))
         for index in range(len(pending)):
             pending[index] = None
 
@@ -858,40 +916,39 @@ def _remaining(deadline: float | None) -> float | None:
     return None if deadline is None else deadline - time.monotonic()
 
 
-async def _flush_one_batch(deadline: float | None = None) -> int:
-    """Pop up to BATCH_SIZE events, serialize off-loop, hand groups to the sink.
+async def _flush_one_batch(runtime: CaptureRuntime, deadline: float | None = None) -> int:
+    """Pop up to batch_size events, serialize off-loop, hand groups to the sink.
 
     Returns the number of events popped; 0 means there was nothing to pop, and
     callers stop on it so a batch that pops nothing can never spin.
 
     ``deadline`` (``time.monotonic()``) is ``drain()``'s budget. It bounds the
     serialization wait and every sink write (each is also bounded by
-    ``SINK_TIMEOUT_S``); once it is spent, whatever is not yet delivered —
+    ``sink_timeout_s``); once it is spent, whatever is not yet delivered —
     including the group that was being written — goes back to the head of the
     buffer for the flusher / the atexit hook (at-least-once, see the module
     docstring). The flusher passes no deadline.
 
-    The popped events are tracked in ``_in_flight`` for this loop from pop to
-    delivery so ``drain()`` can wait for a batch another consumer is still
-    serializing, and so ``_prune_closed_loops`` can recover the batch if the
-    loop dies under it.
+    The popped events are tracked in ``runtime.in_flight`` for this loop from
+    pop to delivery so ``drain()`` can wait for a batch another consumer is
+    still serializing, and so ``_prune_closed_loops`` can recover the batch if
+    the loop dies under it.
     """
-    global _dropped
-    buffer = _buffer
+    buffer = runtime.buffer
     batch: list[CaptureEvent] = []
     try:
-        while buffer and len(batch) < BATCH_SIZE:
+        while buffer and len(batch) < runtime.batch_size:
             batch.append(buffer.popleft())
     except IndexError:
         pass  # raced with another consumer (drain + flusher split the work)
     if not batch:
         return 0
 
-    sink = _sink
+    sink = runtime.sink
     if sink is None:
         # Sink cleared after these were queued: nothing to deliver to. Account
         # for the loss instead of hiding it.
-        _dropped += _account_dropped(batch)
+        runtime.dropped += _account_dropped(batch)
         logger.debug("capture sink cleared, %d buffered event(s) dropped", len(batch))
         return len(batch)
 
@@ -899,7 +956,7 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
     # One slot per event, blanked as its group is acknowledged; on cancellation
     # or a spent deadline the rest goes back to the buffer.
     pending: list[CaptureEvent | None] = list(batch)
-    _track_in_flight(loop, pending)
+    _track_in_flight(runtime, loop, pending)
     try:
         records: list[dict] | None = None
         remaining = _remaining(deadline)
@@ -917,7 +974,7 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
             for indexes in groups.values():
                 # Bounded: a wedged sink (S3 under partition) must not pin the
                 # flusher — nor a drain() past its own budget.
-                bound = SINK_TIMEOUT_S
+                bound = runtime.sink_timeout_s
                 if deadline is not None:
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:
@@ -932,16 +989,16 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
                 except asyncio.TimeoutError as exc:
                     if deadline is not None and time.monotonic() >= deadline:
                         break  # the caller's budget ran out, not the sink's: retry later
-                    # The sink blew SINK_TIMEOUT_S; its write was cancelled and
+                    # The sink blew sink_timeout_s; its write was cancelled and
                     # the slots are blanked below, so these events are gone.
                     # Account for the loss instead of hiding it: a run whose sink
                     # is wedged must not report events_dropped = 0.
-                    _dropped += _account_dropped(slots)
+                    runtime.dropped += _account_dropped(slots)
                     logger.debug(
                         "capture sink timed out, %d event(s) dropped (%s)", len(indexes), exc
                     )
                 except Exception as exc:
-                    _dropped += _account_dropped(slots)
+                    runtime.dropped += _account_dropped(slots)
                     logger.debug("capture sink failed, %d event(s) dropped (%s)", len(indexes), exc)
                 if delivered:
                     _account_delivered(slots)
@@ -951,24 +1008,24 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
                 await asyncio.sleep(0)
 
         # Deadline leftovers (never any for the flusher, which has no deadline).
-        _requeue(pending)
+        _requeue(runtime, pending)
     except Exception as exc:
         # Not re-queued: a deterministic failure would pin the head of the
         # buffer forever. Account for the loss instead of hiding it.
         lost = _account_dropped(pending)
-        _dropped += lost
+        runtime.dropped += lost
         logger.debug("capture flush failed, %d event(s) dropped (%s)", lost, exc)
     except BaseException:
         # Cancellation (asyncio.run teardown, uvicorn shutdown, a cancelled
         # drain() caller) or a custom BaseException escaping a sink: do not lose
         # the popped batch. KeyboardInterrupt/SystemExit from a sink do NOT
         # reach here - asyncio re-raises those out of the loop itself.
-        _requeue(pending)
+        _requeue(runtime, pending)
         raise
     finally:
         # Whatever was not delivered is either back in the buffer or dropped:
         # in no case is it still in flight.
-        _untrack_in_flight(loop, pending)
+        _untrack_in_flight(runtime, loop, pending)
     return len(batch)
 
 
@@ -977,19 +1034,20 @@ async def _flush_one_batch(deadline: float | None = None) -> int:
 # ---------------------------------------------------------------------------
 
 
-async def _drain_until(deadline: float) -> bool:
+async def _drain_until(runtime: CaptureRuntime, deadline: float) -> bool:
     # Batches stranded on loops closed since the last pass go back to the
     # buffer first, so this drain covers them too.
-    _prune_closed_loops()
+    _prune_closed_loops(runtime)
     # (a) Inline on the calling loop: flush what is buffered NOW. The deque is
     # the coordination point — popleft is atomic, so a concurrently running
     # flusher and this drain simply split the work (blob names are
     # collision-free). Budgeted by the entry count so a producer faster than
     # the sink cannot pin the caller (the flusher owns whatever arrives later),
     # and by the deadline, which _flush_one_batch enforces inside the batch.
-    budget = len(_buffer)
-    while budget > 0 and _buffer and time.monotonic() < deadline:
-        popped = await _flush_one_batch(deadline)
+    buffer = runtime.buffer
+    budget = len(buffer)
+    while budget > 0 and buffer and time.monotonic() < deadline:
+        popped = await _flush_one_batch(runtime, deadline)
         if popped == 0:
             break  # the flusher took the rest; never spin
         budget -= popped
@@ -998,9 +1056,9 @@ async def _drain_until(deadline: float) -> bool:
     # on loops that are running. A batch on a stopped loop cannot complete
     # while it is stopped; waiting for it would turn every later drain() in
     # the process into a full timeout.
-    while _in_flight_live() > 0 and time.monotonic() < deadline:
+    while _in_flight_live(runtime) > 0 and time.monotonic() < deadline:
         await asyncio.sleep(0.01)
-    return not _buffer and _in_flight_live() == 0
+    return not buffer and _in_flight_live(runtime) == 0
 
 
 async def drain(timeout: float | None = None) -> bool:
@@ -1025,10 +1083,11 @@ async def drain(timeout: float | None = None) -> bool:
     pipeline wiring uses it to decide whether its manifest can be drained
     inline too.
     """
+    runtime = _runtime
     if timeout is None:
-        timeout = DRAIN_TIMEOUT_S
+        timeout = runtime.drain_timeout_s
     try:
-        return await _drain_until(time.monotonic() + timeout)
+        return await _drain_until(runtime, time.monotonic() + timeout)
     except Exception as exc:
         logger.debug("capture drain failed (%s)", exc)
         return False
@@ -1042,12 +1101,13 @@ async def shutdown(timeout: float = 5.0) -> None:
     after shutdown (one more request during a lifespan shutdown) does not
     start a new flusher: it stays in the deque for the atexit hook.
     """
+    runtime = _runtime
     deadline = time.monotonic() + timeout
     grace = min(timeout, _CANCEL_GRACE_S)
     await drain(timeout)
     current_loop = _get_running_loop()
     same_loop_tasks: list[asyncio.Task] = []
-    for flusher in list(_flushers.values()):
+    for flusher in list(runtime.flushers.values()):
         if flusher.loop is current_loop and not flusher.task.done():
             same_loop_tasks.append(flusher.task)
         _cancel_flusher(flusher, wait=False)
@@ -1056,9 +1116,9 @@ async def shutdown(timeout: float = 5.0) -> None:
         await asyncio.wait(same_loop_tasks, timeout=grace)
     # A flusher cancelled mid-batch re-buffered it; no flusher is left to pick
     # it up, so deliver it here rather than leaving it to the atexit hook.
-    if _buffer:
+    if runtime.buffer:
         try:
-            await _drain_until(max(deadline, time.monotonic() + grace))
+            await _drain_until(runtime, max(deadline, time.monotonic() + grace))
         except Exception as exc:
             logger.debug("capture drain failed (%s)", exc)
 
@@ -1095,14 +1155,14 @@ def should_capture(kind: str) -> bool:
     """Per-run sampling gate for retrieval kinds; every other kind is captured.
 
     Inside a ``run_scope`` the decision was made ONCE at scope entry (no
-    per-emit RNG); without a scope fall back to ``RETRIEVAL_SAMPLE_RATE``.
+    per-emit RNG); without a scope fall back to ``retrieval_sample_rate``.
     """
     if not kind.startswith(RETRIEVAL_KIND_PREFIX):
         return True
     scope = _current_scope.get()
     if scope is not None:
         return scope.sampled
-    return random.random() < RETRIEVAL_SAMPLE_RATE
+    return random.random() < _runtime.retrieval_sample_rate
 
 
 # ---------------------------------------------------------------------------
@@ -1111,28 +1171,18 @@ def should_capture(kind: str) -> bool:
 
 
 def _reset_for_tests() -> None:
-    """Return the module to its pristine state (sync).
+    """Swap in a pristine runtime (sync).
 
-    Cancels flusher tasks whose loop is still open — and, when that loop is not
-    running, runs it until the cancellation is delivered — so pytest-asyncio
-    0.21.x (which closes loops without cancelling tasks) never destroys a
-    pending flusher.
+    Cancels the current runtime's flusher tasks whose loop is still open —
+    and, when that loop is not running, runs it until the cancellation is
+    delivered — so pytest-asyncio 0.21.x (which closes loops without
+    cancelling tasks) never destroys a pending flusher. The old runtime is
+    then simply dropped: a flusher on a foreign running loop, cancelled
+    asynchronously, keeps draining the old instance it was bound to and can
+    never touch the new one.
     """
-    global _sink, _initialized, _dropped
-    for flusher in list(_flushers.values()):
+    global _runtime
+    for flusher in list(_runtime.flushers.values()):
         _cancel_flusher(flusher, wait=True)
-    _flushers.clear()
-    _buffer.clear()
-    _in_flight.clear()
-    _dropped = 0
-    _sink = None
-    _initialized = False
-    _configure(
-        queue_size=_FIELDS["cognee_capture_queue_size"].default,
-        batch_size=_FIELDS["cognee_capture_batch_size"].default,
-        flush_interval_s=_FIELDS["cognee_capture_flush_interval_s"].default,
-        retrieval_sample_rate=_FIELDS["cognee_capture_retrieval_sample_rate"].default,
-        sink_timeout_s=_FIELDS["cognee_capture_sink_timeout_s"].default,
-        drain_timeout_s=_FIELDS["cognee_capture_drain_timeout_s"].default,
-    )
+    _runtime = CaptureRuntime()
     get_capture_config.cache_clear()

--- a/cognee/modules/observability/capture/hook.py
+++ b/cognee/modules/observability/capture/hook.py
@@ -130,7 +130,7 @@ _FIELDS = CaptureConfig.model_fields
 QUEUE_SIZE: int = _FIELDS["cognee_capture_queue_size"].default
 BATCH_SIZE: int = _FIELDS["cognee_capture_batch_size"].default
 FLUSH_INTERVAL_S: float = _FIELDS["cognee_capture_flush_interval_s"].default
-SAMPLE_RATE: float = _FIELDS["cognee_capture_sample_rate"].default
+RETRIEVAL_SAMPLE_RATE: float = _FIELDS["cognee_capture_retrieval_sample_rate"].default
 SINK_TIMEOUT_S: float = _FIELDS["cognee_capture_sink_timeout_s"].default
 DRAIN_TIMEOUT_S: float = _FIELDS["cognee_capture_drain_timeout_s"].default
 # Floor for the interval tick: a non-positive interval would spin the flusher.
@@ -213,7 +213,7 @@ def _configure(
     queue_size: int | None = None,
     batch_size: int | None = None,
     flush_interval_s: float | None = None,
-    sample_rate: float | None = None,
+    retrieval_sample_rate: float | None = None,
     sink_timeout_s: float | None = None,
     drain_timeout_s: float | None = None,
 ) -> None:
@@ -224,15 +224,21 @@ def _configure(
     nothing without ever suspending would monopolise its event loop; a
     non-positive interval would spin the flusher.
     """
-    global QUEUE_SIZE, BATCH_SIZE, FLUSH_INTERVAL_S, SAMPLE_RATE, SINK_TIMEOUT_S, DRAIN_TIMEOUT_S
+    global \
+        QUEUE_SIZE, \
+        BATCH_SIZE, \
+        FLUSH_INTERVAL_S, \
+        RETRIEVAL_SAMPLE_RATE, \
+        SINK_TIMEOUT_S, \
+        DRAIN_TIMEOUT_S
     if queue_size is not None:
         QUEUE_SIZE = max(1, queue_size)
     if batch_size is not None:
         BATCH_SIZE = max(1, batch_size)
     if flush_interval_s is not None:
         FLUSH_INTERVAL_S = max(_MIN_FLUSH_INTERVAL_S, flush_interval_s)
-    if sample_rate is not None:
-        SAMPLE_RATE = sample_rate
+    if retrieval_sample_rate is not None:
+        RETRIEVAL_SAMPLE_RATE = retrieval_sample_rate
     if sink_timeout_s is not None:
         SINK_TIMEOUT_S = sink_timeout_s
     if drain_timeout_s is not None:
@@ -244,7 +250,7 @@ def _load_knobs(config: CaptureConfig) -> None:
         queue_size=config.cognee_capture_queue_size,
         batch_size=config.cognee_capture_batch_size,
         flush_interval_s=config.cognee_capture_flush_interval_s,
-        sample_rate=config.cognee_capture_sample_rate,
+        retrieval_sample_rate=config.cognee_capture_retrieval_sample_rate,
         sink_timeout_s=config.cognee_capture_sink_timeout_s,
         drain_timeout_s=config.cognee_capture_drain_timeout_s,
     )
@@ -1089,14 +1095,14 @@ def should_capture(kind: str) -> bool:
     """Per-run sampling gate for retrieval kinds; every other kind is captured.
 
     Inside a ``run_scope`` the decision was made ONCE at scope entry (no
-    per-emit RNG); without a scope fall back to ``SAMPLE_RATE``.
+    per-emit RNG); without a scope fall back to ``RETRIEVAL_SAMPLE_RATE``.
     """
     if not kind.startswith(RETRIEVAL_KIND_PREFIX):
         return True
     scope = _current_scope.get()
     if scope is not None:
         return scope.sampled
-    return random.random() < SAMPLE_RATE
+    return random.random() < RETRIEVAL_SAMPLE_RATE
 
 
 # ---------------------------------------------------------------------------
@@ -1125,7 +1131,7 @@ def _reset_for_tests() -> None:
         queue_size=_FIELDS["cognee_capture_queue_size"].default,
         batch_size=_FIELDS["cognee_capture_batch_size"].default,
         flush_interval_s=_FIELDS["cognee_capture_flush_interval_s"].default,
-        sample_rate=_FIELDS["cognee_capture_sample_rate"].default,
+        retrieval_sample_rate=_FIELDS["cognee_capture_retrieval_sample_rate"].default,
         sink_timeout_s=_FIELDS["cognee_capture_sink_timeout_s"].default,
         drain_timeout_s=_FIELDS["cognee_capture_drain_timeout_s"].default,
     )

--- a/cognee/modules/observability/capture/manifest.py
+++ b/cognee/modules/observability/capture/manifest.py
@@ -8,7 +8,10 @@ generator. The ``RunScope`` is mutated IN PLACE and the contextvar is bound to
 that one object before any task fan-out, so ``note()``/``bump()`` from
 ``create_task`` children reach the same accumulator. On exit a
 ``run.manifest`` event is enqueued (no drain here — callers ``await drain()``
-themselves where appropriate).
+themselves where appropriate). A caller whose scope outlives its drain —
+run_tasks, whose ``with`` encloses the terminal ``yield`` — calls
+``RunScope.finish()`` first so the drain covers the run's own manifest; the
+exit path then skips the duplicate.
 """
 
 from __future__ import annotations
@@ -41,6 +44,8 @@ class RunScope:
     counters: Counter[str] = field(default_factory=Counter)
     dropped_at_enter: int = 0
     parent: RunScope | None = None
+    # Set by finish(): the manifest has been enqueued, exit must not emit again.
+    finished: bool = False
 
     def set_dataset(self, dataset_id: UUID | str | None) -> None:
         """Bind the dataset late. Because ``CaptureEvent.scope`` is resolved at
@@ -58,6 +63,10 @@ class RunScope:
     def to_manifest(self) -> dict[str, Any]:
         ended_at = time.time()
         return {
+            # Fields first so the envelope keys below always win: a note() under
+            # "run_id" or "kind" cannot re-file the manifest, and a note()
+            # under "counters" is not silently discarded.
+            **self.fields,
             "run_id": None if self.run_id is None else str(self.run_id),
             "dataset_id": None if self.dataset_id is None else str(self.dataset_id),
             "kind": self.kind,
@@ -65,11 +74,36 @@ class RunScope:
             "started_at": self.started_at,
             "ended_at": ended_at,
             "duration_s": ended_at - self.started_at,
-            **self.fields,
             "counters": dict(self.counters),
             # Process-global counter delta: an approximation under concurrent runs.
-            "dropped_events": hook._dropped - self.dropped_at_enter,
+            "dropped_events": max(0, hook._dropped - self.dropped_at_enter),
         }
+
+    def finish(self) -> None:
+        """Enqueue the manifest now; idempotent.
+
+        ``run_scope`` calls this on exit. A caller that drains BEFORE its scope
+        closes (run_tasks: the scope encloses the terminal ``yield``) calls it
+        right before the drain so the run's most important record is covered
+        by that drain rather than left to the interval tick or the atexit hook.
+        Manifests bypass the queue bound: an overflowing run must still report
+        ``dropped_events``.
+        """
+        if self.finished:
+            return
+        self.finished = True
+        if not self.sampled:
+            return
+        try:
+            hook._emit_unbounded(
+                KIND_RUN_MANIFEST,
+                self.to_manifest(),
+                payload_kind="json",
+                run_id=self.run_id,
+                dataset_id=self.dataset_id,
+            )
+        except Exception as exc:
+            hook.logger.debug("capture manifest emit failed (%s)", exc)
 
 
 def current_scope() -> RunScope | None:
@@ -87,7 +121,9 @@ def run_scope(
     """Bracket one run; enqueue its manifest on exit when the run is sampled.
 
     Sampling is per run: operation scopes roll ``SAMPLE_RATE`` once here,
-    pipeline scopes are always sampled.
+    pipeline scopes are always sampled. Entry also starts the running loop's
+    flusher so emits from worker threads during the run are flushed on the
+    interval tick even if nothing ever emits on-loop.
     """
     scope = RunScope(
         run_id=run_id,
@@ -99,20 +135,11 @@ def run_scope(
         parent=hook._current_scope.get(),
     )
     token = hook._current_scope.set(scope)
+    hook.ensure_flusher()
     try:
         yield scope
     finally:
-        if scope.sampled:
-            try:
-                hook.emit(
-                    KIND_RUN_MANIFEST,
-                    scope.to_manifest(),
-                    payload_kind="json",
-                    run_id=scope.run_id,
-                    dataset_id=scope.dataset_id,
-                )
-            except Exception as exc:
-                hook.logger.debug("capture manifest emit failed (%s)", exc)
+        scope.finish()
         # Same cross-context tolerance as operation_usage_scope: the enclosing
         # generator may be finalized from a context other than the one that
         # resumed it last, in which case reset() raises ValueError.

--- a/cognee/modules/observability/capture/manifest.py
+++ b/cognee/modules/observability/capture/manifest.py
@@ -86,8 +86,9 @@ class RunScope:
         closes (run_tasks: the scope encloses the terminal ``yield``) calls it
         right before the drain so the run's most important record is covered
         by that drain rather than left to the interval tick or the atexit hook.
-        Manifests bypass the queue bound: an overflowing run must still report
-        ``dropped_events``.
+        Manifests get headroom past the queue bound (up to ``2 * QUEUE_SIZE``
+        buffered events in total): an overflowing run must still report
+        ``dropped_events``, but the buffer stays finite under a wedged sink.
         """
         if self.finished:
             return
@@ -95,7 +96,7 @@ class RunScope:
         if not self.sampled:
             return
         try:
-            hook._emit_unbounded(
+            hook._emit_manifest(
                 KIND_RUN_MANIFEST,
                 self.to_manifest(),
                 payload_kind="json",

--- a/cognee/modules/observability/capture/manifest.py
+++ b/cognee/modules/observability/capture/manifest.py
@@ -110,12 +110,18 @@ class RunScope:
         Manifests get headroom past the queue bound (up to ``2 * QUEUE_SIZE``
         buffered events in total): an overflowing run must still report
         ``dropped_events``, but the buffer stays finite under a wedged sink.
+
+        An unsampled run still gets its manifest. Sampling gates ``retrieval.*``
+        payloads (see ``should_capture``), not the record that identifies the run:
+        every other kind is captured at full rate regardless, so suppressing the
+        manifest would leave those events — and any nested pipeline manifest
+        pointing here via ``parent_run_id`` — joined to a run that no consumer can
+        resolve. The decision is on the payload as ``sampled`` instead, so an
+        offline consumer can filter on it.
         """
         if self.finished:
             return
         self.finished = True
-        if not self.sampled:
-            return
         try:
             hook._emit_manifest(
                 KIND_RUN_MANIFEST,

--- a/cognee/modules/observability/capture/manifest.py
+++ b/cognee/modules/observability/capture/manifest.py
@@ -54,6 +54,21 @@ class RunScope:
         under ``nodataset/`` — the manifest is authoritative."""
         self.dataset_id = dataset_id
 
+    def resolved_dataset_id(self) -> UUID | str | None:
+        """This run's dataset, or the nearest enclosing run's when it has none.
+
+        A ``record_operation``-wrapped search executed by a pipeline task opens an
+        operation scope with no dataset of its own inside a pipeline scope that
+        knows it; attributing to the parent keeps ``nodataset/`` for runs that
+        are genuinely dataset-less.
+        """
+        scope: RunScope | None = self
+        while scope is not None:
+            if scope.dataset_id is not None:
+                return scope.dataset_id
+            scope = scope.parent
+        return None
+
     def note(self, key: str, value: Any) -> None:
         self.fields[key] = value
 
@@ -62,13 +77,19 @@ class RunScope:
 
     def to_manifest(self) -> dict[str, Any]:
         ended_at = time.time()
+        dataset_id = self.resolved_dataset_id()
+        parent = self.parent
+        parent_run_id = None if parent is None or parent.run_id is None else str(parent.run_id)
         return {
             # Fields first so the envelope keys below always win: a note() under
             # "run_id" or "kind" cannot re-file the manifest, and a note()
             # under "counters" is not silently discarded.
             **self.fields,
             "run_id": None if self.run_id is None else str(self.run_id),
-            "dataset_id": None if self.dataset_id is None else str(self.dataset_id),
+            # Lets a nested run (an operation recorded inside a pipeline task)
+            # be joined to its enclosing run offline.
+            "parent_run_id": parent_run_id,
+            "dataset_id": None if dataset_id is None else str(dataset_id),
             "kind": self.kind,
             "sampled": self.sampled,
             "started_at": self.started_at,
@@ -101,7 +122,7 @@ class RunScope:
                 self.to_manifest(),
                 payload_kind="json",
                 run_id=self.run_id,
-                dataset_id=self.dataset_id,
+                dataset_id=self.resolved_dataset_id(),
             )
         except Exception as exc:
             hook.logger.debug("capture manifest emit failed (%s)", exc)

--- a/cognee/modules/observability/capture/manifest.py
+++ b/cognee/modules/observability/capture/manifest.py
@@ -1,0 +1,138 @@
+"""Run manifests for eval capture (SDK-529).
+
+A ``run_scope`` brackets one operation or pipeline run. It is a SYNC
+``@contextmanager`` — the same shape as ``operation_usage_scope`` /
+``parent_run_scope`` in ``cognee/modules/operations/usage_accumulator.py`` — so
+it stacks on the existing ``with`` line inside the ``run_tasks`` async
+generator. The ``RunScope`` is mutated IN PLACE and the contextvar is bound to
+that one object before any task fan-out, so ``note()``/``bump()`` from
+``create_task`` children reach the same accumulator. On exit a
+``run.manifest`` event is enqueued (no drain here — callers ``await drain()``
+themselves where appropriate).
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from collections import Counter
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Iterator
+from uuid import UUID
+
+from . import hook
+from .events import KIND_RUN_MANIFEST
+
+
+@dataclass
+class RunScope:
+    """Mutable per-run accumulator; the payload source of the run manifest."""
+
+    run_id: UUID | str | None
+    # Mutable — bound late via set_dataset() by record_operation's callers.
+    dataset_id: UUID | str | None = None
+    # "operation" | "pipeline"
+    kind: str = "operation"
+    # Decided once at scope entry; retrieval-kind events consult it via should_capture().
+    sampled: bool = True
+    started_at: float = field(default_factory=time.time)
+    fields: dict[str, Any] = field(default_factory=dict)
+    counters: Counter[str] = field(default_factory=Counter)
+    dropped_at_enter: int = 0
+    parent: RunScope | None = None
+
+    def set_dataset(self, dataset_id: UUID | str | None) -> None:
+        """Bind the dataset late. Because ``CaptureEvent.scope`` is resolved at
+        serialization time, events already buffered for this run pick it up too;
+        only events flushed BEFORE this call (≤ FLUSH_INTERVAL_S window) can land
+        under ``nodataset/`` — the manifest is authoritative."""
+        self.dataset_id = dataset_id
+
+    def note(self, key: str, value: Any) -> None:
+        self.fields[key] = value
+
+    def bump(self, counter: str, n: int = 1) -> None:
+        self.counters[counter] += n
+
+    def to_manifest(self) -> dict[str, Any]:
+        ended_at = time.time()
+        return {
+            "run_id": None if self.run_id is None else str(self.run_id),
+            "dataset_id": None if self.dataset_id is None else str(self.dataset_id),
+            "kind": self.kind,
+            "sampled": self.sampled,
+            "started_at": self.started_at,
+            "ended_at": ended_at,
+            "duration_s": ended_at - self.started_at,
+            **self.fields,
+            "counters": dict(self.counters),
+            # Process-global counter delta: an approximation under concurrent runs.
+            "dropped_events": hook._dropped - self.dropped_at_enter,
+        }
+
+
+def current_scope() -> RunScope | None:
+    """The innermost active run scope, if any."""
+    return hook._current_scope.get()
+
+
+@contextmanager
+def run_scope(
+    run_id: UUID | str | None,
+    dataset_id: UUID | str | None = None,
+    *,
+    kind: str = "operation",
+) -> Iterator[RunScope]:
+    """Bracket one run; enqueue its manifest on exit when the run is sampled.
+
+    Sampling is per run: operation scopes roll ``SAMPLE_RATE`` once here,
+    pipeline scopes are always sampled.
+    """
+    scope = RunScope(
+        run_id=run_id,
+        dataset_id=dataset_id,
+        kind=kind,
+        sampled=(kind != "operation") or random.random() < hook.SAMPLE_RATE,
+        started_at=time.time(),
+        dropped_at_enter=hook._dropped,
+        parent=hook._current_scope.get(),
+    )
+    token = hook._current_scope.set(scope)
+    try:
+        yield scope
+    finally:
+        if scope.sampled:
+            try:
+                hook.emit(
+                    KIND_RUN_MANIFEST,
+                    scope.to_manifest(),
+                    payload_kind="json",
+                    run_id=scope.run_id,
+                    dataset_id=scope.dataset_id,
+                )
+            except Exception as exc:
+                hook.logger.debug("capture manifest emit failed (%s)", exc)
+        # Same cross-context tolerance as operation_usage_scope: the enclosing
+        # generator may be finalized from a context other than the one that
+        # resumed it last, in which case reset() raises ValueError.
+        try:
+            hook._current_scope.reset(token)
+        except ValueError:
+            pass
+
+
+def note(key: str, value: Any) -> None:
+    """Record a manifest field on the active scope; no-op without one (~15 ns)."""
+    scope = hook._current_scope.get()
+    if scope is None:
+        return
+    scope.fields[key] = value
+
+
+def bump(counter: str, n: int = 1) -> None:
+    """Increment a manifest counter on the active scope; no-op without one."""
+    scope = hook._current_scope.get()
+    if scope is None:
+        return
+    scope.counters[counter] += n

--- a/cognee/modules/observability/capture/manifest.py
+++ b/cognee/modules/observability/capture/manifest.py
@@ -30,7 +30,17 @@ from .events import KIND_RUN_MANIFEST
 
 @dataclass
 class RunScope:
-    """Mutable per-run accumulator; the payload source of the run manifest."""
+    """Mutable per-run accumulator; the payload source of the run manifest.
+
+    ``emitted`` / ``dropped`` / ``delivered`` are this run's own capture
+    accounting, kept by the hook (``emit()`` and the flusher, via
+    ``CaptureEvent.scope``), so the manifest reports exact per-run counts
+    rather than a delta of a process-wide counter that concurrent runs
+    pollute. Manifests themselves are not counted. The one imprecision:
+    ``dropped`` is bumped from both the emitting thread (buffer full) and the
+    flusher's thread (sink failure), and a simultaneous pair of unlocked
+    increments can lose one — a lock on the emit path is not worth that.
+    """
 
     run_id: UUID | str | None
     # Mutable — bound late via set_dataset() by record_operation's callers.
@@ -42,7 +52,10 @@ class RunScope:
     started_at: float = field(default_factory=time.time)
     fields: dict[str, Any] = field(default_factory=dict)
     counters: Counter[str] = field(default_factory=Counter)
-    dropped_at_enter: int = 0
+    # Per-run capture accounting; see the class docstring.
+    emitted: int = 0
+    dropped: int = 0
+    delivered: int = 0
     parent: RunScope | None = None
     # Set by finish(): the manifest has been enqueued, exit must not emit again.
     finished: bool = False
@@ -101,8 +114,18 @@ class RunScope:
             "ended_at": ended_at,
             "duration_s": ended_at - self.started_at,
             "counters": dict(self.counters),
-            # Process-global counter delta: an approximation under concurrent runs.
-            "dropped_events": max(0, hook._dropped - self.dropped_at_enter),
+            # Exact per-run accounting (see the class docstring). A consumer
+            # verifies completeness by comparing the records it finds under the
+            # run with events_emitted; capture_complete says whether capture
+            # itself lost anything by the time this manifest was written.
+            # Pipeline runs drain before finishing, so for them every emitted
+            # event is delivered or dropped here and events_delivered equals
+            # events_emitted when complete; an operation run (never drained)
+            # reports what the sink had acknowledged so far.
+            "events_emitted": self.emitted,
+            "events_dropped": self.dropped,
+            "events_delivered": self.delivered,
+            "capture_complete": self.dropped == 0,
         }
 
     def finish(self) -> None:
@@ -114,7 +137,7 @@ class RunScope:
         by that drain rather than left to the interval tick or the atexit hook.
         Manifests get headroom past the queue bound (up to ``2 * QUEUE_SIZE``
         buffered events in total): an overflowing run must still report
-        ``dropped_events``, but the buffer stays finite under a wedged sink.
+        ``events_dropped``, but the buffer stays finite under a wedged sink.
 
         An unsampled run still gets its manifest. Sampling gates ``retrieval.*``
         payloads (see ``should_capture``), not the record that identifies the run:
@@ -164,7 +187,6 @@ def run_scope(
         kind=kind,
         sampled=(kind != "operation") or random.random() < hook.SAMPLE_RATE,
         started_at=time.time(),
-        dropped_at_enter=hook._dropped,
         parent=hook._current_scope.get(),
     )
     token = hook._current_scope.set(scope)

--- a/cognee/modules/observability/capture/manifest.py
+++ b/cognee/modules/observability/capture/manifest.py
@@ -49,9 +49,14 @@ class RunScope:
 
     def set_dataset(self, dataset_id: UUID | str | None) -> None:
         """Bind the dataset late. Because ``CaptureEvent.scope`` is resolved at
-        serialization time, events already buffered for this run pick it up too;
-        only events flushed BEFORE this call (≤ FLUSH_INTERVAL_S window) can land
-        under ``nodataset/`` — the manifest is authoritative."""
+        serialization time, events already buffered for this run pick it up too.
+
+        Only events flushed BEFORE this call can land under ``nodataset/``, so
+        callers bind as soon as they know the dataset — ``OperationContext.
+        set_dataset`` forwards here immediately — never at operation exit, where
+        every flush tick of the body (one per ``FLUSH_INTERVAL_S``) would have
+        filed the run's events under ``nodataset/`` already. The manifest is
+        authoritative either way."""
         self.dataset_id = dataset_id
 
     def resolved_dataset_id(self) -> UUID | str | None:

--- a/cognee/modules/observability/capture/manifest.py
+++ b/cognee/modules/observability/capture/manifest.py
@@ -185,7 +185,7 @@ def run_scope(
         run_id=run_id,
         dataset_id=dataset_id,
         kind=kind,
-        sampled=(kind != "operation") or random.random() < hook.RETRIEVAL_SAMPLE_RATE,
+        sampled=(kind != "operation") or random.random() < hook._runtime.retrieval_sample_rate,
         started_at=time.time(),
         parent=hook._current_scope.get(),
     )

--- a/cognee/modules/observability/capture/manifest.py
+++ b/cognee/modules/observability/capture/manifest.py
@@ -176,7 +176,7 @@ def run_scope(
 ) -> Iterator[RunScope]:
     """Bracket one run; enqueue its manifest on exit when the run is sampled.
 
-    Sampling is per run: operation scopes roll ``SAMPLE_RATE`` once here,
+    Sampling is per run: operation scopes roll ``RETRIEVAL_SAMPLE_RATE`` once here,
     pipeline scopes are always sampled. Entry also starts the running loop's
     flusher so emits from worker threads during the run are flushed on the
     interval tick even if nothing ever emits on-loop.
@@ -185,7 +185,7 @@ def run_scope(
         run_id=run_id,
         dataset_id=dataset_id,
         kind=kind,
-        sampled=(kind != "operation") or random.random() < hook.SAMPLE_RATE,
+        sampled=(kind != "operation") or random.random() < hook.RETRIEVAL_SAMPLE_RATE,
         started_at=time.time(),
         parent=hook._current_scope.get(),
     )

--- a/cognee/modules/observability/capture/prompt_hash.py
+++ b/cognee/modules/observability/capture/prompt_hash.py
@@ -1,32 +1,12 @@
 """Prompt fingerprints for eval capture (SDK-529).
 
-Used by later emit points to tag captured output with the prompt version that
-produced it; only reached under ``is_active()``.
+Used by the extraction and summarization emit points to tag captured output
+with the prompt version that produced it; only reached under ``is_active()``.
 """
 
 import hashlib
-import os
 
 
 def prompt_fingerprint(text: str) -> str:
     """Short, stable fingerprint of a prompt text: ``sha256:<16 hex chars>``."""
     return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
-
-
-# path -> (mtime, fingerprint). Keyed by path so a rewritten file replaces its
-# stale entry instead of accumulating one entry per mtime.
-_file_fingerprints: dict[str, tuple[float, str]] = {}
-
-
-def prompt_file_fingerprint(path: str) -> str:
-    """Fingerprint of a prompt file's contents, cached by ``(path, mtime)``."""
-    mtime = os.path.getmtime(path)
-    cached = _file_fingerprints.get(path)
-    if cached is not None and cached[0] == mtime:
-        return cached[1]
-
-    with open(path, "r", encoding="utf-8") as prompt_file:
-        fingerprint = prompt_fingerprint(prompt_file.read())
-
-    _file_fingerprints[path] = (mtime, fingerprint)
-    return fingerprint

--- a/cognee/modules/observability/capture/prompt_hash.py
+++ b/cognee/modules/observability/capture/prompt_hash.py
@@ -1,0 +1,32 @@
+"""Prompt fingerprints for eval capture (SDK-529).
+
+Used by later emit points to tag captured output with the prompt version that
+produced it; only reached under ``is_active()``.
+"""
+
+import hashlib
+import os
+
+
+def prompt_fingerprint(text: str) -> str:
+    """Short, stable fingerprint of a prompt text: ``sha256:<16 hex chars>``."""
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+# path -> (mtime, fingerprint). Keyed by path so a rewritten file replaces its
+# stale entry instead of accumulating one entry per mtime.
+_file_fingerprints: dict[str, tuple[float, str]] = {}
+
+
+def prompt_file_fingerprint(path: str) -> str:
+    """Fingerprint of a prompt file's contents, cached by ``(path, mtime)``."""
+    mtime = os.path.getmtime(path)
+    cached = _file_fingerprints.get(path)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+
+    with open(path, "r", encoding="utf-8") as prompt_file:
+        fingerprint = prompt_fingerprint(prompt_file.read())
+
+    _file_fingerprints[path] = (mtime, fingerprint)
+    return fingerprint

--- a/cognee/modules/observability/capture/sinks.py
+++ b/cognee/modules/observability/capture/sinks.py
@@ -13,8 +13,14 @@ qualify. Delivery is at-least-once: a flush cancelled or cut off by
 sink may receive the same records twice (``StorageSink`` never overwrites —
 blob names are collision-free — so consumers that need exactly-once counts
 should dedupe on ``(run_id, kind, ts)``). Sinks must raise ``Exception``
-subclasses only; a ``BaseException`` from a sink escapes the flusher's
-never-raise guards by design.
+subclasses only: a ``BaseException`` from a sink re-buffers the batch and ends
+the flusher (the next emit starts a replacement). A sink must let
+``CancelledError`` propagate — the flusher cancels a write that outlives
+``SINK_TIMEOUT_S`` or a ``drain()`` budget and waits for that cancel to land.
+Sinks must not depend on the default executor or on threads: the atexit drain
+runs after ``threading._shutdown()``, when ``asyncio.to_thread`` raises and the
+write is lost; ``StorageSink`` goes through ``run_off_loop``, which falls back
+to an inline call there.
 """
 
 from __future__ import annotations

--- a/cognee/modules/observability/capture/sinks.py
+++ b/cognee/modules/observability/capture/sinks.py
@@ -1,8 +1,8 @@
 """Capture sinks (SDK-529).
 
-A sink is a bare async callable taking a list of already-serialized records
-(shape-compatible with ``ActivitySink``). Sinks are invoked only from the
-background flusher or from ``drain()``/``shutdown()``, never inline from
+A sink is a bare async callable taking a list of already-serialized records:
+``async def sink(records: list[dict]) -> None``. Sinks are invoked only from
+the background flusher or from ``drain()``/``shutdown()``, never inline from
 ``emit()``.
 
 Contract for implementations: usable from any loop/thread — two flushers on
@@ -14,9 +14,13 @@ sink may receive the same records twice (``StorageSink`` never overwrites —
 blob names are collision-free — so consumers that need exactly-once counts
 should dedupe on ``(run_id, kind, ts)``). Sinks must raise ``Exception``
 subclasses only: a ``BaseException`` from a sink re-buffers the batch and ends
-the flusher (the next emit starts a replacement). A sink must let
-``CancelledError`` propagate — the flusher cancels a write that outlives
-``SINK_TIMEOUT_S`` or a ``drain()`` budget and waits for that cancel to land.
+the flusher (the next emit starts a replacement). ``KeyboardInterrupt`` and
+``SystemExit`` are the exception to that: asyncio's ``Task.__step`` re-raises
+both out of the event loop, so they escape past the flusher and cannot be
+contained here. A sink must let ``CancelledError`` propagate — the flusher
+cancels a write that outlives ``SINK_TIMEOUT_S`` or a ``drain()`` budget and
+waits ``_CANCEL_GRACE_S`` for that cancel to land before abandoning the write
+and re-buffering the batch.
 Sinks must not depend on the default executor or on threads: the atexit drain
 runs after ``threading._shutdown()``, when ``asyncio.to_thread`` raises and the
 write is lost; ``StorageSink`` goes through ``run_off_loop``, which falls back
@@ -140,5 +144,3 @@ class StorageSink:
                 io.BytesIO(blob),
                 overwrite=True,
             )
-
-    write = __call__

--- a/cognee/modules/observability/capture/sinks.py
+++ b/cognee/modules/observability/capture/sinks.py
@@ -96,6 +96,13 @@ class StorageSink:
     Every file carries the same record envelope (``kind``, ``run_id``,
     ``dataset_id``, ``stage``, ``ts``, ``payload``); the manifest's fields live
     under ``payload``. Nothing is written to the relational DB.
+
+    Runs on the flusher task only, never on an emit path. Encoding (the CPU-heavy
+    part) is pushed off-loop; the ``store()`` call itself is awaited on the loop,
+    and ``LocalFileStorage.store`` is an ``async def`` with a blocking body
+    (makedirs, write, rename) — sub-millisecond for a gzipped batch on local disk,
+    unbounded on a slow network filesystem. That is pre-existing storage-layer
+    behaviour this sink inherits rather than introduces.
     """
 
     def __init__(self, storage: StorageManager, root: str = "") -> None:

--- a/cognee/modules/observability/capture/sinks.py
+++ b/cognee/modules/observability/capture/sinks.py
@@ -1,0 +1,94 @@
+"""Capture sinks (SDK-529).
+
+A sink is a bare async callable taking a list of already-serialized records
+(shape-compatible with ``ActivitySink``). Sinks are invoked only from the
+background flusher or from ``drain()``/``shutdown()``, never inline from
+``emit()``.
+
+Contract for implementations: usable from any loop/thread — two flushers on
+different loops (run_sync's thread, the dataset-queue reaper thread) can call a
+sink concurrently — so no loop-bound clients. ``StorageManager`` Local/S3
+qualify.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import io
+import itertools
+import json
+import os
+import time
+from typing import TYPE_CHECKING, Awaitable, Callable
+
+from .events import KIND_RUN_MANIFEST
+
+if TYPE_CHECKING:
+    from cognee.infrastructure.files.storage import StorageManager
+
+CaptureSink = Callable[[list[dict]], Awaitable[None]]
+
+# Process-wide blob sequence: together with time_ns and pid this makes blob
+# names collision-free across loops/threads/processes without coordination. A
+# per-sink NNNNNN counter with overwrite=True would silently clobber blobs
+# under two concurrent flushers.
+_blob_sequence = itertools.count()
+
+
+def _encode_group(records: list[dict]) -> bytes:
+    """JSONL + gzip. compresslevel=1 is ~2x faster than 6 for a marginal size cost."""
+    lines = "".join(json.dumps(record, default=str) + "\n" for record in records)
+    return gzip.compress(lines.encode("utf-8"), compresslevel=1)
+
+
+class StorageSink:
+    """Write capture records to a ``StorageManager`` (Local or S3).
+
+    Layout under ``root``::
+
+        {dataset or "nodataset"}/{run or "norun"}/{kind}/batch-{ts_ns}-{pid}-{seq:06d}.jsonl.gz
+        {dataset or "nodataset"}/{run or "norun"}/manifest.json   (kind run.manifest, pretty JSON)
+
+    Every file carries the same record envelope (``kind``, ``run_id``,
+    ``dataset_id``, ``stage``, ``ts``, ``payload``); the manifest's fields live
+    under ``payload``. Nothing is written to the relational DB.
+    """
+
+    def __init__(self, storage: StorageManager, root: str = "") -> None:
+        self._storage = storage
+        self._root = root if not root or root.endswith("/") else root + "/"
+
+    async def __call__(self, records: list[dict]) -> None:
+        groups: dict[tuple[str, str, str], list[dict]] = {}
+        for record in records:
+            key = (
+                record.get("dataset_id") or "nodataset",
+                record.get("run_id") or "norun",
+                record["kind"],
+            )
+            groups.setdefault(key, []).append(record)
+
+        for (dataset, run, kind), group in groups.items():
+            if kind == KIND_RUN_MANIFEST:
+                for record in group:
+                    # str branch writes UTF-8; overwrite is write-then-rename on Local.
+                    await self._storage.store(
+                        f"{self._root}{dataset}/{run}/manifest.json",
+                        json.dumps(record, indent=2, default=str),
+                        overwrite=True,
+                    )
+                continue
+
+            # Encoding is pure CPU; keep it off the loop like the flusher's
+            # serialization step.
+            blob = await asyncio.to_thread(_encode_group, group)
+            blob_name = f"batch-{time.time_ns()}-{os.getpid()}-{next(_blob_sequence):06d}.jsonl.gz"
+            # BytesIO, not raw bytes, honors the ``BinaryIO | str`` annotation.
+            await self._storage.store(
+                f"{self._root}{dataset}/{run}/{kind}/{blob_name}",
+                io.BytesIO(blob),
+                overwrite=True,
+            )
+
+    write = __call__

--- a/cognee/modules/observability/capture/sinks.py
+++ b/cognee/modules/observability/capture/sinks.py
@@ -20,7 +20,7 @@ import itertools
 import json
 import os
 import time
-from typing import TYPE_CHECKING, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, TypeVar
 
 from .events import KIND_RUN_MANIFEST
 
@@ -28,6 +28,28 @@ if TYPE_CHECKING:
     from cognee.infrastructure.files.storage import StorageManager
 
 CaptureSink = Callable[[list[dict]], Awaitable[None]]
+
+T = TypeVar("T")
+
+
+async def run_off_loop(func: Callable[..., T], /, *args: Any) -> T:
+    """Run pure-CPU work in a worker thread, inline once the executor is gone.
+
+    Serialization and gzip run via ``asyncio.to_thread`` so they never freeze
+    concurrent coroutines. Inside atexit handlers ``threading._shutdown()`` has
+    already run and the default executor refuses new work with
+    ``RuntimeError`` ("cannot schedule new futures after interpreter
+    shutdown") — raised at submit time, before ``func`` starts. Falling back to
+    an inline call there is what lets the atexit drain persist the batch it
+    popped instead of silently losing it. Shared by the flusher and
+    ``StorageSink``. (Should ``func`` itself raise ``RuntimeError``, the inline
+    retry re-raises it.)
+    """
+    try:
+        return await asyncio.to_thread(func, *args)
+    except RuntimeError:
+        return func(*args)
+
 
 # Process-wide blob sequence: together with time_ns and pid this makes blob
 # names collision-free across loops/threads/processes without coordination. A
@@ -81,8 +103,8 @@ class StorageSink:
                 continue
 
             # Encoding is pure CPU; keep it off the loop like the flusher's
-            # serialization step.
-            blob = await asyncio.to_thread(_encode_group, group)
+            # serialization step (inline at interpreter exit, see run_off_loop).
+            blob = await run_off_loop(_encode_group, group)
             blob_name = f"batch-{time.time_ns()}-{os.getpid()}-{next(_blob_sequence):06d}.jsonl.gz"
             # BytesIO, not raw bytes, honors the ``BinaryIO | str`` annotation.
             await self._storage.store(

--- a/cognee/modules/observability/capture/sinks.py
+++ b/cognee/modules/observability/capture/sinks.py
@@ -8,12 +8,20 @@ background flusher or from ``drain()``/``shutdown()``, never inline from
 Contract for implementations: usable from any loop/thread — two flushers on
 different loops (run_sync's thread, the dataset-queue reaper thread) can call a
 sink concurrently — so no loop-bound clients. ``StorageManager`` Local/S3
-qualify.
+qualify. Delivery is at-least-once: a flush cancelled or cut off by
+``drain()``'s budget mid-write is re-buffered and written again later, so a
+sink may receive the same records twice (``StorageSink`` never overwrites —
+blob names are collision-free — so consumers that need exactly-once counts
+should dedupe on ``(run_id, kind, ts)``). Sinks must raise ``Exception``
+subclasses only; a ``BaseException`` from a sink escapes the flusher's
+never-raise guards by design.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextvars
+import functools
 import gzip
 import io
 import itertools
@@ -35,20 +43,27 @@ T = TypeVar("T")
 async def run_off_loop(func: Callable[..., T], /, *args: Any) -> T:
     """Run pure-CPU work in a worker thread, inline once the executor is gone.
 
-    Serialization and gzip run via ``asyncio.to_thread`` so they never freeze
-    concurrent coroutines. Inside atexit handlers ``threading._shutdown()`` has
-    already run and the default executor refuses new work with
-    ``RuntimeError`` ("cannot schedule new futures after interpreter
-    shutdown") — raised at submit time, before ``func`` starts. Falling back to
-    an inline call there is what lets the atexit drain persist the batch it
-    popped instead of silently losing it. Shared by the flusher and
-    ``StorageSink``. (Should ``func`` itself raise ``RuntimeError``, the inline
-    retry re-raises it.)
+    Serialization and gzip run in the default executor (the body of
+    ``asyncio.to_thread``) so they never freeze concurrent coroutines. Inside
+    atexit handlers ``threading._shutdown()`` has already run and the executor
+    refuses new work with ``RuntimeError`` ("cannot schedule new futures after
+    interpreter shutdown") — raised at SUBMIT time, before ``func`` starts.
+    Falling back to an inline call there is what lets the atexit drain persist
+    the batch it popped instead of silently losing it. Shared by the flusher
+    and ``StorageSink``.
+
+    Only the submit-time failure triggers the fallback: an error raised by
+    ``func`` itself in the worker thread — a ``RecursionError`` (a
+    ``RuntimeError`` subclass) on a pathologically deep payload, say —
+    propagates instead of being retried on the event loop.
     """
+    loop = asyncio.get_running_loop()
+    context = contextvars.copy_context()
     try:
-        return await asyncio.to_thread(func, *args)
+        future = loop.run_in_executor(None, functools.partial(context.run, func, *args))
     except RuntimeError:
         return func(*args)
+    return await future
 
 
 # Process-wide blob sequence: together with time_ns and pid this makes blob

--- a/cognee/modules/observability/capture/sinks.py
+++ b/cognee/modules/observability/capture/sinks.py
@@ -23,8 +23,17 @@ waits ``_CANCEL_GRACE_S`` for that cancel to land before abandoning the write
 and re-buffering the batch.
 Sinks must not depend on the default executor or on threads: the atexit drain
 runs after ``threading._shutdown()``, when ``asyncio.to_thread`` raises and the
-write is lost; ``StorageSink`` goes through ``run_off_loop``, which falls back
-to an inline call there.
+write is lost; ``StorageSink`` goes through ``run_off_loop`` /
+``run_coroutine_off_loop``, which fall back to an inline call there.
+
+A sink write must have a REAL suspension point. The flusher bounds each write
+with ``SINK_TIMEOUT_S`` (and ``drain()`` with its budget) by cancelling it, and
+a coroutine can only be cancelled where it awaits something that actually
+suspends: ``LocalFileStorage.store`` is an ``async def`` whose body never does
+(makedirs, write, rename), so awaited directly it would pin the flusher — and
+every other coroutine on that loop — for as long as the filesystem takes, and
+neither timeout could fire. ``StorageSink`` therefore drives the whole write on
+a worker thread (``run_coroutine_off_loop``).
 """
 
 from __future__ import annotations
@@ -76,6 +85,35 @@ async def run_off_loop(func: Callable[..., T], /, *args: Any) -> T:
     return await future
 
 
+def _run_to_completion(make_coroutine: Callable[[], Awaitable[T]]) -> T:
+    """Worker-thread body: build the coroutine HERE (never on the caller's side,
+    so a submit-time failure leaves no never-awaited coroutine behind) and drive
+    it on a private loop."""
+    return asyncio.run(make_coroutine())
+
+
+async def run_coroutine_off_loop(make_coroutine: Callable[[], Awaitable[T]]) -> T:
+    """Drive a coroutine to completion in a worker thread; inline once the executor is gone.
+
+    For an ``async def`` whose body blocks — ``LocalFileStorage.store`` (no
+    suspension point at all) — or that offloads internally with no
+    interpreter-exit fallback (``S3FileStorage.store``). Running it on its own
+    loop in a worker thread gives the awaiting flusher a real suspension point,
+    so ``SINK_TIMEOUT_S`` and ``drain()``'s budget can actually cut the wait
+    (the worker then finishes on its own: abandoned, not interrupted — which is
+    why blob names are collision-free and manifests are written atomically) and
+    a stalled filesystem no longer freezes every coroutine on the flusher's loop.
+    Same submit-time fallback as ``run_off_loop``: inside the atexit drain the
+    executor is gone, and the coroutine is awaited inline on the drain's own loop.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        future = loop.run_in_executor(None, functools.partial(_run_to_completion, make_coroutine))
+    except RuntimeError:
+        return await make_coroutine()
+    return await future
+
+
 # Process-wide blob sequence: together with time_ns and pid this makes blob
 # names collision-free across loops/threads/processes without coordination. A
 # per-sink NNNNNN counter with overwrite=True would silently clobber blobs
@@ -101,12 +139,12 @@ class StorageSink:
     ``dataset_id``, ``stage``, ``ts``, ``payload``); the manifest's fields live
     under ``payload``. Nothing is written to the relational DB.
 
-    Runs on the flusher task only, never on an emit path. Encoding (the CPU-heavy
-    part) is pushed off-loop; the ``store()`` call itself is awaited on the loop,
-    and ``LocalFileStorage.store`` is an ``async def`` with a blocking body
-    (makedirs, write, rename) — sub-millisecond for a gzipped batch on local disk,
-    unbounded on a slow network filesystem. That is pre-existing storage-layer
-    behaviour this sink inherits rather than introduces.
+    Runs on the flusher task only, never on an emit path. Each write — the
+    encode and the ``store()`` call — runs as one unit on a worker thread
+    (``run_coroutine_off_loop``): ``LocalFileStorage.store`` is an ``async def``
+    with a blocking body (makedirs, write, rename), sub-millisecond on local
+    disk and unbounded on a slow network filesystem, and awaited on the loop it
+    would pin the flusher past every timeout (see the module docstring).
     """
 
     def __init__(self, storage: StorageManager, root: str = "") -> None:
@@ -126,21 +164,27 @@ class StorageSink:
         for (dataset, run, kind), group in groups.items():
             if kind == KIND_RUN_MANIFEST:
                 for record in group:
-                    # str branch writes UTF-8; overwrite is write-then-rename on Local.
-                    await self._storage.store(
-                        f"{self._root}{dataset}/{run}/manifest.json",
-                        json.dumps(record, indent=2, default=str),
-                        overwrite=True,
+                    await run_coroutine_off_loop(
+                        functools.partial(
+                            self._write_manifest,
+                            f"{self._root}{dataset}/{run}/manifest.json",
+                            record,
+                        )
                     )
                 continue
 
-            # Encoding is pure CPU; keep it off the loop like the flusher's
-            # serialization step (inline at interpreter exit, see run_off_loop).
-            blob = await run_off_loop(_encode_group, group)
             blob_name = f"batch-{time.time_ns()}-{os.getpid()}-{next(_blob_sequence):06d}.jsonl.gz"
-            # BytesIO, not raw bytes, honors the ``BinaryIO | str`` annotation.
-            await self._storage.store(
-                f"{self._root}{dataset}/{run}/{kind}/{blob_name}",
-                io.BytesIO(blob),
-                overwrite=True,
+            await run_coroutine_off_loop(
+                functools.partial(
+                    self._write_blob, f"{self._root}{dataset}/{run}/{kind}/{blob_name}", group
+                )
             )
+
+    async def _write_manifest(self, path: str, record: dict) -> None:
+        # str branch writes UTF-8; overwrite is write-then-rename on Local.
+        await self._storage.store(path, json.dumps(record, indent=2, default=str), overwrite=True)
+
+    async def _write_blob(self, path: str, group: list[dict]) -> None:
+        # Encode and write on the same worker: the encode is pure CPU, the write
+        # blocks. BytesIO, not raw bytes, honors the ``BinaryIO | str`` annotation.
+        await self._storage.store(path, io.BytesIO(_encode_group(group)), overwrite=True)

--- a/cognee/modules/observability/capture/sinks.py
+++ b/cognee/modules/observability/capture/sinks.py
@@ -12,7 +12,8 @@ qualify. Delivery is at-least-once: a flush cancelled or cut off by
 ``drain()``'s budget mid-write is re-buffered and written again later, so a
 sink may receive the same records twice (``StorageSink`` never overwrites —
 blob names are collision-free — so consumers that need exactly-once counts
-should dedupe on ``(run_id, kind, ts)``). Sinks must raise ``Exception``
+dedupe on the record's ``event_id``, which is the same on both copies). Sinks
+must raise ``Exception``
 subclasses only: a ``BaseException`` from a sink re-buffers the batch and ends
 the flusher (the next emit starts a replacement). ``KeyboardInterrupt`` and
 ``SystemExit`` are the exception to that: asyncio's ``Task.__step`` re-raises
@@ -135,9 +136,10 @@ class StorageSink:
         {dataset or "nodataset"}/{run or "norun"}/{kind}/batch-{ts_ns}-{pid}-{seq:06d}.jsonl.gz
         {dataset or "nodataset"}/{run or "norun"}/manifest.json   (kind run.manifest, pretty JSON)
 
-    Every file carries the same record envelope (``kind``, ``run_id``,
-    ``dataset_id``, ``stage``, ``ts``, ``payload``); the manifest's fields live
-    under ``payload``. Nothing is written to the relational DB.
+    Every file carries the same record envelope (``schema_version``,
+    ``event_id``, ``kind``, ``run_id``, ``dataset_id``, ``stage``, ``ts``,
+    ``payload``); the manifest's fields live under ``payload``. Nothing is
+    written to the relational DB.
 
     Runs on the flusher task only, never on an emit path. Each write — the
     encode and the ``store()`` call — runs as one unit on a worker thread

--- a/cognee/modules/ontology/construct_data_points_and_edges_with_ontology.py
+++ b/cognee/modules/ontology/construct_data_points_and_edges_with_ontology.py
@@ -90,17 +90,56 @@ def _find_ontology_match(
     )
 
 
+def _emit_fuzzy_matches(
+    chunk_index: int, data_chunk: DocumentChunk, resolutions: list[dict]
+) -> None:
+    """One ``extraction.fuzzy_match`` event for a chunk's ontology resolutions (SDK-529).
+
+    ``resolutions`` is a list of plain scalar dicts built by the caller only while
+    capture is active; the manifest counts every lookup and every hit.
+    """
+    from cognee.modules.observability import capture as eval_capture
+
+    matched = sum(1 for resolution in resolutions if resolution["matched"])
+    eval_capture.emit(
+        eval_capture.KIND_EXTRACTION_FUZZY_MATCH,
+        {
+            "chunk_id": str(data_chunk.id),
+            "chunk_index": chunk_index,
+            "matches": resolutions,
+            "lookups": len(resolutions),
+            "count": matched,
+        },
+        payload_kind="json",
+        stage="extract_graph_from_data",
+    )
+    eval_capture.bump("extraction.fuzzy_lookups", len(resolutions))
+    eval_capture.bump("extraction.fuzzy_matches", matched)
+
+
 def _find_ontology_matches_for_extracted_graphs(
     data_chunks: list[DocumentChunk],
     extracted_graphs: list[KnowledgeGraph],
     ontology_resolver: BaseOntologyResolver,
 ) -> OntologyMatchLookup:
-    """Find one ontology match for each distinct extracted name and type."""
+    """Find one ontology match for each distinct extracted name and type.
+
+    Eval capture (SDK-529): the lookup is shared across the batch, so a name is resolved
+    by the first chunk that mentions it and skipped afterwards. While capture is active,
+    each chunk that triggered at least one resolution emits ONE ``extraction.fuzzy_match``
+    event listing those resolutions (matched or not) — never one event per node. Nothing
+    is collected when capture is off.
+    """
+    from cognee.modules.observability import capture as eval_capture
+
+    active = eval_capture.is_active()
+
     ontology_match_lookup: OntologyMatchLookup = {}
-    for data_chunk, extracted_graph in zip(data_chunks, extracted_graphs):
+    for chunk_index, (data_chunk, extracted_graph) in enumerate(zip(data_chunks, extracted_graphs)):
         if not extracted_graph:
             continue
 
+        resolutions: Optional[list[dict]] = [] if active else None
         for node in extracted_graph.nodes:
             for node_category, extracted_name in (
                 (_ONTOLOGY_CLASS_CATEGORY, node.type),
@@ -111,12 +150,29 @@ def _find_ontology_matches_for_extracted_graphs(
                 if lookup_key in ontology_match_lookup:
                     continue
 
-                ontology_match_lookup[lookup_key] = _find_ontology_match(
+                ontology_match = _find_ontology_match(
                     ontology_resolver,
                     normalized_extracted_name,
                     node_category,
                     data_chunk,
                 )
+                ontology_match_lookup[lookup_key] = ontology_match
+                if resolutions is not None:
+                    resolutions.append(
+                        {
+                            "category": node_category,
+                            "extracted": extracted_name,
+                            "normalized": normalized_extracted_name,
+                            "canonical": (
+                                None if ontology_match is None else ontology_match.canonical_name
+                            ),
+                            "uri": None if ontology_match is None else ontology_match.canonical_uri,
+                            "matched": ontology_match is not None,
+                        }
+                    )
+
+        if resolutions:
+            _emit_fuzzy_matches(chunk_index, data_chunk, resolutions)
 
     return ontology_match_lookup
 

--- a/cognee/modules/ontology/construct_data_points_and_edges_with_ontology.py
+++ b/cognee/modules/ontology/construct_data_points_and_edges_with_ontology.py
@@ -100,21 +100,28 @@ def _emit_fuzzy_matches(
     """
     from cognee.modules.observability import capture as eval_capture
 
-    matched = sum(1 for resolution in resolutions if resolution["matched"])
-    eval_capture.emit(
-        eval_capture.KIND_EXTRACTION_FUZZY_MATCH,
-        {
-            "chunk_id": str(data_chunk.id),
-            "chunk_index": chunk_index,
-            "matches": resolutions,
-            "lookups": len(resolutions),
-            "count": matched,
-        },
-        payload_kind="json",
-        stage="extract_graph_from_data",
-    )
-    eval_capture.bump("extraction.fuzzy_lookups", len(resolutions))
-    eval_capture.bump("extraction.fuzzy_matches", matched)
+    # Guarded: the caller only ever stores the chunk object and never reads
+    # ``.id`` itself, so a duck-typed chunk without one must not turn a working
+    # ontology pass into a hard failure just because capture is on. Capture
+    # never breaks the extraction it observes.
+    try:
+        matched = sum(1 for resolution in resolutions if resolution["matched"])
+        eval_capture.emit(
+            eval_capture.KIND_EXTRACTION_FUZZY_MATCH,
+            {
+                "chunk_id": str(data_chunk.id),
+                "chunk_index": chunk_index,
+                "matches": resolutions,
+                "lookups": len(resolutions),
+                "count": matched,
+            },
+            payload_kind="json",
+            stage="extract_graph_from_data",
+        )
+        eval_capture.bump("extraction.fuzzy_lookups", len(resolutions))
+        eval_capture.bump("extraction.fuzzy_matches", matched)
+    except Exception as exc:
+        logger.debug("fuzzy-match capture skipped (%s)", exc)
 
 
 def _find_ontology_matches_for_extracted_graphs(

--- a/cognee/modules/operations/record_operation.py
+++ b/cognee/modules/operations/record_operation.py
@@ -16,7 +16,7 @@ Guarantees:
   is swallowed by design.)
 """
 
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, nullcontext
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, AsyncIterator, Optional
@@ -178,23 +178,40 @@ async def record_operation(
         outcome = OperationOutcome.SUCCEEDED
         error_class: Optional[str] = None
         error_message: Optional[str] = None
-        try:
-            with parent_run_scope(context.operation_id):
-                yield context
-        except BaseException as exc:
-            outcome = OperationOutcome.FAILED
-            error_class = type(exc).__name__
-            error_message = scrub_error_message(exc)
-            raise
-        finally:
-            _current_operation.reset(context_token)
+
+        # Eval capture (SDK-529). Imported lazily so ``import cognee`` never pays
+        # for the capture package; is_active() is one global read once
+        # initialized, and the OFF path constructs no scope at all. No drain()
+        # here: this wraps the user-facing recall/search path, and the manifest
+        # lands within FLUSH_INTERVAL_S like any other event.
+        from cognee.modules.observability import capture as eval_capture
+
+        capture_scope_cm = (
+            eval_capture.run_scope(context.operation_id, dataset_id, kind="operation")
+            if eval_capture.is_active()
+            else nullcontext()
+        )
+        with capture_scope_cm as capture_scope:
             try:
-                await _write_operation_row(
-                    context, started_at, outcome.value, error_class, error_message
-                )
-            except Exception as write_error:
-                logger.warning(
-                    "record_operation: failed to persist %s record (%s)",
-                    operation_name,
-                    write_error,
-                )
+                with parent_run_scope(context.operation_id):
+                    yield context
+            except BaseException as exc:
+                outcome = OperationOutcome.FAILED
+                error_class = type(exc).__name__
+                error_message = scrub_error_message(exc)
+                raise
+            finally:
+                if capture_scope is not None:
+                    # Callers bind the dataset lazily via context.set_dataset().
+                    capture_scope.set_dataset(context.dataset_id)
+                _current_operation.reset(context_token)
+                try:
+                    await _write_operation_row(
+                        context, started_at, outcome.value, error_class, error_message
+                    )
+                except Exception as write_error:
+                    logger.warning(
+                        "record_operation: failed to persist %s record (%s)",
+                        operation_name,
+                        write_error,
+                    )

--- a/cognee/modules/operations/record_operation.py
+++ b/cognee/modules/operations/record_operation.py
@@ -183,7 +183,10 @@ async def record_operation(
         # for the capture package; is_active() is one global read once
         # initialized, and the OFF path constructs no scope at all. No drain()
         # here: this wraps the user-facing recall/search path, and the manifest
-        # lands within FLUSH_INTERVAL_S like any other event.
+        # lands within FLUSH_INTERVAL_S like any other event. The manifest
+        # mirrors the row's attribution fields (operation, outcome,
+        # error_class) so a captured run can be filtered offline without
+        # joining back to ``pipeline_runs``.
         from cognee.modules.observability import capture as eval_capture
 
         capture_scope_cm = (
@@ -192,6 +195,8 @@ async def record_operation(
             else nullcontext()
         )
         with capture_scope_cm as capture_scope:
+            if capture_scope is not None:
+                capture_scope.note("operation", operation_name)
             try:
                 with parent_run_scope(context.operation_id):
                     yield context
@@ -204,6 +209,9 @@ async def record_operation(
                 if capture_scope is not None:
                     # Callers bind the dataset lazily via context.set_dataset().
                     capture_scope.set_dataset(context.dataset_id)
+                    capture_scope.note("outcome", outcome.value)
+                    # None on success, kept for a stable manifest shape.
+                    capture_scope.note("error_class", error_class)
                 _current_operation.reset(context_token)
                 try:
                     await _write_operation_row(

--- a/cognee/modules/operations/record_operation.py
+++ b/cognee/modules/operations/record_operation.py
@@ -81,6 +81,10 @@ class OperationContext:
         self.session_id = session_id
         self.background = background
         self.parent_operation_id = parent_operation_id
+        # The eval-capture run scope opened for this operation, when capture is
+        # active (SDK-529). Bound by ``record_operation`` so ``set_dataset``
+        # can forward the dataset the moment the caller learns it.
+        self._capture_scope = None
 
     def set_user(self, user) -> None:
         """Bind the triggering user (tolerates None and partial objects)."""
@@ -90,8 +94,19 @@ class OperationContext:
         self.tenant_id = getattr(user, "tenant_id", None)
 
     def set_dataset(self, dataset_id: Optional[UUID]) -> None:
-        """Bind the target dataset, when the operation has exactly one."""
+        """Bind the target dataset, when the operation has exactly one.
+
+        Forwarded to the eval-capture scope immediately, not at operation exit:
+        capture resolves an event's dataset when the event is FLUSHED, and the
+        flusher ticks every ``FLUSH_INTERVAL_S`` (2 s) while a search's LLM
+        completion runs for longer than that. Binding only in the ``finally``
+        filed essentially every search's ``retrieval.candidates`` under
+        ``nodataset/`` while its manifest landed under ``<dataset>/``.
+        """
         self.dataset_id = dataset_id
+        capture_scope = self._capture_scope
+        if capture_scope is not None:
+            capture_scope.set_dataset(dataset_id)
 
     def set_session_id(self, session_id: Optional[str]) -> None:
         """Bind the active session-cache id (joins SessionModelUsage)."""
@@ -197,6 +212,10 @@ async def record_operation(
         with capture_scope_cm as capture_scope:
             if capture_scope is not None:
                 capture_scope.note("operation", operation_name)
+                # So context.set_dataset() reaches the scope as soon as the
+                # caller resolves its dataset; the ``finally`` below is only a
+                # backstop for callers that never call it.
+                context._capture_scope = capture_scope
             try:
                 with parent_run_scope(context.operation_id):
                     yield context
@@ -207,7 +226,8 @@ async def record_operation(
                 raise
             finally:
                 if capture_scope is not None:
-                    # Callers bind the dataset lazily via context.set_dataset().
+                    # Backstop: set_dataset() already forwarded the dataset when
+                    # the caller bound it; this covers a dataset passed at entry.
                     capture_scope.set_dataset(context.dataset_id)
                     capture_scope.note("outcome", outcome.value)
                     # None on success, kept for a stable manifest shape.

--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -284,8 +284,10 @@ async def run_tasks(
                     tokens_out=run_usage.tokens_out,
                 )
 
-                # A pipeline run is seconds-to-minutes and LLM-bound, so one sink
-                # write is noise here; drain() swallows its own exceptions.
+                # A pipeline run is seconds-to-minutes and LLM-bound, so a drain
+                # is noise here: it returns within its timeout even under a
+                # wedged sink (leftovers stay with the flusher / the atexit
+                # hook) and swallows its own exceptions.
                 if eval_capture.is_active():
                     if capture_scope is not None:
                         capture_scope.finish()
@@ -335,6 +337,7 @@ async def run_tasks(
                     tokens_out=run_usage.tokens_out,
                 )
 
+                # Same bound as on the success path: within drain()'s timeout.
                 if eval_capture.is_active():
                     if capture_scope is not None:
                         capture_scope.finish()

--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import nullcontext
 
 from typing import Any, Awaitable, Callable, List, Optional, Union
 from uuid import UUID
@@ -88,7 +89,19 @@ async def run_tasks(
     # parent_run_scope makes nested runs (a pipeline started by one of our
     # tasks, or a recorded operation called mid-pipeline) parent to THIS run,
     # mirroring how their tokens chain into run_usage.
-    with operation_usage_scope() as run_usage, parent_run_scope(pipeline_run_id):
+    # Eval capture (SDK-529): lazy import keeps ``import cognee`` free of the
+    # capture package. Pipeline scopes are always sampled.
+    from cognee.modules.observability import capture as eval_capture
+
+    with (
+        operation_usage_scope() as run_usage,
+        parent_run_scope(pipeline_run_id),
+        (
+            eval_capture.run_scope(pipeline_run_id, dataset.id, kind="pipeline")
+            if eval_capture.is_active()
+            else nullcontext()
+        ),
+    ):
         async with set_database_global_context_variables(
             dataset.id,
             dataset.owner_id,
@@ -268,6 +281,11 @@ async def run_tasks(
                     tokens_out=run_usage.tokens_out,
                 )
 
+                # A pipeline run is seconds-to-minutes and LLM-bound, so one sink
+                # write is noise here; drain() swallows its own exceptions.
+                if eval_capture.is_active():
+                    await eval_capture.drain()
+
                 yield PipelineRunCompleted(
                     pipeline_run_id=pipeline_run_id,
                     dataset_id=dataset.id,
@@ -311,6 +329,9 @@ async def run_tasks(
                     tokens_in=run_usage.tokens_in,
                     tokens_out=run_usage.tokens_out,
                 )
+
+                if eval_capture.is_active():
+                    await eval_capture.drain()
 
                 yield PipelineRunErrored(
                     pipeline_run_id=pipeline_run_id,

--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -90,7 +90,10 @@ async def run_tasks(
     # tasks, or a recorded operation called mid-pipeline) parent to THIS run,
     # mirroring how their tokens chain into run_usage.
     # Eval capture (SDK-529): lazy import keeps ``import cognee`` free of the
-    # capture package. Pipeline scopes are always sampled.
+    # capture package. Pipeline scopes are always sampled. The scope encloses
+    # the terminal yield, so its exit runs only after the consumer finishes the
+    # generator — later than the drain below; capture_scope.finish() before
+    # each drain gets the manifest in ahead of it (exit then skips the duplicate).
     from cognee.modules.observability import capture as eval_capture
 
     with (
@@ -100,7 +103,7 @@ async def run_tasks(
             eval_capture.run_scope(pipeline_run_id, dataset.id, kind="pipeline")
             if eval_capture.is_active()
             else nullcontext()
-        ),
+        ) as capture_scope,
     ):
         async with set_database_global_context_variables(
             dataset.id,
@@ -284,6 +287,8 @@ async def run_tasks(
                 # A pipeline run is seconds-to-minutes and LLM-bound, so one sink
                 # write is noise here; drain() swallows its own exceptions.
                 if eval_capture.is_active():
+                    if capture_scope is not None:
+                        capture_scope.finish()
                     await eval_capture.drain()
 
                 yield PipelineRunCompleted(
@@ -331,6 +336,8 @@ async def run_tasks(
                 )
 
                 if eval_capture.is_active():
+                    if capture_scope is not None:
+                        capture_scope.finish()
                     await eval_capture.drain()
 
                 yield PipelineRunErrored(

--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -16,7 +16,7 @@ from cognee.modules.pipelines.utils import generate_pipeline_id
 from cognee.modules.pipelines.exceptions import PipelineRunFailedError
 from cognee.tasks.ingestion import resolve_data_directories
 from cognee.modules.pipelines.layers.validate_pipeline_tasks import validate_pipeline_tasks
-from cognee.modules.pipelines.models import PipelineContext
+from cognee.modules.pipelines.models import OperationOutcome, PipelineContext
 from cognee.modules.pipelines.models.PipelineRunInfo import (
     PipelineRunCompleted,
     PipelineRunErrored,
@@ -34,6 +34,26 @@ from ..tasks.task import Task
 
 
 logger = get_logger("run_tasks(tasks: [Task], data)")
+
+
+async def _close_capture_run(eval_capture, capture_scope) -> None:
+    """Deliver the run's events, then its manifest — in that order (SDK-529).
+
+    The manifest carries the run's own capture accounting (``events_delivered``,
+    ``capture_complete``), so it is finished only after the drain that delivers
+    the run's events: a sink failure during that drain is then charged to the
+    run before its manifest is written, instead of after. The manifest is
+    drained inline too, but only when the first drain finished — under a wedged
+    sink, or with a concurrent run's events still arriving, it is left to the
+    flusher / the atexit hook rather than adding a second full budget to the
+    pipeline's tail. Both drains are bounded by DRAIN_TIMEOUT_S and swallow
+    their own exceptions.
+    """
+    complete = await eval_capture.drain()
+    if capture_scope is not None:
+        capture_scope.finish()
+        if complete:
+            await eval_capture.drain()
 
 
 async def run_tasks(
@@ -92,8 +112,11 @@ async def run_tasks(
     # Eval capture (SDK-529): lazy import keeps ``import cognee`` free of the
     # capture package. Pipeline scopes are always sampled. The scope encloses
     # the terminal yield, so its exit runs only after the consumer finishes the
-    # generator — later than the drain below; capture_scope.finish() before
-    # each drain gets the manifest in ahead of it (exit then skips the duplicate).
+    # generator — later than the drains below; _close_capture_run finishes the
+    # scope between them so the manifest is delivered before the terminal
+    # yield (exit then skips the duplicate). The manifest mirrors the pipeline
+    # log's attribution (pipeline_name, outcome, error_class), like an
+    # operation manifest mirrors its pipeline_runs row.
     from cognee.modules.observability import capture as eval_capture
 
     with (
@@ -105,6 +128,8 @@ async def run_tasks(
             else nullcontext()
         ) as capture_scope,
     ):
+        if capture_scope is not None:
+            capture_scope.note("pipeline_name", pipeline_name)
         async with set_database_global_context_variables(
             dataset.id,
             dataset.owner_id,
@@ -290,8 +315,10 @@ async def run_tasks(
                 # hook) and swallows its own exceptions.
                 if eval_capture.is_active():
                     if capture_scope is not None:
-                        capture_scope.finish()
-                    await eval_capture.drain()
+                        capture_scope.note("outcome", OperationOutcome.SUCCEEDED.value)
+                        # None on success, kept for a stable manifest shape.
+                        capture_scope.note("error_class", None)
+                    await _close_capture_run(eval_capture, capture_scope)
 
                 yield PipelineRunCompleted(
                     pipeline_run_id=pipeline_run_id,
@@ -340,8 +367,9 @@ async def run_tasks(
                 # Same bound as on the success path: within drain()'s timeout.
                 if eval_capture.is_active():
                     if capture_scope is not None:
-                        capture_scope.finish()
-                    await eval_capture.drain()
+                        capture_scope.note("outcome", OperationOutcome.FAILED.value)
+                        capture_scope.note("error_class", type(error).__name__)
+                    await _close_capture_run(eval_capture, capture_scope)
 
                 yield PipelineRunErrored(
                     pipeline_run_id=pipeline_run_id,

--- a/cognee/modules/retrieval/graph_completion_context_extension_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_context_extension_retriever.py
@@ -6,6 +6,9 @@ from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
 from cognee.modules.retrieval.utils.query_state import QueryState
 from cognee.modules.retrieval.utils.validate_queries import validate_retriever_input
 from cognee.shared.logging_utils import get_logger
+from cognee.modules.retrieval.utils.brute_force_triplet_search import (
+    DEFAULT_TRIPLET_DISTANCE_PENALTY,
+)
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.modules.retrieval.utils.completion import generate_completion_batch
 
@@ -28,7 +31,7 @@ class GraphCompletionContextExtensionRetriever(GraphCompletionRetriever):
         node_name: Optional[List[str]] = None,
         node_name_filter_operator: str = "OR",
         wide_search_top_k: Optional[int] = 100,
-        triplet_distance_penalty: Optional[float] = 6.5,
+        triplet_distance_penalty: Optional[float] = DEFAULT_TRIPLET_DISTANCE_PENALTY,
         feedback_influence: float = get_base_config().default_feedback_influence,
         context_extension_rounds: int = 4,
         session_id: Optional[str] = None,

--- a/cognee/modules/retrieval/graph_completion_cot_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_cot_retriever.py
@@ -9,6 +9,9 @@ from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
 from cognee.modules.retrieval.utils.query_state import QueryState
 from cognee.modules.retrieval.utils.validate_queries import validate_retriever_input
 from cognee.shared.logging_utils import get_logger
+from cognee.modules.retrieval.utils.brute_force_triplet_search import (
+    DEFAULT_TRIPLET_DISTANCE_PENALTY,
+)
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.modules.retrieval.utils.completion import (
     batch_llm_completion,
@@ -64,7 +67,7 @@ class GraphCompletionCotRetriever(GraphCompletionRetriever):
         node_name: Optional[List[str]] = None,
         node_name_filter_operator: str = "OR",
         wide_search_top_k: Optional[int] = 100,
-        triplet_distance_penalty: Optional[float] = 6.5,
+        triplet_distance_penalty: Optional[float] = DEFAULT_TRIPLET_DISTANCE_PENALTY,
         feedback_influence: float = get_base_config().default_feedback_influence,
         max_iter: int = 4,
         session_id: Optional[str] = None,

--- a/cognee/modules/retrieval/graph_completion_decomposition_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_decomposition_retriever.py
@@ -7,6 +7,9 @@ from cognee.infrastructure.llm.LLMGateway import LLMGateway
 from cognee.infrastructure.llm.prompts import read_query_prompt
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
 from cognee.modules.retrieval.exceptions.exceptions import QueryValidationError
+from cognee.modules.retrieval.utils.brute_force_triplet_search import (
+    DEFAULT_TRIPLET_DISTANCE_PENALTY,
+)
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.modules.retrieval.utils.completion import generate_completion
 from cognee.modules.retrieval.utils.query_decomposition import (
@@ -40,7 +43,7 @@ class GraphCompletionDecompositionRetriever(GraphCompletionRetriever):
         node_name: Optional[List[str]] = None,
         node_name_filter_operator: str = "OR",
         wide_search_top_k: Optional[int] = 100,
-        triplet_distance_penalty: Optional[float] = 6.5,
+        triplet_distance_penalty: Optional[float] = DEFAULT_TRIPLET_DISTANCE_PENALTY,
         feedback_influence: float = get_base_config().default_feedback_influence,
         session_id: Optional[str] = None,
         response_model: Type = str,

--- a/cognee/modules/retrieval/graph_completion_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_retriever.py
@@ -8,7 +8,10 @@ from cognee.modules.retrieval.utils.validate_queries import validate_retriever_i
 from cognee.modules.graph.utils import resolve_edges_to_text
 from cognee.modules.graph.utils.convert_node_to_data_point import get_all_subclasses
 from cognee.modules.retrieval.base_retriever import BaseRetriever
-from cognee.modules.retrieval.utils.brute_force_triplet_search import brute_force_triplet_search
+from cognee.modules.retrieval.utils.brute_force_triplet_search import (
+    DEFAULT_TRIPLET_DISTANCE_PENALTY,
+    brute_force_triplet_search,
+)
 from cognee.modules.retrieval.utils.merge_results import (
     conversational_reserve,
     edge_identity,
@@ -57,7 +60,7 @@ class GraphCompletionRetriever(BaseRetriever):
         node_name: Optional[List[str]] = None,
         node_name_filter_operator: str = "OR",
         wide_search_top_k: Optional[int] = 100,
-        triplet_distance_penalty: Optional[float] = 6.5,
+        triplet_distance_penalty: Optional[float] = DEFAULT_TRIPLET_DISTANCE_PENALTY,
         feedback_influence: float = get_base_config().default_feedback_influence,
         session_id: Optional[str] = None,
         response_model: Type = str,
@@ -77,7 +80,9 @@ class GraphCompletionRetriever(BaseRetriever):
         self.node_name = node_name
         self.node_name_filter_operator = node_name_filter_operator
         self.triplet_distance_penalty = (
-            6.5 if triplet_distance_penalty is None else triplet_distance_penalty
+            DEFAULT_TRIPLET_DISTANCE_PENALTY
+            if triplet_distance_penalty is None
+            else triplet_distance_penalty
         )
         self.feedback_influence = feedback_influence
         # session_id (Optional[str]): Identifier for managing conversation history.

--- a/cognee/modules/retrieval/graph_summary_completion_retriever.py
+++ b/cognee/modules/retrieval/graph_summary_completion_retriever.py
@@ -1,6 +1,9 @@
 from typing import Optional, Type, List
 
 from cognee.base_config import get_base_config
+from cognee.modules.retrieval.utils.brute_force_triplet_search import (
+    DEFAULT_TRIPLET_DISTANCE_PENALTY,
+)
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.modules.retrieval.utils.completion import summarize_text
 
@@ -28,7 +31,7 @@ class GraphSummaryCompletionRetriever(GraphCompletionRetriever):
         node_name: Optional[List[str]] = None,
         node_name_filter_operator: str = "OR",
         wide_search_top_k: Optional[int] = 100,
-        triplet_distance_penalty: Optional[float] = 6.5,
+        triplet_distance_penalty: Optional[float] = DEFAULT_TRIPLET_DISTANCE_PENALTY,
         feedback_influence: float = get_base_config().default_feedback_influence,
         session_id: Optional[str] = None,
         include_references: bool = False,

--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -8,6 +8,9 @@ from cognee.base_config import get_base_config
 from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.infrastructure.llm.prompts import render_prompt
 from cognee.infrastructure.llm import LLMGateway
+from cognee.modules.retrieval.utils.brute_force_triplet_search import (
+    DEFAULT_TRIPLET_DISTANCE_PENALTY,
+)
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.modules.retrieval.utils.used_graph_elements import extract_from_temporal_dict
 from cognee.shared.logging_utils import get_logger
@@ -43,7 +46,7 @@ class TemporalRetriever(GraphCompletionRetriever):
         node_name: Optional[List[str]] = None,
         node_name_filter_operator: str = "OR",
         wide_search_top_k: Optional[int] = 100,
-        triplet_distance_penalty: Optional[float] = 6.5,
+        triplet_distance_penalty: Optional[float] = DEFAULT_TRIPLET_DISTANCE_PENALTY,
         feedback_influence: float = get_base_config().default_feedback_influence,
         session_id: Optional[str] = None,
         response_model: Type = str,

--- a/cognee/modules/retrieval/utils/brute_force_triplet_search.py
+++ b/cognee/modules/retrieval/utils/brute_force_triplet_search.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple, Type, Union, cast
 
 from cognee.modules.observability import OtelStatusCode as StatusCode
 
@@ -169,7 +169,12 @@ def _emit_retrieval_candidates(
         default_penalty = (
             6.5 if triplet_distance_penalty is None else float(triplet_distance_penalty)
         )
-        per_query = [(0, results)] if query_list_length is None else list(enumerate(results))
+        # Single mode carries one flat edge list; batch mode one list per query.
+        per_query: list[tuple[int, Sequence[Edge]]] = (
+            [(0, cast(List[Edge], results))]
+            if query_list_length is None
+            else list(enumerate(cast(List[List[Edge]], results)))
+        )
         for query_index, top_edges in per_query:
             eval_capture.emit(
                 eval_capture.KIND_RETRIEVAL_CANDIDATES,
@@ -480,7 +485,11 @@ async def brute_force_triplet_search(
         if capture_active:
             # The bounding settings of this search, mirrored from the span into
             # the run manifest so an offline eval can tie a candidate pool to the
-            # knobs that produced it. No-ops outside a run scope.
+            # knobs that produced it. No-ops outside a run scope. Last-wins: a
+            # retriever that runs several searches inside one operation scope
+            # (context extension, decomposition, node_name-seeded lookups) leaves
+            # the final call's knobs on the manifest, while every search still
+            # emits its own retrieval.candidates event.
             eval_capture.note("retrieval.top_k", top_k)
             eval_capture.note("retrieval.wide_search_top_k", wide_search_top_k)
             eval_capture.note("retrieval.neighborhood_seed_top_k", neighborhood_seed_top_k)

--- a/cognee/modules/retrieval/utils/brute_force_triplet_search.py
+++ b/cognee/modules/retrieval/utils/brute_force_triplet_search.py
@@ -26,6 +26,11 @@ if TYPE_CHECKING:
 
 logger = get_logger(level=ERROR)
 
+# Distance assigned to a graph element the vector search did not score, and the
+# default for every ``triplet_distance_penalty`` parameter. Shared so the
+# retrievers and the capture payload cannot drift apart.
+DEFAULT_TRIPLET_DISTANCE_PENALTY = 6.5
+
 # Eval capture (SDK-529): cap on the candidate pool carried by one
 # ``retrieval.candidates`` event. Batch mode searches every collection with no
 # limit, so without a cap a single event could carry thousands of entries.
@@ -167,7 +172,9 @@ def _emit_retrieval_candidates(
 
     try:
         default_penalty = (
-            6.5 if triplet_distance_penalty is None else float(triplet_distance_penalty)
+            DEFAULT_TRIPLET_DISTANCE_PENALTY
+            if triplet_distance_penalty is None
+            else float(triplet_distance_penalty)
         )
         # Single mode carries one flat edge list; batch mode one list per query.
         per_query: list[tuple[int, Sequence[Edge]]] = (
@@ -216,7 +223,7 @@ async def get_memory_fragment(
     node_name_filter_operator: str = "OR",
     relevant_ids_to_filter: Optional[List[str]] = None,
     memory_fragment_filter: Optional[List[dict]] = None,
-    triplet_distance_penalty: Optional[float] = 6.5,
+    triplet_distance_penalty: Optional[float] = DEFAULT_TRIPLET_DISTANCE_PENALTY,
     feedback_influence: float = get_base_config().default_feedback_influence,
     graph_engine=None,
     neighborhood_depth: Optional[int] = None,
@@ -395,7 +402,7 @@ async def brute_force_triplet_search(
     node_name: Optional[List[str]] = None,
     node_name_filter_operator: str = "OR",
     wide_search_top_k: Optional[int] = 100,
-    triplet_distance_penalty: Optional[float] = 6.5,
+    triplet_distance_penalty: Optional[float] = DEFAULT_TRIPLET_DISTANCE_PENALTY,
     feedback_influence: float = get_base_config().default_feedback_influence,
     unified_engine: Optional[UnifiedStoreEngine] = None,
     neighborhood_depth: Optional[int] = None,

--- a/cognee/modules/retrieval/utils/brute_force_triplet_search.py
+++ b/cognee/modules/retrieval/utils/brute_force_triplet_search.py
@@ -7,7 +7,10 @@ from cognee.modules.observability import OtelStatusCode as StatusCode
 from cognee.base_config import get_base_config
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
-from cognee.modules.graph.cognee_graph.CogneeGraph import CogneeGraph
+from cognee.modules.graph.cognee_graph.CogneeGraph import (
+    DEFAULT_TRIPLET_DISTANCE_PENALTY,
+    CogneeGraph,
+)
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
 from cognee.modules.graph.exceptions.exceptions import EntityNotFoundError
 from cognee.modules.observability import (
@@ -25,11 +28,6 @@ if TYPE_CHECKING:
     from cognee.infrastructure.databases.unified import UnifiedStoreEngine
 
 logger = get_logger(level=ERROR)
-
-# Distance assigned to a graph element the vector search did not score, and the
-# default for every ``triplet_distance_penalty`` parameter. Shared so the
-# retrievers and the capture payload cannot drift apart.
-DEFAULT_TRIPLET_DISTANCE_PENALTY = 6.5
 
 # Eval capture (SDK-529): cap on the candidate pool carried by one
 # ``retrieval.candidates`` event. Batch mode searches every collection with no

--- a/cognee/modules/retrieval/utils/brute_force_triplet_search.py
+++ b/cognee/modules/retrieval/utils/brute_force_triplet_search.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 from cognee.modules.observability import OtelStatusCode as StatusCode
 
@@ -25,6 +25,163 @@ if TYPE_CHECKING:
     from cognee.infrastructure.databases.unified import UnifiedStoreEngine
 
 logger = get_logger(level=ERROR)
+
+# Eval capture (SDK-529): cap on the candidate pool carried by one
+# ``retrieval.candidates`` event. Batch mode searches every collection with no
+# limit, so without a cap a single event could carry thousands of entries.
+_CAPTURE_POOL_CAP = 500
+_CAPTURE_STAGE = "brute_force_triplet_search"
+
+
+def _distance_at(attributes: Dict, query_index: int, default: float) -> float:
+    """The vector distance an element carries for one query; ``default`` when unset."""
+    distances = attributes.get("vector_distance")
+    if isinstance(distances, list) and query_index < len(distances):
+        try:
+            return float(distances[query_index])
+        except (TypeError, ValueError):
+            return default
+    return default
+
+
+def _scored_for_query(
+    scored: Sequence, query_index: int, query_list_length: Optional[int]
+) -> Sequence:
+    """One query's slice of a ``NodeEdgeVectorSearch`` distance list.
+
+    Single-query mode stores flat lists; batch mode stores one list per query.
+    """
+    if query_list_length is None:
+        return scored or ()
+    if query_index < len(scored):
+        return scored[query_index] or ()
+    return ()
+
+
+def _retrieval_candidates_payload(
+    vector_search: NodeEdgeVectorSearch,
+    top_edges: Sequence[Edge],
+    query_index: int,
+    query_list_length: Optional[int],
+    default_penalty: float,
+) -> Dict:
+    """Flat ``retrieval.candidates`` payload for one query (SDK-529). Scalars only.
+
+    The pool is rebuilt from the ``id``/``score`` attributes of the vector-search
+    results and the cut from the ids and attributes of the returned edges — never
+    the ScoredResult / Node / Edge objects themselves (ScoredResult carries chunk
+    text, Node/Edge back-reference the whole projected fragment).
+
+    Pool: every scored candidate the distance-mapping step saw, as
+    ``(id, collection, score)``, capped at ``_CAPTURE_POOL_CAP``. When the cap
+    bites, each collection keeps the head of its (best-first) results up to an
+    equal quota and the remaining room is filled in collection order, so one large
+    collection cannot crowd the others out of the record.
+
+    Cut: the returned triplets, ``score`` being the summed raw vector distance of
+    source, edge, and target for this query — the un-weighted ranking input. The
+    exact ranking key (importance-weight, feedback, and personal blends) is a
+    closure inside ``CogneeGraph._calculate_query_top_triplet_importances`` and is
+    not stored on the edge; it is deliberately not duplicated here.
+    """
+    per_collection: List[Tuple[str, Sequence]] = [
+        (collection, _scored_for_query(scored, query_index, query_list_length))
+        for collection, scored in vector_search.node_distances.items()
+    ]
+    per_collection.append(
+        (
+            vector_search.edge_collection,
+            _scored_for_query(vector_search.edge_distances, query_index, query_list_length),
+        )
+    )
+
+    pool_size = sum(len(scored) for _, scored in per_collection)
+    if pool_size <= _CAPTURE_POOL_CAP:
+        taken = [(collection, result) for collection, scored in per_collection for result in scored]
+    else:
+        quota = max(1, _CAPTURE_POOL_CAP // len(per_collection))
+        taken = [
+            (collection, result)
+            for collection, scored in per_collection
+            for result in scored[:quota]
+        ]
+        room = _CAPTURE_POOL_CAP - len(taken)
+        for collection, scored in per_collection:
+            if room <= 0:
+                break
+            extra = scored[quota : quota + room]
+            taken.extend((collection, result) for result in extra)
+            room -= len(extra)
+
+    pool = [
+        {
+            "id": str(getattr(result, "id", "")),
+            "collection": collection,
+            "score": float(getattr(result, "score", default_penalty)),
+        }
+        for collection, result in taken
+    ]
+
+    cut = []
+    for edge in top_edges:
+        node1 = edge.node1
+        node2 = edge.node2
+        attributes = edge.attributes
+        rel = (
+            attributes.get("relationship_type")
+            or attributes.get("relationship_name")
+            or attributes.get("edge_text")
+            or ""
+        )
+        score = (
+            _distance_at(node1.attributes, query_index, default_penalty)
+            + _distance_at(attributes, query_index, default_penalty)
+            + _distance_at(node2.attributes, query_index, default_penalty)
+        )
+        cut.append(
+            {"source": str(node1.id), "target": str(node2.id), "rel": str(rel), "score": score}
+        )
+
+    return {
+        "query_index": query_index,
+        "pool": pool,
+        "top_k": cut,
+        "pool_size": pool_size,
+        "pool_truncated": pool_size > _CAPTURE_POOL_CAP,
+        "cut_size": len(cut),
+    }
+
+
+def _emit_retrieval_candidates(
+    vector_search: NodeEdgeVectorSearch,
+    results: Union[List[Edge], List[List[Edge]]],
+    query_list_length: Optional[int],
+    triplet_distance_penalty: Optional[float],
+) -> None:
+    """Emit one ``retrieval.candidates`` event per query (SDK-529). Sync; never raises.
+
+    Called only under ``is_active() and should_capture(...)`` — the OFF path never
+    reaches this function, so it builds nothing when capture is disabled.
+    """
+    from cognee.modules.observability import capture as eval_capture
+
+    try:
+        default_penalty = (
+            6.5 if triplet_distance_penalty is None else float(triplet_distance_penalty)
+        )
+        per_query = [(0, results)] if query_list_length is None else list(enumerate(results))
+        for query_index, top_edges in per_query:
+            eval_capture.emit(
+                eval_capture.KIND_RETRIEVAL_CANDIDATES,
+                _retrieval_candidates_payload(
+                    vector_search, top_edges, query_index, query_list_length, default_penalty
+                ),
+                payload_kind="json",
+                stage=_CAPTURE_STAGE,
+            )
+    except Exception as exc:
+        # Capture never breaks the retrieval it observes.
+        logger.debug("retrieval candidates capture skipped (%s)", exc)
 
 
 def format_triplets(edges):
@@ -313,6 +470,24 @@ async def brute_force_triplet_search(
         otel_span.set_attribute("cognee.retrieval.collection_count", len(collections))
         otel_span.set_attribute(COGNEE_VECTOR_COLLECTION, ", ".join(collections))
 
+        # Eval capture (SDK-529). Imported lazily so ``import cognee`` never pays
+        # for the capture package; is_active() is one global read once
+        # initialized and is read once per search. The OFF path does nothing else:
+        # no notes, no payload, no sampling roll.
+        from cognee.modules.observability import capture as eval_capture
+
+        capture_active = eval_capture.is_active()
+        if capture_active:
+            # The bounding settings of this search, mirrored from the span into
+            # the run manifest so an offline eval can tie a candidate pool to the
+            # knobs that produced it. No-ops outside a run scope.
+            eval_capture.note("retrieval.top_k", top_k)
+            eval_capture.note("retrieval.wide_search_top_k", wide_search_top_k)
+            eval_capture.note("retrieval.neighborhood_seed_top_k", neighborhood_seed_top_k)
+            eval_capture.note("retrieval.feedback_influence", feedback_influence)
+            eval_capture.note("retrieval.mode", "batch" if query_batch is not None else "single")
+            eval_capture.note("retrieval.collections", list(collections))
+
         try:
             vector_engine = unified_engine.vector if unified_engine else None
             graph_engine = unified_engine.graph if unified_engine else None
@@ -360,6 +535,16 @@ async def brute_force_triplet_search(
                 COGNEE_RESULT_SUMMARY,
                 f"Found {result_count} triplet(s) from {len(collections)} collection(s)",
             )
+
+            # Candidate pool + final cut, after the result is computed and with no
+            # await: emit() only buffers. Sampled per run for retrieval kinds; the
+            # payload is built only when this search is sampled in.
+            if capture_active and eval_capture.should_capture(
+                eval_capture.KIND_RETRIEVAL_CANDIDATES
+            ):
+                _emit_retrieval_candidates(
+                    vector_search, results, query_list_length, triplet_distance_penalty
+                )
 
             return results
         except CollectionNotFoundError:

--- a/cognee/tasks/graph/extract_graph_from_data.py
+++ b/cognee/tasks/graph/extract_graph_from_data.py
@@ -36,20 +36,24 @@ logger = get_logger("extract_graph_from_data")
 
 
 def _remove_duplicate_extracted_nodes_by_id(
+    data_chunks: List[DocumentChunk],
     extracted_graphs: list[KnowledgeGraph],
 ) -> None:
     """Keep the first extracted node for each graph-local ID.
 
     Eval capture (SDK-529): while capture is active, every chunk graph that lost nodes
     emits ONE ``extraction.dropped_duplicates`` event carrying the dropped ids, and the
-    run manifest counts them under ``extraction.dropped_duplicate_nodes``. Nothing is
-    collected when capture is off.
+    run manifest counts them under ``extraction.dropped_duplicate_nodes``. The event
+    carries ``chunk_id`` as the join key to its ``extraction.chunk_graph`` record:
+    ``chunk_index`` is the position within this batch and restarts at 0 for every
+    batch of a run, so it alone cannot identify the chunk. Nothing is collected when
+    capture is off.
     """
     from cognee.modules.observability import capture as eval_capture
 
     active = eval_capture.is_active()
 
-    for chunk_index, extracted_graph in enumerate(extracted_graphs):
+    for chunk_index, (chunk, extracted_graph) in enumerate(zip(data_chunks, extracted_graphs)):
         if not extracted_graph:
             continue
 
@@ -72,6 +76,7 @@ def _remove_duplicate_extracted_nodes_by_id(
             eval_capture.emit(
                 eval_capture.KIND_EXTRACTION_DROPPED_DUPLICATES,
                 {
+                    "chunk_id": str(chunk.id),
                     "chunk_index": chunk_index,
                     "dropped_node_ids": dropped_node_ids,
                     "count": len(dropped_node_ids),
@@ -88,9 +93,13 @@ def _capture_chunk_graphs(data_chunks: List[DocumentChunk], chunk_graphs: list) 
     Runs right after extraction and BEFORE ``_remove_duplicate_extracted_nodes_by_id``
     and the ontology canonicalization, both of which mutate the graphs in place — so
     the payload is a ``model_dump(mode="json")`` taken now, never the live object or a
-    ``model_copy``. ``chunk_index`` is the position in this batch (the index the
-    dropped-duplicates and fuzzy-match events use too); ``chunk_size_chars`` records
-    the chunk boundary. A structural no-op (no dump, no allocation) when capture is off.
+    ``model_copy``. That holds for a custom DataPoint-derived ``graph_model`` too: at
+    this point the graph is the freshly validated LLM output, not yet attached to its
+    chunk (``integrate_chunk_graphs`` does that afterwards), so the dump is acyclic; a
+    non-model graph dumps as ``None``. ``chunk_id`` is the join key shared with the
+    dropped-duplicates and fuzzy-match events; ``chunk_index`` is the position in this
+    batch (it restarts at 0 per batch); ``chunk_size_chars`` records the chunk boundary.
+    A structural no-op (no dump, no allocation) when capture is off.
     """
     from cognee.modules.observability import capture as eval_capture
 
@@ -233,7 +242,7 @@ async def integrate_chunk_graphs(
 
         return data_chunks
 
-    _remove_duplicate_extracted_nodes_by_id(chunk_graphs)
+    _remove_duplicate_extracted_nodes_by_id(data_chunks, chunk_graphs)
 
     if ontology_resolver is None:
         data_points_by_id, edges_by_identity = construct_data_points_and_edges(

--- a/cognee/tasks/graph/extract_graph_from_data.py
+++ b/cognee/tasks/graph/extract_graph_from_data.py
@@ -38,22 +38,112 @@ logger = get_logger("extract_graph_from_data")
 def _remove_duplicate_extracted_nodes_by_id(
     extracted_graphs: list[KnowledgeGraph],
 ) -> None:
-    """Keep the first extracted node for each graph-local ID."""
-    for extracted_graph in extracted_graphs:
+    """Keep the first extracted node for each graph-local ID.
+
+    Eval capture (SDK-529): while capture is active, every chunk graph that lost nodes
+    emits ONE ``extraction.dropped_duplicates`` event carrying the dropped ids, and the
+    run manifest counts them under ``extraction.dropped_duplicate_nodes``. Nothing is
+    collected when capture is off.
+    """
+    from cognee.modules.observability import capture as eval_capture
+
+    active = eval_capture.is_active()
+
+    for chunk_index, extracted_graph in enumerate(extracted_graphs):
         if not extracted_graph:
             continue
 
         nodes_by_id = {}
+        dropped_node_ids = [] if active else None
         for node in extracted_graph.nodes:
             if node.id in nodes_by_id:
                 # NOTE: This is a lossy strategy; duplicate IDs may deserve more careful handling.
                 logger.warning("Ignoring duplicate extracted node ID: %s", node.id)
+                if dropped_node_ids is not None:
+                    dropped_node_ids.append(node.id)
                 continue
 
             nodes_by_id[node.id] = node
 
         if len(nodes_by_id) != len(extracted_graph.nodes):
             extracted_graph.nodes = list(nodes_by_id.values())
+
+        if dropped_node_ids:
+            eval_capture.emit(
+                eval_capture.KIND_EXTRACTION_DROPPED_DUPLICATES,
+                {
+                    "chunk_index": chunk_index,
+                    "dropped_node_ids": dropped_node_ids,
+                    "count": len(dropped_node_ids),
+                },
+                payload_kind="json",
+                stage="extract_graph_from_data",
+            )
+            eval_capture.bump("extraction.dropped_duplicate_nodes", len(dropped_node_ids))
+
+
+def _capture_chunk_graphs(data_chunks: List[DocumentChunk], chunk_graphs: list) -> None:
+    """Snapshot every raw per-chunk graph for eval capture (SDK-529).
+
+    Runs right after extraction and BEFORE ``_remove_duplicate_extracted_nodes_by_id``
+    and the ontology canonicalization, both of which mutate the graphs in place — so
+    the payload is a ``model_dump(mode="json")`` taken now, never the live object or a
+    ``model_copy``. ``chunk_index`` is the position in this batch (the index the
+    dropped-duplicates and fuzzy-match events use too); ``chunk_size_chars`` records
+    the chunk boundary. A structural no-op (no dump, no allocation) when capture is off.
+    """
+    from cognee.modules.observability import capture as eval_capture
+
+    if not eval_capture.is_active():
+        return
+
+    for chunk_index, (chunk, chunk_graph) in enumerate(zip(data_chunks, chunk_graphs)):
+        eval_capture.emit(
+            eval_capture.KIND_EXTRACTION_CHUNK_GRAPH,
+            {
+                "chunk_id": str(chunk.id),
+                "chunk_index": chunk_index,
+                "chunk_size_chars": len(chunk.text),
+                "graph": (
+                    chunk_graph.model_dump(mode="json")
+                    if isinstance(chunk_graph, BaseModel)
+                    else None
+                ),
+            },
+            payload_kind="json",
+            stage="extract_graph_from_data",
+        )
+
+
+def _note_ontology_config(
+    ontology_resolver: Optional[BaseOntologyResolver], ontology_mode: Optional[str]
+) -> None:
+    """Record the run's effective ontology configuration on the eval-capture manifest.
+
+    SDK-529. ``ontology.mode`` is the mode this integration applies (a ``None``
+    per-call mode falls back to ONTOLOGY_MODE, exactly as the constructor does); the
+    resolver and its matching strategy are reported by class name, and
+    ``ontology.threshold`` is the strategy's ``cutoff`` where it has one
+    (``FuzzyMatchingStrategy``). All ``None`` for a run without an ontology. A no-op
+    when capture is off.
+    """
+    from cognee.modules.observability import capture as eval_capture
+
+    if not eval_capture.is_active():
+        return
+
+    if ontology_mode is None:
+        ontology_mode = get_configured_ontology_mode()
+    strategy = getattr(ontology_resolver, "matching_strategy", None)
+    eval_capture.note("ontology.mode", ontology_mode)
+    eval_capture.note(
+        "ontology.resolver",
+        None if ontology_resolver is None else type(ontology_resolver).__name__,
+    )
+    eval_capture.note(
+        "ontology.matching_strategy", None if strategy is None else type(strategy).__name__
+    )
+    eval_capture.note("ontology.threshold", getattr(strategy, "cutoff", None))
 
 
 def _stamp_provenance_deep(data, pipeline_name, task_name, visited=None):
@@ -129,6 +219,8 @@ async def integrate_chunk_graphs(
         raise InvalidGraphModelError(graph_model)
     if ontology_resolver is not None and not hasattr(ontology_resolver, "get_subgraph"):
         raise InvalidOntologyAdapterError(type(ontology_resolver).__name__)
+
+    _note_ontology_config(ontology_resolver, ontology_mode)
 
     if not issubclass(graph_model, KnowledgeGraph):
         for chunk_index, chunk_graph in enumerate(chunk_graphs):
@@ -214,6 +306,9 @@ async def extract_graph_from_data(
                     for chunk in data_chunks
                 ]
             )
+    # Eval capture (SDK-529): snapshot the raw graphs before anything mutates them.
+    _capture_chunk_graphs(data_chunks, chunk_graphs)
+
     cache_entity_embeddings = kwargs.get("cache_entity_embeddings")
     if callable(cache_entity_embeddings):
         callback_result = cache_entity_embeddings(chunk_graphs, **kwargs)

--- a/cognee/tasks/graph/extract_graph_from_data.py
+++ b/cognee/tasks/graph/extract_graph_from_data.py
@@ -94,7 +94,7 @@ def _remove_duplicate_extracted_nodes_by_id(
             eval_capture.bump("extraction.dropped_duplicate_nodes", len(dropped_node_ids))
 
 
-def _capture_chunk_graphs(data_chunks: List[DocumentChunk], chunk_graphs: list) -> None:
+def capture_chunk_graphs(data_chunks: List[DocumentChunk], chunk_graphs: list) -> None:
     """Snapshot every raw per-chunk graph for eval capture (SDK-529).
 
     Runs right after extraction and BEFORE ``_remove_duplicate_extracted_nodes_by_id``
@@ -335,7 +335,7 @@ async def extract_graph_from_data(
                 ]
             )
     # Eval capture (SDK-529): snapshot the raw graphs before anything mutates them.
-    _capture_chunk_graphs(data_chunks, chunk_graphs)
+    capture_chunk_graphs(data_chunks, chunk_graphs)
 
     cache_entity_embeddings = kwargs.get("cache_entity_embeddings")
     if callable(cache_entity_embeddings):

--- a/cognee/tasks/graph/extract_graph_from_data.py
+++ b/cognee/tasks/graph/extract_graph_from_data.py
@@ -48,14 +48,21 @@ def _remove_duplicate_extracted_nodes_by_id(
     ``chunk_index`` is the position within this batch and restarts at 0 for every
     batch of a run, so it alone cannot identify the chunk. Nothing is collected when
     capture is off.
+
+    The loop runs over ``extracted_graphs``, never over ``zip(...)``: deduplication is
+    the caller's contract and must cover every graph even if the two lists ever differ
+    in length (reachable through the ``calculate_chunk_graphs`` hook). Only the capture
+    event needs a chunk, so a graph without one is deduplicated silently.
     """
     from cognee.modules.observability import capture as eval_capture
 
     active = eval_capture.is_active()
 
-    for chunk_index, (chunk, extracted_graph) in enumerate(zip(data_chunks, extracted_graphs)):
+    for chunk_index, extracted_graph in enumerate(extracted_graphs):
         if not extracted_graph:
             continue
+
+        chunk = data_chunks[chunk_index] if chunk_index < len(data_chunks) else None
 
         nodes_by_id = {}
         dropped_node_ids = [] if active else None
@@ -72,7 +79,7 @@ def _remove_duplicate_extracted_nodes_by_id(
         if len(nodes_by_id) != len(extracted_graph.nodes):
             extracted_graph.nodes = list(nodes_by_id.values())
 
-        if dropped_node_ids:
+        if dropped_node_ids and chunk is not None:
             eval_capture.emit(
                 eval_capture.KIND_EXTRACTION_DROPPED_DUPLICATES,
                 {
@@ -93,13 +100,18 @@ def _capture_chunk_graphs(data_chunks: List[DocumentChunk], chunk_graphs: list) 
     Runs right after extraction and BEFORE ``_remove_duplicate_extracted_nodes_by_id``
     and the ontology canonicalization, both of which mutate the graphs in place — so
     the payload is a ``model_dump(mode="json")`` taken now, never the live object or a
-    ``model_copy``. That holds for a custom DataPoint-derived ``graph_model`` too: at
-    this point the graph is the freshly validated LLM output, not yet attached to its
-    chunk (``integrate_chunk_graphs`` does that afterwards), so the dump is acyclic; a
-    non-model graph dumps as ``None``. ``chunk_id`` is the join key shared with the
-    dropped-duplicates and fuzzy-match events; ``chunk_index`` is the position in this
-    batch (it restarts at 0 per batch); ``chunk_size_chars`` records the chunk boundary.
-    A structural no-op (no dump, no allocation) when capture is off.
+    ``model_copy``. ``chunk_id`` is the join key shared with the dropped-duplicates and
+    fuzzy-match events; ``chunk_index`` is the position in this batch (it restarts at 0
+    per batch); ``chunk_size_chars`` records the chunk boundary. A structural no-op (no
+    dump, no allocation) when capture is off.
+
+    The whole per-chunk payload build is guarded, because the graph is an object this
+    function does not own: the standard route hands it freshly validated LLM output,
+    but the ``calculate_chunk_graphs`` extension hook and a custom DataPoint-derived
+    ``graph_model`` (``arbitrary_types_allowed``) can supply a graph whose dump raises —
+    a reference cycle or a non-JSON-native field value. Capture never breaks the
+    extraction it observes, so a graph that will not dump costs its own event and
+    nothing else.
     """
     from cognee.modules.observability import capture as eval_capture
 
@@ -107,9 +119,8 @@ def _capture_chunk_graphs(data_chunks: List[DocumentChunk], chunk_graphs: list) 
         return
 
     for chunk_index, (chunk, chunk_graph) in enumerate(zip(data_chunks, chunk_graphs)):
-        eval_capture.emit(
-            eval_capture.KIND_EXTRACTION_CHUNK_GRAPH,
-            {
+        try:
+            payload = {
                 "chunk_id": str(chunk.id),
                 "chunk_index": chunk_index,
                 "chunk_size_chars": len(chunk.text),
@@ -118,7 +129,15 @@ def _capture_chunk_graphs(data_chunks: List[DocumentChunk], chunk_graphs: list) 
                     if isinstance(chunk_graph, BaseModel)
                     else None
                 ),
-            },
+            }
+        except Exception as exc:
+            # Capture never breaks the extraction it observes.
+            logger.debug("chunk graph capture skipped (%s)", exc)
+            continue
+
+        eval_capture.emit(
+            eval_capture.KIND_EXTRACTION_CHUNK_GRAPH,
+            payload,
             payload_kind="json",
             stage="extract_graph_from_data",
         )

--- a/cognee/tasks/graph/extract_graph_from_data.py
+++ b/cognee/tasks/graph/extract_graph_from_data.py
@@ -80,21 +80,36 @@ def _remove_duplicate_extracted_nodes_by_id(
             extracted_graph.nodes = list(nodes_by_id.values())
 
         if dropped_node_ids and chunk is not None:
-            eval_capture.emit(
-                eval_capture.KIND_EXTRACTION_DROPPED_DUPLICATES,
-                {
-                    "chunk_id": str(chunk.id),
-                    "chunk_index": chunk_index,
-                    "dropped_node_ids": dropped_node_ids,
-                    "count": len(dropped_node_ids),
-                },
-                payload_kind="json",
-                stage="extract_graph_from_data",
-            )
-            eval_capture.bump("extraction.dropped_duplicate_nodes", len(dropped_node_ids))
+            # Guarded like every other emit point: the chunk is duck-typed (only
+            # ``.text`` is validated upstream), so ``chunk.id`` can raise here on
+            # an input the non-capture path handles fine. Capture never breaks
+            # the extraction it observes — a chunk that will not attribute costs
+            # its own event and nothing else.
+            try:
+                eval_capture.emit(
+                    eval_capture.KIND_EXTRACTION_DROPPED_DUPLICATES,
+                    {
+                        "chunk_id": str(chunk.id),
+                        "chunk_index": chunk_index,
+                        "dropped_node_ids": dropped_node_ids,
+                        "count": len(dropped_node_ids),
+                    },
+                    payload_kind="json",
+                    stage="extract_graph_from_data",
+                )
+                eval_capture.bump("extraction.dropped_duplicate_nodes", len(dropped_node_ids))
+            except Exception as exc:
+                logger.debug("dropped-duplicates capture skipped (%s)", exc)
 
 
-def capture_chunk_graphs(data_chunks: List[DocumentChunk], chunk_graphs: list) -> None:
+# Yield to the event loop this often while snapshotting a batch: the capture
+# flusher's wake is a loop callback, so a synchronous loop over a whole task
+# batch (``chunks_per_batch``, 2000 by default) would fill the buffer before the
+# flusher could pop a single event. Matches the flusher's default BATCH_SIZE.
+_CAPTURE_YIELD_EVERY = 64
+
+
+async def capture_chunk_graphs(data_chunks: List[DocumentChunk], chunk_graphs: list) -> None:
     """Snapshot every raw per-chunk graph for eval capture (SDK-529).
 
     Runs right after extraction and BEFORE ``_remove_duplicate_extracted_nodes_by_id``
@@ -104,6 +119,11 @@ def capture_chunk_graphs(data_chunks: List[DocumentChunk], chunk_graphs: list) -
     fuzzy-match events; ``chunk_index`` is the position in this batch (it restarts at 0
     per batch); ``chunk_size_chars`` records the chunk boundary. A structural no-op (no
     dump, no allocation) when capture is off.
+
+    The snapshot is the one real per-chunk cost of capture, so it is built lazily
+    through ``emit_lazy``: a full buffer costs the drop counter, not a dump per
+    dropped event. The loop also yields every ``_CAPTURE_YIELD_EVERY`` chunks so the
+    flusher can drain while the batch is still being snapshotted.
 
     The whole per-chunk payload build is guarded, because the graph is an object this
     function does not own: the standard route hands it freshly validated LLM output,
@@ -119,8 +139,11 @@ def capture_chunk_graphs(data_chunks: List[DocumentChunk], chunk_graphs: list) -
         return
 
     for chunk_index, (chunk, chunk_graph) in enumerate(zip(data_chunks, chunk_graphs)):
-        try:
-            payload = {
+        if chunk_index and chunk_index % _CAPTURE_YIELD_EVERY == 0:
+            await asyncio.sleep(0)
+
+        def build_payload(chunk=chunk, chunk_graph=chunk_graph, chunk_index=chunk_index):
+            return {
                 "chunk_id": str(chunk.id),
                 "chunk_index": chunk_index,
                 "chunk_size_chars": len(chunk.text),
@@ -130,17 +153,17 @@ def capture_chunk_graphs(data_chunks: List[DocumentChunk], chunk_graphs: list) -
                     else None
                 ),
             }
-        except Exception as exc:
-            # Capture never breaks the extraction it observes.
-            logger.debug("chunk graph capture skipped (%s)", exc)
-            continue
 
-        eval_capture.emit(
-            eval_capture.KIND_EXTRACTION_CHUNK_GRAPH,
-            payload,
-            payload_kind="json",
-            stage="extract_graph_from_data",
-        )
+        try:
+            eval_capture.emit_lazy(
+                eval_capture.KIND_EXTRACTION_CHUNK_GRAPH,
+                build_payload,
+                payload_kind="json",
+                stage="extract_graph_from_data",
+            )
+        except Exception as exc:
+            # emit_lazy swallows a failing builder itself; this covers everything else.
+            logger.debug("chunk graph capture skipped (%s)", exc)
 
 
 def _note_ontology_config(
@@ -335,7 +358,7 @@ async def extract_graph_from_data(
                 ]
             )
     # Eval capture (SDK-529): snapshot the raw graphs before anything mutates them.
-    capture_chunk_graphs(data_chunks, chunk_graphs)
+    await capture_chunk_graphs(data_chunks, chunk_graphs)
 
     cache_entity_embeddings = kwargs.get("cache_entity_embeddings")
     if callable(cache_entity_embeddings):

--- a/cognee/tasks/graph/extract_graph_from_data_v2.py
+++ b/cognee/tasks/graph/extract_graph_from_data_v2.py
@@ -12,7 +12,7 @@ from cognee.tasks.graph.cascade_extract.utils.extract_edge_triplets import (
     extract_edge_triplets,
 )
 from cognee.tasks.graph.extract_graph_from_data import (
-    _capture_chunk_graphs,
+    capture_chunk_graphs,
     integrate_chunk_graphs,
 )
 
@@ -64,7 +64,7 @@ async def extract_graph_from_data(
     # Eval capture (SDK-529): snapshot the raw graphs before integrate_chunk_graphs
     # mutates them, so a cascade run's merge-decision events have the
     # extraction.chunk_graph record their chunk_id joins to.
-    _capture_chunk_graphs(data_chunks, chunk_graphs)
+    capture_chunk_graphs(data_chunks, chunk_graphs)
 
     return await integrate_chunk_graphs(
         data_chunks=data_chunks,

--- a/cognee/tasks/graph/extract_graph_from_data_v2.py
+++ b/cognee/tasks/graph/extract_graph_from_data_v2.py
@@ -11,7 +11,10 @@ from cognee.tasks.graph.cascade_extract.utils.extract_content_nodes_and_relation
 from cognee.tasks.graph.cascade_extract.utils.extract_edge_triplets import (
     extract_edge_triplets,
 )
-from cognee.tasks.graph.extract_graph_from_data import integrate_chunk_graphs
+from cognee.tasks.graph.extract_graph_from_data import (
+    _capture_chunk_graphs,
+    integrate_chunk_graphs,
+)
 
 
 from cognee.modules.pipelines.tasks.task import task_summary
@@ -57,6 +60,11 @@ async def extract_graph_from_data(
             for chunk, nodes, rels in zip(data_chunks, updated_nodes, relationships)
         ]
     )
+
+    # Eval capture (SDK-529): snapshot the raw graphs before integrate_chunk_graphs
+    # mutates them, so a cascade run's merge-decision events have the
+    # extraction.chunk_graph record their chunk_id joins to.
+    _capture_chunk_graphs(data_chunks, chunk_graphs)
 
     return await integrate_chunk_graphs(
         data_chunks=data_chunks,

--- a/cognee/tasks/storage/add_data_points.py
+++ b/cognee/tasks/storage/add_data_points.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import TYPE_CHECKING, Dict, List, Optional
+from collections import Counter
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from cognee.modules.pipelines.tasks.task import task_summary
 from cognee.infrastructure.engine import DataPoint
@@ -23,6 +24,12 @@ from cognee.modules.graph.utils import (
 from .index_data_points import index_data_points
 from .index_graph_edges import index_graph_edges
 from cognee.modules.engine.models import Triplet
+from cognee.modules.observability import (
+    MEMORY_OPERATION,
+    MEMORY_SYSTEM,
+    increment_graph_edges,
+    increment_graph_nodes,
+)
 from cognee.shared.logging_utils import get_logger
 from cognee.tasks.storage.exceptions import (
     InvalidDataPointsInAddDataPointsError,
@@ -33,6 +40,11 @@ if TYPE_CHECKING:
     from cognee.modules.pipelines.models import PipelineContext
 
 logger = get_logger("add_data_points")
+
+# Past this many nodes the storage.delta capture event carries the node count
+# and type histogram only, not the id list, so one bulk write cannot produce an
+# unbounded event.
+_STORAGE_DELTA_MAX_NODE_IDS = 500
 
 
 @task_summary("Stored {n} data point(s)")
@@ -100,6 +112,10 @@ async def add_data_points(
         if isinstance(custom_edges, list) and custom_edges
         else None
     )
+    # Counted before the writes: ``edges`` absorbs ``custom_edges`` further down
+    # (for the hybrid attach pass and triplet embedding).
+    edge_count = len(edges)
+    custom_edge_count = len(custom_edges) if custom_edges else 0
 
     if graph_only:
         from cognee.infrastructure.databases.graph.get_graph_engine import get_graph_engine
@@ -257,7 +273,72 @@ async def add_data_points(
             await index_data_points(triplets, vector_engine=vector_engine)
             logger.info(f"Created and indexed {len(triplets)} triplets from graph structure")
 
+    _record_storage_delta(nodes, edge_count, custom_edge_count, pipeline_run_id)
+
     return data_points
+
+
+def _record_storage_delta(
+    nodes: List[DataPoint],
+    edge_count: int,
+    custom_edge_count: int,
+    pipeline_run_id: Any,
+) -> None:
+    """Report what this call wrote: OTel counters always, eval capture when active.
+
+    ``add_data_points`` is the one choke point every graph write goes through
+    (cognify, memify, the code-graph route, every backend path above), so the
+    per-run node/edge delta is taken here once rather than in each caller. The
+    OTel counters are ``_NullInstrument`` no-ops without a meter provider. The
+    capture branch is a structural no-op when capture is off: one global read,
+    then return — no id list, no type histogram, no event.
+    """
+    node_count = len(nodes)
+    total_edges = edge_count + custom_edge_count
+    attributes = {MEMORY_SYSTEM: "cognee", MEMORY_OPERATION: "process"}
+    increment_graph_nodes(node_count, attributes)
+    increment_graph_edges(total_edges, attributes)
+
+    # Lazy on purpose: ``import cognee`` must not load the capture package.
+    from cognee.modules.observability import capture as eval_capture
+
+    if not eval_capture.is_active():
+        return
+
+    eval_capture.bump("storage.nodes_written", node_count)
+    eval_capture.bump("storage.edges_written", total_edges)
+    eval_capture.emit(
+        eval_capture.KIND_STORAGE_DELTA,
+        _storage_delta_payload(nodes, edge_count, custom_edge_count, pipeline_run_id),
+        payload_kind="json",
+        stage="add_data_points",
+    )
+
+
+def _storage_delta_payload(
+    nodes: List[DataPoint],
+    edge_count: int,
+    custom_edge_count: int,
+    pipeline_run_id: Any,
+) -> Dict[str, Any]:
+    """Ids, types and counts only — never the DataPoint instances.
+
+    The event is serialized later by the capture flusher, so this plain dict is
+    what gets buffered; a DataPoint would drag its whole subgraph along
+    (``DocumentChunk.contains`` recurses). Above ``_STORAGE_DELTA_MAX_NODE_IDS``
+    the id list is replaced by ``None``; the count and histogram stay.
+    """
+    node_count = len(nodes)
+    return {
+        "node_count": node_count,
+        "edge_count": edge_count,
+        "custom_edge_count": custom_edge_count,
+        "node_types": dict(Counter(node.type for node in nodes)),
+        "node_ids": (
+            [str(node.id) for node in nodes] if node_count <= _STORAGE_DELTA_MAX_NODE_IDS else None
+        ),
+        "pipeline_run_id": str(pipeline_run_id) if pipeline_run_id else None,
+    }
 
 
 def _extract_embeddable_text_from_datapoint(data_point: DataPoint) -> str:

--- a/cognee/tasks/storage/add_data_points.py
+++ b/cognee/tasks/storage/add_data_points.py
@@ -273,31 +273,41 @@ async def add_data_points(
             await index_data_points(triplets, vector_engine=vector_engine)
             logger.info(f"Created and indexed {len(triplets)} triplets from graph structure")
 
-    _record_storage_delta(nodes, edge_count, custom_edge_count, pipeline_run_id)
+    _record_graph_metrics(len(nodes), edge_count + custom_edge_count)
+    _emit_storage_delta(nodes, edge_count, custom_edge_count, pipeline_run_id)
 
     return data_points
 
 
-def _record_storage_delta(
+def _record_graph_metrics(node_count: int, total_edges: int) -> None:
+    """Report the nodes/edges this call wrote to the OTel graph counters.
+
+    Unconditional and independent of eval capture: these are the ordinary
+    process metrics, ``_NullInstrument`` no-ops without a meter provider. The
+    counters were previously defined but never called from anywhere; this is
+    their first live call site.
+    """
+    attributes = {MEMORY_SYSTEM: "cognee", MEMORY_OPERATION: "process"}
+    increment_graph_nodes(node_count, attributes)
+    increment_graph_edges(total_edges, attributes)
+
+
+def _emit_storage_delta(
     nodes: List[DataPoint],
     edge_count: int,
     custom_edge_count: int,
     pipeline_run_id: Any,
 ) -> None:
-    """Report what this call wrote: OTel counters always, eval capture when active.
+    """Buffer this call's ``storage.delta`` eval-capture event (SDK-529).
 
     ``add_data_points`` is the one choke point every graph write goes through
     (cognify, memify, the code-graph route, every backend path above), so the
-    per-run node/edge delta is taken here once rather than in each caller. The
-    OTel counters are ``_NullInstrument`` no-ops without a meter provider. The
-    capture branch is a structural no-op when capture is off: one global read,
-    then return — no id list, no type histogram, no event.
+    per-run node/edge delta is taken here once rather than in each caller. A
+    structural no-op when capture is off: one global read, then return — no id
+    list, no type histogram, no event.
     """
     node_count = len(nodes)
     total_edges = edge_count + custom_edge_count
-    attributes = {MEMORY_SYSTEM: "cognee", MEMORY_OPERATION: "process"}
-    increment_graph_nodes(node_count, attributes)
-    increment_graph_edges(total_edges, attributes)
 
     # Lazy on purpose: ``import cognee`` must not load the capture package.
     from cognee.modules.observability import capture as eval_capture

--- a/cognee/tasks/storage/add_data_points.py
+++ b/cognee/tasks/storage/add_data_points.py
@@ -315,14 +315,20 @@ def _emit_storage_delta(
     if not eval_capture.is_active():
         return
 
-    eval_capture.bump("storage.nodes_written", node_count)
-    eval_capture.bump("storage.edges_written", total_edges)
-    eval_capture.emit(
-        eval_capture.KIND_STORAGE_DELTA,
-        _storage_delta_payload(nodes, edge_count, custom_edge_count, pipeline_run_id),
-        payload_kind="json",
-        stage="add_data_points",
-    )
+    # Guarded like every other emit point: the payload reads ``id``/``type`` off
+    # caller-supplied DataPoints, and capture must never break the write it
+    # observes.
+    try:
+        eval_capture.bump("storage.nodes_written", node_count)
+        eval_capture.bump("storage.edges_written", total_edges)
+        eval_capture.emit(
+            eval_capture.KIND_STORAGE_DELTA,
+            _storage_delta_payload(nodes, edge_count, custom_edge_count, pipeline_run_id),
+            payload_kind="json",
+            stage="add_data_points",
+        )
+    except Exception as exc:
+        logger.debug("storage delta capture skipped (%s)", exc)
 
 
 def _storage_delta_payload(

--- a/cognee/tasks/summarization/models.py
+++ b/cognee/tasks/summarization/models.py
@@ -35,6 +35,14 @@ class TextSummary(DataPoint):
     source_chunk_id: Optional[str] = None
     summarized_in: Optional[GlobalContextSummary] = None
     global_context_bucket_id: Optional[str] = None
+    # Eval-capture provenance (SDK-529): the model id and prompt fingerprint that
+    # produced this summary and the fingerprint of the source chunk text. Filled
+    # by ``summarize_text`` only while capture is active, None otherwise. Plain
+    # node properties — deliberately kept out of ``index_fields`` so they are
+    # never embedded.
+    model: Optional[str] = None
+    prompt_fingerprint: Optional[str] = None
+    source_text_hash: Optional[str] = None
     metadata: dict = {"index_fields": ["text"]}
     importance_weight: Optional[float] = 0.5
 

--- a/cognee/tasks/summarization/models.py
+++ b/cognee/tasks/summarization/models.py
@@ -35,14 +35,6 @@ class TextSummary(DataPoint):
     source_chunk_id: Optional[str] = None
     summarized_in: Optional[GlobalContextSummary] = None
     global_context_bucket_id: Optional[str] = None
-    # Eval-capture provenance (SDK-529): the model id and prompt fingerprint that
-    # produced this summary and the fingerprint of the source chunk text. Filled
-    # by ``summarize_text`` only while capture is active, None otherwise. Plain
-    # node properties — deliberately kept out of ``index_fields`` so they are
-    # never embedded.
-    model: Optional[str] = None
-    prompt_fingerprint: Optional[str] = None
-    source_text_hash: Optional[str] = None
     metadata: dict = {"index_fields": ["text"]}
     importance_weight: Optional[float] = 0.5
 

--- a/cognee/tasks/summarization/summarize_text.py
+++ b/cognee/tasks/summarization/summarize_text.py
@@ -29,11 +29,14 @@ async def summarize_text(
     each chunk. If the provided list of data chunks is empty, it simply returns the list as
     is.
 
-    While eval capture is active (SDK-529) every summary also carries its provenance —
-    the model id, the fingerprint of the summarization prompt and the fingerprint of the
-    source chunk text — and one ``summary.generated`` event per chunk is emitted (ids,
-    fingerprints and a character count only; never the summary or chunk text). With
-    capture off nothing is hashed or emitted and the provenance fields stay ``None``.
+    While eval capture is active (SDK-529) one ``summary.generated`` event per chunk is
+    emitted, carrying that summary's provenance — the model id, the fingerprint of the
+    summarization prompt and the fingerprint of the source chunk text — alongside the
+    chunk and summary ids and a character count; never the summary or chunk text. The
+    provenance is computed for the event only and is deliberately NOT stored on the
+    ``TextSummary`` node: the event is keyed by ``summary_id``, so offline joins have it
+    either way, and graph content must not depend on whether capture happened to be on.
+    With capture off nothing is hashed and nothing is emitted.
 
     Parameters:
     -----------
@@ -80,10 +83,13 @@ async def summarize_text(
     # Every chunk reads the same prompt file, so its fingerprint is computed once.
     prompt_fingerprints: dict[str, str] = {}
     summaries: list[TextSummary] = []
+    # Run-wide provenance for the manifest; the stage model and prompt are the
+    # same for every chunk, so the last chunk's values describe the run.
+    run_model: Optional[str] = None
+    run_prompt_fingerprint: Optional[str] = None
 
     for chunk, (llm_output, prompt_text, model_name) in zip(data_chunks, results):
-        # Provenance stays None unless capture is active.
-        model: Optional[str] = None
+        # Capture-only provenance; never stored on the node.
         prompt_fingerprint: Optional[str] = None
         source_text_hash: Optional[str] = None
         if active:
@@ -93,7 +99,6 @@ async def summarize_text(
             if prompt_fingerprint is None:
                 prompt_fingerprint = eval_capture.prompt_fingerprint(prompt_text)
                 prompt_fingerprints[prompt_text] = prompt_fingerprint
-            model = model_name
             source_text_hash = eval_capture.prompt_fingerprint(chunk.text)
 
         summary = TextSummary(
@@ -103,33 +108,42 @@ async def summarize_text(
             belongs_to_set=chunk.belongs_to_set,
             text=llm_output.summary,
             importance_weight=chunk.importance_weight,
-            model=model,
-            prompt_fingerprint=prompt_fingerprint,
-            source_text_hash=source_text_hash,
         )
         summaries.append(summary)
 
         if active:
-            _emit_summary_generated(eval_capture, summary, chunk)
+            _emit_summary_generated(
+                summary, chunk, model_name, prompt_fingerprint, source_text_hash
+            )
+            run_model, run_prompt_fingerprint = model_name, prompt_fingerprint
 
     if active:
-        # Once per run, not per chunk: the stage model and prompt are run-wide.
-        eval_capture.note("summarization.model", summaries[0].model)
-        eval_capture.note("summarization.prompt_fingerprint", summaries[0].prompt_fingerprint)
+        # Once per run, not per chunk. Taken from the locals that produced the
+        # summaries, not from the node (which no longer carries them).
+        eval_capture.note("summarization.model", run_model)
+        eval_capture.note("summarization.prompt_fingerprint", run_prompt_fingerprint)
 
     return summaries
 
 
-def _emit_summary_generated(eval_capture, summary: TextSummary, chunk: DocumentChunk) -> None:
+def _emit_summary_generated(
+    summary: TextSummary,
+    chunk: DocumentChunk,
+    model: Optional[str],
+    prompt_fingerprint: Optional[str],
+    source_text_hash: Optional[str],
+) -> None:
     """Buffer one ``summary.generated`` event: ids, fingerprints and a size — no text."""
+    from cognee.modules.observability import capture as eval_capture
+
     eval_capture.emit(
         eval_capture.KIND_SUMMARY_GENERATED,
         {
             "chunk_id": str(chunk.id),
             "summary_id": str(summary.id),
-            "model": summary.model,
-            "prompt_fingerprint": summary.prompt_fingerprint,
-            "source_text_hash": summary.source_text_hash,
+            "model": model,
+            "prompt_fingerprint": prompt_fingerprint,
+            "source_text_hash": source_text_hash,
             "summary_chars": len(summary.text),
         },
         payload_kind="json",

--- a/cognee/tasks/summarization/summarize_text.py
+++ b/cognee/tasks/summarization/summarize_text.py
@@ -5,13 +5,16 @@ from pydantic import BaseModel
 
 from cognee.tasks.summarization.exceptions import InvalidSummaryInputsError
 from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
-from cognee.infrastructure.llm.extraction import extract_summary
+from cognee.infrastructure.llm.extraction.extract_summary import extract_summary_with_provenance
 from cognee.infrastructure.llm.pipeline_stage import pipeline_stage
 from cognee.modules.cognify.config import get_cognify_config
 from cognee.tasks.summarization.models import TextSummary
 
 
 from cognee.modules.pipelines.tasks.task import task_summary
+
+# Stage label on the summary.generated events (SDK-529).
+CAPTURE_STAGE = "summarize_text"
 
 
 @task_summary("Summarized {n} chunk(s)")
@@ -25,6 +28,12 @@ async def summarize_text(
     configuration. It processes the data chunks asynchronously and returns summaries for
     each chunk. If the provided list of data chunks is empty, it simply returns the list as
     is.
+
+    While eval capture is active (SDK-529) every summary also carries its provenance —
+    the model id, the fingerprint of the summarization prompt and the fingerprint of the
+    source chunk text — and one ``summary.generated`` event per chunk is emitted (ids,
+    fingerprints and a character count only; never the summary or chunk text). With
+    capture off nothing is hashed or emitted and the provenance fields stay ``None``.
 
     Parameters:
     -----------
@@ -54,21 +63,73 @@ async def summarize_text(
         cognee_config = get_cognify_config()
         summarization_model = cognee_config.summarization_model
 
+    # Lazy on purpose: ``import cognee`` must not load the capture package.
+    from cognee.modules.observability import capture as eval_capture
+
+    # One global read, hoisted out of the per-chunk loop.
+    active = eval_capture.is_active()
+
     with pipeline_stage("summarization"):
-        chunk_summaries = await asyncio.gather(
-            *[extract_summary(chunk.text, summarization_model) for chunk in data_chunks]
+        results = await asyncio.gather(
+            *[
+                extract_summary_with_provenance(chunk.text, summarization_model)
+                for chunk in data_chunks
+            ]
         )
 
-    summaries = [
-        TextSummary(
+    # Every chunk reads the same prompt file, so its fingerprint is computed once.
+    prompt_fingerprints: dict[str, str] = {}
+    summaries: list[TextSummary] = []
+
+    for chunk, (llm_output, prompt_text, model_name) in zip(data_chunks, results):
+        provenance: dict[str, str] = {}
+        if active:
+            # The sanctioned snapshot cost: sha256 of the chunk text (and of each
+            # distinct prompt) — only while capturing.
+            prompt_fingerprint = prompt_fingerprints.get(prompt_text)
+            if prompt_fingerprint is None:
+                prompt_fingerprint = eval_capture.prompt_fingerprint(prompt_text)
+                prompt_fingerprints[prompt_text] = prompt_fingerprint
+            provenance = {
+                "model": model_name,
+                "prompt_fingerprint": prompt_fingerprint,
+                "source_text_hash": eval_capture.prompt_fingerprint(chunk.text),
+            }
+
+        summary = TextSummary(
             id=uuid5(chunk.id, "TextSummary"),
             made_from=chunk,
             source_chunk_id=str(chunk.id),
             belongs_to_set=chunk.belongs_to_set,
-            text=chunk_summaries[chunk_index].summary,
+            text=llm_output.summary,
             importance_weight=chunk.importance_weight,
+            **provenance,
         )
-        for (chunk_index, chunk) in enumerate(data_chunks)
-    ]
+        summaries.append(summary)
+
+        if active:
+            _emit_summary_generated(eval_capture, summary, chunk)
+
+    if active:
+        # Once per run, not per chunk: the stage model and prompt are run-wide.
+        eval_capture.note("summarization.model", summaries[0].model)
+        eval_capture.note("summarization.prompt_fingerprint", summaries[0].prompt_fingerprint)
 
     return summaries
+
+
+def _emit_summary_generated(eval_capture, summary: TextSummary, chunk: DocumentChunk) -> None:
+    """Buffer one ``summary.generated`` event: ids, fingerprints and a size — no text."""
+    eval_capture.emit(
+        eval_capture.KIND_SUMMARY_GENERATED,
+        {
+            "chunk_id": str(chunk.id),
+            "summary_id": str(summary.id),
+            "model": summary.model,
+            "prompt_fingerprint": summary.prompt_fingerprint,
+            "source_text_hash": summary.source_text_hash,
+            "summary_chars": len(summary.text),
+        },
+        payload_kind="json",
+        stage=CAPTURE_STAGE,
+    )

--- a/cognee/tasks/summarization/summarize_text.py
+++ b/cognee/tasks/summarization/summarize_text.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Type
+from typing import Optional, Type
 from uuid import uuid5
 from pydantic import BaseModel
 
@@ -82,7 +82,10 @@ async def summarize_text(
     summaries: list[TextSummary] = []
 
     for chunk, (llm_output, prompt_text, model_name) in zip(data_chunks, results):
-        provenance: dict[str, str] = {}
+        # Provenance stays None unless capture is active.
+        model: Optional[str] = None
+        prompt_fingerprint: Optional[str] = None
+        source_text_hash: Optional[str] = None
         if active:
             # The sanctioned snapshot cost: sha256 of the chunk text (and of each
             # distinct prompt) — only while capturing.
@@ -90,11 +93,8 @@ async def summarize_text(
             if prompt_fingerprint is None:
                 prompt_fingerprint = eval_capture.prompt_fingerprint(prompt_text)
                 prompt_fingerprints[prompt_text] = prompt_fingerprint
-            provenance = {
-                "model": model_name,
-                "prompt_fingerprint": prompt_fingerprint,
-                "source_text_hash": eval_capture.prompt_fingerprint(chunk.text),
-            }
+            model = model_name
+            source_text_hash = eval_capture.prompt_fingerprint(chunk.text)
 
         summary = TextSummary(
             id=uuid5(chunk.id, "TextSummary"),
@@ -103,7 +103,9 @@ async def summarize_text(
             belongs_to_set=chunk.belongs_to_set,
             text=llm_output.summary,
             importance_weight=chunk.importance_weight,
-            **provenance,
+            model=model,
+            prompt_fingerprint=prompt_fingerprint,
+            source_text_hash=source_text_hash,
         )
         summaries.append(summary)
 

--- a/cognee/tasks/summarization/summarize_text.py
+++ b/cognee/tasks/summarization/summarize_text.py
@@ -19,7 +19,7 @@ CAPTURE_STAGE = "summarize_text"
 
 @task_summary("Summarized {n} chunk(s)")
 async def summarize_text(
-    data_chunks: list[DocumentChunk], summarization_model: Type[BaseModel] = None
+    data_chunks: list[DocumentChunk], summarization_model: Optional[Type[BaseModel]] = None
 ):
     """
     Summarize the text contained in the provided data chunks.

--- a/cognee/tasks/summarization/summarize_text.py
+++ b/cognee/tasks/summarization/summarize_text.py
@@ -8,10 +8,13 @@ from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
 from cognee.infrastructure.llm.extraction.extract_summary import extract_summary_with_provenance
 from cognee.infrastructure.llm.pipeline_stage import pipeline_stage
 from cognee.modules.cognify.config import get_cognify_config
+from cognee.shared.logging_utils import get_logger
 from cognee.tasks.summarization.models import TextSummary
 
 
 from cognee.modules.pipelines.tasks.task import task_summary
+
+logger = get_logger("summarize_text")
 
 # Stage label on the summary.generated events (SDK-529).
 CAPTURE_STAGE = "summarize_text"
@@ -94,12 +97,18 @@ async def summarize_text(
         source_text_hash: Optional[str] = None
         if active:
             # The sanctioned snapshot cost: sha256 of the chunk text (and of each
-            # distinct prompt) — only while capturing.
-            prompt_fingerprint = prompt_fingerprints.get(prompt_text)
-            if prompt_fingerprint is None:
-                prompt_fingerprint = eval_capture.prompt_fingerprint(prompt_text)
-                prompt_fingerprints[prompt_text] = prompt_fingerprint
-            source_text_hash = eval_capture.prompt_fingerprint(chunk.text)
+            # distinct prompt) — only while capturing. Guarded: the chunk is
+            # duck-typed (only ``.text`` is validated), and a text that will not
+            # hash must cost this chunk's provenance, never the summarization.
+            try:
+                prompt_fingerprint = prompt_fingerprints.get(prompt_text)
+                if prompt_fingerprint is None:
+                    prompt_fingerprint = eval_capture.prompt_fingerprint(prompt_text)
+                    prompt_fingerprints[prompt_text] = prompt_fingerprint
+                source_text_hash = eval_capture.prompt_fingerprint(chunk.text)
+            except Exception as exc:
+                logger.debug("summary provenance capture skipped (%s)", exc)
+                prompt_fingerprint = source_text_hash = None
 
         summary = TextSummary(
             id=uuid5(chunk.id, "TextSummary"),
@@ -133,19 +142,26 @@ def _emit_summary_generated(
     prompt_fingerprint: Optional[str],
     source_text_hash: Optional[str],
 ) -> None:
-    """Buffer one ``summary.generated`` event: ids, fingerprints and a size — no text."""
+    """Buffer one ``summary.generated`` event: ids, fingerprints and a size — no text.
+
+    Guarded like every other emit point: capture never breaks the summarization it
+    observes, so a summary that will not attribute costs its own event and nothing else.
+    """
     from cognee.modules.observability import capture as eval_capture
 
-    eval_capture.emit(
-        eval_capture.KIND_SUMMARY_GENERATED,
-        {
-            "chunk_id": str(chunk.id),
-            "summary_id": str(summary.id),
-            "model": model,
-            "prompt_fingerprint": prompt_fingerprint,
-            "source_text_hash": source_text_hash,
-            "summary_chars": len(summary.text),
-        },
-        payload_kind="json",
-        stage=CAPTURE_STAGE,
-    )
+    try:
+        eval_capture.emit(
+            eval_capture.KIND_SUMMARY_GENERATED,
+            {
+                "chunk_id": str(chunk.id),
+                "summary_id": str(summary.id),
+                "model": model,
+                "prompt_fingerprint": prompt_fingerprint,
+                "source_text_hash": source_text_hash,
+                "summary_chars": len(summary.text),
+            },
+            payload_kind="json",
+            stage=CAPTURE_STAGE,
+        )
+    except Exception as exc:
+        logger.debug("summary capture skipped (%s)", exc)

--- a/cognee/tests/unit/infrastructure/llm/test_extract_summary.py
+++ b/cognee/tests/unit/infrastructure/llm/test_extract_summary.py
@@ -1,0 +1,96 @@
+"""extract_summary keeps its single-value contract; extract_summary_with_provenance
+(SDK-529) returns the prompt text and the stage model alongside the LLM output.
+
+The gateway call is patched — no LLM, no network.
+"""
+
+import importlib
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import BaseModel
+
+from cognee.context_global_variables import llm_config as llm_config_ctx
+from cognee.infrastructure.llm.config import LLMConfig
+from cognee.infrastructure.llm.pipeline_stage import pipeline_stage
+
+extract_summary_module = importlib.import_module(
+    "cognee.infrastructure.llm.extraction.extract_summary"
+)
+
+PROMPT = "PROMPT<summarize_content.txt>"
+
+
+class Summary(BaseModel):
+    summary: str
+
+
+@pytest.fixture
+def gateway(monkeypatch):
+    """Patch the gateway and the prompt read; returns (mock, llm_output)."""
+    output = Summary(summary="short")
+    mock = AsyncMock(return_value=output)
+    monkeypatch.setattr(extract_summary_module.LLMGateway, "acreate_structured_output", mock)
+    monkeypatch.setattr(extract_summary_module, "read_query_prompt", lambda name: f"PROMPT<{name}>")
+    return mock, output
+
+
+@pytest.fixture
+def llm_context():
+    """Bind an LLMConfig with a summarization-stage override on the LLM ContextVar."""
+    config = LLMConfig(
+        llm_provider="openai",
+        llm_model="base-model",
+        llm_endpoint="",
+        llm_api_key="base-key",
+        llm_summarization_model="summarization-model",
+    )
+    token = llm_config_ctx.set(config)
+    try:
+        yield config
+    finally:
+        llm_config_ctx.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_extract_summary_with_provenance_returns_output_prompt_and_model(
+    gateway, llm_context
+):
+    mock, output = gateway
+
+    result = await extract_summary_module.extract_summary_with_provenance("content", Summary)
+
+    assert result == (output, PROMPT, "base-model")
+    mock.assert_awaited_once_with("content", PROMPT, Summary)
+
+
+@pytest.mark.asyncio
+async def test_extract_summary_with_provenance_reports_the_stage_model(gateway, llm_context):
+    _mock, output = gateway
+
+    with pipeline_stage("summarization"):
+        result = await extract_summary_module.extract_summary_with_provenance("content", Summary)
+
+    assert result == (output, PROMPT, "summarization-model")
+
+
+@pytest.mark.asyncio
+async def test_extract_summary_keeps_its_single_value_contract(gateway, llm_context):
+    mock, output = gateway
+
+    assert await extract_summary_module.extract_summary("content", Summary) is output
+    mock.assert_awaited_once_with("content", PROMPT, Summary)
+
+
+@pytest.mark.asyncio
+async def test_extract_summary_with_provenance_tolerates_a_missing_prompt_file(
+    gateway, llm_context, monkeypatch
+):
+    mock, output = gateway
+    monkeypatch.setattr(extract_summary_module, "read_query_prompt", lambda name: None)
+
+    result = await extract_summary_module.extract_summary_with_provenance("content", Summary)
+
+    # Same fallback as before: an unreadable prompt file sends an empty system prompt.
+    assert result == (output, "", "base-model")
+    mock.assert_awaited_once_with("content", "", Summary)

--- a/cognee/tests/unit/modules/cognify/test_capture_chunking_notes.py
+++ b/cognee/tests/unit/modules/cognify/test_capture_chunking_notes.py
@@ -1,0 +1,51 @@
+"""cognify's chunking manifest notes (SDK-529): the per-item task resolver records the
+chunker and chunk size on the active run scope, read off the task list it resolved."""
+
+import importlib
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.chunking.TextChunker import TextChunker
+from cognee.modules.observability import capture
+from cognee.modules.pipelines.tasks.task import Task
+from cognee.tasks.documents import classify_documents, extract_chunks_from_documents
+
+cognify_module = importlib.import_module("cognee.api.v1.cognify.cognify")
+
+pytestmark = pytest.mark.usefixtures("capture_reset")
+
+
+def test_notes_chunker_and_chunk_size_from_the_resolved_task_list(fake_capture_sink):
+    tasks = [
+        Task(classify_documents),
+        Task(extract_chunks_from_documents, max_chunk_size=321, chunker=TextChunker),
+    ]
+
+    with capture.run_scope(uuid4(), uuid4(), kind="pipeline") as scope:
+        cognify_module._note_chunking_config(tasks)
+
+    assert scope.fields["chunking.chunker"] == "TextChunker"
+    assert scope.fields["chunking.chunk_size"] == 321
+
+
+def test_a_task_list_without_a_chunking_task_notes_nothing(fake_capture_sink):
+    with capture.run_scope(uuid4(), uuid4(), kind="pipeline") as scope:
+        cognify_module._note_chunking_config([Task(classify_documents)])
+
+    assert "chunking.chunker" not in scope.fields
+    assert "chunking.chunk_size" not in scope.fields
+
+
+def test_off_path_never_inspects_the_tasks(monkeypatch):
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+
+    class _Explodes:
+        @property
+        def executable(self):
+            raise AssertionError("tasks must not be inspected while capture is off")
+
+    cognify_module._note_chunking_config([_Explodes()])
+
+    assert capture.is_active() is False
+    assert capture.current_scope() is None

--- a/cognee/tests/unit/modules/cognify/test_capture_chunking_notes.py
+++ b/cognee/tests/unit/modules/cognify/test_capture_chunking_notes.py
@@ -1,19 +1,41 @@
 """cognify's chunking manifest notes (SDK-529): the per-item task resolver records the
-chunker and chunk size on the active run scope, read off the task list it resolved."""
+chunker and chunk size on the active run scope, read off the task list it resolved.
+
+Two layers are covered. ``_note_chunking_config`` on its own, and the wiring: the
+``tasks`` cognify() hands the pipeline executor is a per-item resolver, and it is that
+resolver — invoked by ``run_tasks`` once per data item, INSIDE the pipeline's run
+scope — which takes the note. The task lists themselves are built before any scope
+exists, so a note taken at construction time would land nowhere; the wiring tests
+therefore drive ``cognify()`` with a fake executor that resolves items inside a
+``run_scope(kind="pipeline")`` exactly the way run_tasks does.
+"""
 
 import importlib
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
 from cognee.modules.chunking.TextChunker import TextChunker
+from cognee.modules.cognify.config import CognifyConfig
 from cognee.modules.observability import capture
 from cognee.modules.pipelines.tasks.task import Task
 from cognee.tasks.documents import classify_documents, extract_chunks_from_documents
 
+# Module objects (not the re-exported cognify FUNCTION) for patch.object; dotted
+# string targets break on Python 3.10 — see test_contradiction_detection_wiring.py.
 cognify_module = importlib.import_module("cognee.api.v1.cognify.cognify")
+_mod_serve_state = importlib.import_module("cognee.api.v1.serve.state")
+_mod_migrations_startup = importlib.import_module("cognee.modules.migrations.startup")
 
 pytestmark = pytest.mark.usefixtures("capture_reset")
+
+
+# ---------------------------------------------------------------------------
+# The note helper on its own
+# ---------------------------------------------------------------------------
 
 
 def test_notes_chunker_and_chunk_size_from_the_resolved_task_list(fake_capture_sink):
@@ -49,3 +71,107 @@ def test_off_path_never_inspects_the_tasks(monkeypatch):
 
     assert capture.is_active() is False
     assert capture.current_scope() is None
+
+
+# ---------------------------------------------------------------------------
+# The wiring: cognify() -> resolver -> note, inside the pipeline run scope
+# ---------------------------------------------------------------------------
+
+
+def _text_item():
+    return SimpleNamespace(system_metadata=None, extension="txt")
+
+
+def _code_item():
+    # Tagged at add time by ingest_data; routes to the LLM-free code list.
+    return SimpleNamespace(system_metadata={"source": "code"}, extension="py")
+
+
+async def _run_cognify_resolving(items, **cognify_kwargs):
+    """Drive cognify() with a fake executor that resolves ``items`` inside a run scope.
+
+    Mirrors run_tasks: the resolver cognify() passes as ``tasks`` is called once per
+    data item inside ``capture.run_scope(..., kind="pipeline")``. Nothing else runs —
+    the executor is where the pipeline would start. Returns the scope the resolver ran
+    under and the task lists it resolved, in item order.
+    """
+    captured = {}
+
+    def _fake_executor(run_in_background=False):
+        async def _run(**executor_kwargs):
+            resolver = executor_kwargs["tasks"]
+            assert callable(resolver), "cognify() must hand the executor a per-item resolver"
+            with capture.run_scope(uuid4(), uuid4(), kind="pipeline") as scope:
+                captured["resolved"] = [resolver(item) for item in items]
+            captured["scope"] = scope
+            return {}
+
+        return _run
+
+    with (
+        patch.dict(os.environ, {"TELEMETRY_DISABLED": "1"}),
+        patch.object(cognify_module, "get_cognify_config", return_value=CognifyConfig()),
+        patch.object(cognify_module, "get_pipeline_executor", _fake_executor),
+        patch.object(_mod_migrations_startup, "run_migrations_and_block", new=AsyncMock()),
+        patch.object(_mod_serve_state, "get_remote_client", return_value=None),
+    ):
+        await cognify_module.cognify(
+            datasets=["ds"],
+            # A non-None config skips the ontology-env branch; chunk_size is explicit
+            # so get_max_chunk_tokens() (an LLM/embedding config read) never runs.
+            config={"ontology_config": {"ontology_resolver": None}},
+            **cognify_kwargs,
+        )
+    return captured["scope"], captured["resolved"]
+
+
+@pytest.mark.asyncio
+async def test_cognify_resolver_notes_chunking_on_the_pipeline_run_scope(fake_capture_sink):
+    scope, (tasks,) = await _run_cognify_resolving(
+        [_text_item()], chunker=TextChunker, chunk_size=321
+    )
+
+    # The standard list was resolved and its chunking task is what got noted.
+    names = [task.executable.__name__ for task in tasks]
+    assert names[:2] == ["classify_documents", "extract_chunks_from_documents"]
+    assert scope.fields["chunking.chunker"] == "TextChunker"
+    assert scope.fields["chunking.chunk_size"] == 321
+
+    # ... and the note reaches the pipeline manifest the scope emits on exit.
+    await capture.drain()
+    [manifest] = [
+        record
+        for record in fake_capture_sink.records
+        if record["kind"] == capture.KIND_RUN_MANIFEST
+    ]
+    assert manifest["payload"]["kind"] == "pipeline"
+    assert manifest["payload"]["chunking.chunker"] == "TextChunker"
+    assert manifest["payload"]["chunking.chunk_size"] == 321
+
+
+@pytest.mark.asyncio
+async def test_cognify_resolver_notes_nothing_for_a_code_item(fake_capture_sink):
+    """The note follows the RESOLVED list: a code item runs the enola list, which
+    chunks nothing, so no chunking fields appear even though a standard list (with
+    a chunking task) was built up front."""
+    scope, (tasks,) = await _run_cognify_resolving([_code_item()], chunk_size=321)
+
+    assert [task.executable.__name__ for task in tasks] == ["extract_code_files_graph"]
+    assert "chunking.chunker" not in scope.fields
+    assert "chunking.chunk_size" not in scope.fields
+
+
+@pytest.mark.asyncio
+async def test_cognify_resolver_calls_the_note_helper_once_per_item(fake_capture_sink):
+    """Placement contract: _note_chunking_config is invoked by the resolver, once per
+    resolved item, with the list that item resolved to — not at construction time."""
+    spy = MagicMock(wraps=cognify_module._note_chunking_config)
+
+    with patch.object(cognify_module, "_note_chunking_config", spy):
+        _scope, resolved = await _run_cognify_resolving(
+            [_text_item(), _code_item()], chunk_size=321
+        )
+
+    assert spy.call_count == 2
+    assert [call.args[0] for call in spy.call_args_list] == resolved
+    assert capture.current_scope() is None  # the fake executor's scope has closed

--- a/cognee/tests/unit/modules/conftest.py
+++ b/cognee/tests/unit/modules/conftest.py
@@ -80,6 +80,11 @@ def capture_reset(event_loop):
     Depends on ``event_loop`` so this teardown runs BEFORE pytest-asyncio closes
     the loop: pytest-asyncio 0.21.x closes loops without cancelling tasks, and a
     flusher task left behind would be destroyed while pending.
+
+    Version assumption: requesting ``event_loop`` directly is deprecated in
+    pytest-asyncio 0.23 and removed in 1.0. The ``dev`` extra pins ``<0.22``;
+    moving past it means replacing this ordering trick (e.g. a loop-scoped
+    fixture or an ``asyncio`` ``pytest_fixture_post_finalizer`` hook).
     """
     from cognee.modules.observability.capture import hook
 

--- a/cognee/tests/unit/modules/conftest.py
+++ b/cognee/tests/unit/modules/conftest.py
@@ -57,3 +57,42 @@ def runner_plumbing(monkeypatch):
         return logs
 
     return _wire
+
+
+class FakeCaptureSink:
+    """In-memory eval-capture sink (SDK-529): records every batch it receives."""
+
+    def __init__(self):
+        self.calls: list[list[dict]] = []
+
+    async def __call__(self, records):
+        self.calls.append(list(records))
+
+    @property
+    def records(self) -> list[dict]:
+        return [record for call in self.calls for record in call]
+
+
+@pytest.fixture
+def capture_reset(event_loop):
+    """Reset eval-capture module state around a test (SDK-529).
+
+    Depends on ``event_loop`` so this teardown runs BEFORE pytest-asyncio closes
+    the loop: pytest-asyncio 0.21.x closes loops without cancelling tasks, and a
+    flusher task left behind would be destroyed while pending.
+    """
+    from cognee.modules.observability.capture import hook
+
+    hook._reset_for_tests()
+    yield
+    hook._reset_for_tests()
+
+
+@pytest.fixture
+def fake_capture_sink(capture_reset):
+    """Register a FakeCaptureSink as the process-wide capture sink."""
+    from cognee.modules.observability import capture
+
+    sink = FakeCaptureSink()
+    capture.register_capture_sink(sink)
+    return sink

--- a/cognee/tests/unit/modules/conftest.py
+++ b/cognee/tests/unit/modules/conftest.py
@@ -74,7 +74,7 @@ class FakeCaptureSink:
 
 
 @pytest.fixture
-def capture_reset(event_loop):
+def capture_reset(event_loop, monkeypatch):
     """Reset eval-capture module state around a test (SDK-529).
 
     Depends on ``event_loop`` so this teardown runs BEFORE pytest-asyncio closes
@@ -85,9 +85,14 @@ def capture_reset(event_loop):
     pytest-asyncio 0.23 and removed in 1.0. The ``dev`` extra pins ``<0.22``;
     moving past it means replacing this ordering trick (e.g. a loop-scoped
     fixture or an ``asyncio`` ``pytest_fixture_post_finalizer`` hook).
-    """
-    from cognee.modules.observability.capture import hook
 
+    Also detaches ``CaptureConfig`` from the repo ``.env`` so a developer's
+    ``COGNEE_CAPTURE_*`` settings cannot flip the off-path tests; the tests set
+    the environment they need explicitly.
+    """
+    from cognee.modules.observability.capture import CaptureConfig, hook
+
+    monkeypatch.setitem(CaptureConfig.model_config, "env_file", None)
     hook._reset_for_tests()
     yield
     hook._reset_for_tests()

--- a/cognee/tests/unit/modules/observability/test_capture_config.py
+++ b/cognee/tests/unit/modules/observability/test_capture_config.py
@@ -9,9 +9,11 @@ from pathlib import Path
 import pytest
 
 from cognee.base_config import get_base_config
+from cognee.modules.observability import capture
 from cognee.modules.observability.capture import (
     CaptureConfig,
     get_capture_config,
+    hook,
     prompt_file_fingerprint,
     prompt_fingerprint,
 )
@@ -98,6 +100,33 @@ def test_sample_rate_out_of_range_raises(clean_capture_env, monkeypatch):
 def test_sink_timeout_must_be_positive(clean_capture_env):
     with pytest.raises(ValueError, match=r"SINK_TIMEOUT_S must be positive, got 0\.0"):
         CaptureConfig(cognee_capture_sink_timeout_s=0.0)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("cognee_capture_queue_size", 0, r"QUEUE_SIZE must be at least 1, got 0"),
+        ("cognee_capture_batch_size", 0, r"BATCH_SIZE must be at least 1, got 0"),
+        ("cognee_capture_batch_size", -3, r"BATCH_SIZE must be at least 1, got -3"),
+        ("cognee_capture_flush_interval_s", 0.0, r"FLUSH_INTERVAL_S must be positive, got 0\.0"),
+        ("cognee_capture_flush_interval_s", -1.0, r"FLUSH_INTERVAL_S must be positive, got -1\.0"),
+    ],
+)
+def test_degenerate_queue_knobs_are_rejected(clean_capture_env, field, value, message):
+    # A batch size of 0 made the flusher pop nothing and spin without yielding.
+    with pytest.raises(ValueError, match=message):
+        CaptureConfig(**{field: value})
+
+
+def test_bad_batch_size_in_env_disables_capture_instead_of_freezing(clean_capture_env, monkeypatch):
+    monkeypatch.setenv("COGNEE_CAPTURE_ENABLED", "true")
+    monkeypatch.setenv("COGNEE_CAPTURE_BATCH_SIZE", "0")
+    get_capture_config.cache_clear()
+
+    # The bad knob is rejected at initialization: capture stays off and the
+    # cached knobs keep their defaults, so the observed operation is unaffected.
+    assert capture.is_active() is False
+    assert hook.BATCH_SIZE == 64
 
 
 def test_prompt_fingerprints(tmp_path):

--- a/cognee/tests/unit/modules/observability/test_capture_config.py
+++ b/cognee/tests/unit/modules/observability/test_capture_config.py
@@ -14,7 +14,6 @@ from cognee.modules.observability.capture import (
     CaptureConfig,
     get_capture_config,
     hook,
-    prompt_file_fingerprint,
     prompt_fingerprint,
 )
 
@@ -129,17 +128,10 @@ def test_bad_batch_size_in_env_disables_capture_instead_of_freezing(clean_captur
     assert hook.BATCH_SIZE == 64
 
 
-def test_prompt_fingerprints(tmp_path):
+def test_prompt_fingerprints():
     assert prompt_fingerprint("hello") == "sha256:2cf24dba5fb0a30e"
     assert prompt_fingerprint("hello") != prompt_fingerprint("hello!")
-
-    prompt_path = tmp_path / "prompt.txt"
-    prompt_path.write_text("hello", encoding="utf-8")
-    assert prompt_file_fingerprint(str(prompt_path)) == prompt_fingerprint("hello")
-
-    prompt_path.write_text("changed", encoding="utf-8")
-    os.utime(prompt_path, (1_700_000_000, 1_700_000_000))  # force a distinct mtime
-    assert prompt_file_fingerprint(str(prompt_path)) == prompt_fingerprint("changed")
+    assert prompt_fingerprint("") == prompt_fingerprint("")
 
 
 def test_import_cognee_does_not_import_capture_package():

--- a/cognee/tests/unit/modules/observability/test_capture_config.py
+++ b/cognee/tests/unit/modules/observability/test_capture_config.py
@@ -1,0 +1,120 @@
+"""CaptureConfig (SDK-529): env-named fields, derived directory, validation, and
+the import-cost guarantee that ``import cognee`` never loads the capture package."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from cognee.base_config import get_base_config
+from cognee.modules.observability.capture import (
+    CaptureConfig,
+    get_capture_config,
+    prompt_file_fingerprint,
+    prompt_fingerprint,
+)
+
+pytestmark = pytest.mark.usefixtures("capture_reset")
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+
+CAPTURE_ENV_VARS = (
+    "COGNEE_CAPTURE_ENABLED",
+    "COGNEE_CAPTURE_DIR",
+    "COGNEE_CAPTURE_QUEUE_SIZE",
+    "COGNEE_CAPTURE_BATCH_SIZE",
+    "COGNEE_CAPTURE_FLUSH_INTERVAL_S",
+    "COGNEE_CAPTURE_SAMPLE_RATE",
+)
+
+
+@pytest.fixture
+def clean_capture_env(monkeypatch):
+    for name in CAPTURE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_defaults_and_derived_dir(clean_capture_env, monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_ROOT_DIRECTORY", str(tmp_path))
+    get_base_config.cache_clear()
+    try:
+        config = CaptureConfig()
+    finally:
+        get_base_config.cache_clear()
+
+    assert config.cognee_capture_enabled is False
+    assert config.cognee_capture_queue_size == 512
+    assert config.cognee_capture_batch_size == 64
+    assert config.cognee_capture_flush_interval_s == 2.0
+    assert config.cognee_capture_sample_rate == 1.0
+    assert config.cognee_capture_dir == os.path.join(str(tmp_path), "capture")
+    assert config.to_dict() == {
+        "cognee_capture_enabled": False,
+        "cognee_capture_dir": os.path.join(str(tmp_path), "capture"),
+        "cognee_capture_queue_size": 512,
+        "cognee_capture_batch_size": 64,
+        "cognee_capture_flush_interval_s": 2.0,
+        "cognee_capture_sample_rate": 1.0,
+    }
+
+
+def test_env_vars_populate_fields(clean_capture_env, monkeypatch):
+    monkeypatch.setenv("COGNEE_CAPTURE_ENABLED", "true")
+    monkeypatch.setenv("COGNEE_CAPTURE_DIR", "/tmp/somewhere")
+    monkeypatch.setenv("COGNEE_CAPTURE_QUEUE_SIZE", "8")
+    monkeypatch.setenv("COGNEE_CAPTURE_BATCH_SIZE", "2")
+    monkeypatch.setenv("COGNEE_CAPTURE_FLUSH_INTERVAL_S", "0.5")
+    monkeypatch.setenv("COGNEE_CAPTURE_SAMPLE_RATE", "0.25")
+    get_capture_config.cache_clear()
+
+    config = get_capture_config()
+
+    assert config.cognee_capture_enabled is True
+    assert config.cognee_capture_dir == "/tmp/somewhere"
+    assert config.cognee_capture_queue_size == 8
+    assert config.cognee_capture_batch_size == 2
+    assert config.cognee_capture_flush_interval_s == 0.5
+    assert config.cognee_capture_sample_rate == 0.25
+    assert get_capture_config() is config  # cached
+
+
+def test_sample_rate_out_of_range_raises(clean_capture_env, monkeypatch):
+    with pytest.raises(ValueError, match=r"must be in \[0, 1\], got 1\.5"):
+        CaptureConfig(cognee_capture_sample_rate=1.5)
+
+    monkeypatch.setenv("COGNEE_CAPTURE_SAMPLE_RATE", "-0.1")
+    get_capture_config.cache_clear()
+    with pytest.raises(ValueError, match=r"must be in \[0, 1\], got -0\.1"):
+        get_capture_config()
+
+
+def test_prompt_fingerprints(tmp_path):
+    assert prompt_fingerprint("hello") == "sha256:2cf24dba5fb0a30e"
+    assert prompt_fingerprint("hello") != prompt_fingerprint("hello!")
+
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("hello", encoding="utf-8")
+    assert prompt_file_fingerprint(str(prompt_path)) == prompt_fingerprint("hello")
+
+    prompt_path.write_text("changed", encoding="utf-8")
+    os.utime(prompt_path, (1_700_000_000, 1_700_000_000))  # force a distinct mtime
+    assert prompt_file_fingerprint(str(prompt_path)) == prompt_fingerprint("changed")
+
+
+def test_import_cognee_does_not_import_capture_package():
+    probe = (
+        "import sys\n"
+        "import cognee\n"
+        "print('CAPTURE_LOADED=' + str('cognee.modules.observability.capture' in sys.modules))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "CAPTURE_LOADED=False" in result.stdout

--- a/cognee/tests/unit/modules/observability/test_capture_config.py
+++ b/cognee/tests/unit/modules/observability/test_capture_config.py
@@ -52,6 +52,7 @@ def test_defaults_and_derived_dir(clean_capture_env, monkeypatch, tmp_path):
     assert config.cognee_capture_flush_interval_s == 2.0
     assert config.cognee_capture_sample_rate == 1.0
     assert config.cognee_capture_sink_timeout_s == 30.0
+    assert config.cognee_capture_drain_timeout_s == 5.0
     assert config.cognee_capture_dir == os.path.join(str(tmp_path), "capture")
     assert config.to_dict() == {
         "cognee_capture_enabled": False,
@@ -61,6 +62,7 @@ def test_defaults_and_derived_dir(clean_capture_env, monkeypatch, tmp_path):
         "cognee_capture_flush_interval_s": 2.0,
         "cognee_capture_sample_rate": 1.0,
         "cognee_capture_sink_timeout_s": 30.0,
+        "cognee_capture_drain_timeout_s": 5.0,
     }
 
 
@@ -72,6 +74,7 @@ def test_env_vars_populate_fields(clean_capture_env, monkeypatch):
     monkeypatch.setenv("COGNEE_CAPTURE_FLUSH_INTERVAL_S", "0.5")
     monkeypatch.setenv("COGNEE_CAPTURE_SAMPLE_RATE", "0.25")
     monkeypatch.setenv("COGNEE_CAPTURE_SINK_TIMEOUT_S", "7.5")
+    monkeypatch.setenv("COGNEE_CAPTURE_DRAIN_TIMEOUT_S", "1.5")
     get_capture_config.cache_clear()
 
     config = get_capture_config()
@@ -83,6 +86,7 @@ def test_env_vars_populate_fields(clean_capture_env, monkeypatch):
     assert config.cognee_capture_flush_interval_s == 0.5
     assert config.cognee_capture_sample_rate == 0.25
     assert config.cognee_capture_sink_timeout_s == 7.5
+    assert config.cognee_capture_drain_timeout_s == 1.5
     assert get_capture_config() is config  # cached
 
 
@@ -99,6 +103,11 @@ def test_sample_rate_out_of_range_raises(clean_capture_env, monkeypatch):
 def test_sink_timeout_must_be_positive(clean_capture_env):
     with pytest.raises(ValueError, match=r"SINK_TIMEOUT_S must be positive, got 0\.0"):
         CaptureConfig(cognee_capture_sink_timeout_s=0.0)
+
+
+def test_drain_timeout_must_be_positive(clean_capture_env):
+    with pytest.raises(ValueError, match=r"DRAIN_TIMEOUT_S must be positive, got 0\.0"):
+        CaptureConfig(cognee_capture_drain_timeout_s=0.0)
 
 
 @pytest.mark.parametrize(

--- a/cognee/tests/unit/modules/observability/test_capture_config.py
+++ b/cognee/tests/unit/modules/observability/test_capture_config.py
@@ -27,6 +27,7 @@ CAPTURE_ENV_VARS = (
     "COGNEE_CAPTURE_BATCH_SIZE",
     "COGNEE_CAPTURE_FLUSH_INTERVAL_S",
     "COGNEE_CAPTURE_SAMPLE_RATE",
+    "COGNEE_CAPTURE_SINK_TIMEOUT_S",
 )
 
 
@@ -49,6 +50,7 @@ def test_defaults_and_derived_dir(clean_capture_env, monkeypatch, tmp_path):
     assert config.cognee_capture_batch_size == 64
     assert config.cognee_capture_flush_interval_s == 2.0
     assert config.cognee_capture_sample_rate == 1.0
+    assert config.cognee_capture_sink_timeout_s == 30.0
     assert config.cognee_capture_dir == os.path.join(str(tmp_path), "capture")
     assert config.to_dict() == {
         "cognee_capture_enabled": False,
@@ -57,6 +59,7 @@ def test_defaults_and_derived_dir(clean_capture_env, monkeypatch, tmp_path):
         "cognee_capture_batch_size": 64,
         "cognee_capture_flush_interval_s": 2.0,
         "cognee_capture_sample_rate": 1.0,
+        "cognee_capture_sink_timeout_s": 30.0,
     }
 
 
@@ -67,6 +70,7 @@ def test_env_vars_populate_fields(clean_capture_env, monkeypatch):
     monkeypatch.setenv("COGNEE_CAPTURE_BATCH_SIZE", "2")
     monkeypatch.setenv("COGNEE_CAPTURE_FLUSH_INTERVAL_S", "0.5")
     monkeypatch.setenv("COGNEE_CAPTURE_SAMPLE_RATE", "0.25")
+    monkeypatch.setenv("COGNEE_CAPTURE_SINK_TIMEOUT_S", "7.5")
     get_capture_config.cache_clear()
 
     config = get_capture_config()
@@ -77,6 +81,7 @@ def test_env_vars_populate_fields(clean_capture_env, monkeypatch):
     assert config.cognee_capture_batch_size == 2
     assert config.cognee_capture_flush_interval_s == 0.5
     assert config.cognee_capture_sample_rate == 0.25
+    assert config.cognee_capture_sink_timeout_s == 7.5
     assert get_capture_config() is config  # cached
 
 
@@ -88,6 +93,11 @@ def test_sample_rate_out_of_range_raises(clean_capture_env, monkeypatch):
     get_capture_config.cache_clear()
     with pytest.raises(ValueError, match=r"must be in \[0, 1\], got -0\.1"):
         get_capture_config()
+
+
+def test_sink_timeout_must_be_positive(clean_capture_env):
+    with pytest.raises(ValueError, match=r"SINK_TIMEOUT_S must be positive, got 0\.0"):
+        CaptureConfig(cognee_capture_sink_timeout_s=0.0)
 
 
 def test_prompt_fingerprints(tmp_path):

--- a/cognee/tests/unit/modules/observability/test_capture_config.py
+++ b/cognee/tests/unit/modules/observability/test_capture_config.py
@@ -47,7 +47,7 @@ def test_defaults_and_derived_dir(clean_capture_env, monkeypatch, tmp_path):
         get_base_config.cache_clear()
 
     assert config.cognee_capture_enabled is False
-    assert config.cognee_capture_queue_size == 512
+    assert config.cognee_capture_queue_size == 2048
     assert config.cognee_capture_batch_size == 64
     assert config.cognee_capture_flush_interval_s == 2.0
     assert config.cognee_capture_sample_rate == 1.0
@@ -57,13 +57,29 @@ def test_defaults_and_derived_dir(clean_capture_env, monkeypatch, tmp_path):
     assert config.to_dict() == {
         "cognee_capture_enabled": False,
         "cognee_capture_dir": os.path.join(str(tmp_path), "capture"),
-        "cognee_capture_queue_size": 512,
+        "cognee_capture_queue_size": 2048,
         "cognee_capture_batch_size": 64,
         "cognee_capture_flush_interval_s": 2.0,
         "cognee_capture_sample_rate": 1.0,
         "cognee_capture_sink_timeout_s": 30.0,
         "cognee_capture_drain_timeout_s": 5.0,
     }
+
+
+def test_the_default_queue_covers_a_default_cognify_batch(clean_capture_env, monkeypatch, tmp_path):
+    """The per-chunk emit points run over a whole task batch, and a burst past
+    QUEUE_SIZE is dropped newest-first — so the default must not be a fraction
+    of cognify's default ``chunks_per_batch`` (the literal 2000 in
+    ``cognee/api/v1/cognify/cognify.py``), or the first stock cognify of a
+    large document silently loses most of its chunk graphs."""
+    monkeypatch.setenv("DATA_ROOT_DIRECTORY", str(tmp_path))
+    get_base_config.cache_clear()
+    try:
+        config = CaptureConfig()
+    finally:
+        get_base_config.cache_clear()
+
+    assert config.cognee_capture_queue_size >= 2000
 
 
 def test_env_vars_populate_fields(clean_capture_env, monkeypatch):
@@ -80,7 +96,8 @@ def test_env_vars_populate_fields(clean_capture_env, monkeypatch):
     config = get_capture_config()
 
     assert config.cognee_capture_enabled is True
-    assert config.cognee_capture_dir == "/tmp/somewhere"
+    # Normalized like every other storage root (symlinks resolved: /private/tmp on macOS).
+    assert config.cognee_capture_dir == str(Path("/tmp/somewhere").resolve())
     assert config.cognee_capture_queue_size == 8
     assert config.cognee_capture_batch_size == 2
     assert config.cognee_capture_flush_interval_s == 0.5
@@ -98,6 +115,27 @@ def test_sample_rate_out_of_range_raises(clean_capture_env, monkeypatch):
     get_capture_config.cache_clear()
     with pytest.raises(ValueError, match=r"must be in \[0, 1\], got -0\.1"):
         get_capture_config()
+
+
+@pytest.mark.parametrize("relative", ["capture_out", "./evals", "data/capture"])
+def test_relative_capture_dir_is_rejected(clean_capture_env, monkeypatch, relative):
+    """Every other storage root goes through ``ensure_absolute_path``; a relative
+    capture dir would resolve against the process CWD and write gzip'd chunk
+    graphs (verbatim entity names) into the repo working tree or wherever a
+    worker happened to start. Loud at startup instead."""
+    with pytest.raises(ValueError, match="must be absolute"):
+        CaptureConfig(cognee_capture_dir=relative)
+
+    monkeypatch.setenv("COGNEE_CAPTURE_DIR", relative)
+    get_capture_config.cache_clear()
+    with pytest.raises(ValueError, match="must be absolute"):
+        get_capture_config()
+
+
+def test_s3_capture_dir_is_absolute_by_definition(clean_capture_env):
+    config = CaptureConfig(cognee_capture_dir="s3://bucket/cognee/capture")
+
+    assert config.cognee_capture_dir == "s3://bucket/cognee/capture"
 
 
 def test_sink_timeout_must_be_positive(clean_capture_env):

--- a/cognee/tests/unit/modules/observability/test_capture_config.py
+++ b/cognee/tests/unit/modules/observability/test_capture_config.py
@@ -172,7 +172,7 @@ def test_bad_batch_size_in_env_disables_capture_instead_of_freezing(clean_captur
     # The bad knob is rejected at initialization: capture stays off and the
     # cached knobs keep their defaults, so the observed operation is unaffected.
     assert capture.is_active() is False
-    assert hook.BATCH_SIZE == 64
+    assert hook._runtime.batch_size == 64
 
 
 def test_prompt_fingerprints():

--- a/cognee/tests/unit/modules/observability/test_capture_config.py
+++ b/cognee/tests/unit/modules/observability/test_capture_config.py
@@ -27,7 +27,7 @@ CAPTURE_ENV_VARS = (
     "COGNEE_CAPTURE_QUEUE_SIZE",
     "COGNEE_CAPTURE_BATCH_SIZE",
     "COGNEE_CAPTURE_FLUSH_INTERVAL_S",
-    "COGNEE_CAPTURE_SAMPLE_RATE",
+    "COGNEE_CAPTURE_RETRIEVAL_SAMPLE_RATE",
     "COGNEE_CAPTURE_SINK_TIMEOUT_S",
 )
 
@@ -50,7 +50,7 @@ def test_defaults_and_derived_dir(clean_capture_env, monkeypatch, tmp_path):
     assert config.cognee_capture_queue_size == 2048
     assert config.cognee_capture_batch_size == 64
     assert config.cognee_capture_flush_interval_s == 2.0
-    assert config.cognee_capture_sample_rate == 1.0
+    assert config.cognee_capture_retrieval_sample_rate == 1.0
     assert config.cognee_capture_sink_timeout_s == 30.0
     assert config.cognee_capture_drain_timeout_s == 5.0
     assert config.cognee_capture_dir == os.path.join(str(tmp_path), "capture")
@@ -60,7 +60,7 @@ def test_defaults_and_derived_dir(clean_capture_env, monkeypatch, tmp_path):
         "cognee_capture_queue_size": 2048,
         "cognee_capture_batch_size": 64,
         "cognee_capture_flush_interval_s": 2.0,
-        "cognee_capture_sample_rate": 1.0,
+        "cognee_capture_retrieval_sample_rate": 1.0,
         "cognee_capture_sink_timeout_s": 30.0,
         "cognee_capture_drain_timeout_s": 5.0,
     }
@@ -88,7 +88,7 @@ def test_env_vars_populate_fields(clean_capture_env, monkeypatch):
     monkeypatch.setenv("COGNEE_CAPTURE_QUEUE_SIZE", "8")
     monkeypatch.setenv("COGNEE_CAPTURE_BATCH_SIZE", "2")
     monkeypatch.setenv("COGNEE_CAPTURE_FLUSH_INTERVAL_S", "0.5")
-    monkeypatch.setenv("COGNEE_CAPTURE_SAMPLE_RATE", "0.25")
+    monkeypatch.setenv("COGNEE_CAPTURE_RETRIEVAL_SAMPLE_RATE", "0.25")
     monkeypatch.setenv("COGNEE_CAPTURE_SINK_TIMEOUT_S", "7.5")
     monkeypatch.setenv("COGNEE_CAPTURE_DRAIN_TIMEOUT_S", "1.5")
     get_capture_config.cache_clear()
@@ -101,7 +101,7 @@ def test_env_vars_populate_fields(clean_capture_env, monkeypatch):
     assert config.cognee_capture_queue_size == 8
     assert config.cognee_capture_batch_size == 2
     assert config.cognee_capture_flush_interval_s == 0.5
-    assert config.cognee_capture_sample_rate == 0.25
+    assert config.cognee_capture_retrieval_sample_rate == 0.25
     assert config.cognee_capture_sink_timeout_s == 7.5
     assert config.cognee_capture_drain_timeout_s == 1.5
     assert get_capture_config() is config  # cached
@@ -109,9 +109,9 @@ def test_env_vars_populate_fields(clean_capture_env, monkeypatch):
 
 def test_sample_rate_out_of_range_raises(clean_capture_env, monkeypatch):
     with pytest.raises(ValueError, match=r"must be in \[0, 1\], got 1\.5"):
-        CaptureConfig(cognee_capture_sample_rate=1.5)
+        CaptureConfig(cognee_capture_retrieval_sample_rate=1.5)
 
-    monkeypatch.setenv("COGNEE_CAPTURE_SAMPLE_RATE", "-0.1")
+    monkeypatch.setenv("COGNEE_CAPTURE_RETRIEVAL_SAMPLE_RATE", "-0.1")
     get_capture_config.cache_clear()
     with pytest.raises(ValueError, match=r"must be in \[0, 1\], got -0\.1"):
         get_capture_config()

--- a/cognee/tests/unit/modules/observability/test_capture_end_to_end.py
+++ b/cognee/tests/unit/modules/observability/test_capture_end_to_end.py
@@ -1,0 +1,529 @@
+"""Eval capture end to end (SDK-529): ONE cognify-shaped pipeline run through the
+real runner, followed by ONE recorded search, observed through a FakeCaptureSink.
+
+What is real: ``run_tasks`` (via ``runner_plumbing``), the per-item task resolver
+notes from ``cognify``, ``classify_documents``, ``extract_chunks_from_documents`` with
+the real ``TextChunker`` over a real temp file, ``extract_graph_and_summarize`` (the
+real ``extract_content_graph`` prompt rendering and ``extract_summary_with_provenance``
+prompt read, the dedup, the ontology canonicalization, ``construct_data_points_*``),
+``add_data_points`` (real ``get_graph_from_model`` + dedup over the produced
+DataPoints), ``record_operation`` and ``brute_force_triplet_search``.
+
+What is faked: the LLM (``LLMGateway.acreate_structured_output``), the embedding
+tokenizer, every database touch (relational session, graph/vector engines, edge
+lookup, operation-row writer), and the retrieval vector engine / memory fragment —
+the same fakes the per-stage unit tests use.
+"""
+
+import importlib
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import NAMESPACE_OID, UUID, uuid4, uuid5
+
+import pytest
+
+import cognee.modules.pipelines.operations.run_tasks as run_tasks_module
+from cognee.infrastructure.databases.provenance import (
+    GRAPH_DELETE_MODE_GRAPH_PROVENANCE,
+    GRAPH_DELETE_MODE_KEY,
+    GRAPH_PROVENANCE_VERSION,
+    GRAPH_PROVENANCE_VERSION_KEY,
+)
+from cognee.infrastructure.llm.config import get_llm_config, get_llm_context_config
+from cognee.infrastructure.llm.extraction.extract_summary import SUMMARY_PROMPT_FILE
+from cognee.infrastructure.llm.LLMGateway import LLMGateway
+from cognee.infrastructure.llm.prompts import read_query_prompt, render_prompt
+from cognee.modules.chunking.TextChunker import TextChunker
+from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge, Node
+from cognee.modules.observability import capture
+from cognee.modules.observability.capture import (
+    KIND_EXTRACTION_CHUNK_GRAPH,
+    KIND_EXTRACTION_DROPPED_DUPLICATES,
+    KIND_EXTRACTION_FUZZY_MATCH,
+    KIND_RETRIEVAL_CANDIDATES,
+    KIND_RUN_MANIFEST,
+    KIND_STORAGE_DELTA,
+    KIND_SUMMARY_GENERATED,
+)
+from cognee.modules.ontology.base_ontology_resolver import BaseOntologyResolver
+from cognee.modules.ontology.matching_strategies import FuzzyMatchingStrategy
+from cognee.modules.ontology.models import AttachedOntologyNode
+from cognee.modules.pipelines.tasks.task import Task
+from cognee.modules.retrieval.utils.brute_force_triplet_search import brute_force_triplet_search
+from cognee.shared.data_models import Edge as KGEdge
+from cognee.shared.data_models import KnowledgeGraph, Node as KGNode, SummarizedContent
+from cognee.tasks.documents import classify_documents, extract_chunks_from_documents
+from cognee.tasks.graph.extract_graph_and_summarize import extract_graph_and_summarize
+from cognee.tasks.storage.add_data_points import add_data_points
+
+cognify_module = importlib.import_module("cognee.api.v1.cognify.cognify")
+record_operation_module = importlib.import_module("cognee.modules.operations.record_operation")
+egd_module = importlib.import_module("cognee.tasks.graph.extract_graph_from_data")
+adp_module = importlib.import_module("cognee.tasks.storage.add_data_points")
+chunks_module = importlib.import_module("cognee.tasks.documents.extract_chunks_from_documents")
+sentence_module = importlib.import_module("cognee.tasks.chunks.chunk_by_sentence")
+
+pytestmark = pytest.mark.usefixtures("capture_reset")
+
+MAX_CHUNK_SIZE = 12  # words (the fake tokenizer counts one token per word)
+PARAGRAPH_ONE = "Alice met Bob in Paris. They founded Acme Corp together.\n\n"
+PARAGRAPH_TWO = "Carol joined Acme Corp later. She leads the research team in Berlin.\n"
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _Canonicalizer(BaseOntologyResolver):
+    """Resolves the ``Person`` class to an ontology node; everything else misses."""
+
+    def __init__(self):
+        super().__init__(FuzzyMatchingStrategy(cutoff=0.85))
+
+    def build_lookup(self) -> None:
+        return None
+
+    def refresh_lookup(self) -> None:
+        return None
+
+    def find_closest_match(self, name: str, category: str):
+        return None
+
+    def get_subgraph(self, node_name: str, node_type: str = "individuals", directed: bool = True):
+        if node_type == "classes" and node_name == "person":
+            root = AttachedOntologyNode("https://example.test/onto#Person", "classes")
+            return [root], [], root
+        return [], [], None
+
+
+def _extracted_graph(chunk_text: str) -> KnowledgeGraph:
+    """A per-chunk graph with one duplicated node id, keyed on the chunk text."""
+    tag = str(uuid5(NAMESPACE_OID, chunk_text))[:8]
+    return KnowledgeGraph(
+        nodes=[
+            KGNode(id=f"p-{tag}", name=f"Person {tag}", type="Person", description="first"),
+            KGNode(id=f"p-{tag}", name=f"Duplicate {tag}", type="Person", description="dupe"),
+            KGNode(id=f"o-{tag}", name=f"Org {tag}", type="Organization", description="org"),
+        ],
+        edges=[
+            KGEdge(
+                source_node_id=f"p-{tag}", target_node_id=f"o-{tag}", relationship_name="works_at"
+            )
+        ],
+    )
+
+
+async def _fake_structured_output(text_input, system_prompt, response_model, **kwargs):
+    if response_model is KnowledgeGraph:
+        return _extracted_graph(text_input)
+    if response_model is SummarizedContent:
+        return SummarizedContent(summary=f"Summary of: {text_input[:20]}", description="d")
+    raise AssertionError(f"unexpected response model {response_model!r}")
+
+
+def _graph_provenance_unified():
+    """A unified engine whose graph is marked graph-provenance (ledger skipped)."""
+    graph_engine = AsyncMock()
+    graph_engine.is_empty = AsyncMock(return_value=True)
+    graph_engine.get_graph_metadata = AsyncMock(
+        return_value={
+            GRAPH_DELETE_MODE_KEY: GRAPH_DELETE_MODE_GRAPH_PROVENANCE,
+            GRAPH_PROVENANCE_VERSION_KEY: GRAPH_PROVENANCE_VERSION,
+        }
+    )
+    unified = AsyncMock()
+    unified.graph = graph_engine
+    unified.vector = AsyncMock()
+    unified.has_capability = lambda capability: False
+    return unified, graph_engine
+
+
+class _ScoredResult:
+    def __init__(self, id, score):
+        self.id = id
+        self.score = score
+        self.payload = {}
+
+
+def _retrieval_edge(source, target, rel, distances):
+    node1 = Node(source, {"name": source})
+    node2 = Node(target, {"name": target})
+    edge = Edge(node1, node2, attributes={"relationship_type": rel})
+    for element, element_distances in zip((node1, edge, node2), distances):
+        element.attributes["vector_distance"] = list(element_distances)
+    return edge
+
+
+def _by_kind(sink, kind):
+    return [record for record in sink.records if record["kind"] == kind]
+
+
+def _assert_flat(value):
+    if isinstance(value, dict):
+        for item in value.values():
+            _assert_flat(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_flat(item)
+    else:
+        assert value is None or isinstance(value, (str, int, float, bool)), repr(value)
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pipeline_fakes(monkeypatch, tmp_path, runner_plumbing):
+    """Stub every database and LLM touch a cognify-shaped run makes; return the collaborators."""
+    dataset = SimpleNamespace(id=uuid4(), name="probe_dataset", owner_id=uuid4())
+    runner_plumbing(run_tasks_module, dataset)
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_progress", AsyncMock())
+    # The source document is read through open_data_file's local allowlist.
+    monkeypatch.setenv("COGNEE_ALLOWED_LOCAL_FILE_ROOTS", str(tmp_path))
+
+    # LLM: one dispatcher for extraction (KnowledgeGraph) and summarization.
+    llm = AsyncMock(side_effect=_fake_structured_output)
+    monkeypatch.setattr(LLMGateway, "acreate_structured_output", llm)
+
+    # Chunking: no embedding engine / tokenizer, no relational token-count write.
+    monkeypatch.setattr(
+        sentence_module, "get_embedding_engine", lambda: SimpleNamespace(tokenizer=None)
+    )
+    monkeypatch.setattr(chunks_module, "update_document_token_count", AsyncMock())
+
+    # Extraction: no graph lookup for existing edges.
+    monkeypatch.setattr(egd_module, "find_existing_edge_identities", AsyncMock(return_value=set()))
+
+    # Storage: graph-provenance-marked unified engine, no vector indexing.
+    unified, graph_engine = _graph_provenance_unified()
+    monkeypatch.setattr(adp_module, "get_unified_engine", AsyncMock(return_value=unified))
+    monkeypatch.setattr(adp_module, "index_data_points", AsyncMock())
+    monkeypatch.setattr(adp_module, "index_graph_edges", AsyncMock())
+
+    # record_operation: no pipeline_runs row.
+    monkeypatch.setattr(record_operation_module, "_write_operation_row", AsyncMock())
+
+    return SimpleNamespace(dataset=dataset, llm=llm, graph_engine=graph_engine)
+
+
+def _cognify_tasks(resolver: BaseOntologyResolver) -> list[Task]:
+    """The standard cognify task list shape (get_default_tasks), with test knobs."""
+    return [
+        Task(classify_documents),
+        Task(extract_chunks_from_documents, max_chunk_size=MAX_CHUNK_SIZE, chunker=TextChunker),
+        Task(
+            extract_graph_and_summarize,
+            graph_model=KnowledgeGraph,
+            config={
+                "ontology_config": {"ontology_resolver": resolver, "ontology_mode": "annotate"}
+            },
+            custom_prompt=None,
+            task_config={"batch_size": 2000},
+        ),
+        Task(add_data_points, embed_triplets=False, task_config={"batch_size": 2000}),
+    ]
+
+
+async def _run_pipeline(tmp_path, fakes, user):
+    source = tmp_path / "notes.txt"
+    source.write_text(PARAGRAPH_ONE + PARAGRAPH_TWO, encoding="utf-8")
+    data_item = SimpleNamespace(
+        id=uuid4(),
+        name="notes",
+        extension="txt",
+        raw_data_location=str(source),
+        mime_type="text/plain",
+        external_metadata={},
+        importance_weight=None,
+        system_metadata={},
+    )
+
+    tasks = _cognify_tasks(_Canonicalizer())
+
+    def resolve_cognify_tasks(item):
+        # Mirrors cognify()'s per-item resolver: the run scope exists only here.
+        cognify_module._note_chunking_config(tasks)
+        return tasks
+
+    events = []
+    async for event in run_tasks_module.run_tasks(
+        tasks=resolve_cognify_tasks,
+        dataset_id=fakes.dataset.id,
+        data=[data_item],
+        user=user,
+        pipeline_name="cognify_pipeline",
+    ):
+        events.append(event)
+    return events
+
+
+async def _run_search(dataset_id):
+    edge = _retrieval_edge("alice", "acme", "works_at", ([0.1], [0.2], [0.3]))
+    engine = AsyncMock()
+    engine.embedding_engine = AsyncMock()
+    engine.embedding_engine.embed_text = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+    pool = {
+        "Entity_name": [_ScoredResult("alice", 0.1), _ScoredResult("acme", 0.4)],
+        "EdgeType_relationship_name": [_ScoredResult("works_at", 0.2)],
+    }
+    engine.search = AsyncMock(side_effect=lambda **kw: pool.get(kw["collection_name"], []))
+    fragment = AsyncMock(
+        map_vector_distances_to_graph_nodes=AsyncMock(),
+        map_vector_distances_to_graph_edges=AsyncMock(),
+        calculate_top_triplet_importances=AsyncMock(return_value=[edge]),
+    )
+
+    with (
+        patch(
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
+            return_value=engine,
+        ),
+        patch(
+            "cognee.modules.retrieval.utils.brute_force_triplet_search.get_memory_fragment",
+            return_value=fragment,
+        ),
+    ):
+        async with record_operation_module.record_operation("search") as context:
+            context.set_dataset(dataset_id)
+            results = await brute_force_triplet_search(
+                query="who works at acme", top_k=3, collections=["Entity_name"]
+            )
+    return context, results
+
+
+# ---------------------------------------------------------------------------
+# The probe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_pipeline_run_and_one_search_yield_every_capture_kind(
+    tmp_path, pipeline_fakes, fake_capture_sink
+):
+    fakes = pipeline_fakes
+    user = SimpleNamespace(id=uuid4(), tenant_id=None, email="probe@example.test")
+
+    async with record_operation_module.record_operation("remember") as remember_context:
+        remember_context.set_dataset(fakes.dataset.id)
+        events = await _run_pipeline(tmp_path, fakes, user)
+
+    pipeline_run_id = str(events[0].pipeline_run_id)
+    assert type(events[-1]).__name__ == "PipelineRunCompleted", events[-1]
+
+    search_context, search_results = await _run_search(fakes.dataset.id)
+    assert len(search_results) == 1
+
+    # The pipeline drained its own events; the operation manifests need one drain.
+    await capture.drain()
+    sink = fake_capture_sink
+
+    # Everything the sink holds is JSON: no Node/Edge/ScoredResult/DataPoint leaked.
+    json.dumps(sink.records)
+    for record in sink.records:
+        _assert_flat(record["payload"])
+
+    # ---- manifests: remember (operation) > pipeline > search (operation) ------
+    manifests = {
+        m["payload"]["kind"] + ":" + m["payload"].get("operation", ""): m
+        for m in _by_kind(sink, KIND_RUN_MANIFEST)
+    }
+    assert set(manifests) == {"operation:remember", "pipeline:", "operation:search"}
+
+    remember = manifests["operation:remember"]["payload"]
+    assert remember["run_id"] == str(remember_context.operation_id)
+    assert remember["dataset_id"] == str(fakes.dataset.id)
+    assert remember["outcome"] == "succeeded"
+    assert remember["error_class"] is None
+    # Notes and counters land on the innermost scope (the pipeline), not the
+    # enclosing operation: the two manifests are joined offline via parent_run_id.
+    assert remember["counters"] == {}
+    assert "extraction.model" not in remember
+    # 3 chunks x (extraction + summarization).
+    assert fakes.llm.await_count == 6
+
+    pipeline = manifests["pipeline:"]["payload"]
+    assert pipeline["run_id"] == pipeline_run_id
+    assert pipeline["parent_run_id"] == str(remember_context.operation_id)
+    assert pipeline["dataset_id"] == str(fakes.dataset.id)
+    assert pipeline["sampled"] is True
+    # chunking.* from the per-item resolver
+    assert pipeline["chunking.chunker"] == "TextChunker"
+    assert pipeline["chunking.chunk_size"] == MAX_CHUNK_SIZE
+    # ontology.* from integrate_chunk_graphs
+    assert pipeline["ontology.mode"] == "annotate"
+    assert pipeline["ontology.resolver"] == "_Canonicalizer"
+    assert pipeline["ontology.matching_strategy"] == "FuzzyMatchingStrategy"
+    assert pipeline["ontology.threshold"] == 0.85
+    # extraction.* from the real extract_content_graph prompt rendering
+    rendered_prompt = render_prompt(get_llm_config().graph_prompt_path, {})
+    assert (
+        pipeline["extraction.model"]
+        == get_llm_context_config().stage_config("extraction").llm_model
+    )
+    assert pipeline["extraction.prompt_fingerprint"] == capture.prompt_fingerprint(rendered_prompt)
+    # summarization.* from the real extract_summary_with_provenance prompt read
+    assert (
+        pipeline["summarization.model"]
+        == get_llm_context_config().stage_config("summarization").llm_model
+    )
+    assert pipeline["summarization.prompt_fingerprint"] == capture.prompt_fingerprint(
+        read_query_prompt(SUMMARY_PROMPT_FILE)
+    )
+
+    # ---- extraction.chunk_graph: one per real chunk, pre-dedup snapshot ---------
+    chunk_graphs = _by_kind(sink, KIND_EXTRACTION_CHUNK_GRAPH)
+    assert len(chunk_graphs) >= 2, "the text must have been split into at least two chunks"
+    assert {e["run_id"] for e in chunk_graphs} == {pipeline_run_id}
+    assert {e["dataset_id"] for e in chunk_graphs} == {str(fakes.dataset.id)}
+    assert {e["stage"] for e in chunk_graphs} == {"extract_graph_from_data"}
+    assert [e["payload"]["chunk_index"] for e in chunk_graphs] == list(range(len(chunk_graphs)))
+    chunk_ids = [e["payload"]["chunk_id"] for e in chunk_graphs]
+    for event in chunk_graphs:
+        graph = event["payload"]["graph"]
+        assert len(graph["nodes"]) == 3, "snapshot taken before dedup"
+        assert graph["nodes"][0]["type"] == "Person", "snapshot taken before canonicalization"
+        assert event["payload"]["chunk_size_chars"] > 0
+
+    # ---- extraction.dropped_duplicates: one per chunk graph that dropped ------
+    dropped = _by_kind(sink, KIND_EXTRACTION_DROPPED_DUPLICATES)
+    assert len(dropped) == len(chunk_graphs)
+    assert {e["run_id"] for e in dropped} == {pipeline_run_id}
+    for event, graph_event in zip(dropped, chunk_graphs):
+        expected_id = graph_event["payload"]["graph"]["nodes"][0]["id"]
+        assert event["payload"] == {
+            "chunk_index": graph_event["payload"]["chunk_index"],
+            "dropped_node_ids": [expected_id],
+            "count": 1,
+        }
+    assert pipeline["counters"]["extraction.dropped_duplicate_nodes"] == len(chunk_graphs)
+
+    # ---- extraction.fuzzy_match: one per chunk that triggered lookups ---------
+    fuzzy = _by_kind(sink, KIND_EXTRACTION_FUZZY_MATCH)
+    assert fuzzy, "the ontology resolver was consulted"
+    assert {e["run_id"] for e in fuzzy} == {pipeline_run_id}
+    first_matches = fuzzy[0]["payload"]["matches"]
+    person = next(
+        m for m in first_matches if m["category"] == "classes" and m["normalized"] == "person"
+    )
+    assert person["matched"] is True
+    assert person["uri"] == "https://example.test/onto#Person"
+    assert fuzzy[0]["payload"]["chunk_id"] == chunk_ids[0]
+    assert pipeline["counters"]["extraction.fuzzy_lookups"] == sum(
+        e["payload"]["lookups"] for e in fuzzy
+    )
+    assert pipeline["counters"]["extraction.fuzzy_matches"] == sum(
+        e["payload"]["count"] for e in fuzzy
+    )
+
+    # ---- summary.generated: one per chunk, joined to the chunk and summary ids -
+    summaries = _by_kind(sink, KIND_SUMMARY_GENERATED)
+    assert [e["payload"]["chunk_id"] for e in summaries] == chunk_ids
+    assert {e["run_id"] for e in summaries} == {pipeline_run_id}
+    assert {e["stage"] for e in summaries} == {"summarize_text"}
+    for event in summaries:
+        payload = event["payload"]
+        assert payload["summary_id"] == str(uuid5(UUID(payload["chunk_id"]), "TextSummary"))
+        assert payload["model"] == pipeline["summarization.model"]
+        assert payload["prompt_fingerprint"] == pipeline["summarization.prompt_fingerprint"]
+        assert payload["source_text_hash"].startswith("sha256:")
+        assert payload["summary_chars"] > 0
+        assert "text" not in payload and "summary" not in payload
+
+    # ---- storage.delta: one per add_data_points call, ids/types/counts only ---
+    [delta] = _by_kind(sink, KIND_STORAGE_DELTA)
+    assert delta["run_id"] == pipeline_run_id
+    assert delta["dataset_id"] == str(fakes.dataset.id)
+    assert delta["stage"] == "add_data_points"
+    payload = delta["payload"]
+    assert payload["pipeline_run_id"] == pipeline_run_id
+    fakes.graph_engine.add_nodes.assert_awaited_once()
+    written_nodes = fakes.graph_engine.add_nodes.await_args.args[0]
+    assert payload["node_count"] == len(written_nodes)
+    assert sorted(payload["node_ids"]) == sorted(str(node.id) for node in written_nodes)
+    assert payload["node_types"]["TextSummary"] == len(chunk_ids)
+    assert payload["node_types"]["DocumentChunk"] == len(chunk_ids)
+    assert payload["node_types"]["TextDocument"] == 1
+    assert payload["node_types"]["Entity"] == 2 * len(chunk_ids)  # person + org per chunk
+    assert set(s["payload"]["summary_id"] for s in summaries) <= set(payload["node_ids"])
+    assert set(chunk_ids) <= set(payload["node_ids"])
+    fakes.graph_engine.add_edges.assert_awaited_once()
+    assert payload["edge_count"] == len(fakes.graph_engine.add_edges.await_args.args[0])
+    assert payload["custom_edge_count"] == 0
+    assert pipeline["counters"]["storage.nodes_written"] == payload["node_count"]
+    assert pipeline["counters"]["storage.edges_written"] == payload["edge_count"]
+
+    # ---- retrieval.candidates: under the search operation, dataset bound late -
+    search = manifests["operation:search"]["payload"]
+    assert search["run_id"] == str(search_context.operation_id)
+    assert search["dataset_id"] == str(fakes.dataset.id)
+    assert search["outcome"] == "succeeded"
+    assert search["retrieval.top_k"] == 3
+    assert search["retrieval.mode"] == "single"
+    assert search["retrieval.collections"] == ["Entity_name", "EdgeType_relationship_name"]
+
+    [candidates] = _by_kind(sink, KIND_RETRIEVAL_CANDIDATES)
+    assert candidates["run_id"] == str(search_context.operation_id)
+    assert candidates["dataset_id"] == str(fakes.dataset.id)
+    assert candidates["stage"] == "brute_force_triplet_search"
+    payload = candidates["payload"]
+    assert payload["query_index"] == 0
+    assert payload["pool"] == [
+        {"id": "alice", "collection": "Entity_name", "score": 0.1},
+        {"id": "acme", "collection": "Entity_name", "score": 0.4},
+        {"id": "works_at", "collection": "EdgeType_relationship_name", "score": 0.2},
+    ]
+    assert payload["top_k"] == [
+        {"source": "alice", "target": "acme", "rel": "works_at", "score": pytest.approx(0.6)}
+    ]
+    assert (payload["pool_size"], payload["pool_truncated"], payload["cut_size"]) == (3, False, 1)
+
+    # No event of any kind is attributed to nothing.
+    assert all(record["run_id"] is not None for record in sink.records)
+    assert all(record["dataset_id"] == str(fakes.dataset.id) for record in sink.records)
+    assert not capture.hook._buffer
+
+
+@pytest.mark.asyncio
+async def test_the_same_run_with_capture_off_is_a_structural_no_op(
+    monkeypatch, tmp_path, pipeline_fakes
+):
+    """Capture off: the identical pipeline + search complete, the LLM fake is called the
+    same number of times, and capture buffers nothing, starts no flusher, hashes nothing."""
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+    fakes = pipeline_fakes
+    user = SimpleNamespace(id=uuid4(), tenant_id=None, email="probe@example.test")
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("prompt_fingerprint must not run while capture is off")
+
+    monkeypatch.setattr(capture, "prompt_fingerprint", _boom)
+    emit_spy = AsyncMock()  # never awaited; a plain call would surface as a MagicMock call
+    monkeypatch.setattr(capture, "emit", emit_spy)
+
+    async with record_operation_module.record_operation("remember") as remember_context:
+        remember_context.set_dataset(fakes.dataset.id)
+        events = await _run_pipeline(tmp_path, fakes, user)
+    assert type(events[-1]).__name__ == "PipelineRunCompleted", events[-1]
+
+    _search_context, search_results = await _run_search(fakes.dataset.id)
+    assert len(search_results) == 1
+
+    assert capture.is_active() is False
+    assert capture.current_scope() is None
+    emit_spy.assert_not_called()
+    assert not capture.hook._buffer
+    assert not capture.hook._flushers
+    # 3 chunks x (extraction + summarization) LLM calls, same as with capture on.
+    assert fakes.llm.await_count == 6
+    # The stored summaries carry no provenance when capture is off.
+    written_nodes = fakes.graph_engine.add_nodes.await_args.args[0]
+    summaries = [node for node in written_nodes if node.type == "TextSummary"]
+    assert len(summaries) == 3
+    assert all(
+        (node.model, node.prompt_fingerprint, node.source_text_hash) == (None, None, None)
+        for node in summaries
+    )

--- a/cognee/tests/unit/modules/observability/test_capture_end_to_end.py
+++ b/cognee/tests/unit/modules/observability/test_capture_end_to_end.py
@@ -399,6 +399,7 @@ async def test_one_pipeline_run_and_one_search_yield_every_capture_kind(
     for event, graph_event in zip(dropped, chunk_graphs):
         expected_id = graph_event["payload"]["graph"]["nodes"][0]["id"]
         assert event["payload"] == {
+            "chunk_id": graph_event["payload"]["chunk_id"],
             "chunk_index": graph_event["payload"]["chunk_index"],
             "dropped_node_ids": [expected_id],
             "count": 1,

--- a/cognee/tests/unit/modules/observability/test_capture_end_to_end.py
+++ b/cognee/tests/unit/modules/observability/test_capture_end_to_end.py
@@ -524,12 +524,12 @@ async def test_the_same_run_with_capture_off_is_a_structural_no_op(
     assert not capture.hook._flushers
     # 3 chunks x (extraction + summarization) LLM calls, same as with capture on.
     assert fakes.llm.await_count == 6
-    # The stored summaries carry no provenance when capture is off.
+    # Stored summaries never carry capture provenance, on or off.
     written_nodes = fakes.graph_engine.add_nodes.await_args.args[0]
     summaries = [node for node in written_nodes if node.type == "TextSummary"]
     assert len(summaries) == 3
     assert all(
-        (node.model, node.prompt_fingerprint, node.source_text_hash) == (None, None, None)
+        not any(hasattr(node, f) for f in ("model", "prompt_fingerprint", "source_text_hash"))
         for node in summaries
     )
 

--- a/cognee/tests/unit/modules/observability/test_capture_end_to_end.py
+++ b/cognee/tests/unit/modules/observability/test_capture_end_to_end.py
@@ -1,5 +1,7 @@
 """Eval capture end to end (SDK-529): ONE cognify-shaped pipeline run through the
-real runner, followed by ONE recorded search, observed through a FakeCaptureSink.
+real runner, followed by ONE recorded search, observed through a FakeCaptureSink —
+and once more with capture switched on through the environment, so the real
+``StorageSink`` persists the same run in its documented on-disk layout.
 
 What is real: ``run_tasks`` (via ``runner_plumbing``), the per-item task resolver
 notes from ``cognify``, ``classify_documents``, ``extract_chunks_from_documents`` with
@@ -15,8 +17,10 @@ lookup, operation-row writer), and the retrieval vector engine / memory fragment
 the same fakes the per-stage unit tests use.
 """
 
+import gzip
 import importlib
 import json
+import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from uuid import NAMESPACE_OID, UUID, uuid4, uuid5
@@ -527,3 +531,116 @@ async def test_the_same_run_with_capture_off_is_a_structural_no_op(
         (node.model, node.prompt_fingerprint, node.source_text_hash) == (None, None, None)
         for node in summaries
     )
+
+
+def _read_capture_dir(root):
+    """Every record persisted under ``root`` by the StorageSink, keyed by relative path."""
+    persisted = {}
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for filename in filenames:
+            path = os.path.join(dirpath, filename)
+            relative = os.path.relpath(path, root)
+            if filename == "manifest.json":
+                with open(path, encoding="utf-8") as handle:
+                    persisted[relative] = [json.load(handle)]
+            elif filename.endswith(".jsonl.gz"):
+                with gzip.open(path, "rt", encoding="utf-8") as handle:
+                    persisted[relative] = [json.loads(line) for line in handle if line.strip()]
+            else:
+                raise AssertionError(f"unexpected file in the capture directory: {relative}")
+    return persisted
+
+
+@pytest.mark.asyncio
+async def test_env_enabled_capture_persists_the_run_through_the_storage_sink(
+    monkeypatch, tmp_path, pipeline_fakes
+):
+    """Capture switched on the way a deployment does it — ``COGNEE_CAPTURE_ENABLED`` and
+    ``COGNEE_CAPTURE_DIR`` in the environment, no sink registered by hand — so the first
+    ``is_active()`` auto-registers the real ``StorageSink`` over the local file storage,
+    and one pipeline run plus one search land on disk in the documented layout::
+
+        {dataset}/{run}/manifest.json
+        {dataset}/{run}/{kind}/batch-*.jsonl.gz
+    """
+    capture_root = tmp_path / "capture"
+    monkeypatch.setenv("COGNEE_CAPTURE_ENABLED", "true")
+    monkeypatch.setenv("COGNEE_CAPTURE_DIR", str(capture_root))
+    fakes = pipeline_fakes
+    user = SimpleNamespace(id=uuid4(), tenant_id=None, email="probe@example.test")
+
+    async with record_operation_module.record_operation("remember") as remember_context:
+        remember_context.set_dataset(fakes.dataset.id)
+        events = await _run_pipeline(tmp_path, fakes, user)
+    assert type(events[-1]).__name__ == "PipelineRunCompleted", events[-1]
+    pipeline_run_id = str(events[0].pipeline_run_id)
+
+    search_context, search_results = await _run_search(fakes.dataset.id)
+    assert len(search_results) == 1
+
+    assert isinstance(capture.hook._sink, capture.StorageSink), "env did not register the sink"
+    await capture.drain()
+    assert not capture.hook._buffer
+
+    persisted = _read_capture_dir(capture_root)
+    dataset = str(fakes.dataset.id)
+    remember_run = str(remember_context.operation_id)
+    search_run = str(search_context.operation_id)
+
+    # Layout: three runs under the one dataset, nothing under nodataset/ or norun/.
+    assert {path.split(os.sep)[0] for path in persisted} == {dataset}
+    assert {path.split(os.sep)[1] for path in persisted} == {
+        remember_run,
+        pipeline_run_id,
+        search_run,
+    }
+
+    def kinds_under(run_id):
+        kinds = set()
+        for path in persisted:
+            parts = path.split(os.sep)
+            if parts[1] != run_id:
+                continue
+            kinds.add("manifest.json" if parts[2] == "manifest.json" else parts[2])
+        return kinds
+
+    assert kinds_under(remember_run) == {"manifest.json"}
+    assert kinds_under(pipeline_run_id) == {
+        "manifest.json",
+        KIND_EXTRACTION_CHUNK_GRAPH,
+        KIND_EXTRACTION_DROPPED_DUPLICATES,
+        KIND_EXTRACTION_FUZZY_MATCH,
+        KIND_SUMMARY_GENERATED,
+        KIND_STORAGE_DELTA,
+    }
+    assert kinds_under(search_run) == {"manifest.json", KIND_RETRIEVAL_CANDIDATES}
+
+    # Every persisted record carries the full envelope and points at its own run.
+    records = [record for group in persisted.values() for record in group]
+    for record in records:
+        assert set(record) == {"kind", "run_id", "dataset_id", "stage", "ts", "payload"}
+        assert record["dataset_id"] == dataset
+        _assert_flat(record["payload"])
+
+    pipeline_manifest = persisted[os.path.join(dataset, pipeline_run_id, "manifest.json")][0]
+    assert pipeline_manifest["kind"] == KIND_RUN_MANIFEST
+    manifest = pipeline_manifest["payload"]
+    assert manifest["parent_run_id"] == remember_run
+    assert manifest["chunking.chunker"] == "TextChunker"
+    assert manifest["extraction.model"] and manifest["extraction.prompt_fingerprint"]
+    assert manifest["summarization.model"] and manifest["summarization.prompt_fingerprint"]
+    assert manifest["ontology.mode"] == "annotate"
+    assert manifest["counters"]["storage.nodes_written"] > 0
+    assert manifest["dropped_events"] == 0
+
+    chunk_graph_records = [
+        record for record in records if record["kind"] == KIND_EXTRACTION_CHUNK_GRAPH
+    ]
+    assert len(chunk_graph_records) >= 2
+    assert {record["run_id"] for record in chunk_graph_records} == {pipeline_run_id}
+    [candidates] = [record for record in records if record["kind"] == KIND_RETRIEVAL_CANDIDATES]
+    assert candidates["run_id"] == search_run
+    assert candidates["payload"]["cut_size"] == 1
+    search_manifest = persisted[os.path.join(dataset, search_run, "manifest.json")][0]
+    assert search_manifest["payload"]["operation"] == "search"
+    assert search_manifest["payload"]["outcome"] == "succeeded"

--- a/cognee/tests/unit/modules/observability/test_capture_end_to_end.py
+++ b/cognee/tests/unit/modules/observability/test_capture_end_to_end.py
@@ -489,7 +489,7 @@ async def test_one_pipeline_run_and_one_search_yield_every_capture_kind(
     # No event of any kind is attributed to nothing.
     assert all(record["run_id"] is not None for record in sink.records)
     assert all(record["dataset_id"] == str(fakes.dataset.id) for record in sink.records)
-    assert not capture.hook._buffer
+    assert not capture.hook._runtime.buffer
 
 
 @pytest.mark.asyncio
@@ -520,8 +520,8 @@ async def test_the_same_run_with_capture_off_is_a_structural_no_op(
     assert capture.is_active() is False
     assert capture.current_scope() is None
     emit_spy.assert_not_called()
-    assert not capture.hook._buffer
-    assert not capture.hook._flushers
+    assert not capture.hook._runtime.buffer
+    assert not capture.hook._runtime.flushers
     # 3 chunks x (extraction + summarization) LLM calls, same as with capture on.
     assert fakes.llm.await_count == 6
     # Stored summaries never carry capture provenance, on or off.
@@ -579,9 +579,11 @@ async def test_env_enabled_capture_persists_the_run_through_the_storage_sink(
     search_context, search_results = await _run_search(fakes.dataset.id)
     assert len(search_results) == 1
 
-    assert isinstance(capture.hook._sink, capture.StorageSink), "env did not register the sink"
+    assert isinstance(capture.hook._runtime.sink, capture.StorageSink), (
+        "env did not register the sink"
+    )
     await capture.drain()
-    assert not capture.hook._buffer
+    assert not capture.hook._runtime.buffer
 
     persisted = _read_capture_dir(capture_root)
     dataset = str(fakes.dataset.id)

--- a/cognee/tests/unit/modules/observability/test_capture_end_to_end.py
+++ b/cognee/tests/unit/modules/observability/test_capture_end_to_end.py
@@ -619,7 +619,17 @@ async def test_env_enabled_capture_persists_the_run_through_the_storage_sink(
     # Every persisted record carries the full envelope and points at its own run.
     records = [record for group in persisted.values() for record in group]
     for record in records:
-        assert set(record) == {"kind", "run_id", "dataset_id", "stage", "ts", "payload"}
+        assert set(record) == {
+            "schema_version",
+            "event_id",
+            "kind",
+            "run_id",
+            "dataset_id",
+            "stage",
+            "ts",
+            "payload",
+        }
+        assert record["schema_version"] == 1
         assert record["dataset_id"] == dataset
         _assert_flat(record["payload"])
 
@@ -632,7 +642,7 @@ async def test_env_enabled_capture_persists_the_run_through_the_storage_sink(
     assert manifest["summarization.model"] and manifest["summarization.prompt_fingerprint"]
     assert manifest["ontology.mode"] == "annotate"
     assert manifest["counters"]["storage.nodes_written"] > 0
-    assert manifest["dropped_events"] == 0
+    assert manifest["events_dropped"] == 0
 
     chunk_graph_records = [
         record for record in records if record["kind"] == KIND_EXTRACTION_CHUNK_GRAPH

--- a/cognee/tests/unit/modules/observability/test_capture_hook.py
+++ b/cognee/tests/unit/modules/observability/test_capture_hook.py
@@ -33,6 +33,7 @@ from cognee.modules.observability.capture import (
     get_capture_config,
     hook,
 )
+from cognee.modules.observability.capture.sinks import run_off_loop
 from cognee.shared.data_models import KnowledgeGraph
 
 pytestmark = pytest.mark.usefixtures("capture_reset")
@@ -116,6 +117,25 @@ def test_off_by_default_costs_nothing(monkeypatch):
     assert capture.current_scope() is None
 
 
+def test_emit_before_any_is_active_never_initializes(monkeypatch):
+    # With this set, an emit() that lazily initialized would auto-register a
+    # sink and buffer the event; the contract is that only is_active() may.
+    monkeypatch.setenv("COGNEE_CAPTURE_ENABLED", "true")
+
+    def forbidden():
+        raise AssertionError("emit() must never reach _ensure_initialized()")
+
+    monkeypatch.setattr(hook, "_ensure_initialized", forbidden)
+
+    capture.emit(KIND_SUMMARY_GENERATED, _Explosive())
+    capture.emit(KIND_RUN_MANIFEST, {"kind": "pipeline"}, payload_kind="json")
+
+    assert hook._initialized is False
+    assert hook._sink is None
+    assert not hook._buffer
+    assert not hook._flushers
+
+
 def test_auto_registers_storage_sink_from_env(monkeypatch, tmp_path):
     monkeypatch.setenv("COGNEE_CAPTURE_ENABLED", "true")
     monkeypatch.setenv("DATA_ROOT_DIRECTORY", str(tmp_path))
@@ -177,6 +197,7 @@ def test_register_capture_sink_keeps_the_caller_sink_but_loads_env_knobs(monkeyp
 @pytest.mark.asyncio
 async def test_drain_delivers_all_payload_kinds(fake_capture_sink):
     run_id = uuid4()
+    other_run = uuid4()
     graph = _graph(["alice"])
 
     capture.emit(KIND_EXTRACTION_CHUNK_GRAPH, graph, run_id=run_id)
@@ -188,22 +209,28 @@ async def test_drain_delivers_all_payload_kinds(fake_capture_sink):
         stage="fuzzy",
     )
     capture.emit(KIND_SUMMARY_GENERATED, "a summary", payload_kind="text", run_id=run_id)
+    # Same kind under another run: must land in its own sink call.
+    capture.emit(KIND_SUMMARY_GENERATED, "other run", payload_kind="text", run_id=other_run)
 
     await capture.drain()
 
     records = fake_capture_sink.records
-    assert len(records) == 3
-    by_kind = {record["kind"]: record for record in records}
+    assert len(records) == 4
+    by_kind = {record["kind"]: record for record in records if record["run_id"] == str(run_id)}
     assert by_kind[KIND_EXTRACTION_CHUNK_GRAPH]["payload"] == graph.model_dump(mode="json")
     assert isinstance(by_kind[KIND_EXTRACTION_CHUNK_GRAPH]["payload"], dict)
     assert by_kind[KIND_EXTRACTION_FUZZY_MATCH]["payload"] == {"matches": [{"a": "b"}]}
     assert by_kind[KIND_EXTRACTION_FUZZY_MATCH]["stage"] == "fuzzy"
     assert by_kind[KIND_SUMMARY_GENERATED]["payload"] == "a summary"
-    assert all(record["run_id"] == str(run_id) for record in records)
+    [other] = [record for record in records if record["run_id"] == str(other_run)]
+    assert other["payload"] == "other run"
     assert all(record["dataset_id"] is None for record in records)
     assert all(isinstance(record["ts"], float) for record in records)
-    # Sink batches are grouped by (run_id, kind).
-    assert all(len({r["kind"] for r in call}) == 1 for call in fake_capture_sink.calls)
+    # Sink batches are grouped by (run_id, kind): four groups, one call each.
+    assert len(fake_capture_sink.calls) == 4
+    assert all(
+        len({(r["run_id"], r["kind"]) for r in call}) == 1 for call in fake_capture_sink.calls
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -369,14 +396,23 @@ async def test_emit_never_serializes_on_the_hot_path(fake_capture_sink):
 async def test_model_dump_snapshot_survives_later_mutation(fake_capture_sink):
     graph = _graph(["alice", "bob"])
 
-    capture.emit(KIND_EXTRACTION_CHUNK_GRAPH, graph.model_dump(mode="json"), payload_kind="json")
+    capture.emit(
+        KIND_EXTRACTION_CHUNK_GRAPH,
+        graph.model_dump(mode="json"),
+        payload_kind="json",
+        stage="snapshot",
+    )
+    # Negative control: by reference, emit() holds the object and never copies
+    # (a "helpful" deep copy inside emit() is forbidden on cost grounds).
+    capture.emit(KIND_EXTRACTION_CHUNK_GRAPH, graph, payload_kind="pydantic", stage="reference")
     for node in graph.nodes:
         node.name = node.name.upper()
 
     await capture.drain()
 
-    [record] = fake_capture_sink.records
-    assert [node["name"] for node in record["payload"]["nodes"]] == ["alice", "bob"]
+    by_stage = {record["stage"]: record for record in fake_capture_sink.records}
+    assert [n["name"] for n in by_stage["snapshot"]["payload"]["nodes"]] == ["alice", "bob"]
+    assert [n["name"] for n in by_stage["reference"]["payload"]["nodes"]] == ["ALICE", "BOB"]
 
 
 # ---------------------------------------------------------------------------
@@ -425,7 +461,7 @@ async def test_failing_sink_is_logged_at_debug_and_next_batch_delivered(monkeypa
 
     assert [call[0]["payload"] for call in calls] == ["one", "two"]
     fake_logger.debug.assert_any_call("capture sink failed (%s)", ANY)
-    assert hook._in_flight == 0
+    assert hook._in_flight_total() == 0
 
 
 # ---------------------------------------------------------------------------
@@ -495,7 +531,7 @@ async def test_drain_waits_for_a_batch_the_flusher_is_serializing(
         capture.emit(KIND_SUMMARY_GENERATED, f"e{index}", payload_kind="text")
     await _wait_until(entered.is_set)  # flusher popped 4, parked in the worker thread
     assert len(hook._buffer) == 4
-    assert hook._in_flight == 1
+    assert hook._in_flight_total() == 4  # counted per event, from pop to delivery
 
     async def release_later():
         await asyncio.sleep(0.1)
@@ -507,7 +543,7 @@ async def test_drain_waits_for_a_batch_the_flusher_is_serializing(
 
     # Both halves landed before drain returned: its own 4 inline, the flusher's 4 awaited.
     assert sorted(r["payload"] for r in fake_capture_sink.records) == [f"e{i}" for i in range(8)]
-    assert hook._in_flight == 0
+    assert hook._in_flight_total() == 0
 
 
 @pytest.mark.asyncio
@@ -529,7 +565,7 @@ async def test_shutdown_recovers_a_batch_cancelled_mid_serialization(
     assert sorted(r["payload"] for r in fake_capture_sink.records) == [f"e{i}" for i in range(8)]
     assert not hook._buffer
     assert not hook._flushers
-    assert hook._in_flight == 0
+    assert hook._in_flight_total() == 0
 
 
 @pytest.mark.asyncio
@@ -575,9 +611,9 @@ async def test_hung_sink_write_times_out_and_the_flusher_recovers(monkeypatch):
 
     capture.emit(KIND_SUMMARY_GENERATED, "e0", payload_kind="text")
     capture.emit(KIND_SUMMARY_GENERATED, "e1", payload_kind="text")
-    await _wait_until(lambda: hook._in_flight == 1)
+    await _wait_until(lambda: hook._in_flight_total() == 2)
     # The sink timeout, not a drain, frees the flusher.
-    await _wait_until(lambda: hook._in_flight == 0)
+    await _wait_until(lambda: hook._in_flight_total() == 0)
     fake_logger.debug.assert_any_call("capture sink failed (%s)", ANY)
 
     capture.emit(KIND_SUMMARY_GENERATED, "e2", payload_kind="text")
@@ -611,9 +647,197 @@ async def test_flush_failure_before_the_sink_is_accounted_not_requeued(monkeypat
     # forever; the batch is dropped and counted instead of vanishing silently.
     assert not hook._buffer
     assert hook._dropped == 1
-    assert hook._in_flight == 0
+    assert hook._in_flight_total() == 0
     assert delivered == []
     fake_logger.debug.assert_any_call("capture flush failed, %d event(s) dropped (%s)", 1, ANY)
+
+
+@pytest.mark.asyncio
+async def test_events_orphaned_by_clearing_the_sink_are_counted_as_dropped(fake_capture_sink):
+    capture.emit(KIND_SUMMARY_GENERATED, "one", payload_kind="text")
+    capture.emit(KIND_SUMMARY_GENERATED, "two", payload_kind="text")
+    capture.register_capture_sink(None)
+
+    await capture.drain()
+
+    # Nothing to deliver to; the loss is accounted, not hidden.
+    assert not hook._buffer
+    assert fake_capture_sink.records == []
+    assert hook._dropped == 2
+
+
+@pytest.mark.asyncio
+async def test_run_off_loop_does_not_retry_a_worker_failure_inline(monkeypatch):
+    calls = 0
+
+    def deep(_payload):
+        nonlocal calls
+        calls += 1
+        raise RecursionError("maximum recursion depth exceeded")
+
+    with pytest.raises(RecursionError):
+        await run_off_loop(deep, "payload")
+    # RecursionError is a RuntimeError subclass: a broad `except RuntimeError`
+    # around the whole call would re-run the failing work on the event loop.
+    assert calls == 1
+
+    # The submit-time fallback (executor gone at interpreter exit) still works.
+    def refuse(*_args, **_kwargs):
+        raise RuntimeError("cannot schedule new futures after interpreter shutdown")
+
+    monkeypatch.setattr(asyncio.get_running_loop(), "run_in_executor", refuse)
+    assert await run_off_loop(lambda x: x * 2, 21) == 42
+
+
+# ---------------------------------------------------------------------------
+# drain()'s budget is authoritative inside a batch; stranded loops never pin it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drain_deadline_bounds_sink_writes_inside_a_batch():
+    calls: list[list[dict]] = []
+
+    async def slow_sink(records):
+        calls.append(records)
+        await asyncio.sleep(1.0)  # every write takes 1 s (S3 under partition)
+
+    capture.register_capture_sink(slow_sink)
+    hook._configure(batch_size=64, flush_interval_s=60.0)  # SINK_TIMEOUT_S stays at 30 s
+
+    # Three (run_id, kind) groups in ONE batch -> three sequential sink writes.
+    for index in range(3):
+        capture.emit(
+            KIND_SUMMARY_GENERATED, f"g{index}", payload_kind="text", run_id=f"run-{index}"
+        )
+
+    started = time.monotonic()
+    await capture.drain(timeout=0.2)
+    elapsed = time.monotonic() - started
+
+    # Checked only between batches, this would take 3 x min(1 s, SINK_TIMEOUT_S).
+    assert elapsed < 0.6, elapsed
+    assert len(calls) == 1  # the budget ran out during the first write
+    # Nothing is lost: the cut-off group and the two never started are back, in order.
+    assert [event.payload for event in hook._buffer] == ["g0", "g1", "g2"]
+    assert hook._in_flight_total() == 0
+    assert hook._dropped == 0
+
+
+def test_a_batch_stranded_on_a_dead_loop_does_not_pin_later_drains():
+    async def wedged_sink(records):
+        await asyncio.Event().wait()  # never returns
+
+    capture.register_capture_sink(wedged_sink)
+    hook._configure(batch_size=1, flush_interval_s=60.0)
+    stranded = asyncio.new_event_loop()
+
+    async def emit_and_return():
+        capture.emit(KIND_SUMMARY_GENERATED, "stranded", payload_kind="text")  # BATCH_SIZE wake
+        await asyncio.sleep(0.05)  # the flusher popped it and is parked inside the sink
+
+    # run_until_complete returns with the flusher mid-write: the batch is stranded.
+    stranded.run_until_complete(emit_and_return())
+    [flusher] = hook._flushers.values()
+    assert flusher.loop is stranded and not flusher.task.done()
+    assert hook._in_flight_total() == 1
+
+    # (1) Stopped, not closed: a fresh loop's drain must not wait for it.
+    started = time.monotonic()
+    asyncio.run(capture.drain(timeout=1.0))
+    assert time.monotonic() - started < 0.5
+    assert hook._in_flight_total() == 1  # still owned by the stranded loop, not lost
+
+    # (2) Closed without cancelling (pytest-asyncio 0.21 style): the batch is
+    # gone for good, accounted as dropped, and still nobody waits for it.
+    flusher.task._log_destroy_pending = False  # stranded on purpose; no GC noise
+    stranded.close()
+    started = time.monotonic()
+    asyncio.run(capture.drain(timeout=1.0))
+    assert time.monotonic() - started < 0.5
+    assert hook._in_flight_total() == 0
+    assert hook._dropped == 1
+    assert not hook._flushers
+
+
+def test_thread_emits_wake_a_running_loop_not_a_stopped_one():
+    got: list[dict] = []
+
+    async def sink(records):
+        got.extend(records)
+
+    capture.register_capture_sink(sink)
+    hook._configure(batch_size=4, flush_interval_s=60.0)
+    stale = asyncio.new_event_loop()
+
+    async def open_scope_only():
+        with capture.run_scope("stale", kind="pipeline"):
+            pass  # scope entry started a flusher on this loop
+
+    stale.run_until_complete(open_scope_only())
+    # Stopped, not closed: it stays registered, first in insertion order.
+    assert next(iter(hook._flushers)) is stale
+
+    async def live_run():
+        with capture.run_scope("live", kind="pipeline"):
+
+            def worker():
+                for index in range(8):
+                    capture.emit(KIND_SUMMARY_GENERATED, f"t{index}", payload_kind="text")
+
+            thread = threading.Thread(target=worker)
+            thread.start()
+            thread.join()
+            # No drain and a 60 s interval: only the BATCH_SIZE wake can deliver
+            # these, and only if it reached THIS loop's flusher, not the stale one
+            # (a wake scheduled on a stopped loop never runs).
+            await _wait_until(lambda: len(got) >= 8, timeout=1.0)
+
+    try:
+        asyncio.run(live_run())
+        assert hook._flushers[stale].wake_pending is False
+    finally:
+        stale_flusher = hook._flushers.get(stale)
+        if stale_flusher is not None:
+            hook._cancel_flusher(stale_flusher, wait=True)
+        stale.close()
+
+
+def test_flusher_burst_loop_terminates_when_a_batch_pops_nothing(monkeypatch, fake_capture_sink):
+    # Bypass the clamp on purpose: this is the shape a misconfigured (or raced)
+    # flush takes — _flush_one_batch pops nothing and returns without suspending.
+    monkeypatch.setattr(hook, "BATCH_SIZE", 0)
+    finished = threading.Event()
+    outcome: dict = {}
+
+    async def scenario():
+        capture.emit(KIND_SUMMARY_GENERATED, "x", payload_kind="text")  # the wake fires at once
+        # A flusher spinning without yielding would never let this sleep return.
+        await asyncio.sleep(0.05)
+        started = time.monotonic()
+        await capture.drain(timeout=0.5)
+        outcome["drain_s"] = time.monotonic() - started
+        outcome["buffered"] = len(hook._buffer)
+
+    def runner():
+        try:
+            asyncio.run(scenario())
+        finally:
+            finished.set()
+
+    threading.Thread(target=runner, daemon=True).start()
+    # Off-thread with a hard wait so a regression fails instead of hanging pytest.
+    assert finished.wait(timeout=5.0), "the flusher monopolised its event loop"
+    assert outcome["drain_s"] < 0.2  # stopped on the empty pop, not at its deadline
+    assert outcome["buffered"] == 1  # inert, not fatal: nothing delivered, nothing lost
+
+
+def test_configure_clamps_degenerate_knobs():
+    hook._configure(queue_size=0, batch_size=-1, flush_interval_s=0.0)
+
+    assert hook.QUEUE_SIZE == 1
+    assert hook.BATCH_SIZE == 1
+    assert hook.FLUSH_INTERVAL_S == hook._MIN_FLUSH_INTERVAL_S
 
 
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/modules/observability/test_capture_hook.py
+++ b/cognee/tests/unit/modules/observability/test_capture_hook.py
@@ -63,7 +63,7 @@ class _Explosive:
         raise AssertionError("model_dump must not be called by emit()")
 
 
-async def _wait_until(predicate, timeout: float = 2.0) -> None:
+async def _wait_until(predicate, timeout: float = 10.0) -> None:
     deadline = asyncio.get_running_loop().time() + timeout
     while not predicate():
         if asyncio.get_running_loop().time() > deadline:
@@ -514,8 +514,12 @@ async def test_failing_sink_is_logged_at_debug_and_next_batch_delivered(monkeypa
     await capture.drain()
 
     assert [call[0]["payload"] for call in calls] == ["one", "two"]
-    fake_logger.debug.assert_any_call("capture sink failed (%s)", ANY)
+    fake_logger.debug.assert_any_call("capture sink failed, %d event(s) dropped (%s)", 1, ANY)
     assert hook._in_flight_total() == 0
+    # The event the sink rejected is gone: it must be accounted for, not hidden,
+    # or the run manifest reports dropped_events = 0 while records were lost.
+    assert hook._dropped == 1
+    assert not hook._buffer
 
 
 @pytest.mark.asyncio
@@ -828,7 +832,9 @@ async def test_hung_sink_write_times_out_and_the_flusher_recovers(monkeypatch):
     await _wait_until(lambda: hook._in_flight_total() == 2)
     # The sink timeout, not a drain, frees the flusher.
     await _wait_until(lambda: hook._in_flight_total() == 0)
-    fake_logger.debug.assert_any_call("capture sink failed (%s)", ANY)
+    fake_logger.debug.assert_any_call("capture sink timed out, %d event(s) dropped (%s)", 2, ANY)
+    # The abandoned write's events are counted, not silently lost.
+    assert hook._dropped == 2
 
     capture.emit(KIND_SUMMARY_GENERATED, "e2", payload_kind="text")
     started = time.monotonic()
@@ -1115,3 +1121,33 @@ def test_atexit_hook_persists_leftovers_after_asyncio_run(tmp_path):
     with gzip.open(blob, "rt", encoding="utf-8") as lines:
         payloads = [json.loads(line)["payload"] for line in lines if line.strip()]
     assert payloads == ["s0", "s1", "s2"]
+
+
+@pytest.mark.asyncio
+async def test_drain_is_bounded_even_when_a_sink_swallows_its_cancellation():
+    """A sink that ignores CancelledError must not pin drain() forever.
+
+    Sinks are contractually required to let the cancel propagate, but
+    register_capture_sink is public API. Before the _CANCEL_GRACE_S bound the
+    post-cancel wait was unbounded, so drain() ran past its budget without limit
+    and no outer wait_for could rescue the caller (the CancelledError branch had
+    the same unbounded wait) — hanging run_tasks, which awaits drain() inline.
+    """
+
+    async def uncancellable(records):
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            await asyncio.sleep(30)  # swallows the cancel
+
+    capture.register_capture_sink(uncancellable)
+    hook._configure(flush_interval_s=60.0, sink_timeout_s=0.1)
+
+    capture.emit(KIND_SUMMARY_GENERATED, "wedged", payload_kind="text")
+
+    started = time.monotonic()
+    await capture.drain(timeout=0.2)
+    elapsed = time.monotonic() - started
+
+    # The budget plus at most one cancellation grace, not 30s.
+    assert elapsed < 0.2 + hook._CANCEL_GRACE_S + 1.0

--- a/cognee/tests/unit/modules/observability/test_capture_hook.py
+++ b/cognee/tests/unit/modules/observability/test_capture_hook.py
@@ -1,0 +1,369 @@
+"""Eval capture hook contract (SDK-529): zero cost when off, non-blocking when on.
+
+Covers the hot-path contract (no serialization/await in emit), lazy
+auto-registration from the environment, overflow accounting, the BATCH_SIZE
+wake-up, loop-boundary and flusher-less draining, and flusher resilience to
+bad payloads, failing sinks, and cancellation.
+"""
+
+import asyncio
+import os
+import threading
+from types import SimpleNamespace
+from unittest.mock import ANY, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from cognee.base_config import get_base_config
+from cognee.modules.observability import capture
+from cognee.modules.observability.capture import (
+    KIND_EXTRACTION_CHUNK_GRAPH,
+    KIND_EXTRACTION_FUZZY_MATCH,
+    KIND_RUN_MANIFEST,
+    KIND_SUMMARY_GENERATED,
+    StorageSink,
+    get_capture_config,
+    hook,
+)
+from cognee.shared.data_models import KnowledgeGraph
+
+pytestmark = pytest.mark.usefixtures("capture_reset")
+
+
+def _graph(names: list[str]) -> KnowledgeGraph:
+    # Superset of the fields both KnowledgeGraph variants (default / gemini) need.
+    return KnowledgeGraph.model_validate(
+        {
+            "summary": "s",
+            "description": "d",
+            "nodes": [
+                {"id": name, "name": name, "type": "Person", "description": "x", "label": "L"}
+                for name in names
+            ],
+            "edges": [],
+        }
+    )
+
+
+class _Explosive:
+    """A payload whose serialization must never happen on the hot path."""
+
+    def model_dump(self, *args, **kwargs):
+        raise AssertionError("model_dump must not be called by emit()")
+
+
+async def _wait_until(predicate, timeout: float = 2.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError("condition not met in time")
+        await asyncio.sleep(0.005)
+
+
+# ---------------------------------------------------------------------------
+# 1 + 2: off by default; auto-registration from the environment
+# ---------------------------------------------------------------------------
+
+
+def test_off_by_default_costs_nothing(monkeypatch):
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+
+    assert capture.is_active() is False
+    capture.emit(KIND_SUMMARY_GENERATED, _Explosive())
+    capture.emit(KIND_SUMMARY_GENERATED, {"a": 1}, payload_kind="json")
+
+    assert not hook._buffer
+    assert not hook._flushers
+    assert hook._dropped == 0
+    # note()/bump() are no-ops without a scope.
+    capture.note("k", "v")
+    capture.bump("c")
+    assert capture.current_scope() is None
+
+
+def test_auto_registers_storage_sink_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("COGNEE_CAPTURE_ENABLED", "true")
+    monkeypatch.setenv("DATA_ROOT_DIRECTORY", str(tmp_path))
+    get_capture_config.cache_clear()
+    get_base_config.cache_clear()
+    try:
+        # No emit() has happened yet: is_active() itself is the initialization point.
+        assert capture.is_active() is True
+        assert isinstance(hook._sink, StorageSink)
+        assert get_capture_config().cognee_capture_dir == os.path.join(str(tmp_path), "capture")
+    finally:
+        get_base_config.cache_clear()
+
+
+def test_initialization_failure_leaves_capture_off(monkeypatch):
+    monkeypatch.setenv("COGNEE_CAPTURE_ENABLED", "true")
+    monkeypatch.setenv("COGNEE_CAPTURE_SAMPLE_RATE", "7")
+    get_capture_config.cache_clear()
+    fake_logger = MagicMock()
+    monkeypatch.setattr(hook, "logger", fake_logger)
+
+    assert capture.is_active() is False
+    assert hook._initialized is True
+    fake_logger.warning.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 3: fake sink receives everything, serialized
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drain_delivers_all_payload_kinds(fake_capture_sink):
+    run_id = uuid4()
+    graph = _graph(["alice"])
+
+    capture.emit(KIND_EXTRACTION_CHUNK_GRAPH, graph, run_id=run_id)
+    capture.emit(
+        KIND_EXTRACTION_FUZZY_MATCH,
+        {"matches": [{"a": "b"}]},
+        payload_kind="json",
+        run_id=run_id,
+        stage="fuzzy",
+    )
+    capture.emit(KIND_SUMMARY_GENERATED, "a summary", payload_kind="text", run_id=run_id)
+
+    await capture.drain()
+
+    records = fake_capture_sink.records
+    assert len(records) == 3
+    by_kind = {record["kind"]: record for record in records}
+    assert by_kind[KIND_EXTRACTION_CHUNK_GRAPH]["payload"] == graph.model_dump(mode="json")
+    assert isinstance(by_kind[KIND_EXTRACTION_CHUNK_GRAPH]["payload"], dict)
+    assert by_kind[KIND_EXTRACTION_FUZZY_MATCH]["payload"] == {"matches": [{"a": "b"}]}
+    assert by_kind[KIND_EXTRACTION_FUZZY_MATCH]["stage"] == "fuzzy"
+    assert by_kind[KIND_SUMMARY_GENERATED]["payload"] == "a summary"
+    assert all(record["run_id"] == str(run_id) for record in records)
+    assert all(record["dataset_id"] is None for record in records)
+    assert all(isinstance(record["ts"], float) for record in records)
+    # Sink batches are grouped by (run_id, kind).
+    assert all(len({r["kind"] for r in call}) == 1 for call in fake_capture_sink.calls)
+
+
+# ---------------------------------------------------------------------------
+# 4: overflow drops newest and is accounted for in the manifest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_overflow_drops_newest_and_reports_delta(fake_capture_sink):
+    hook._configure(queue_size=3)
+
+    with capture.run_scope(uuid4(), kind="pipeline"):
+        for index in range(5):
+            capture.emit(KIND_SUMMARY_GENERATED, f"s{index}", payload_kind="text")
+        assert hook._dropped == 2
+        assert len(hook._buffer) == 3
+        await capture.drain()
+    await capture.drain()
+
+    records = fake_capture_sink.records
+    delivered = [r["payload"] for r in records if r["kind"] == KIND_SUMMARY_GENERATED]
+    assert delivered == ["s0", "s1", "s2"]
+    [manifest] = [r for r in records if r["kind"] == KIND_RUN_MANIFEST]
+    assert manifest["payload"]["dropped_events"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 5: the BATCH_SIZE trigger wakes the flusher without a drain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batch_size_wakes_flusher_without_drain(fake_capture_sink):
+    hook._configure(batch_size=4, flush_interval_s=60.0)
+
+    with capture.run_scope(uuid4(), kind="pipeline"):
+        for index in range(4):
+            capture.emit(KIND_SUMMARY_GENERATED, f"s{index}", payload_kind="text")
+        # No drain: the wake fired via call_soon_threadsafe, not the 60 s interval.
+        await _wait_until(lambda: len(fake_capture_sink.records) >= 4)
+
+    assert sorted(r["payload"] for r in fake_capture_sink.records) == ["s0", "s1", "s2", "s3"]
+    [flusher] = hook._flushers.values()
+    assert flusher.loop is asyncio.get_running_loop()
+    assert not flusher.task.done()
+
+
+# ---------------------------------------------------------------------------
+# 9 + 10: loop boundaries and flusher-less draining
+# ---------------------------------------------------------------------------
+
+
+def test_emit_and_drain_across_asyncio_run_boundaries(fake_capture_sink):
+    async def _round(tag):
+        capture.emit(KIND_SUMMARY_GENERATED, tag, payload_kind="text")
+        await capture.drain()
+
+    asyncio.run(_round("first"))
+
+    # A loop closed WITHOUT cancelling its flusher (pytest-asyncio 0.21 style)
+    # leaves a stale entry; the next emit must prune it.
+    stale_loop = asyncio.new_event_loop()
+    stale_loop.close()
+    hook._flushers[stale_loop] = hook._Flusher(
+        task=SimpleNamespace(done=lambda: False), loop=stale_loop, wake=asyncio.Event()
+    )
+
+    async def _second():
+        capture.emit(KIND_SUMMARY_GENERATED, "second", payload_kind="text")
+        await capture.drain()
+        assert len(hook._flushers) == 1
+        [flusher] = hook._flushers.values()
+        assert flusher.loop is asyncio.get_running_loop()
+        assert not flusher.loop.is_closed()
+
+    asyncio.run(_second())
+
+    assert [r["payload"] for r in fake_capture_sink.records] == ["first", "second"]
+
+
+def test_drain_without_a_flusher_delivers_everything(fake_capture_sink):
+    # No running loop here: emit buffers, starts nothing.
+    capture.emit(KIND_SUMMARY_GENERATED, "sync", payload_kind="text")
+
+    worker = threading.Thread(
+        target=lambda: capture.emit(KIND_SUMMARY_GENERATED, "thread", payload_kind="text")
+    )
+    worker.start()
+    worker.join()
+
+    assert len(hook._buffer) == 2
+    assert not hook._flushers
+
+    asyncio.run(capture.drain())
+
+    assert sorted(r["payload"] for r in fake_capture_sink.records) == ["sync", "thread"]
+    assert not hook._buffer
+
+
+# ---------------------------------------------------------------------------
+# 11: the hot path never serializes; snapshots protect against later mutation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_never_serializes_on_the_hot_path(fake_capture_sink):
+    capture.emit(KIND_EXTRACTION_CHUNK_GRAPH, _Explosive())
+    assert len(hook._buffer) == 1
+    # Held by reference until the flusher serializes it (off the hot path).
+    assert isinstance(hook._buffer[0].payload, _Explosive)
+
+
+@pytest.mark.asyncio
+async def test_model_dump_snapshot_survives_later_mutation(fake_capture_sink):
+    graph = _graph(["alice", "bob"])
+
+    capture.emit(KIND_EXTRACTION_CHUNK_GRAPH, graph.model_dump(mode="json"), payload_kind="json")
+    for node in graph.nodes:
+        node.name = node.name.upper()
+
+    await capture.drain()
+
+    [record] = fake_capture_sink.records
+    assert [node["name"] for node in record["payload"]["nodes"]] == ["alice", "bob"]
+
+
+# ---------------------------------------------------------------------------
+# 12: flusher resilience
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bad_payload_becomes_error_record_and_flusher_survives(fake_capture_sink):
+    hook._configure(batch_size=2, flush_interval_s=60.0)
+
+    capture.emit(KIND_EXTRACTION_CHUNK_GRAPH, _Explosive())
+    capture.emit(KIND_SUMMARY_GENERATED, "ok", payload_kind="text")
+    await _wait_until(lambda: len(fake_capture_sink.records) >= 2)
+
+    by_kind = {r["kind"]: r for r in fake_capture_sink.records}
+    assert "AssertionError" in by_kind[KIND_EXTRACTION_CHUNK_GRAPH]["payload"]["error"]
+    assert by_kind[KIND_SUMMARY_GENERATED]["payload"] == "ok"
+
+    # The flusher task is still alive and keeps delivering.
+    [flusher] = hook._flushers.values()
+    assert not flusher.task.done()
+    capture.emit(KIND_SUMMARY_GENERATED, "again", payload_kind="text")
+    await capture.drain()
+    assert "again" in [r["payload"] for r in fake_capture_sink.records]
+
+
+@pytest.mark.asyncio
+async def test_failing_sink_is_logged_at_debug_and_next_batch_delivered(monkeypatch):
+    fake_logger = MagicMock()
+    monkeypatch.setattr(hook, "logger", fake_logger)
+
+    calls: list[list[dict]] = []
+
+    async def flaky_sink(records):
+        calls.append(records)
+        if len(calls) == 1:
+            raise RuntimeError("boom")
+
+    capture.register_capture_sink(flaky_sink)
+
+    capture.emit(KIND_SUMMARY_GENERATED, "one", payload_kind="text")
+    await capture.drain()
+    capture.emit(KIND_SUMMARY_GENERATED, "two", payload_kind="text")
+    await capture.drain()
+
+    assert [call[0]["payload"] for call in calls] == ["one", "two"]
+    fake_logger.debug.assert_any_call("capture sink failed (%s)", ANY)
+    assert hook._in_flight == 0
+
+
+# ---------------------------------------------------------------------------
+# 13: cancellation puts the popped batch back
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancelled_flush_requeues_popped_events(monkeypatch, fake_capture_sink):
+    hook._configure(batch_size=1, flush_interval_s=60.0)
+    entered = threading.Event()
+    release = threading.Event()
+    real_serialize = hook._serialize_batch
+
+    def blocking_serialize(batch):
+        entered.set()
+        release.wait(timeout=5.0)
+        return real_serialize(batch)
+
+    monkeypatch.setattr(hook, "_serialize_batch", blocking_serialize)
+    try:
+        capture.emit(KIND_SUMMARY_GENERATED, "one", payload_kind="text")
+        flusher = hook._flushers[asyncio.get_running_loop()]
+        await _wait_until(entered.is_set)
+        assert not hook._buffer  # popped, mid-serialization in the worker thread
+
+        flusher.task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await flusher.task
+
+        assert [event.payload for event in hook._buffer] == ["one"]
+        assert asyncio.get_running_loop() not in hook._flushers
+    finally:
+        release.set()
+
+    # A later drain still delivers the re-queued event.
+    monkeypatch.setattr(hook, "_serialize_batch", real_serialize)
+    await capture.drain()
+    assert [r["payload"] for r in fake_capture_sink.records] == ["one"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drains_and_stops_the_flusher(fake_capture_sink):
+    capture.emit(KIND_SUMMARY_GENERATED, "last", payload_kind="text")
+    [flusher] = hook._flushers.values()
+
+    await capture.shutdown()
+
+    assert [r["payload"] for r in fake_capture_sink.records] == ["last"]
+    assert flusher.task.done()
+    assert not hook._flushers

--- a/cognee/tests/unit/modules/observability/test_capture_hook.py
+++ b/cognee/tests/unit/modules/observability/test_capture_hook.py
@@ -7,8 +7,15 @@ bad payloads, failing sinks, and cancellation.
 """
 
 import asyncio
+import gzip
+import json
 import os
+import subprocess
+import sys
+import textwrap
 import threading
+import time
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock
 from uuid import uuid4
@@ -29,6 +36,8 @@ from cognee.modules.observability.capture import (
 from cognee.shared.data_models import KnowledgeGraph
 
 pytestmark = pytest.mark.usefixtures("capture_reset")
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
 
 
 def _graph(names: list[str]) -> KnowledgeGraph:
@@ -59,6 +68,31 @@ async def _wait_until(predicate, timeout: float = 2.0) -> None:
         if asyncio.get_running_loop().time() > deadline:
             raise AssertionError("condition not met in time")
         await asyncio.sleep(0.005)
+
+
+@pytest.fixture
+def block_first_serialize(monkeypatch):
+    """Make the FIRST ``_serialize_batch`` call park in its worker thread.
+
+    Returns ``(entered, release)`` threading.Events: ``entered`` fires when the
+    flusher's batch is popped and stuck mid-serialization — the exact window
+    where ``drain()``/``shutdown()`` used to see an empty buffer and return.
+    """
+    entered = threading.Event()
+    release = threading.Event()
+    real_serialize = hook._serialize_batch
+    first = [True]
+
+    def slow_first(batch):
+        if first[0]:
+            first[0] = False
+            entered.set()
+            release.wait(timeout=5.0)
+        return real_serialize(batch)
+
+    monkeypatch.setattr(hook, "_serialize_batch", slow_first)
+    yield entered, release
+    release.set()
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +140,33 @@ def test_initialization_failure_leaves_capture_off(monkeypatch):
     assert capture.is_active() is False
     assert hook._initialized is True
     fake_logger.warning.assert_called_once()
+
+
+def test_register_capture_sink_keeps_the_caller_sink_but_loads_env_knobs(monkeypatch, tmp_path):
+    monkeypatch.setenv("COGNEE_CAPTURE_ENABLED", "true")
+    monkeypatch.setenv("DATA_ROOT_DIRECTORY", str(tmp_path))
+    monkeypatch.setenv("COGNEE_CAPTURE_QUEUE_SIZE", "7")
+    monkeypatch.setenv("COGNEE_CAPTURE_BATCH_SIZE", "3")
+    monkeypatch.setenv("COGNEE_CAPTURE_FLUSH_INTERVAL_S", "0.25")
+    monkeypatch.setenv("COGNEE_CAPTURE_SINK_TIMEOUT_S", "3.5")
+    get_capture_config.cache_clear()
+    get_base_config.cache_clear()
+
+    async def sink(records):
+        pass
+
+    try:
+        # Registered BEFORE any is_active(): the explicit sink wins over env
+        # auto-registration, but the tuning knobs still come from the environment.
+        capture.register_capture_sink(sink)
+    finally:
+        get_base_config.cache_clear()
+
+    assert hook._sink is sink
+    assert hook.QUEUE_SIZE == 7
+    assert hook.BATCH_SIZE == 3
+    assert hook.FLUSH_INTERVAL_S == 0.25
+    assert hook.SINK_TIMEOUT_S == 3.5
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +251,53 @@ async def test_batch_size_wakes_flusher_without_drain(fake_capture_sink):
     assert not flusher.task.done()
 
 
+@pytest.mark.asyncio
+async def test_batch_wake_is_scheduled_once_per_synchronous_burst(monkeypatch, fake_capture_sink):
+    hook._configure(batch_size=4, flush_interval_s=60.0)
+    loop = asyncio.get_running_loop()
+    real_call_soon_threadsafe = loop.call_soon_threadsafe
+    scheduled = []
+
+    def counting(callback, *args):
+        scheduled.append(callback)
+        return real_call_soon_threadsafe(callback, *args)
+
+    monkeypatch.setattr(loop, "call_soon_threadsafe", counting)
+
+    # A per-chunk loop that never yields: the scheduled wake.set() has not run
+    # yet, so without the pending flag every emit past BATCH_SIZE re-schedules.
+    for index in range(40):
+        capture.emit(KIND_SUMMARY_GENERATED, f"s{index}", payload_kind="text")
+
+    assert len(scheduled) == 1
+    await _wait_until(lambda: len(fake_capture_sink.records) >= 40)
+    [flusher] = hook._flushers.values()
+    assert flusher.wake_pending is False
+
+
+@pytest.mark.asyncio
+async def test_scope_entry_starts_a_flusher_for_worker_thread_emits(fake_capture_sink):
+    hook._configure(flush_interval_s=0.05)
+
+    with capture.run_scope(uuid4(), kind="pipeline"):
+        # Started eagerly at scope entry — before any on-loop emit.
+        [flusher] = hook._flushers.values()
+        assert flusher.loop is asyncio.get_running_loop()
+
+        def worker():
+            for index in range(5):
+                capture.emit(KIND_SUMMARY_GENERATED, f"t{index}", payload_kind="text")
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+        assert len(hook._buffer) == 5
+        # No drain, no on-loop emit: the interval tick alone delivers them.
+        await _wait_until(lambda: len(fake_capture_sink.records) >= 5)
+
+    assert sorted(r["payload"] for r in fake_capture_sink.records) == [f"t{i}" for i in range(5)]
+
+
 # ---------------------------------------------------------------------------
 # 9 + 10: loop boundaries and flusher-less draining
 # ---------------------------------------------------------------------------
@@ -201,14 +309,16 @@ def test_emit_and_drain_across_asyncio_run_boundaries(fake_capture_sink):
         await capture.drain()
 
     asyncio.run(_round("first"))
+    # asyncio.run cancelled the flusher; its done-callback removed the entry.
+    assert not hook._flushers
 
     # A loop closed WITHOUT cancelling its flusher (pytest-asyncio 0.21 style)
     # leaves a stale entry; the next emit must prune it.
     stale_loop = asyncio.new_event_loop()
     stale_loop.close()
-    hook._flushers[stale_loop] = hook._Flusher(
-        task=SimpleNamespace(done=lambda: False), loop=stale_loop, wake=asyncio.Event()
-    )
+    stale = hook._Flusher(loop=stale_loop, wake=asyncio.Event())
+    stale.task = SimpleNamespace(done=lambda: False)
+    hook._flushers[stale_loop] = stale
 
     async def _second():
         capture.emit(KIND_SUMMARY_GENERATED, "second", payload_kind="text")
@@ -367,3 +477,193 @@ async def test_shutdown_drains_and_stops_the_flusher(fake_capture_sink):
     assert [r["payload"] for r in fake_capture_sink.records] == ["last"]
     assert flusher.task.done()
     assert not hook._flushers
+
+
+# ---------------------------------------------------------------------------
+# drain()/shutdown() cover a batch the flusher is still serializing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_a_batch_the_flusher_is_serializing(
+    block_first_serialize, fake_capture_sink
+):
+    entered, release = block_first_serialize
+    hook._configure(batch_size=4, flush_interval_s=60.0)
+
+    for index in range(8):
+        capture.emit(KIND_SUMMARY_GENERATED, f"e{index}", payload_kind="text")
+    await _wait_until(entered.is_set)  # flusher popped 4, parked in the worker thread
+    assert len(hook._buffer) == 4
+    assert hook._in_flight == 1
+
+    async def release_later():
+        await asyncio.sleep(0.1)
+        release.set()
+
+    releaser = asyncio.create_task(release_later())
+    await capture.drain()
+    await releaser
+
+    # Both halves landed before drain returned: its own 4 inline, the flusher's 4 awaited.
+    assert sorted(r["payload"] for r in fake_capture_sink.records) == [f"e{i}" for i in range(8)]
+    assert hook._in_flight == 0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_recovers_a_batch_cancelled_mid_serialization(
+    block_first_serialize, fake_capture_sink
+):
+    entered, _release = block_first_serialize
+    hook._configure(batch_size=4, flush_interval_s=60.0)
+
+    for index in range(8):
+        capture.emit(KIND_SUMMARY_GENERATED, f"e{index}", payload_kind="text")
+    await _wait_until(entered.is_set)
+
+    # The flusher never gets released: drain times out, the cancel re-buffers
+    # its batch, and shutdown must deliver that batch itself — no flusher is
+    # left to do it and the atexit hook is a last resort, not the plan.
+    await capture.shutdown(timeout=0.2)
+
+    assert sorted(r["payload"] for r in fake_capture_sink.records) == [f"e{i}" for i in range(8)]
+    assert not hook._buffer
+    assert not hook._flushers
+    assert hook._in_flight == 0
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_bounds_it_under_a_continuous_producer():
+    async def slow_sink(records):
+        await asyncio.sleep(0.05)
+
+    capture.register_capture_sink(slow_sink)
+    hook._configure(batch_size=8, flush_interval_s=60.0, queue_size=10_000)
+    stop = False
+
+    async def producer():
+        while not stop:
+            for _ in range(20):
+                capture.emit(KIND_SUMMARY_GENERATED, "x", payload_kind="text")
+            await asyncio.sleep(0.01)
+
+    producer_task = asyncio.create_task(producer())
+    await asyncio.sleep(0.05)
+    started = time.monotonic()
+    await capture.drain(timeout=0.3)
+    elapsed = time.monotonic() - started
+    stop = True
+    await producer_task
+
+    # Producer outruns the sink, so an unbounded inline loop would never end.
+    assert elapsed < 1.0, elapsed
+
+
+@pytest.mark.asyncio
+async def test_hung_sink_write_times_out_and_the_flusher_recovers(monkeypatch):
+    fake_logger = MagicMock()
+    monkeypatch.setattr(hook, "logger", fake_logger)
+    calls: list[list[dict]] = []
+
+    async def hanging_first(records):
+        calls.append(records)
+        if len(calls) == 1:
+            await asyncio.Event().wait()  # never completes
+
+    capture.register_capture_sink(hanging_first)
+    hook._configure(batch_size=2, flush_interval_s=60.0, sink_timeout_s=0.1)
+
+    capture.emit(KIND_SUMMARY_GENERATED, "e0", payload_kind="text")
+    capture.emit(KIND_SUMMARY_GENERATED, "e1", payload_kind="text")
+    await _wait_until(lambda: hook._in_flight == 1)
+    # The sink timeout, not a drain, frees the flusher.
+    await _wait_until(lambda: hook._in_flight == 0)
+    fake_logger.debug.assert_any_call("capture sink failed (%s)", ANY)
+
+    capture.emit(KIND_SUMMARY_GENERATED, "e2", payload_kind="text")
+    started = time.monotonic()
+    await capture.drain(timeout=2.0)
+    assert time.monotonic() - started < 1.0  # not pinned by the abandoned write
+    assert [r["payload"] for r in calls[1]] == ["e2"]
+    [flusher] = hook._flushers.values()
+    assert not flusher.task.done()
+
+
+@pytest.mark.asyncio
+async def test_flush_failure_before_the_sink_is_accounted_not_requeued(monkeypatch):
+    fake_logger = MagicMock()
+    monkeypatch.setattr(hook, "logger", fake_logger)
+    delivered: list[dict] = []
+
+    async def sink(records):
+        delivered.extend(records)
+
+    capture.register_capture_sink(sink)
+
+    def broken_serialize(batch):
+        raise ValueError("serializer exploded")
+
+    monkeypatch.setattr(hook, "_serialize_batch", broken_serialize)
+    capture.emit(KIND_SUMMARY_GENERATED, "lost", payload_kind="text")
+    await capture.drain()
+
+    # Re-queuing would pin a deterministic failure at the head of the buffer
+    # forever; the batch is dropped and counted instead of vanishing silently.
+    assert not hook._buffer
+    assert hook._dropped == 1
+    assert hook._in_flight == 0
+    assert delivered == []
+    fake_logger.debug.assert_any_call("capture flush failed, %d event(s) dropped (%s)", 1, ANY)
+
+
+# ---------------------------------------------------------------------------
+# atexit: the CLI story end to end (asyncio.run per command, no drain)
+# ---------------------------------------------------------------------------
+
+
+def test_atexit_hook_persists_leftovers_after_asyncio_run(tmp_path):
+    script = textwrap.dedent(
+        f"""
+        import asyncio
+
+        from cognee.infrastructure.files.storage import StorageManager
+        from cognee.infrastructure.files.storage.LocalFileStorage import LocalFileStorage
+        from cognee.modules.observability import capture
+        from cognee.modules.observability.capture import hook
+
+        storage = StorageManager(LocalFileStorage({str(tmp_path)!r}))
+        capture.register_capture_sink(capture.StorageSink(storage))
+        hook._configure(flush_interval_s=60.0)
+
+        async def command():
+            # One asyncio.run per CLI command and no drain: the flusher is
+            # asleep on its interval when asyncio.run tears the loop down.
+            with capture.run_scope("run-1", "ds-1", kind="pipeline"):
+                for index in range(3):
+                    capture.emit(
+                        capture.KIND_SUMMARY_GENERATED, f"s{{index}}", payload_kind="text"
+                    )
+
+        asyncio.run(command())
+        # 3 events + the manifest are still buffered; only the atexit hook remains.
+        assert len(hook._buffer) == 4, len(hook._buffer)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=REPO_ROOT,
+        env={**os.environ, "TELEMETRY_DISABLED": "1"},
+    )
+    assert result.returncode == 0, result.stderr
+
+    run_dir = tmp_path / "ds-1" / "run-1"
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["payload"]["kind"] == "pipeline"
+    assert manifest["payload"]["dropped_events"] == 0
+    [blob] = (run_dir / KIND_SUMMARY_GENERATED).glob("batch-*.jsonl.gz")
+    with gzip.open(blob, "rt", encoding="utf-8") as lines:
+        payloads = [json.loads(line)["payload"] for line in lines if line.strip()]
+    assert payloads == ["s0", "s1", "s2"]

--- a/cognee/tests/unit/modules/observability/test_capture_hook.py
+++ b/cognee/tests/unit/modules/observability/test_capture_hook.py
@@ -101,8 +101,15 @@ def block_first_serialize(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_off_by_default_costs_nothing(monkeypatch):
-    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+# Async on purpose: with a running loop, "no flusher task created" is a claim
+# that can fail (a sync test has no loop for _enqueue to start one on).
+@pytest.mark.asyncio
+@pytest.mark.parametrize("env_value", [None, "false"])
+async def test_off_by_default_costs_nothing(monkeypatch, env_value):
+    if env_value is None:
+        monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("COGNEE_CAPTURE_ENABLED", env_value)
 
     assert capture.is_active() is False
     capture.emit(KIND_SUMMARY_GENERATED, _Explosive())
@@ -117,7 +124,8 @@ def test_off_by_default_costs_nothing(monkeypatch):
     assert capture.current_scope() is None
 
 
-def test_emit_before_any_is_active_never_initializes(monkeypatch):
+@pytest.mark.asyncio
+async def test_emit_before_any_is_active_never_initializes(monkeypatch):
     # With this set, an emit() that lazily initialized would auto-register a
     # sink and buffer the event; the contract is that only is_active() may.
     monkeypatch.setenv("COGNEE_CAPTURE_ENABLED", "true")
@@ -336,8 +344,11 @@ def test_emit_and_drain_across_asyncio_run_boundaries(fake_capture_sink):
         await capture.drain()
 
     asyncio.run(_round("first"))
-    # asyncio.run cancelled the flusher; its done-callback removed the entry.
-    assert not hook._flushers
+    # asyncio.run cancelled the flusher; the entry stays as a tombstone for the
+    # closed loop until the next flusher start prunes it.
+    [tombstone] = hook._flushers.values()
+    assert tombstone.loop.is_closed()
+    assert tombstone.task.cancelled()
 
     # A loop closed WITHOUT cancelling its flusher (pytest-asyncio 0.21 style)
     # leaves a stale entry; the next emit must prune it.
@@ -377,6 +388,49 @@ def test_drain_without_a_flusher_delivers_everything(fake_capture_sink):
 
     assert sorted(r["payload"] for r in fake_capture_sink.records) == ["sync", "thread"]
     assert not hook._buffer
+
+
+def test_emit_during_loop_teardown_starts_no_flusher_on_the_closing_loop(fake_capture_sink):
+    hook._configure(batch_size=2, flush_interval_s=60.0)
+    kept_alive: list = []
+    seen: dict = {}
+
+    async def pipeline_like():
+        # run_tasks-shaped: the scope encloses the yields, so a generator its
+        # consumer abandoned is finalized by asyncio.run's shutdown_asyncgens()
+        # — AFTER _cancel_all_tasks() cancelled this loop's flusher.
+        with capture.run_scope("run-1", "ds-1", kind="pipeline"):
+            yield "started"
+            yield "never reached"
+
+    async def main():
+        agen = pipeline_like()
+        kept_alive.append(agen)  # not garbage-collected: finalized at loop teardown
+        await agen.__anext__()
+        # BATCH_SIZE - 1 buffered: the manifest emitted at teardown completes a batch.
+        capture.emit(KIND_SUMMARY_GENERATED, "x", payload_kind="text", run_id="run-0")
+        seen["flusher"] = hook._flushers[asyncio.get_running_loop()]
+
+    asyncio.run(main())
+
+    # The manifest landed while the loop was closing. A fresh flusher started
+    # there would have popped the batch and been destroyed with the loop; the
+    # cancelled flusher's tombstone keeps the events in the deque instead.
+    flusher = seen["flusher"]
+    assert flusher.task.cancelled() and flusher.loop.is_closed()
+    assert hook._flushers[flusher.loop] is flusher
+    assert [event.kind for event in hook._buffer] == [KIND_SUMMARY_GENERATED, KIND_RUN_MANIFEST]
+    assert hook._in_flight_total() == 0
+    assert hook._dropped == 0
+
+    asyncio.run(capture.drain())
+
+    kinds = [record["kind"] for record in fake_capture_sink.records]
+    assert sorted(kinds) == sorted([KIND_SUMMARY_GENERATED, KIND_RUN_MANIFEST])
+    [manifest] = [r for r in fake_capture_sink.records if r["kind"] == KIND_RUN_MANIFEST]
+    assert manifest["run_id"] == "run-1" and manifest["dataset_id"] == "ds-1"
+    assert hook._dropped == 0
+    assert not hook._flushers  # the closed loop's tombstone was pruned by the drain
 
 
 # ---------------------------------------------------------------------------
@@ -464,6 +518,49 @@ async def test_failing_sink_is_logged_at_debug_and_next_batch_delivered(monkeypa
     assert hook._in_flight_total() == 0
 
 
+@pytest.mark.asyncio
+async def test_base_exception_from_a_sink_requeues_the_batch_and_the_flusher_is_replaced(
+    monkeypatch,
+):
+    fake_logger = MagicMock()
+    monkeypatch.setattr(hook, "logger", fake_logger)
+
+    class Escaping(BaseException):
+        pass
+
+    calls: list[list[dict]] = []
+
+    async def sink(records):
+        calls.append(records)
+        if len(calls) == 1:
+            raise Escaping("boom")
+
+    capture.register_capture_sink(sink)
+    hook._configure(batch_size=2, flush_interval_s=60.0)
+
+    capture.emit(KIND_SUMMARY_GENERATED, "a", payload_kind="text")
+    capture.emit(KIND_SUMMARY_GENERATED, "b", payload_kind="text")  # BATCH_SIZE wake
+    [flusher] = hook._flushers.values()
+    await _wait_until(flusher.task.done)
+
+    # Out of contract (sinks raise Exception subclasses only), but the batch is
+    # not lost and the crash is retrieved — no "Task exception was never
+    # retrieved" ERROR. A crashed (not cancelled) flusher is not a tombstone.
+    assert not flusher.task.cancelled()
+    assert [event.payload for event in hook._buffer] == ["a", "b"]
+    assert hook._dropped == 0
+    assert hook._in_flight_total() == 0
+    assert asyncio.get_running_loop() not in hook._flushers
+    fake_logger.debug.assert_any_call("capture flusher stopped (%r)", ANY)
+
+    capture.emit(KIND_SUMMARY_GENERATED, "c", payload_kind="text")
+    [replacement] = hook._flushers.values()
+    assert replacement is not flusher and not replacement.task.done()
+    await capture.drain()
+    redelivered = [record["payload"] for call in calls[1:] for record in call]
+    assert sorted(redelivered) == ["a", "b", "c"]
+
+
 # ---------------------------------------------------------------------------
 # 13: cancellation puts the popped batch back
 # ---------------------------------------------------------------------------
@@ -493,11 +590,14 @@ async def test_cancelled_flush_requeues_popped_events(monkeypatch, fake_capture_
             await flusher.task
 
         assert [event.payload for event in hook._buffer] == ["one"]
-        assert asyncio.get_running_loop() not in hook._flushers
+        # The cancelled entry stays as a tombstone: a cancelled flusher means
+        # its loop is going away, and no replacement is started on it.
+        assert hook._flushers[asyncio.get_running_loop()] is flusher
+        assert hook._any_live_flusher() is None
     finally:
         release.set()
 
-    # A later drain still delivers the re-queued event.
+    # A later drain still delivers the re-queued event: drain needs no flusher.
     monkeypatch.setattr(hook, "_serialize_batch", real_serialize)
     await capture.drain()
     assert [r["payload"] for r in fake_capture_sink.records] == ["one"]
@@ -511,8 +611,122 @@ async def test_shutdown_drains_and_stops_the_flusher(fake_capture_sink):
     await capture.shutdown()
 
     assert [r["payload"] for r in fake_capture_sink.records] == ["last"]
-    assert flusher.task.done()
-    assert not hook._flushers
+    assert flusher.task.cancelled()
+    loop = asyncio.get_running_loop()
+    assert hook._flushers[loop] is flusher  # tombstone
+
+    # An emit after shutdown (one more request during a lifespan shutdown) does
+    # not resurrect a flusher; it stays buffered for the atexit hook.
+    capture.emit(KIND_SUMMARY_GENERATED, "post", payload_kind="text")
+    assert hook._flushers[loop] is flusher
+    assert [event.payload for event in hook._buffer] == ["post"]
+
+    # Registering a sink re-arms the loop: the next emit gets a fresh flusher.
+    capture.register_capture_sink(fake_capture_sink)
+    capture.emit(KIND_SUMMARY_GENERATED, "rearmed", payload_kind="text")
+    assert hook._flushers[loop] is not flusher
+    assert not hook._flushers[loop].task.done()
+    await capture.drain()
+    assert [r["payload"] for r in fake_capture_sink.records] == ["last", "post", "rearmed"]
+
+
+# ---------------------------------------------------------------------------
+# Cancellation is never swallowed (asyncio.wait_for on CPython < 3.12 loses a
+# cancel that races the inner completion: a flusher that survives its cancel
+# hangs asyncio.run() teardown and shutdown() forever)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bounded_wait_propagates_a_cancel_racing_the_inner_completion():
+    inner = asyncio.get_running_loop().create_future()
+    waiter = asyncio.create_task(hook._wait_bounded(inner, 60.0))
+    await asyncio.sleep(0)  # parked on the timed wait
+
+    # Completion and cancel land in the SAME loop iteration: here wait_for
+    # returns the inner result and the cancel request is lost (bpo-42130).
+    inner.set_result("done")
+    waiter.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+    assert waiter.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_bounded_wait_times_out_and_cancels_the_inner():
+    inner_cancelled = asyncio.Event()
+
+    async def inner():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            inner_cancelled.set()
+            raise
+
+    with pytest.raises(asyncio.TimeoutError):
+        await hook._wait_bounded(inner(), 0.02)
+    assert inner_cancelled.is_set()  # not left running after the timeout
+
+    assert await hook._wait_bounded(asyncio.sleep(0, result="ok"), 1.0) == "ok"
+    assert await hook._wait_bounded(asyncio.sleep(0, result="ok"), None) == "ok"
+
+
+@pytest.mark.asyncio
+async def test_flusher_cancelled_as_its_wake_lands_finishes_cancelled(fake_capture_sink):
+    hook._configure(batch_size=4, flush_interval_s=60.0)
+    hook.ensure_flusher()
+    [flusher] = hook._flushers.values()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)  # parked on its interval wait
+
+    # The BATCH_SIZE wake arrives through the loop (as emit() sends it from any
+    # thread) and the cancel lands right behind it — asyncio.run's teardown
+    # timing when the last batch fills up as the command returns.
+    asyncio.get_running_loop().call_soon_threadsafe(flusher.wake.set)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    flusher.task.cancel()
+
+    done, _pending = await asyncio.wait({flusher.task}, timeout=1.0)
+    assert flusher.task in done, "the flusher swallowed its cancellation and is still running"
+    assert flusher.task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_drain_propagates_the_callers_cancellation():
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    delivered: list[dict] = []
+
+    async def gated_sink(records):
+        entered.set()
+        await release.wait()
+        delivered.extend(records)
+
+    capture.register_capture_sink(gated_sink)
+    hook._configure(flush_interval_s=60.0)
+    for index in range(3):
+        capture.emit(KIND_SUMMARY_GENERATED, f"c{index}", payload_kind="text")
+
+    caller = asyncio.create_task(capture.drain(5.0))
+    await entered.wait()  # drain popped the batch and is inside the sink write
+
+    # The write completes and the cancel lands right behind it. A cancelled
+    # pipeline run must not continue past its own cancellation (run_tasks
+    # awaits drain() right before yielding PipelineRunCompleted).
+    release.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    caller.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+    assert caller.cancelled()
+    assert [r["payload"] for r in delivered] == ["c0", "c1", "c2"]
+    # The acknowledgement never ran, so the group is re-buffered: at-least-once.
+    assert [event.payload for event in hook._buffer] == ["c0", "c1", "c2"]
+    assert hook._in_flight_total() == 0
 
 
 # ---------------------------------------------------------------------------
@@ -564,7 +778,7 @@ async def test_shutdown_recovers_a_batch_cancelled_mid_serialization(
 
     assert sorted(r["payload"] for r in fake_capture_sink.records) == [f"e{i}" for i in range(8)]
     assert not hook._buffer
-    assert not hook._flushers
+    assert hook._any_live_flusher() is None
     assert hook._in_flight_total() == 0
 
 
@@ -724,7 +938,7 @@ async def test_drain_deadline_bounds_sink_writes_inside_a_batch():
     assert hook._dropped == 0
 
 
-def test_a_batch_stranded_on_a_dead_loop_does_not_pin_later_drains():
+def test_a_batch_stranded_on_a_dead_loop_is_recovered_not_waited_for():
     async def wedged_sink(records):
         await asyncio.Event().wait()  # never returns
 
@@ -748,15 +962,25 @@ def test_a_batch_stranded_on_a_dead_loop_does_not_pin_later_drains():
     assert time.monotonic() - started < 0.5
     assert hook._in_flight_total() == 1  # still owned by the stranded loop, not lost
 
-    # (2) Closed without cancelling (pytest-asyncio 0.21 style): the batch is
-    # gone for good, accounted as dropped, and still nobody waits for it.
+    # (2) Closed without cancelling (pytest-asyncio 0.21 style): the task died
+    # with its loop, so its batch goes back to the buffer and the next drain
+    # delivers it — at-least-once, never dropped — and still nobody waits for
+    # the dead loop.
+    delivered: list[dict] = []
+
+    async def recording_sink(records):
+        delivered.extend(records)
+
+    capture.register_capture_sink(recording_sink)
     flusher.task._log_destroy_pending = False  # stranded on purpose; no GC noise
     stranded.close()
     started = time.monotonic()
     asyncio.run(capture.drain(timeout=1.0))
     assert time.monotonic() - started < 0.5
+    assert [record["payload"] for record in delivered] == ["stranded"]
     assert hook._in_flight_total() == 0
-    assert hook._dropped == 1
+    assert hook._dropped == 0
+    assert not hook._buffer
     assert not hook._flushers
 
 

--- a/cognee/tests/unit/modules/observability/test_capture_hook.py
+++ b/cognee/tests/unit/modules/observability/test_capture_hook.py
@@ -115,9 +115,9 @@ async def test_off_by_default_costs_nothing(monkeypatch, env_value):
     capture.emit(KIND_SUMMARY_GENERATED, _Explosive())
     capture.emit(KIND_SUMMARY_GENERATED, {"a": 1}, payload_kind="json")
 
-    assert not hook._buffer
-    assert not hook._flushers
-    assert hook._dropped == 0
+    assert not hook._runtime.buffer
+    assert not hook._runtime.flushers
+    assert hook._runtime.dropped == 0
     # note()/bump() are no-ops without a scope.
     capture.note("k", "v")
     capture.bump("c")
@@ -138,10 +138,10 @@ async def test_emit_before_any_is_active_never_initializes(monkeypatch):
     capture.emit(KIND_SUMMARY_GENERATED, _Explosive())
     capture.emit(KIND_RUN_MANIFEST, {"kind": "pipeline"}, payload_kind="json")
 
-    assert hook._initialized is False
-    assert hook._sink is None
-    assert not hook._buffer
-    assert not hook._flushers
+    assert hook._runtime.initialized is False
+    assert hook._runtime.sink is None
+    assert not hook._runtime.buffer
+    assert not hook._runtime.flushers
 
 
 def test_auto_registers_storage_sink_from_env(monkeypatch, tmp_path):
@@ -152,7 +152,7 @@ def test_auto_registers_storage_sink_from_env(monkeypatch, tmp_path):
     try:
         # No emit() has happened yet: is_active() itself is the initialization point.
         assert capture.is_active() is True
-        assert isinstance(hook._sink, StorageSink)
+        assert isinstance(hook._runtime.sink, StorageSink)
         assert get_capture_config().cognee_capture_dir == os.path.join(str(tmp_path), "capture")
     finally:
         get_base_config.cache_clear()
@@ -166,7 +166,7 @@ def test_initialization_failure_leaves_capture_off(monkeypatch):
     monkeypatch.setattr(hook, "logger", fake_logger)
 
     assert capture.is_active() is False
-    assert hook._initialized is True
+    assert hook._runtime.initialized is True
     fake_logger.warning.assert_called_once()
 
 
@@ -190,11 +190,11 @@ def test_register_capture_sink_keeps_the_caller_sink_but_loads_env_knobs(monkeyp
     finally:
         get_base_config.cache_clear()
 
-    assert hook._sink is sink
-    assert hook.QUEUE_SIZE == 7
-    assert hook.BATCH_SIZE == 3
-    assert hook.FLUSH_INTERVAL_S == 0.25
-    assert hook.SINK_TIMEOUT_S == 3.5
+    assert hook._runtime.sink is sink
+    assert hook._runtime.queue_size == 7
+    assert hook._runtime.batch_size == 3
+    assert hook._runtime.flush_interval_s == 0.25
+    assert hook._runtime.sink_timeout_s == 3.5
 
 
 # ---------------------------------------------------------------------------
@@ -253,8 +253,8 @@ async def test_overflow_drops_newest_and_reports_delta(fake_capture_sink):
     with capture.run_scope(uuid4(), kind="pipeline"):
         for index in range(5):
             capture.emit(KIND_SUMMARY_GENERATED, f"s{index}", payload_kind="text")
-        assert hook._dropped == 2
-        assert len(hook._buffer) == 3
+        assert hook._runtime.dropped == 2
+        assert len(hook._runtime.buffer) == 3
         await capture.drain()
     await capture.drain()
 
@@ -281,7 +281,7 @@ async def test_batch_size_wakes_flusher_without_drain(fake_capture_sink):
         await _wait_until(lambda: len(fake_capture_sink.records) >= 4)
 
     assert sorted(r["payload"] for r in fake_capture_sink.records) == ["s0", "s1", "s2", "s3"]
-    [flusher] = hook._flushers.values()
+    [flusher] = hook._runtime.flushers.values()
     assert flusher.loop is asyncio.get_running_loop()
     assert not flusher.task.done()
 
@@ -306,7 +306,7 @@ async def test_batch_wake_is_scheduled_once_per_synchronous_burst(monkeypatch, f
 
     assert len(scheduled) == 1
     await _wait_until(lambda: len(fake_capture_sink.records) >= 40)
-    [flusher] = hook._flushers.values()
+    [flusher] = hook._runtime.flushers.values()
     assert flusher.wake_pending is False
 
 
@@ -316,7 +316,7 @@ async def test_scope_entry_starts_a_flusher_for_worker_thread_emits(fake_capture
 
     with capture.run_scope(uuid4(), kind="pipeline"):
         # Started eagerly at scope entry — before any on-loop emit.
-        [flusher] = hook._flushers.values()
+        [flusher] = hook._runtime.flushers.values()
         assert flusher.loop is asyncio.get_running_loop()
 
         def worker():
@@ -326,7 +326,7 @@ async def test_scope_entry_starts_a_flusher_for_worker_thread_emits(fake_capture
         thread = threading.Thread(target=worker)
         thread.start()
         thread.join()
-        assert len(hook._buffer) == 5
+        assert len(hook._runtime.buffer) == 5
         # No drain, no on-loop emit: the interval tick alone delivers them.
         await _wait_until(lambda: len(fake_capture_sink.records) >= 5)
 
@@ -346,7 +346,7 @@ def test_emit_and_drain_across_asyncio_run_boundaries(fake_capture_sink):
     asyncio.run(_round("first"))
     # asyncio.run cancelled the flusher; the entry stays as a tombstone for the
     # closed loop until the next flusher start prunes it.
-    [tombstone] = hook._flushers.values()
+    [tombstone] = hook._runtime.flushers.values()
     assert tombstone.loop.is_closed()
     assert tombstone.task.cancelled()
 
@@ -354,15 +354,15 @@ def test_emit_and_drain_across_asyncio_run_boundaries(fake_capture_sink):
     # leaves a stale entry; the next emit must prune it.
     stale_loop = asyncio.new_event_loop()
     stale_loop.close()
-    stale = hook._Flusher(loop=stale_loop, wake=asyncio.Event())
+    stale = hook._Flusher(runtime=hook._runtime, loop=stale_loop, wake=asyncio.Event())
     stale.task = SimpleNamespace(done=lambda: False)
-    hook._flushers[stale_loop] = stale
+    hook._runtime.flushers[stale_loop] = stale
 
     async def _second():
         capture.emit(KIND_SUMMARY_GENERATED, "second", payload_kind="text")
         await capture.drain()
-        assert len(hook._flushers) == 1
-        [flusher] = hook._flushers.values()
+        assert len(hook._runtime.flushers) == 1
+        [flusher] = hook._runtime.flushers.values()
         assert flusher.loop is asyncio.get_running_loop()
         assert not flusher.loop.is_closed()
 
@@ -381,13 +381,13 @@ def test_drain_without_a_flusher_delivers_everything(fake_capture_sink):
     worker.start()
     worker.join()
 
-    assert len(hook._buffer) == 2
-    assert not hook._flushers
+    assert len(hook._runtime.buffer) == 2
+    assert not hook._runtime.flushers
 
     asyncio.run(capture.drain())
 
     assert sorted(r["payload"] for r in fake_capture_sink.records) == ["sync", "thread"]
-    assert not hook._buffer
+    assert not hook._runtime.buffer
 
 
 def test_emit_during_loop_teardown_starts_no_flusher_on_the_closing_loop(fake_capture_sink):
@@ -409,7 +409,7 @@ def test_emit_during_loop_teardown_starts_no_flusher_on_the_closing_loop(fake_ca
         await agen.__anext__()
         # BATCH_SIZE - 1 buffered: the manifest emitted at teardown completes a batch.
         capture.emit(KIND_SUMMARY_GENERATED, "x", payload_kind="text", run_id="run-0")
-        seen["flusher"] = hook._flushers[asyncio.get_running_loop()]
+        seen["flusher"] = hook._runtime.flushers[asyncio.get_running_loop()]
 
     asyncio.run(main())
 
@@ -418,10 +418,13 @@ def test_emit_during_loop_teardown_starts_no_flusher_on_the_closing_loop(fake_ca
     # cancelled flusher's tombstone keeps the events in the deque instead.
     flusher = seen["flusher"]
     assert flusher.task.cancelled() and flusher.loop.is_closed()
-    assert hook._flushers[flusher.loop] is flusher
-    assert [event.kind for event in hook._buffer] == [KIND_SUMMARY_GENERATED, KIND_RUN_MANIFEST]
+    assert hook._runtime.flushers[flusher.loop] is flusher
+    assert [event.kind for event in hook._runtime.buffer] == [
+        KIND_SUMMARY_GENERATED,
+        KIND_RUN_MANIFEST,
+    ]
     assert hook._in_flight_total() == 0
-    assert hook._dropped == 0
+    assert hook._runtime.dropped == 0
 
     asyncio.run(capture.drain())
 
@@ -429,8 +432,8 @@ def test_emit_during_loop_teardown_starts_no_flusher_on_the_closing_loop(fake_ca
     assert sorted(kinds) == sorted([KIND_SUMMARY_GENERATED, KIND_RUN_MANIFEST])
     [manifest] = [r for r in fake_capture_sink.records if r["kind"] == KIND_RUN_MANIFEST]
     assert manifest["run_id"] == "run-1" and manifest["dataset_id"] == "ds-1"
-    assert hook._dropped == 0
-    assert not hook._flushers  # the closed loop's tombstone was pruned by the drain
+    assert hook._runtime.dropped == 0
+    assert not hook._runtime.flushers  # the closed loop's tombstone was pruned by the drain
 
 
 # ---------------------------------------------------------------------------
@@ -441,9 +444,9 @@ def test_emit_during_loop_teardown_starts_no_flusher_on_the_closing_loop(fake_ca
 @pytest.mark.asyncio
 async def test_emit_never_serializes_on_the_hot_path(fake_capture_sink):
     capture.emit(KIND_EXTRACTION_CHUNK_GRAPH, _Explosive())
-    assert len(hook._buffer) == 1
+    assert len(hook._runtime.buffer) == 1
     # Held by reference until the flusher serializes it (off the hot path).
-    assert isinstance(hook._buffer[0].payload, _Explosive)
+    assert isinstance(hook._runtime.buffer[0].payload, _Explosive)
 
 
 @pytest.mark.asyncio
@@ -487,7 +490,7 @@ async def test_bad_payload_becomes_error_record_and_flusher_survives(fake_captur
     assert by_kind[KIND_SUMMARY_GENERATED]["payload"] == "ok"
 
     # The flusher task is still alive and keeps delivering.
-    [flusher] = hook._flushers.values()
+    [flusher] = hook._runtime.flushers.values()
     assert not flusher.task.done()
     capture.emit(KIND_SUMMARY_GENERATED, "again", payload_kind="text")
     await capture.drain()
@@ -518,8 +521,8 @@ async def test_failing_sink_is_logged_at_debug_and_next_batch_delivered(monkeypa
     assert hook._in_flight_total() == 0
     # The event the sink rejected is gone: it must be accounted for, not hidden,
     # or the run manifest reports events_dropped = 0 while records were lost.
-    assert hook._dropped == 1
-    assert not hook._buffer
+    assert hook._runtime.dropped == 1
+    assert not hook._runtime.buffer
 
 
 @pytest.mark.asyncio
@@ -544,21 +547,21 @@ async def test_base_exception_from_a_sink_requeues_the_batch_and_the_flusher_is_
 
     capture.emit(KIND_SUMMARY_GENERATED, "a", payload_kind="text")
     capture.emit(KIND_SUMMARY_GENERATED, "b", payload_kind="text")  # BATCH_SIZE wake
-    [flusher] = hook._flushers.values()
+    [flusher] = hook._runtime.flushers.values()
     await _wait_until(flusher.task.done)
 
     # Out of contract (sinks raise Exception subclasses only), but the batch is
     # not lost and the crash is retrieved — no "Task exception was never
     # retrieved" ERROR. A crashed (not cancelled) flusher is not a tombstone.
     assert not flusher.task.cancelled()
-    assert [event.payload for event in hook._buffer] == ["a", "b"]
-    assert hook._dropped == 0
+    assert [event.payload for event in hook._runtime.buffer] == ["a", "b"]
+    assert hook._runtime.dropped == 0
     assert hook._in_flight_total() == 0
-    assert asyncio.get_running_loop() not in hook._flushers
+    assert asyncio.get_running_loop() not in hook._runtime.flushers
     fake_logger.debug.assert_any_call("capture flusher stopped (%r)", ANY)
 
     capture.emit(KIND_SUMMARY_GENERATED, "c", payload_kind="text")
-    [replacement] = hook._flushers.values()
+    [replacement] = hook._runtime.flushers.values()
     assert replacement is not flusher and not replacement.task.done()
     await capture.drain()
     redelivered = [record["payload"] for call in calls[1:] for record in call]
@@ -585,18 +588,18 @@ async def test_cancelled_flush_requeues_popped_events(monkeypatch, fake_capture_
     monkeypatch.setattr(hook, "_serialize_batch", blocking_serialize)
     try:
         capture.emit(KIND_SUMMARY_GENERATED, "one", payload_kind="text")
-        flusher = hook._flushers[asyncio.get_running_loop()]
+        flusher = hook._runtime.flushers[asyncio.get_running_loop()]
         await _wait_until(entered.is_set)
-        assert not hook._buffer  # popped, mid-serialization in the worker thread
+        assert not hook._runtime.buffer  # popped, mid-serialization in the worker thread
 
         flusher.task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await flusher.task
 
-        assert [event.payload for event in hook._buffer] == ["one"]
+        assert [event.payload for event in hook._runtime.buffer] == ["one"]
         # The cancelled entry stays as a tombstone: a cancelled flusher means
         # its loop is going away, and no replacement is started on it.
-        assert hook._flushers[asyncio.get_running_loop()] is flusher
+        assert hook._runtime.flushers[asyncio.get_running_loop()] is flusher
         assert hook._any_live_flusher() is None
     finally:
         release.set()
@@ -610,26 +613,26 @@ async def test_cancelled_flush_requeues_popped_events(monkeypatch, fake_capture_
 @pytest.mark.asyncio
 async def test_shutdown_drains_and_stops_the_flusher(fake_capture_sink):
     capture.emit(KIND_SUMMARY_GENERATED, "last", payload_kind="text")
-    [flusher] = hook._flushers.values()
+    [flusher] = hook._runtime.flushers.values()
 
     await capture.shutdown()
 
     assert [r["payload"] for r in fake_capture_sink.records] == ["last"]
     assert flusher.task.cancelled()
     loop = asyncio.get_running_loop()
-    assert hook._flushers[loop] is flusher  # tombstone
+    assert hook._runtime.flushers[loop] is flusher  # tombstone
 
     # An emit after shutdown (one more request during a lifespan shutdown) does
     # not resurrect a flusher; it stays buffered for the atexit hook.
     capture.emit(KIND_SUMMARY_GENERATED, "post", payload_kind="text")
-    assert hook._flushers[loop] is flusher
-    assert [event.payload for event in hook._buffer] == ["post"]
+    assert hook._runtime.flushers[loop] is flusher
+    assert [event.payload for event in hook._runtime.buffer] == ["post"]
 
     # Registering a sink re-arms the loop: the next emit gets a fresh flusher.
     capture.register_capture_sink(fake_capture_sink)
     capture.emit(KIND_SUMMARY_GENERATED, "rearmed", payload_kind="text")
-    assert hook._flushers[loop] is not flusher
-    assert not hook._flushers[loop].task.done()
+    assert hook._runtime.flushers[loop] is not flusher
+    assert not hook._runtime.flushers[loop].task.done()
     await capture.drain()
     assert [r["payload"] for r in fake_capture_sink.records] == ["last", "post", "rearmed"]
 
@@ -680,7 +683,7 @@ async def test_bounded_wait_times_out_and_cancels_the_inner():
 async def test_flusher_cancelled_as_its_wake_lands_finishes_cancelled(fake_capture_sink):
     hook._configure(batch_size=4, flush_interval_s=60.0)
     hook.ensure_flusher()
-    [flusher] = hook._flushers.values()
+    [flusher] = hook._runtime.flushers.values()
     await asyncio.sleep(0)
     await asyncio.sleep(0)  # parked on its interval wait
 
@@ -729,7 +732,7 @@ async def test_drain_propagates_the_callers_cancellation():
     assert caller.cancelled()
     assert [r["payload"] for r in delivered] == ["c0", "c1", "c2"]
     # The acknowledgement never ran, so the group is re-buffered: at-least-once.
-    assert [event.payload for event in hook._buffer] == ["c0", "c1", "c2"]
+    assert [event.payload for event in hook._runtime.buffer] == ["c0", "c1", "c2"]
     assert hook._in_flight_total() == 0
 
 
@@ -748,7 +751,7 @@ async def test_drain_waits_for_a_batch_the_flusher_is_serializing(
     for index in range(8):
         capture.emit(KIND_SUMMARY_GENERATED, f"e{index}", payload_kind="text")
     await _wait_until(entered.is_set)  # flusher popped 4, parked in the worker thread
-    assert len(hook._buffer) == 4
+    assert len(hook._runtime.buffer) == 4
     assert hook._in_flight_total() == 4  # counted per event, from pop to delivery
 
     async def release_later():
@@ -781,7 +784,7 @@ async def test_shutdown_recovers_a_batch_cancelled_mid_serialization(
     await capture.shutdown(timeout=0.2)
 
     assert sorted(r["payload"] for r in fake_capture_sink.records) == [f"e{i}" for i in range(8)]
-    assert not hook._buffer
+    assert not hook._runtime.buffer
     assert hook._any_live_flusher() is None
     assert hook._in_flight_total() == 0
 
@@ -834,14 +837,14 @@ async def test_hung_sink_write_times_out_and_the_flusher_recovers(monkeypatch):
     await _wait_until(lambda: hook._in_flight_total() == 0)
     fake_logger.debug.assert_any_call("capture sink timed out, %d event(s) dropped (%s)", 2, ANY)
     # The abandoned write's events are counted, not silently lost.
-    assert hook._dropped == 2
+    assert hook._runtime.dropped == 2
 
     capture.emit(KIND_SUMMARY_GENERATED, "e2", payload_kind="text")
     started = time.monotonic()
     await capture.drain(timeout=2.0)
     assert time.monotonic() - started < 1.0  # not pinned by the abandoned write
     assert [r["payload"] for r in calls[1]] == ["e2"]
-    [flusher] = hook._flushers.values()
+    [flusher] = hook._runtime.flushers.values()
     assert not flusher.task.done()
 
 
@@ -865,8 +868,8 @@ async def test_flush_failure_before_the_sink_is_accounted_not_requeued(monkeypat
 
     # Re-queuing would pin a deterministic failure at the head of the buffer
     # forever; the batch is dropped and counted instead of vanishing silently.
-    assert not hook._buffer
-    assert hook._dropped == 1
+    assert not hook._runtime.buffer
+    assert hook._runtime.dropped == 1
     assert hook._in_flight_total() == 0
     assert delivered == []
     fake_logger.debug.assert_any_call("capture flush failed, %d event(s) dropped (%s)", 1, ANY)
@@ -881,9 +884,9 @@ async def test_events_orphaned_by_clearing_the_sink_are_counted_as_dropped(fake_
     await capture.drain()
 
     # Nothing to deliver to; the loss is accounted, not hidden.
-    assert not hook._buffer
+    assert not hook._runtime.buffer
     assert fake_capture_sink.records == []
-    assert hook._dropped == 2
+    assert hook._runtime.dropped == 2
 
 
 @pytest.mark.asyncio
@@ -939,9 +942,9 @@ async def test_drain_deadline_bounds_sink_writes_inside_a_batch():
     assert elapsed < 0.6, elapsed
     assert len(calls) == 1  # the budget ran out during the first write
     # Nothing is lost: the cut-off group and the two never started are back, in order.
-    assert [event.payload for event in hook._buffer] == ["g0", "g1", "g2"]
+    assert [event.payload for event in hook._runtime.buffer] == ["g0", "g1", "g2"]
     assert hook._in_flight_total() == 0
-    assert hook._dropped == 0
+    assert hook._runtime.dropped == 0
 
 
 def test_a_batch_stranded_on_a_dead_loop_is_recovered_not_waited_for():
@@ -958,7 +961,7 @@ def test_a_batch_stranded_on_a_dead_loop_is_recovered_not_waited_for():
 
     # run_until_complete returns with the flusher mid-write: the batch is stranded.
     stranded.run_until_complete(emit_and_return())
-    [flusher] = hook._flushers.values()
+    [flusher] = hook._runtime.flushers.values()
     assert flusher.loop is stranded and not flusher.task.done()
     assert hook._in_flight_total() == 1
 
@@ -985,9 +988,9 @@ def test_a_batch_stranded_on_a_dead_loop_is_recovered_not_waited_for():
     assert time.monotonic() - started < 0.5
     assert [record["payload"] for record in delivered] == ["stranded"]
     assert hook._in_flight_total() == 0
-    assert hook._dropped == 0
-    assert not hook._buffer
-    assert not hook._flushers
+    assert hook._runtime.dropped == 0
+    assert not hook._runtime.buffer
+    assert not hook._runtime.flushers
 
 
 def test_thread_emits_wake_a_running_loop_not_a_stopped_one():
@@ -1006,7 +1009,7 @@ def test_thread_emits_wake_a_running_loop_not_a_stopped_one():
 
     stale.run_until_complete(open_scope_only())
     # Stopped, not closed: it stays registered, first in insertion order.
-    assert next(iter(hook._flushers)) is stale
+    assert next(iter(hook._runtime.flushers)) is stale
 
     async def live_run():
         with capture.run_scope("live", kind="pipeline"):
@@ -1025,9 +1028,9 @@ def test_thread_emits_wake_a_running_loop_not_a_stopped_one():
 
     try:
         asyncio.run(live_run())
-        assert hook._flushers[stale].wake_pending is False
+        assert hook._runtime.flushers[stale].wake_pending is False
     finally:
-        stale_flusher = hook._flushers.get(stale)
+        stale_flusher = hook._runtime.flushers.get(stale)
         if stale_flusher is not None:
             hook._cancel_flusher(stale_flusher, wait=True)
         stale.close()
@@ -1036,7 +1039,7 @@ def test_thread_emits_wake_a_running_loop_not_a_stopped_one():
 def test_flusher_burst_loop_terminates_when_a_batch_pops_nothing(monkeypatch, fake_capture_sink):
     # Bypass the clamp on purpose: this is the shape a misconfigured (or raced)
     # flush takes — _flush_one_batch pops nothing and returns without suspending.
-    monkeypatch.setattr(hook, "BATCH_SIZE", 0)
+    monkeypatch.setattr(hook._runtime, "batch_size", 0)
     finished = threading.Event()
     outcome: dict = {}
 
@@ -1047,7 +1050,7 @@ def test_flusher_burst_loop_terminates_when_a_batch_pops_nothing(monkeypatch, fa
         started = time.monotonic()
         await capture.drain(timeout=0.5)
         outcome["drain_s"] = time.monotonic() - started
-        outcome["buffered"] = len(hook._buffer)
+        outcome["buffered"] = len(hook._runtime.buffer)
 
     def runner():
         try:
@@ -1065,9 +1068,9 @@ def test_flusher_burst_loop_terminates_when_a_batch_pops_nothing(monkeypatch, fa
 def test_configure_clamps_degenerate_knobs():
     hook._configure(queue_size=0, batch_size=-1, flush_interval_s=0.0)
 
-    assert hook.QUEUE_SIZE == 1
-    assert hook.BATCH_SIZE == 1
-    assert hook.FLUSH_INTERVAL_S == hook._MIN_FLUSH_INTERVAL_S
+    assert hook._runtime.queue_size == 1
+    assert hook._runtime.batch_size == 1
+    assert hook._runtime.flush_interval_s == hook._MIN_FLUSH_INTERVAL_S
 
 
 # ---------------------------------------------------------------------------
@@ -1100,7 +1103,7 @@ def test_atexit_hook_persists_leftovers_after_asyncio_run(tmp_path):
 
         asyncio.run(command())
         # 3 events + the manifest are still buffered; only the atexit hook remains.
-        assert len(hook._buffer) == 4, len(hook._buffer)
+        assert len(hook._runtime.buffer) == 4, len(hook._runtime.buffer)
         """
     )
     result = subprocess.run(
@@ -1202,16 +1205,16 @@ async def test_event_id_survives_a_requeue_and_redelivery(monkeypatch, fake_capt
     monkeypatch.setattr(hook, "_serialize_batch", blocking_serialize)
     try:
         capture.emit(KIND_SUMMARY_GENERATED, "one", payload_kind="text")
-        [event] = hook._buffer
+        [event] = hook._runtime.buffer
         seq = event.seq
-        flusher = hook._flushers[asyncio.get_running_loop()]
+        flusher = hook._runtime.flushers[asyncio.get_running_loop()]
         await _wait_until(entered.is_set)
 
         flusher.task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await flusher.task
 
-        [requeued] = hook._buffer
+        [requeued] = hook._runtime.buffer
         assert requeued is event and requeued.seq == seq
     finally:
         release.set()
@@ -1258,8 +1261,8 @@ def test_has_room_and_emit_lazy_are_no_ops_when_off():
     capture.emit_lazy(KIND_EXTRACTION_CHUNK_GRAPH, lambda: builds.append(1))
 
     assert builds == []
-    assert not hook._buffer
-    assert hook._dropped == 0
+    assert not hook._runtime.buffer
+    assert hook._runtime.dropped == 0
 
 
 @pytest.mark.asyncio
@@ -1291,8 +1294,8 @@ async def test_emit_lazy_never_calls_the_builder_for_an_event_the_full_buffer_dr
     capture.emit_lazy(KIND_EXTRACTION_CHUNK_GRAPH, lambda: builds.append(1))
 
     assert builds == []
-    assert hook._dropped == 2  # accounted for exactly like emit()'s drop-newest
-    assert len(hook._buffer) == 1
+    assert hook._runtime.dropped == 2  # accounted for exactly like emit()'s drop-newest
+    assert len(hook._runtime.buffer) == 1
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/observability/test_capture_hook.py
+++ b/cognee/tests/unit/modules/observability/test_capture_hook.py
@@ -262,7 +262,7 @@ async def test_overflow_drops_newest_and_reports_delta(fake_capture_sink):
     delivered = [r["payload"] for r in records if r["kind"] == KIND_SUMMARY_GENERATED]
     assert delivered == ["s0", "s1", "s2"]
     [manifest] = [r for r in records if r["kind"] == KIND_RUN_MANIFEST]
-    assert manifest["payload"]["dropped_events"] == 2
+    assert manifest["payload"]["events_dropped"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -517,7 +517,7 @@ async def test_failing_sink_is_logged_at_debug_and_next_batch_delivered(monkeypa
     fake_logger.debug.assert_any_call("capture sink failed, %d event(s) dropped (%s)", 1, ANY)
     assert hook._in_flight_total() == 0
     # The event the sink rejected is gone: it must be accounted for, not hidden,
-    # or the run manifest reports dropped_events = 0 while records were lost.
+    # or the run manifest reports events_dropped = 0 while records were lost.
     assert hook._dropped == 1
     assert not hook._buffer
 
@@ -1116,7 +1116,7 @@ def test_atexit_hook_persists_leftovers_after_asyncio_run(tmp_path):
     run_dir = tmp_path / "ds-1" / "run-1"
     manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["payload"]["kind"] == "pipeline"
-    assert manifest["payload"]["dropped_events"] == 0
+    assert manifest["payload"]["events_dropped"] == 0
     [blob] = (run_dir / KIND_SUMMARY_GENERATED).glob("batch-*.jsonl.gz")
     with gzip.open(blob, "rt", encoding="utf-8") as lines:
         payloads = [json.loads(line)["payload"] for line in lines if line.strip()]
@@ -1151,6 +1151,99 @@ async def test_drain_is_bounded_even_when_a_sink_swallows_its_cancellation():
 
     # The budget plus at most one cancellation grace, not 30s.
     assert elapsed < 0.2 + hook._CANCEL_GRACE_S + 1.0
+
+
+# ---------------------------------------------------------------------------
+# Envelope: schema_version and a stable, process-unique event_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_records_carry_a_schema_version_and_a_sequenced_event_id(fake_capture_sink):
+    from cognee.modules.observability.capture.events import CAPTURE_SCHEMA_VERSION
+
+    capture.emit(KIND_SUMMARY_GENERATED, "a", payload_kind="text")
+    capture.emit(KIND_SUMMARY_GENERATED, "b", payload_kind="text")
+    await capture.drain()
+
+    first, second = fake_capture_sink.records
+    assert set(first) == {
+        "schema_version",
+        "event_id",
+        "kind",
+        "run_id",
+        "dataset_id",
+        "stage",
+        "ts",
+        "payload",
+    }
+    assert first["schema_version"] == CAPTURE_SCHEMA_VERSION == 1
+    prefix_a, seq_a = first["event_id"].rsplit("-", 1)
+    prefix_b, seq_b = second["event_id"].rsplit("-", 1)
+    assert prefix_a == prefix_b == hook._PROCESS_ID
+    assert int(seq_b) == int(seq_a) + 1
+
+
+@pytest.mark.asyncio
+async def test_event_id_survives_a_requeue_and_redelivery(monkeypatch, fake_capture_sink):
+    """Delivery is at-least-once, so a consumer dedupes on event_id — which only
+    works if the id is assigned at emit and a requeued event keeps it, rather
+    than being minted afresh each time the record is serialized."""
+    hook._configure(batch_size=1, flush_interval_s=60.0)
+    entered = threading.Event()
+    release = threading.Event()
+    real_serialize = hook._serialize_batch
+
+    def blocking_serialize(batch):
+        entered.set()
+        release.wait(timeout=5.0)
+        return real_serialize(batch)
+
+    monkeypatch.setattr(hook, "_serialize_batch", blocking_serialize)
+    try:
+        capture.emit(KIND_SUMMARY_GENERATED, "one", payload_kind="text")
+        [event] = hook._buffer
+        seq = event.seq
+        flusher = hook._flushers[asyncio.get_running_loop()]
+        await _wait_until(entered.is_set)
+
+        flusher.task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await flusher.task
+
+        [requeued] = hook._buffer
+        assert requeued is event and requeued.seq == seq
+    finally:
+        release.set()
+
+    monkeypatch.setattr(hook, "_serialize_batch", real_serialize)
+    await capture.drain()
+    [record] = fake_capture_sink.records
+    assert record["event_id"] == f"{hook._PROCESS_ID}-{seq}"
+
+
+def test_delivery_is_credited_to_a_run_once_even_when_delivered_twice():
+    from cognee.modules.observability.capture.manifest import RunScope
+
+    scope = RunScope(run_id="r")
+    event = hook.CaptureEvent(
+        kind=KIND_SUMMARY_GENERATED,
+        payload="x",
+        payload_kind="text",
+        run_id=None,
+        dataset_id=None,
+        scope=scope,
+        stage=None,
+        ts=0.0,
+        seq=1,
+    )
+
+    hook._account_delivered([event, None, event])
+    hook._account_delivered([event])
+
+    assert scope.delivered == 1
+    assert hook._account_dropped([event, None]) == 1
+    assert scope.dropped == 1
 
 
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/modules/observability/test_capture_hook.py
+++ b/cognee/tests/unit/modules/observability/test_capture_hook.py
@@ -1151,3 +1151,68 @@ async def test_drain_is_bounded_even_when_a_sink_swallows_its_cancellation():
 
     # The budget plus at most one cancellation grace, not 30s.
     assert elapsed < 0.2 + hook._CANCEL_GRACE_S + 1.0
+
+
+# ---------------------------------------------------------------------------
+# emit_lazy / has_room: an expensive payload is built only if it will be buffered
+# ---------------------------------------------------------------------------
+
+
+def test_has_room_and_emit_lazy_are_no_ops_when_off():
+    builds = []
+
+    assert capture.has_room() is False
+    capture.emit_lazy(KIND_EXTRACTION_CHUNK_GRAPH, lambda: builds.append(1))
+
+    assert builds == []
+    assert not hook._buffer
+    assert hook._dropped == 0
+
+
+@pytest.mark.asyncio
+async def test_emit_lazy_builds_and_buffers_while_there_is_room(fake_capture_sink):
+    hook._configure(flush_interval_s=60.0)
+
+    assert capture.has_room() is True
+    capture.emit_lazy(KIND_EXTRACTION_CHUNK_GRAPH, lambda: {"graph": "snapshot"}, stage="s")
+    await capture.drain()
+
+    [record] = fake_capture_sink.records
+    assert record["kind"] == KIND_EXTRACTION_CHUNK_GRAPH
+    assert record["payload"] == {"graph": "snapshot"}
+    assert record["stage"] == "s"
+
+
+@pytest.mark.asyncio
+async def test_emit_lazy_never_calls_the_builder_for_an_event_the_full_buffer_drops(
+    fake_capture_sink,
+):
+    """The whole point: a synchronous burst past QUEUE_SIZE (a 2000-chunk cognify
+    batch against a smaller buffer) must not pay a snapshot per dropped event."""
+    hook._configure(queue_size=1, flush_interval_s=60.0)
+    capture.emit(KIND_SUMMARY_GENERATED, "fills", payload_kind="text")
+    builds = []
+
+    assert capture.has_room() is False
+    capture.emit_lazy(KIND_EXTRACTION_CHUNK_GRAPH, lambda: builds.append(1))
+    capture.emit_lazy(KIND_EXTRACTION_CHUNK_GRAPH, lambda: builds.append(1))
+
+    assert builds == []
+    assert hook._dropped == 2  # accounted for exactly like emit()'s drop-newest
+    assert len(hook._buffer) == 1
+
+
+@pytest.mark.asyncio
+async def test_emit_lazy_swallows_a_raising_builder(monkeypatch, fake_capture_sink):
+    fake_logger = MagicMock()
+    monkeypatch.setattr(hook, "logger", fake_logger)
+
+    def explode():
+        raise ValueError("cyclic graph")
+
+    capture.emit_lazy(KIND_EXTRACTION_CHUNK_GRAPH, explode)
+    capture.emit_lazy(KIND_EXTRACTION_CHUNK_GRAPH, lambda: "fine")
+    await capture.drain()
+
+    assert [r["payload"] for r in fake_capture_sink.records] == ["fine"]
+    fake_logger.debug.assert_any_call("capture payload build failed (%s)", ANY)

--- a/cognee/tests/unit/modules/observability/test_capture_hook.py
+++ b/cognee/tests/unit/modules/observability/test_capture_hook.py
@@ -160,7 +160,7 @@ def test_auto_registers_storage_sink_from_env(monkeypatch, tmp_path):
 
 def test_initialization_failure_leaves_capture_off(monkeypatch):
     monkeypatch.setenv("COGNEE_CAPTURE_ENABLED", "true")
-    monkeypatch.setenv("COGNEE_CAPTURE_SAMPLE_RATE", "7")
+    monkeypatch.setenv("COGNEE_CAPTURE_RETRIEVAL_SAMPLE_RATE", "7")
     get_capture_config.cache_clear()
     fake_logger = MagicMock()
     monkeypatch.setattr(hook, "logger", fake_logger)

--- a/cognee/tests/unit/modules/observability/test_capture_manifest.py
+++ b/cognee/tests/unit/modules/observability/test_capture_manifest.py
@@ -117,6 +117,33 @@ def test_nested_scopes_restore_the_parent():
 
 
 @pytest.mark.asyncio
+async def test_nested_operation_inherits_the_enclosing_dataset(fake_capture_sink):
+    pipeline_run = uuid4()
+    dataset_id = uuid4()
+    operation_id = uuid4()
+
+    # A record_operation-wrapped search executed by a pipeline task: the
+    # operation scope has no dataset of its own, the enclosing run knows it.
+    with capture.run_scope(pipeline_run, dataset_id, kind="pipeline"):
+        with capture.run_scope(operation_id, kind="operation") as inner:
+            assert inner.dataset_id is None
+            assert inner.resolved_dataset_id() == dataset_id
+            capture.emit(KIND_RETRIEVAL_CANDIDATES, [{"id": "n1"}], payload_kind="json")
+
+    await capture.drain()
+
+    [candidates] = [r for r in fake_capture_sink.records if r["kind"] == KIND_RETRIEVAL_CANDIDATES]
+    assert candidates["run_id"] == str(operation_id)
+    assert candidates["dataset_id"] == str(dataset_id)  # not filed under nodataset/
+    manifests = {m["run_id"]: m for m in _manifests(fake_capture_sink)}
+    inner_manifest = manifests[str(operation_id)]
+    assert inner_manifest["dataset_id"] == str(dataset_id)
+    assert inner_manifest["payload"]["dataset_id"] == str(dataset_id)
+    assert inner_manifest["payload"]["parent_run_id"] == str(pipeline_run)  # joinable offline
+    assert manifests[str(pipeline_run)]["payload"]["parent_run_id"] is None
+
+
+@pytest.mark.asyncio
 async def test_manifest_is_emitted_even_when_the_body_raises(fake_capture_sink):
     with pytest.raises(RuntimeError):
         with capture.run_scope(uuid4(), kind="pipeline"):

--- a/cognee/tests/unit/modules/observability/test_capture_manifest.py
+++ b/cognee/tests/unit/modules/observability/test_capture_manifest.py
@@ -1,0 +1,167 @@
+"""run_scope / RunScope manifest contract and per-run sampling (SDK-529)."""
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.observability import capture
+from cognee.modules.observability.capture import (
+    KIND_EXTRACTION_CHUNK_GRAPH,
+    KIND_RETRIEVAL_CANDIDATES,
+    KIND_RUN_MANIFEST,
+    KIND_SUMMARY_GENERATED,
+    hook,
+)
+
+pytestmark = pytest.mark.usefixtures("capture_reset")
+
+
+def _manifests(sink):
+    return [record for record in sink.records if record["kind"] == KIND_RUN_MANIFEST]
+
+
+# ---------------------------------------------------------------------------
+# 7: manifest contents, late-bound dataset, child-task accumulation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manifest_carries_fields_counters_and_timing(fake_capture_sink):
+    run_id = uuid4()
+    dataset_id = uuid4()
+
+    with capture.run_scope(run_id, dataset_id, kind="pipeline") as scope:
+        assert capture.current_scope() is scope
+        capture.note("llm_model", "gpt-5-mini")
+        capture.bump("chunks")
+        capture.bump("chunks", 2)
+        scope.note("prompt", "sha256:abc")
+        scope.bump("nodes", 5)
+    assert capture.current_scope() is None
+
+    await capture.drain()
+
+    [manifest] = _manifests(fake_capture_sink)
+    assert manifest["run_id"] == str(run_id)
+    assert manifest["dataset_id"] == str(dataset_id)
+    payload = manifest["payload"]
+    assert payload["run_id"] == str(run_id)
+    assert payload["dataset_id"] == str(dataset_id)
+    assert payload["kind"] == "pipeline"
+    assert payload["sampled"] is True
+    assert payload["llm_model"] == "gpt-5-mini"
+    assert payload["prompt"] == "sha256:abc"
+    assert payload["counters"] == {"chunks": 3, "nodes": 5}
+    assert payload["ended_at"] >= payload["started_at"]
+    assert payload["duration_s"] >= 0
+    assert payload["dropped_events"] == 0
+
+
+@pytest.mark.asyncio
+async def test_set_dataset_late_binds_already_buffered_events(fake_capture_sink):
+    run_id = uuid4()
+    dataset_id = uuid4()
+
+    with capture.run_scope(run_id, kind="operation") as scope:
+        capture.emit(KIND_SUMMARY_GENERATED, "before", payload_kind="text")
+        assert hook._buffer[0].dataset_id is None
+        scope.set_dataset(dataset_id)
+
+    await capture.drain()
+
+    records = fake_capture_sink.records
+    assert len(records) == 2
+    assert all(record["run_id"] == str(run_id) for record in records)
+    assert all(record["dataset_id"] == str(dataset_id) for record in records)
+    [manifest] = _manifests(fake_capture_sink)
+    assert manifest["payload"]["dataset_id"] == str(dataset_id)
+
+
+@pytest.mark.asyncio
+async def test_explicit_event_ids_override_scope(fake_capture_sink):
+    override_run = uuid4()
+
+    with capture.run_scope(uuid4(), uuid4(), kind="pipeline"):
+        capture.emit(KIND_SUMMARY_GENERATED, "x", payload_kind="text", run_id=override_run)
+
+    await capture.drain()
+
+    [record] = [r for r in fake_capture_sink.records if r["kind"] == KIND_SUMMARY_GENERATED]
+    assert record["run_id"] == str(override_run)
+
+
+@pytest.mark.asyncio
+async def test_child_task_bump_reaches_parent_manifest(fake_capture_sink):
+    async def child():
+        capture.bump("child_hits")
+        capture.note("from_child", True)
+
+    with capture.run_scope(uuid4(), kind="pipeline"):
+        await asyncio.gather(asyncio.create_task(child()), asyncio.create_task(child()))
+
+    await capture.drain()
+
+    [manifest] = _manifests(fake_capture_sink)
+    assert manifest["payload"]["counters"] == {"child_hits": 2}
+    assert manifest["payload"]["from_child"] is True
+
+
+def test_nested_scopes_restore_the_parent():
+    with capture.run_scope("outer", kind="pipeline") as outer:
+        with capture.run_scope("inner", kind="pipeline") as inner:
+            assert inner.parent is outer
+            assert capture.current_scope() is inner
+        assert capture.current_scope() is outer
+    assert capture.current_scope() is None
+
+
+@pytest.mark.asyncio
+async def test_manifest_is_emitted_even_when_the_body_raises(fake_capture_sink):
+    with pytest.raises(RuntimeError):
+        with capture.run_scope(uuid4(), kind="pipeline"):
+            raise RuntimeError("body failed")
+
+    await capture.drain()
+    assert len(_manifests(fake_capture_sink)) == 1
+
+
+# ---------------------------------------------------------------------------
+# 8: sampling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sample_rate_zero_unsamples_operation_scopes_only(fake_capture_sink):
+    hook._configure(sample_rate=0.0)
+
+    with capture.run_scope(uuid4(), kind="operation") as scope:
+        assert scope.sampled is False
+        assert capture.should_capture(KIND_RETRIEVAL_CANDIDATES) is False
+        assert capture.should_capture(KIND_EXTRACTION_CHUNK_GRAPH) is True
+    await capture.drain()
+    assert _manifests(fake_capture_sink) == []
+
+    with capture.run_scope(uuid4(), kind="pipeline") as scope:
+        assert scope.sampled is True
+        assert capture.should_capture(KIND_RETRIEVAL_CANDIDATES) is True
+    await capture.drain()
+    assert len(_manifests(fake_capture_sink)) == 1
+
+    # No active scope: fall back to the rate.
+    assert capture.should_capture(KIND_RETRIEVAL_CANDIDATES) is False
+    assert capture.should_capture(KIND_SUMMARY_GENERATED) is True
+
+
+@pytest.mark.asyncio
+async def test_sample_rate_one_keeps_everything(fake_capture_sink):
+    hook._configure(sample_rate=1.0)
+
+    for _ in range(5):
+        with capture.run_scope(uuid4(), kind="operation") as scope:
+            assert scope.sampled is True
+            assert capture.should_capture(KIND_RETRIEVAL_CANDIDATES) is True
+    assert capture.should_capture(KIND_RETRIEVAL_CANDIDATES) is True
+
+    await capture.drain()
+    assert len(_manifests(fake_capture_sink)) == 5

--- a/cognee/tests/unit/modules/observability/test_capture_manifest.py
+++ b/cognee/tests/unit/modules/observability/test_capture_manifest.py
@@ -240,13 +240,18 @@ async def test_sample_rate_zero_unsamples_operation_scopes_only(fake_capture_sin
         assert capture.should_capture(KIND_RETRIEVAL_CANDIDATES) is False
         assert capture.should_capture(KIND_EXTRACTION_CHUNK_GRAPH) is True
     await capture.drain()
-    assert _manifests(fake_capture_sink) == []
+    # Sampling gates retrieval.* payloads, never the manifest: the kinds that are
+    # still captured at full rate would otherwise name an unresolvable run.
+    unsampled = _manifests(fake_capture_sink)
+    assert len(unsampled) == 1
+    assert unsampled[0]["payload"]["sampled"] is False
 
     with capture.run_scope(uuid4(), kind="pipeline") as scope:
         assert scope.sampled is True
         assert capture.should_capture(KIND_RETRIEVAL_CANDIDATES) is True
     await capture.drain()
-    assert len(_manifests(fake_capture_sink)) == 1
+    assert len(_manifests(fake_capture_sink)) == 2
+    assert _manifests(fake_capture_sink)[1]["payload"]["sampled"] is True
 
     # No active scope: fall back to the rate.
     assert capture.should_capture(KIND_RETRIEVAL_CANDIDATES) is False

--- a/cognee/tests/unit/modules/observability/test_capture_manifest.py
+++ b/cognee/tests/unit/modules/observability/test_capture_manifest.py
@@ -126,6 +126,65 @@ async def test_manifest_is_emitted_even_when_the_body_raises(fake_capture_sink):
     assert len(_manifests(fake_capture_sink)) == 1
 
 
+@pytest.mark.asyncio
+async def test_manifest_survives_a_full_buffer_and_reports_the_drops(fake_capture_sink):
+    hook._configure(queue_size=2, flush_interval_s=60.0)
+    run_id = uuid4()
+
+    with capture.run_scope(run_id, uuid4(), kind="pipeline"):
+        for index in range(5):
+            capture.emit(KIND_SUMMARY_GENERATED, f"s{index}", payload_kind="text")
+        assert hook._dropped == 3
+        assert len(hook._buffer) == 2
+    # The manifest bypasses the bound: it is the record that reports the drops.
+    assert len(hook._buffer) == 3
+
+    await capture.drain()
+
+    [manifest] = _manifests(fake_capture_sink)
+    assert manifest["run_id"] == str(run_id)
+    assert manifest["payload"]["dropped_events"] == 3
+
+
+@pytest.mark.asyncio
+async def test_finish_emits_the_manifest_once_and_exit_skips_the_duplicate(fake_capture_sink):
+    with capture.run_scope(uuid4(), kind="pipeline") as scope:
+        capture.bump("items", 2)
+        assert scope.finished is False
+        scope.finish()
+        assert scope.finished is True
+        # A caller that drains before its scope closes sees its own manifest.
+        await capture.drain()
+        [manifest] = _manifests(fake_capture_sink)
+        assert manifest["payload"]["counters"] == {"items": 2}
+        scope.finish()  # idempotent
+
+    await capture.drain()
+    assert len(_manifests(fake_capture_sink)) == 1
+
+
+@pytest.mark.asyncio
+async def test_note_cannot_overwrite_envelope_keys(fake_capture_sink):
+    run_id = uuid4()
+
+    with capture.run_scope(run_id, kind="pipeline"):
+        capture.note("run_id", "spoofed")
+        capture.note("kind", "spoofed")
+        capture.note("counters", "not a dict")
+        capture.note("model", "gpt-5-mini")
+        capture.bump("hits")
+
+    await capture.drain()
+
+    [manifest] = _manifests(fake_capture_sink)
+    payload = manifest["payload"]
+    assert manifest["run_id"] == str(run_id)  # filed under the real run
+    assert payload["run_id"] == str(run_id)
+    assert payload["kind"] == "pipeline"
+    assert payload["counters"] == {"hits": 1}
+    assert payload["model"] == "gpt-5-mini"
+
+
 # ---------------------------------------------------------------------------
 # 8: sampling
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/modules/observability/test_capture_manifest.py
+++ b/cognee/tests/unit/modules/observability/test_capture_manifest.py
@@ -136,7 +136,7 @@ async def test_manifest_survives_a_full_buffer_and_reports_the_drops(fake_captur
             capture.emit(KIND_SUMMARY_GENERATED, f"s{index}", payload_kind="text")
         assert hook._dropped == 3
         assert len(hook._buffer) == 2
-    # The manifest bypasses the bound: it is the record that reports the drops.
+    # The manifest gets headroom past the bound: it is the record that reports the drops.
     assert len(hook._buffer) == 3
 
     await capture.drain()
@@ -144,6 +144,20 @@ async def test_manifest_survives_a_full_buffer_and_reports_the_drops(fake_captur
     [manifest] = _manifests(fake_capture_sink)
     assert manifest["run_id"] == str(run_id)
     assert manifest["payload"]["dropped_events"] == 3
+
+
+def test_manifests_are_bounded_past_queue_size(fake_capture_sink):
+    # A sync caller with no loop anywhere: nothing can flush, so every completed
+    # run's manifest stays buffered. Manifests bypass QUEUE_SIZE, but not 2x it.
+    hook._configure(queue_size=4)
+
+    for index in range(50):
+        with capture.run_scope(f"run-{index}", kind="pipeline"):
+            pass
+
+    assert len(hook._buffer) == 2 * hook.QUEUE_SIZE
+    assert hook._dropped == 50 - 2 * hook.QUEUE_SIZE
+    assert not hook._flushers
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/observability/test_capture_manifest.py
+++ b/cognee/tests/unit/modules/observability/test_capture_manifest.py
@@ -1,6 +1,7 @@
 """run_scope / RunScope manifest contract and per-run sampling (SDK-529)."""
 
 import asyncio
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -55,7 +56,10 @@ async def test_manifest_carries_fields_counters_and_timing(fake_capture_sink):
     assert payload["counters"] == {"chunks": 3, "nodes": 5}
     assert payload["ended_at"] >= payload["started_at"]
     assert payload["duration_s"] >= 0
-    assert payload["dropped_events"] == 0
+    assert payload["events_emitted"] == 0
+    assert payload["events_dropped"] == 0
+    assert payload["events_delivered"] == 0
+    assert payload["capture_complete"] is True
 
 
 @pytest.mark.asyncio
@@ -170,7 +174,85 @@ async def test_manifest_survives_a_full_buffer_and_reports_the_drops(fake_captur
 
     [manifest] = _manifests(fake_capture_sink)
     assert manifest["run_id"] == str(run_id)
-    assert manifest["payload"]["dropped_events"] == 3
+    assert manifest["payload"]["events_emitted"] == 2
+    assert manifest["payload"]["events_dropped"] == 3
+    assert manifest["payload"]["capture_complete"] is False
+
+
+# ---------------------------------------------------------------------------
+# 7b: per-run accounting is exact, not a delta of the process counter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drops_are_charged_to_the_run_that_emitted_them(fake_capture_sink):
+    """Two runs share the process (an operation recorded inside a pipeline task
+    here; concurrent requests in a server). A delta of the process-wide counter
+    charged the inner run's overflow to the outer run too; the counts are per
+    run now, via the scope each event was emitted under."""
+    hook._configure(queue_size=2, flush_interval_s=60.0)
+
+    with capture.run_scope("pipeline", kind="pipeline") as outer:
+        capture.emit(KIND_SUMMARY_GENERATED, "outer", payload_kind="text")
+        with capture.run_scope("operation", kind="operation") as inner:
+            for index in range(3):
+                capture.emit(KIND_RETRIEVAL_CANDIDATES, f"inner{index}", payload_kind="text")
+
+    assert (outer.emitted, outer.dropped) == (1, 0)
+    assert (inner.emitted, inner.dropped) == (1, 2)
+    assert hook._dropped == 2
+
+    await capture.drain()
+
+    manifests = {m["run_id"]: m["payload"] for m in _manifests(fake_capture_sink)}
+    assert manifests["pipeline"]["events_dropped"] == 0
+    assert manifests["pipeline"]["capture_complete"] is True
+    assert manifests["operation"]["events_emitted"] == 1
+    assert manifests["operation"]["events_dropped"] == 2
+    assert manifests["operation"]["capture_complete"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_sink_failure_is_charged_to_the_run_and_marks_it_incomplete(monkeypatch):
+    """Drops happen on the flusher's side too (a sink that rejects a batch).
+    They reach the run through the event's own scope — the flusher runs
+    outside the run's context, so the contextvar would say nothing."""
+    monkeypatch.setattr(hook, "logger", MagicMock())
+    calls = []
+
+    async def flaky_sink(records):
+        calls.append(records)
+        if len(calls) == 1:
+            raise RuntimeError("boom")
+
+    capture.register_capture_sink(flaky_sink)
+
+    with capture.run_scope(uuid4(), kind="pipeline") as scope:
+        capture.emit(KIND_SUMMARY_GENERATED, "lost", payload_kind="text")
+        await capture.drain()  # the sink rejects the batch
+        assert (scope.emitted, scope.dropped, scope.delivered) == (1, 1, 0)
+
+    await capture.drain()
+
+    [manifest] = [r for call in calls for r in call if r["kind"] == KIND_RUN_MANIFEST]
+    assert manifest["payload"]["events_dropped"] == 1
+    assert manifest["payload"]["events_delivered"] == 0
+    assert manifest["payload"]["capture_complete"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_drained_run_reports_every_event_delivered(fake_capture_sink):
+    with capture.run_scope(uuid4(), kind="pipeline") as scope:
+        capture.emit(KIND_SUMMARY_GENERATED, "a", payload_kind="text")
+        capture.emit(KIND_SUMMARY_GENERATED, "b", payload_kind="text")
+        assert (scope.emitted, scope.dropped, scope.delivered) == (2, 0, 0)
+        await capture.drain()
+        assert (scope.emitted, scope.dropped, scope.delivered) == (2, 0, 2)
+
+    await capture.drain()
+    [manifest] = _manifests(fake_capture_sink)
+    assert manifest["payload"]["events_delivered"] == manifest["payload"]["events_emitted"] == 2
+    assert manifest["payload"]["capture_complete"] is True
 
 
 def test_manifests_are_bounded_past_queue_size(fake_capture_sink):

--- a/cognee/tests/unit/modules/observability/test_capture_manifest.py
+++ b/cognee/tests/unit/modules/observability/test_capture_manifest.py
@@ -315,7 +315,7 @@ async def test_note_cannot_overwrite_envelope_keys(fake_capture_sink):
 
 @pytest.mark.asyncio
 async def test_sample_rate_zero_unsamples_operation_scopes_only(fake_capture_sink):
-    hook._configure(sample_rate=0.0)
+    hook._configure(retrieval_sample_rate=0.0)
 
     with capture.run_scope(uuid4(), kind="operation") as scope:
         assert scope.sampled is False
@@ -342,7 +342,7 @@ async def test_sample_rate_zero_unsamples_operation_scopes_only(fake_capture_sin
 
 @pytest.mark.asyncio
 async def test_sample_rate_one_keeps_everything(fake_capture_sink):
-    hook._configure(sample_rate=1.0)
+    hook._configure(retrieval_sample_rate=1.0)
 
     for _ in range(5):
         with capture.run_scope(uuid4(), kind="operation") as scope:

--- a/cognee/tests/unit/modules/observability/test_capture_manifest.py
+++ b/cognee/tests/unit/modules/observability/test_capture_manifest.py
@@ -69,7 +69,7 @@ async def test_set_dataset_late_binds_already_buffered_events(fake_capture_sink)
 
     with capture.run_scope(run_id, kind="operation") as scope:
         capture.emit(KIND_SUMMARY_GENERATED, "before", payload_kind="text")
-        assert hook._buffer[0].dataset_id is None
+        assert hook._runtime.buffer[0].dataset_id is None
         scope.set_dataset(dataset_id)
 
     await capture.drain()
@@ -165,10 +165,10 @@ async def test_manifest_survives_a_full_buffer_and_reports_the_drops(fake_captur
     with capture.run_scope(run_id, uuid4(), kind="pipeline"):
         for index in range(5):
             capture.emit(KIND_SUMMARY_GENERATED, f"s{index}", payload_kind="text")
-        assert hook._dropped == 3
-        assert len(hook._buffer) == 2
+        assert hook._runtime.dropped == 3
+        assert len(hook._runtime.buffer) == 2
     # The manifest gets headroom past the bound: it is the record that reports the drops.
-    assert len(hook._buffer) == 3
+    assert len(hook._runtime.buffer) == 3
 
     await capture.drain()
 
@@ -200,7 +200,7 @@ async def test_drops_are_charged_to_the_run_that_emitted_them(fake_capture_sink)
 
     assert (outer.emitted, outer.dropped) == (1, 0)
     assert (inner.emitted, inner.dropped) == (1, 2)
-    assert hook._dropped == 2
+    assert hook._runtime.dropped == 2
 
     await capture.drain()
 
@@ -264,9 +264,9 @@ def test_manifests_are_bounded_past_queue_size(fake_capture_sink):
         with capture.run_scope(f"run-{index}", kind="pipeline"):
             pass
 
-    assert len(hook._buffer) == 2 * hook.QUEUE_SIZE
-    assert hook._dropped == 50 - 2 * hook.QUEUE_SIZE
-    assert not hook._flushers
+    assert len(hook._runtime.buffer) == 2 * hook._runtime.queue_size
+    assert hook._runtime.dropped == 50 - 2 * hook._runtime.queue_size
+    assert not hook._runtime.flushers
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/observability/test_capture_storage_sink.py
+++ b/cognee/tests/unit/modules/observability/test_capture_storage_sink.py
@@ -78,12 +78,12 @@ async def test_layout_roundtrip_manifest_and_nodataset(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_successive_writes_never_clobber_and_write_alias_exists(tmp_path):
+async def test_successive_writes_never_clobber(tmp_path):
     sink = StorageSink(StorageManager(LocalFileStorage(str(tmp_path))))
     run_id = str(uuid4())
 
     await sink([_record(KIND_SUMMARY_GENERATED, run_id, None, "a")])
-    await sink.write([_record(KIND_SUMMARY_GENERATED, run_id, None, "b")])
+    await sink([_record(KIND_SUMMARY_GENERATED, run_id, None, "b")])
 
     blobs = sorted((tmp_path / "nodataset" / run_id / KIND_SUMMARY_GENERATED).glob("*.jsonl.gz"))
     assert len(blobs) == 2

--- a/cognee/tests/unit/modules/observability/test_capture_storage_sink.py
+++ b/cognee/tests/unit/modules/observability/test_capture_storage_sink.py
@@ -1,0 +1,108 @@
+"""StorageSink layout (SDK-529): gzip'd JSONL blobs per (dataset, run, kind) and a
+pretty manifest.json per run, written through the normal StorageManager."""
+
+import gzip
+import json
+from uuid import uuid4
+
+import pytest
+
+from cognee.infrastructure.files.storage import StorageManager
+from cognee.infrastructure.files.storage.LocalFileStorage import LocalFileStorage
+from cognee.modules.observability.capture import (
+    KIND_RUN_MANIFEST,
+    KIND_SUMMARY_GENERATED,
+    StorageSink,
+)
+
+pytestmark = pytest.mark.usefixtures("capture_reset")
+
+
+def _record(kind, run_id, dataset_id, payload, ts=1.0):
+    return {
+        "kind": kind,
+        "run_id": run_id,
+        "dataset_id": dataset_id,
+        "stage": None,
+        "ts": ts,
+        "payload": payload,
+    }
+
+
+def _read_jsonl_gz(path):
+    with gzip.open(path, "rt", encoding="utf-8") as blob:
+        return [json.loads(line) for line in blob if line.strip()]
+
+
+@pytest.mark.asyncio
+async def test_layout_roundtrip_manifest_and_nodataset(tmp_path):
+    sink = StorageSink(StorageManager(LocalFileStorage(str(tmp_path))))
+    run_id = str(uuid4())
+    dataset_id = str(uuid4())
+
+    await sink(
+        [
+            _record(KIND_SUMMARY_GENERATED, run_id, dataset_id, "s1", ts=1.0),
+            _record(KIND_SUMMARY_GENERATED, run_id, dataset_id, "s2", ts=2.0),
+            _record(KIND_RUN_MANIFEST, run_id, dataset_id, {"run_id": run_id, "kind": "pipeline"}),
+            _record(KIND_SUMMARY_GENERATED, run_id, None, "orphan"),
+        ]
+    )
+
+    blobs = list((tmp_path / dataset_id / run_id / KIND_SUMMARY_GENERATED).glob("batch-*.jsonl.gz"))
+    assert len(blobs) == 1
+    lines = _read_jsonl_gz(blobs[0])
+    assert [line["payload"] for line in lines] == ["s1", "s2"]
+    assert lines[0]["kind"] == KIND_SUMMARY_GENERATED
+    assert lines[0]["run_id"] == run_id
+
+    manifest_path = tmp_path / dataset_id / run_id / "manifest.json"
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+    assert "\n  " in manifest_text  # pretty-printed
+    manifest = json.loads(manifest_text)
+    assert manifest["kind"] == KIND_RUN_MANIFEST
+    assert manifest["payload"] == {"run_id": run_id, "kind": "pipeline"}
+
+    orphan_blobs = list(
+        (tmp_path / "nodataset" / run_id / KIND_SUMMARY_GENERATED).glob("batch-*.jsonl.gz")
+    )
+    assert len(orphan_blobs) == 1
+    assert [line["payload"] for line in _read_jsonl_gz(orphan_blobs[0])] == ["orphan"]
+
+
+@pytest.mark.asyncio
+async def test_successive_writes_never_clobber_and_write_alias_exists(tmp_path):
+    sink = StorageSink(StorageManager(LocalFileStorage(str(tmp_path))))
+    run_id = str(uuid4())
+
+    await sink([_record(KIND_SUMMARY_GENERATED, run_id, None, "a")])
+    await sink.write([_record(KIND_SUMMARY_GENERATED, run_id, None, "b")])
+
+    blobs = sorted((tmp_path / "nodataset" / run_id / KIND_SUMMARY_GENERATED).glob("*.jsonl.gz"))
+    assert len(blobs) == 2
+    payloads = sorted(line["payload"] for blob in blobs for line in _read_jsonl_gz(blob))
+    assert payloads == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_manifest_overwrite_keeps_latest_and_root_prefix(tmp_path):
+    sink = StorageSink(StorageManager(LocalFileStorage(str(tmp_path))), root="evals-run-1")
+    run_id = str(uuid4())
+    dataset_id = str(uuid4())
+
+    await sink([_record(KIND_RUN_MANIFEST, run_id, dataset_id, {"v": 1})])
+    await sink([_record(KIND_RUN_MANIFEST, run_id, dataset_id, {"v": 2})])
+
+    manifest_path = tmp_path / "evals-run-1" / dataset_id / run_id / "manifest.json"
+    assert json.loads(manifest_path.read_text(encoding="utf-8"))["payload"] == {"v": 2}
+
+
+@pytest.mark.asyncio
+async def test_non_json_values_are_stringified(tmp_path):
+    sink = StorageSink(StorageManager(LocalFileStorage(str(tmp_path))))
+    run_id = uuid4()
+
+    await sink([_record(KIND_SUMMARY_GENERATED, str(run_id), None, {"id": run_id})])
+
+    [blob] = (tmp_path / "nodataset" / str(run_id) / KIND_SUMMARY_GENERATED).glob("*.jsonl.gz")
+    assert _read_jsonl_gz(blob)[0]["payload"] == {"id": str(run_id)}

--- a/cognee/tests/unit/modules/observability/test_capture_storage_sink.py
+++ b/cognee/tests/unit/modules/observability/test_capture_storage_sink.py
@@ -3,6 +3,7 @@ pretty manifest.json per run, written through the normal StorageManager."""
 
 import gzip
 import json
+import re
 from uuid import uuid4
 
 import pytest
@@ -46,11 +47,14 @@ async def test_layout_roundtrip_manifest_and_nodataset(tmp_path):
             _record(KIND_SUMMARY_GENERATED, run_id, dataset_id, "s2", ts=2.0),
             _record(KIND_RUN_MANIFEST, run_id, dataset_id, {"run_id": run_id, "kind": "pipeline"}),
             _record(KIND_SUMMARY_GENERATED, run_id, None, "orphan"),
+            _record(KIND_SUMMARY_GENERATED, None, dataset_id, "runless"),
         ]
     )
 
     blobs = list((tmp_path / dataset_id / run_id / KIND_SUMMARY_GENERATED).glob("batch-*.jsonl.gz"))
     assert len(blobs) == 1
+    # Collision-free shape: batch-{ts_ns}-{pid}-{seq:06d}.jsonl.gz
+    assert re.fullmatch(r"batch-\d+-\d+-\d{6}\.jsonl\.gz", blobs[0].name), blobs[0].name
     lines = _read_jsonl_gz(blobs[0])
     assert [line["payload"] for line in lines] == ["s1", "s2"]
     assert lines[0]["kind"] == KIND_SUMMARY_GENERATED
@@ -68,6 +72,9 @@ async def test_layout_roundtrip_manifest_and_nodataset(tmp_path):
     )
     assert len(orphan_blobs) == 1
     assert [line["payload"] for line in _read_jsonl_gz(orphan_blobs[0])] == ["orphan"]
+
+    [runless_blob] = (tmp_path / dataset_id / "norun" / KIND_SUMMARY_GENERATED).glob("*.jsonl.gz")
+    assert [line["payload"] for line in _read_jsonl_gz(runless_blob)] == ["runless"]
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/observability/test_capture_storage_sink.py
+++ b/cognee/tests/unit/modules/observability/test_capture_storage_sink.py
@@ -163,8 +163,8 @@ async def test_sink_timeout_cuts_a_wedged_local_write(tmp_path):
     elapsed = time.monotonic() - started
 
     assert elapsed < 0.5  # the 0.05 s timeout, not the 1 s stall
-    assert hook._dropped == 1
-    assert not hook._buffer
+    assert hook._runtime.dropped == 1
+    assert not hook._runtime.buffer
     assert hook._in_flight_total() == 0
 
 

--- a/cognee/tests/unit/modules/observability/test_capture_storage_sink.py
+++ b/cognee/tests/unit/modules/observability/test_capture_storage_sink.py
@@ -1,19 +1,23 @@
 """StorageSink layout (SDK-529): gzip'd JSONL blobs per (dataset, run, kind) and a
 pretty manifest.json per run, written through the normal StorageManager."""
 
+import asyncio
 import gzip
 import json
 import re
+import time
 from uuid import uuid4
 
 import pytest
 
 from cognee.infrastructure.files.storage import StorageManager
 from cognee.infrastructure.files.storage.LocalFileStorage import LocalFileStorage
+from cognee.modules.observability import capture
 from cognee.modules.observability.capture import (
     KIND_RUN_MANIFEST,
     KIND_SUMMARY_GENERATED,
     StorageSink,
+    hook,
 )
 
 pytestmark = pytest.mark.usefixtures("capture_reset")
@@ -102,6 +106,66 @@ async def test_manifest_overwrite_keeps_latest_and_root_prefix(tmp_path):
 
     manifest_path = tmp_path / "evals-run-1" / dataset_id / run_id / "manifest.json"
     assert json.loads(manifest_path.read_text(encoding="utf-8"))["payload"] == {"v": 2}
+
+
+class _StalledLocalFileStorage(LocalFileStorage):
+    """A filesystem that stalls: ``store`` is an ``async def`` whose body blocks
+    without ever suspending — exactly what LocalFileStorage.store is, only slower."""
+
+    stall_s = 0.2
+
+    async def store(self, *args, **kwargs):
+        time.sleep(self.stall_s)
+        return await super().store(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_a_stalled_store_does_not_pin_the_event_loop(tmp_path):
+    """The write runs on a worker thread, so a stalled filesystem freezes neither
+    the flusher's loop nor the coroutines sharing it (a concurrent recall, the
+    pipeline awaiting drain())."""
+    sink = StorageSink(StorageManager(_StalledLocalFileStorage(str(tmp_path))))
+    run_id = str(uuid4())
+    ticks = 0
+
+    async def ticker():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    task = asyncio.create_task(ticker())
+    try:
+        await sink([_record(KIND_SUMMARY_GENERATED, run_id, None, "written")])
+    finally:
+        task.cancel()
+
+    # ~20 ticks fit in a 0.2 s stall; on-loop the ticker would have seen 0-1.
+    assert ticks >= 5
+    [blob] = (tmp_path / "nodataset" / run_id / KIND_SUMMARY_GENERATED).glob("*.jsonl.gz")
+    assert [line["payload"] for line in _read_jsonl_gz(blob)] == ["written"]
+
+
+@pytest.mark.asyncio
+async def test_sink_timeout_cuts_a_wedged_local_write(tmp_path):
+    """SINK_TIMEOUT_S can only fire at a real suspension point. Awaited on the
+    loop, LocalFileStorage.store had none, so a wedged write pinned the flusher
+    past every timeout and drain()'s documented budget was false for the default
+    sink. Off-loop, the timeout lands and the event is accounted for as dropped."""
+    storage = _StalledLocalFileStorage(str(tmp_path))
+    storage.stall_s = 1.0
+    capture.register_capture_sink(StorageSink(StorageManager(storage)))
+    hook._configure(flush_interval_s=60.0, sink_timeout_s=0.05)
+
+    capture.emit(KIND_SUMMARY_GENERATED, "wedged", payload_kind="text")
+    started = time.monotonic()
+    await capture.drain(timeout=0.5)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5  # the 0.05 s timeout, not the 1 s stall
+    assert hook._dropped == 1
+    assert not hook._buffer
+    assert hook._in_flight_total() == 0
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/ontology/test_construct_data_points_and_edges_with_ontology.py
+++ b/cognee/tests/unit/modules/ontology/test_construct_data_points_and_edges_with_ontology.py
@@ -1,11 +1,15 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 
 import cognee.modules.ontology.construct_data_points_and_edges_with_ontology as ontology_module
 
 from cognee.modules.engine.models import Entity, EntityType
+from cognee.modules.observability import capture
+from cognee.modules.observability.capture import KIND_EXTRACTION_FUZZY_MATCH, KIND_RUN_MANIFEST
 from cognee.modules.ontology.base_ontology_resolver import BaseOntologyResolver
 from cognee.modules.ontology.construct_data_points_and_edges_with_ontology import (
     add_ontology_data_points_and_edges,
@@ -302,3 +306,107 @@ def test_strict_mode_logs_one_aggregate_drop_summary(monkeypatch):
     # 1 of 4 nodes dropped, 1 of 1 edges dropped, across 2 graphs.
     assert warning_args[1:3] == (1, 4)
     assert warning_args[4:7] == (1, 1, 2)
+
+
+# --- eval capture: extraction.fuzzy_match (SDK-529) ------------------------------
+
+
+def _make_two_chunk_graphs():
+    first = KnowledgeGraph(
+        nodes=[
+            Node(id="w", name="Widget", type="Gadget", description="matched on both"),
+            Node(id="g", name="Ghost", type="Phantom", description="matched on neither"),
+        ],
+        edges=[],
+    )
+    second = KnowledgeGraph(
+        nodes=[
+            Node(id="w2", name="widget", type="Gadget", description="already looked up"),
+            Node(id="n", name="Nomatch", type="Gadget", description="new name, known type"),
+        ],
+        edges=[],
+    )
+    return [first, second]
+
+
+@pytest.mark.asyncio
+async def test_fuzzy_match_events_are_aggregated_per_chunk(fake_capture_sink):
+    chunks = [_make_chunk(), _make_chunk()]
+    graphs = _make_two_chunk_graphs()
+    run_id = uuid4()
+
+    with capture.run_scope(run_id, uuid4(), kind="pipeline"):
+        canonicalize_extracted_graphs(chunks, graphs, _StubResolver())
+    await capture.drain()
+
+    # Canonicalization itself is unchanged.
+    assert graphs[0].nodes[0].name == "widget_canonical"
+    assert graphs[0].nodes[0].type == "gadget"
+
+    events = [r for r in fake_capture_sink.records if r["kind"] == KIND_EXTRACTION_FUZZY_MATCH]
+    assert [event["payload"]["chunk_index"] for event in events] == [0, 1]
+    assert {event["run_id"] for event in events} == {str(run_id)}
+    first, second = (event["payload"] for event in events)
+
+    # One event for the chunk, listing every lookup it triggered — hits and misses.
+    assert first["chunk_id"] == str(chunks[0].id)
+    assert [
+        (m["category"], m["extracted"], m["normalized"], m["canonical"], m["matched"])
+        for m in first["matches"]
+    ] == [
+        ("classes", "Gadget", "gadget", "gadget", True),
+        ("individuals", "Widget", "widget", "widget_canonical", True),
+        ("classes", "Phantom", "phantom", None, False),
+        ("individuals", "Ghost", "ghost", None, False),
+    ]
+    assert first["matches"][1]["uri"] == "https://example.test/ontology#widget_canonical"
+    assert first["matches"][2]["uri"] is None
+    assert (first["lookups"], first["count"]) == (4, 2)
+
+    # The lookup is shared across the batch: "gadget" and "widget" were resolved by
+    # the first chunk, so the second chunk only reports the name it introduced.
+    assert first["chunk_id"] != second["chunk_id"]
+    assert [(m["category"], m["normalized"], m["matched"]) for m in second["matches"]] == [
+        ("individuals", "nomatch", False)
+    ]
+    assert (second["lookups"], second["count"]) == (1, 0)
+    # Plain scalars only.
+    json.dumps([event["payload"] for event in events])
+
+    [manifest] = [r for r in fake_capture_sink.records if r["kind"] == KIND_RUN_MANIFEST]
+    assert manifest["payload"]["counters"]["extraction.fuzzy_lookups"] == 5
+    assert manifest["payload"]["counters"]["extraction.fuzzy_matches"] == 2
+
+
+@pytest.mark.asyncio
+async def test_fuzzy_match_emits_nothing_for_a_chunk_that_triggered_no_lookup(fake_capture_sink):
+    graphs = [
+        KnowledgeGraph(
+            nodes=[Node(id="a", name="Widget", type="Gadget", description="d")], edges=[]
+        ),
+        KnowledgeGraph(
+            nodes=[Node(id="b", name="widget", type="gadget", description="d")], edges=[]
+        ),
+    ]
+
+    canonicalize_extracted_graphs([_make_chunk(), _make_chunk()], graphs, _StubResolver())
+    await capture.drain()
+
+    events = [r for r in fake_capture_sink.records if r["kind"] == KIND_EXTRACTION_FUZZY_MATCH]
+    assert [event["payload"]["chunk_index"] for event in events] == [0]
+
+
+def test_fuzzy_match_capture_off_collects_nothing(monkeypatch, capture_reset):
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("no fuzzy-match payload may be built while capture is off")
+
+    monkeypatch.setattr(ontology_module, "_emit_fuzzy_matches", _boom)
+    graphs = _make_two_chunk_graphs()
+
+    canonicalize_extracted_graphs([_make_chunk(), _make_chunk()], graphs, _StubResolver())
+
+    assert capture.is_active() is False
+    assert not capture.hook._buffer
+    assert graphs[0].nodes[0].name == "widget_canonical"

--- a/cognee/tests/unit/modules/ontology/test_construct_data_points_and_edges_with_ontology.py
+++ b/cognee/tests/unit/modules/ontology/test_construct_data_points_and_edges_with_ontology.py
@@ -396,6 +396,26 @@ async def test_fuzzy_match_emits_nothing_for_a_chunk_that_triggered_no_lookup(fa
     assert [event["payload"]["chunk_index"] for event in events] == [0]
 
 
+@pytest.mark.asyncio
+async def test_fuzzy_match_capture_never_breaks_canonicalization(fake_capture_sink):
+    """The emit point reads ``chunk.id`` while its caller never does: a duck-typed
+    chunk without one (only ``.text`` is validated upstream) must cost its event,
+    not the ontology pass — turning capture on cannot fail a working run."""
+    chunk = MagicMock()
+    del chunk.id
+    chunk.importance_weight = 0.5
+    chunk.belongs_to_set = []
+    graphs = _make_two_chunk_graphs()
+
+    canonicalize_extracted_graphs([chunk, _make_chunk()], graphs, _StubResolver())
+    await capture.drain()
+
+    assert graphs[0].nodes[0].name == "widget_canonical"
+    events = [r for r in fake_capture_sink.records if r["kind"] == KIND_EXTRACTION_FUZZY_MATCH]
+    # The id-less chunk's event is absent; the second chunk still reports.
+    assert [event["payload"]["chunk_index"] for event in events] == [1]
+
+
 def test_fuzzy_match_capture_off_collects_nothing(monkeypatch, capture_reset):
     monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
 

--- a/cognee/tests/unit/modules/ontology/test_construct_data_points_and_edges_with_ontology.py
+++ b/cognee/tests/unit/modules/ontology/test_construct_data_points_and_edges_with_ontology.py
@@ -428,5 +428,5 @@ def test_fuzzy_match_capture_off_collects_nothing(monkeypatch, capture_reset):
     canonicalize_extracted_graphs([_make_chunk(), _make_chunk()], graphs, _StubResolver())
 
     assert capture.is_active() is False
-    assert not capture.hook._buffer
+    assert not capture.hook._runtime.buffer
     assert graphs[0].nodes[0].name == "widget_canonical"

--- a/cognee/tests/unit/modules/operations/test_capture_wiring.py
+++ b/cognee/tests/unit/modules/operations/test_capture_wiring.py
@@ -1,9 +1,12 @@
 """Eval-capture wirings (SDK-529): record_operation and run_tasks open a run
 scope only when capture is active, the manifest carries the (late-bound)
-dataset, and only the pipeline runner drains.
+dataset plus the operation's name/outcome/error class, only the pipeline
+runner drains — and that drain covers the run's own manifest — and the
+FastAPI lifespan shuts capture down on exit.
 
 ``record_operation``'s row writer is stubbed; ``run_tasks`` is driven through
-``runner_plumbing``. No LLM, no network, no database.
+``runner_plumbing``; the real ``lifespan`` runs with its startup collaborators
+stubbed. No LLM, no network, no database.
 """
 
 import importlib
@@ -87,6 +90,10 @@ async def test_record_operation_emits_manifest_without_draining(
     assert manifest["dataset_id"] == str(dataset_id)
     assert manifest["payload"]["kind"] == "operation"
     assert manifest["payload"]["dataset_id"] == str(dataset_id)
+    # The row's attribution fields are mirrored into the manifest.
+    assert manifest["payload"]["operation"] == "search"
+    assert manifest["payload"]["outcome"] == "succeeded"
+    assert manifest["payload"]["error_class"] is None
     # The event buffered before set_dataset() picked the dataset up too.
     [event] = [r for r in fake_capture_sink.records if r["kind"] == KIND_SUMMARY_GENERATED]
     assert event["run_id"] == str(context.operation_id)
@@ -109,6 +116,9 @@ async def test_record_operation_failure_still_emits_manifest_and_reraises(
     [manifest] = _manifests(fake_capture_sink)
     assert manifest["run_id"] == str(context.operation_id)
     assert manifest["dataset_id"] is None
+    assert manifest["payload"]["operation"] == "recall"
+    assert manifest["payload"]["outcome"] == "failed"
+    assert manifest["payload"]["error_class"] == "ValueError"
 
 
 # ---------------------------------------------------------------------------
@@ -213,6 +223,45 @@ async def test_run_tasks_drains_once_on_the_error_path(
 
 
 @pytest.mark.asyncio
+async def test_run_tasks_manifest_is_in_the_sink_before_the_terminal_yield(
+    monkeypatch, runner_plumbing, fake_capture_sink
+):
+    """The pipeline's own drain delivers its manifest.
+
+    By the time the consumer receives the terminal event the sink already
+    holds the run's manifest — no consumer-side drain, no flusher tick and no
+    atexit hook involved — even though the scope itself only exits once the
+    generator is finalized.
+    """
+    dataset = SimpleNamespace(id=uuid4(), name="ds", owner_id=uuid4())
+    runner_plumbing(run_tasks_module, dataset)
+
+    async def fake_item(*args, **kwargs):
+        capture.emit(KIND_SUMMARY_GENERATED, "from a task", payload_kind="text")
+        return {"run_info": "ok"}
+
+    monkeypatch.setattr(run_tasks_module, "run_tasks_data_item", fake_item)
+
+    manifests_at_yield = []
+    async for event in run_tasks_module.run_tasks(
+        tasks=[],
+        dataset_id=dataset.id,
+        data=["a"],
+        user=SimpleNamespace(id=uuid4(), tenant_id=None),
+        pipeline_name="cognify_pipeline",
+    ):
+        manifests_at_yield.append((type(event).__name__, len(_manifests(fake_capture_sink))))
+
+    assert manifests_at_yield == [("PipelineRunStarted", 0), ("PipelineRunCompleted", 1)]
+    assert not capture.hook._buffer
+    [manifest] = _manifests(fake_capture_sink)
+    assert manifest["payload"]["kind"] == "pipeline"
+    # The task's event and the manifest share the run id: joinable offline.
+    [event] = [r for r in fake_capture_sink.records if r["kind"] == KIND_SUMMARY_GENERATED]
+    assert event["run_id"] == manifest["run_id"]
+
+
+@pytest.mark.asyncio
 async def test_run_tasks_skips_capture_when_off(monkeypatch, runner_plumbing):
     monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
     dataset = SimpleNamespace(id=uuid4(), name="ds", owner_id=uuid4())
@@ -233,3 +282,64 @@ async def test_run_tasks_skips_capture_when_off(monkeypatch, runner_plumbing):
 
     assert seen_scopes == [None]
     spy.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 16: FastAPI lifespan
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def quiet_lifespan_startup(monkeypatch):
+    """Stub the lifespan's startup collaborators so the real ``lifespan`` runs
+    with no database: migrations, default-user creation and stale-run recovery.
+    They are imported lazily inside ``lifespan``, so the patch targets the
+    source modules, not ``cognee.api.client``. Resolved through importlib:
+    ``cognee/__init__.py`` re-exports ``run_migrations`` the function, so
+    ``import cognee.run_migrations as m`` would bind that, not the module."""
+    recovery_mod = importlib.import_module("cognee.modules.cognify.recovery")
+    users_methods = importlib.import_module("cognee.modules.users.methods")
+    run_migrations_mod = importlib.import_module("cognee.run_migrations")
+
+    monkeypatch.setattr(run_migrations_mod, "run_migrations", AsyncMock())
+    monkeypatch.setattr(users_methods, "get_default_user", AsyncMock())
+    monkeypatch.setattr(recovery_mod, "recover_stale_cognify_runs_on_startup", AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_lifespan_shutdown_flushes_capture_and_stops_the_flusher(
+    quiet_lifespan_startup, fake_capture_sink
+):
+    import asyncio
+
+    import cognee.api.client as client_module
+
+    async with client_module.lifespan(client_module.app):
+        # One request's worth of events: buffered, not yet flushed.
+        capture.emit(KIND_SUMMARY_GENERATED, "last request", payload_kind="text")
+        [flusher] = capture.hook._flushers.values()
+        assert not fake_capture_sink.records
+
+    # Delivered by the lifespan's own shutdown — not a flusher tick, not atexit.
+    assert [r["payload"] for r in fake_capture_sink.records] == ["last request"]
+    assert not capture.hook._buffer
+    assert flusher.task.cancelled()
+    # The stopped flusher stays as a tombstone: a late emit during teardown
+    # must not start a fresh flusher on a loop that is going away.
+    assert capture.hook._flushers[asyncio.get_running_loop()] is flusher
+
+
+@pytest.mark.asyncio
+async def test_lifespan_shutdown_skips_capture_when_off(monkeypatch, quiet_lifespan_startup):
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+    spy = AsyncMock()
+    monkeypatch.setattr(capture, "shutdown", spy)
+
+    import cognee.api.client as client_module
+
+    async with client_module.lifespan(client_module.app):
+        pass
+
+    assert capture.is_active() is False
+    spy.assert_not_awaited()
+    assert not capture.hook._flushers

--- a/cognee/tests/unit/modules/operations/test_capture_wiring.py
+++ b/cognee/tests/unit/modules/operations/test_capture_wiring.py
@@ -1,0 +1,223 @@
+"""Eval-capture wirings (SDK-529): record_operation and run_tasks open a run
+scope only when capture is active, the manifest carries the (late-bound)
+dataset, and only the pipeline runner drains.
+
+``record_operation``'s row writer is stubbed; ``run_tasks`` is driven through
+``runner_plumbing``. No LLM, no network, no database.
+"""
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+import cognee.modules.pipelines.operations.run_tasks as run_tasks_module
+from cognee.modules.observability import capture
+from cognee.modules.observability.capture import KIND_RUN_MANIFEST, KIND_SUMMARY_GENERATED
+
+record_operation_mod = importlib.import_module("cognee.modules.operations.record_operation")
+
+pytestmark = pytest.mark.usefixtures("capture_reset")
+
+
+@pytest.fixture
+def no_row_writes(monkeypatch):
+    monkeypatch.setattr(record_operation_mod, "_write_operation_row", AsyncMock())
+
+
+@pytest.fixture
+def drain_spy(monkeypatch):
+    """Replace capture.drain with a spy; returns (spy, real_drain)."""
+    real_drain = capture.drain
+    spy = AsyncMock()
+    monkeypatch.setattr(capture, "drain", spy)
+    return spy, real_drain
+
+
+def _manifests(sink):
+    return [record for record in sink.records if record["kind"] == KIND_RUN_MANIFEST]
+
+
+# ---------------------------------------------------------------------------
+# 14: record_operation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_operation_opens_no_scope_when_capture_is_off(monkeypatch, no_row_writes):
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+
+    async with record_operation_mod.record_operation("search") as context:
+        assert capture.is_active() is False
+        assert capture.current_scope() is None
+        context.set_dataset(uuid4())
+
+    from cognee.modules.observability.capture import hook
+
+    assert not hook._buffer
+    assert not hook._flushers
+
+
+@pytest.mark.asyncio
+async def test_record_operation_emits_manifest_without_draining(
+    no_row_writes, fake_capture_sink, drain_spy
+):
+    spy, real_drain = drain_spy
+    dataset_id = uuid4()
+
+    async with record_operation_mod.record_operation("search") as context:
+        scope = capture.current_scope()
+        assert scope is not None
+        assert scope.kind == "operation"
+        assert scope.run_id == context.operation_id
+        assert scope.dataset_id is None
+        capture.emit(KIND_SUMMARY_GENERATED, "inside", payload_kind="text")
+        # Bound mid-body, the way recall/search do it.
+        context.set_dataset(dataset_id)
+
+    spy.assert_not_awaited()
+    assert capture.current_scope() is None
+
+    await real_drain()
+
+    [manifest] = _manifests(fake_capture_sink)
+    assert manifest["run_id"] == str(context.operation_id)
+    assert manifest["dataset_id"] == str(dataset_id)
+    assert manifest["payload"]["kind"] == "operation"
+    assert manifest["payload"]["dataset_id"] == str(dataset_id)
+    # The event buffered before set_dataset() picked the dataset up too.
+    [event] = [r for r in fake_capture_sink.records if r["kind"] == KIND_SUMMARY_GENERATED]
+    assert event["run_id"] == str(context.operation_id)
+    assert event["dataset_id"] == str(dataset_id)
+
+
+@pytest.mark.asyncio
+async def test_record_operation_failure_still_emits_manifest_and_reraises(
+    no_row_writes, fake_capture_sink, drain_spy
+):
+    spy, real_drain = drain_spy
+
+    with pytest.raises(ValueError, match="boom"):
+        async with record_operation_mod.record_operation("recall") as context:
+            raise ValueError("boom")
+
+    spy.assert_not_awaited()
+    await real_drain()
+
+    [manifest] = _manifests(fake_capture_sink)
+    assert manifest["run_id"] == str(context.operation_id)
+    assert manifest["dataset_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# 15: run_tasks
+# ---------------------------------------------------------------------------
+
+
+async def _drive(run_tasks_module_, dataset):
+    events = []
+    async for event in run_tasks_module_.run_tasks(
+        tasks=[],
+        dataset_id=dataset.id,
+        data=["a"],
+        user=SimpleNamespace(id=uuid4(), tenant_id=None),
+        pipeline_name="cognify_pipeline",
+    ):
+        events.append(event)
+    return events
+
+
+@pytest.mark.asyncio
+async def test_run_tasks_opens_pipeline_scope_and_drains_once_after_terminal_log(
+    monkeypatch, runner_plumbing, fake_capture_sink
+):
+    dataset = SimpleNamespace(id=uuid4(), name="ds", owner_id=uuid4())
+    logs = runner_plumbing(run_tasks_module, dataset)
+
+    order = []
+    logs.complete.side_effect = lambda *args, **kwargs: order.append("complete")
+    real_drain = capture.drain
+
+    async def spy_drain(timeout=5.0):
+        order.append("drain")
+
+    monkeypatch.setattr(capture, "drain", spy_drain)
+
+    seen_scopes = []
+
+    async def fake_item(*args, **kwargs):
+        seen_scopes.append(capture.current_scope())
+        return {"run_info": "ok"}
+
+    monkeypatch.setattr(run_tasks_module, "run_tasks_data_item", fake_item)
+
+    events = await _drive(run_tasks_module, dataset)
+    pipeline_run_id = events[0].pipeline_run_id
+
+    assert order == ["complete", "drain"]
+    [scope] = seen_scopes
+    assert scope.kind == "pipeline"
+    assert scope.run_id == pipeline_run_id
+    assert scope.dataset_id == dataset.id
+    assert scope.sampled is True
+    assert capture.current_scope() is None
+
+    await real_drain()
+
+    [manifest] = _manifests(fake_capture_sink)
+    assert manifest["run_id"] == str(pipeline_run_id)
+    assert manifest["dataset_id"] == str(dataset.id)
+    assert manifest["payload"]["kind"] == "pipeline"
+    assert manifest["payload"]["sampled"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_tasks_drains_once_on_the_error_path(
+    monkeypatch, runner_plumbing, fake_capture_sink
+):
+    dataset = SimpleNamespace(id=uuid4(), name="ds", owner_id=uuid4())
+    logs = runner_plumbing(run_tasks_module, dataset)
+
+    order = []
+    logs.error.side_effect = lambda *args, **kwargs: order.append("error")
+
+    async def spy_drain(timeout=5.0):
+        order.append("drain")
+
+    monkeypatch.setattr(capture, "drain", spy_drain)
+
+    async def failing_item(*args, **kwargs):
+        raise RuntimeError("item exploded")
+
+    monkeypatch.setattr(run_tasks_module, "run_tasks_data_item", failing_item)
+
+    with pytest.raises(RuntimeError, match="item exploded"):
+        await _drive(run_tasks_module, dataset)
+
+    assert order == ["error", "drain"]
+    logs.complete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_tasks_skips_capture_when_off(monkeypatch, runner_plumbing):
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+    dataset = SimpleNamespace(id=uuid4(), name="ds", owner_id=uuid4())
+    runner_plumbing(run_tasks_module, dataset)
+
+    spy = AsyncMock()
+    monkeypatch.setattr(capture, "drain", spy)
+
+    seen_scopes = []
+
+    async def fake_item(*args, **kwargs):
+        seen_scopes.append(capture.current_scope())
+        return {"run_info": "ok"}
+
+    monkeypatch.setattr(run_tasks_module, "run_tasks_data_item", fake_item)
+
+    await _drive(run_tasks_module, dataset)
+
+    assert seen_scopes == [None]
+    spy.assert_not_awaited()

--- a/cognee/tests/unit/modules/operations/test_capture_wiring.py
+++ b/cognee/tests/unit/modules/operations/test_capture_wiring.py
@@ -142,6 +142,7 @@ async def test_run_tasks_opens_pipeline_scope_and_drains_once_after_terminal_log
 
     async def spy_drain(timeout=5.0):
         order.append("drain")
+        await real_drain(timeout)
 
     monkeypatch.setattr(capture, "drain", spy_drain)
 
@@ -162,15 +163,19 @@ async def test_run_tasks_opens_pipeline_scope_and_drains_once_after_terminal_log
     assert scope.run_id == pipeline_run_id
     assert scope.dataset_id == dataset.id
     assert scope.sampled is True
+    assert scope.finished is True
     assert capture.current_scope() is None
 
-    await real_drain()
-
+    # The run's own drain covered its manifest (finish() ran before it); the
+    # scope's exit — after the terminal yield — did not enqueue a duplicate.
+    assert not capture.hook._buffer
     [manifest] = _manifests(fake_capture_sink)
     assert manifest["run_id"] == str(pipeline_run_id)
     assert manifest["dataset_id"] == str(dataset.id)
     assert manifest["payload"]["kind"] == "pipeline"
     assert manifest["payload"]["sampled"] is True
+    await real_drain()
+    assert len(_manifests(fake_capture_sink)) == 1
 
 
 @pytest.mark.asyncio
@@ -182,9 +187,11 @@ async def test_run_tasks_drains_once_on_the_error_path(
 
     order = []
     logs.error.side_effect = lambda *args, **kwargs: order.append("error")
+    real_drain = capture.drain
 
     async def spy_drain(timeout=5.0):
         order.append("drain")
+        await real_drain(timeout)
 
     monkeypatch.setattr(capture, "drain", spy_drain)
 
@@ -198,6 +205,11 @@ async def test_run_tasks_drains_once_on_the_error_path(
 
     assert order == ["error", "drain"]
     logs.complete.assert_not_awaited()
+    # The error path finishes the scope before draining too.
+    [manifest] = _manifests(fake_capture_sink)
+    assert manifest["payload"]["kind"] == "pipeline"
+    await real_drain()
+    assert len(_manifests(fake_capture_sink)) == 1
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/operations/test_capture_wiring.py
+++ b/cognee/tests/unit/modules/operations/test_capture_wiring.py
@@ -101,6 +101,33 @@ async def test_record_operation_emits_manifest_without_draining(
 
 
 @pytest.mark.asyncio
+async def test_set_dataset_reaches_events_flushed_while_the_operation_is_still_running(
+    no_row_writes, fake_capture_sink
+):
+    """The reproduction of the ``nodataset/`` split: search() binds its dataset on
+    the OperationContext before retrieval runs, retrieval emits, and the flusher
+    ticks (every FLUSH_INTERVAL_S) while the LLM completion is still running.
+    Forwarding only in record_operation's ``finally`` filed those events under
+    ``nodataset/`` and the manifest under ``<dataset>/``. The bind must reach the
+    capture scope the moment the caller makes it."""
+    dataset_id = uuid4()
+
+    async with record_operation_mod.record_operation("search") as context:
+        context.set_dataset(dataset_id)
+        assert capture.current_scope().dataset_id == dataset_id
+        capture.emit(KIND_SUMMARY_GENERATED, "candidates", payload_kind="text")
+        # A flush tick lands mid-body, long before the operation ends.
+        await capture.drain()
+        [event] = [r for r in fake_capture_sink.records if r["kind"] == KIND_SUMMARY_GENERATED]
+        assert event["dataset_id"] == str(dataset_id)
+
+    await capture.drain()
+    [manifest] = _manifests(fake_capture_sink)
+    assert manifest["dataset_id"] == str(dataset_id)
+    assert manifest["payload"]["dataset_id"] == str(dataset_id)
+
+
+@pytest.mark.asyncio
 async def test_record_operation_failure_still_emits_manifest_and_reraises(
     no_row_writes, fake_capture_sink, drain_spy
 ):

--- a/cognee/tests/unit/modules/operations/test_capture_wiring.py
+++ b/cognee/tests/unit/modules/operations/test_capture_wiring.py
@@ -59,8 +59,8 @@ async def test_record_operation_opens_no_scope_when_capture_is_off(monkeypatch, 
 
     from cognee.modules.observability.capture import hook
 
-    assert not hook._buffer
-    assert not hook._flushers
+    assert not hook._runtime.buffer
+    assert not hook._runtime.flushers
 
 
 @pytest.mark.asyncio
@@ -207,7 +207,7 @@ async def test_run_tasks_drains_its_events_then_its_manifest_after_the_terminal_
     assert capture.current_scope() is None
 
     # The scope's exit — after the terminal yield — did not enqueue a duplicate.
-    assert not capture.hook._buffer
+    assert not capture.hook._runtime.buffer
     [manifest] = _manifests(fake_capture_sink)
     assert manifest["run_id"] == str(pipeline_run_id)
     assert manifest["dataset_id"] == str(dataset.id)
@@ -290,7 +290,7 @@ async def test_run_tasks_leaves_the_manifest_to_the_flusher_when_its_drain_did_n
 
     assert len(drains) == 1
     # Finished (so exit will not emit a duplicate) and buffered, not delivered.
-    assert [event.kind for event in capture.hook._buffer] == [KIND_RUN_MANIFEST]
+    assert [event.kind for event in capture.hook._runtime.buffer] == [KIND_RUN_MANIFEST]
     assert _manifests(fake_capture_sink) == []
 
 
@@ -325,7 +325,7 @@ async def test_run_tasks_manifest_is_in_the_sink_before_the_terminal_yield(
         manifests_at_yield.append((type(event).__name__, len(_manifests(fake_capture_sink))))
 
     assert manifests_at_yield == [("PipelineRunStarted", 0), ("PipelineRunCompleted", 1)]
-    assert not capture.hook._buffer
+    assert not capture.hook._runtime.buffer
     [manifest] = _manifests(fake_capture_sink)
     assert manifest["payload"]["kind"] == "pipeline"
     # The task's event and the manifest share the run id: joinable offline.
@@ -391,16 +391,16 @@ async def test_lifespan_shutdown_flushes_capture_and_stops_the_flusher(
     async with client_module.lifespan(client_module.app):
         # One request's worth of events: buffered, not yet flushed.
         capture.emit(KIND_SUMMARY_GENERATED, "last request", payload_kind="text")
-        [flusher] = capture.hook._flushers.values()
+        [flusher] = capture.hook._runtime.flushers.values()
         assert not fake_capture_sink.records
 
     # Delivered by the lifespan's own shutdown — not a flusher tick, not atexit.
     assert [r["payload"] for r in fake_capture_sink.records] == ["last request"]
-    assert not capture.hook._buffer
+    assert not capture.hook._runtime.buffer
     assert flusher.task.cancelled()
     # The stopped flusher stays as a tombstone: a late emit during teardown
     # must not start a fresh flusher on a loop that is going away.
-    assert capture.hook._flushers[asyncio.get_running_loop()] is flusher
+    assert capture.hook._runtime.flushers[asyncio.get_running_loop()] is flusher
 
 
 @pytest.mark.asyncio
@@ -416,4 +416,4 @@ async def test_lifespan_shutdown_skips_capture_when_off(monkeypatch, quiet_lifes
 
     assert capture.is_active() is False
     spy.assert_not_awaited()
-    assert not capture.hook._flushers
+    assert not capture.hook._runtime.flushers

--- a/cognee/tests/unit/modules/operations/test_capture_wiring.py
+++ b/cognee/tests/unit/modules/operations/test_capture_wiring.py
@@ -167,7 +167,7 @@ async def _drive(run_tasks_module_, dataset):
 
 
 @pytest.mark.asyncio
-async def test_run_tasks_opens_pipeline_scope_and_drains_once_after_terminal_log(
+async def test_run_tasks_drains_its_events_then_its_manifest_after_the_terminal_log(
     monkeypatch, runner_plumbing, fake_capture_sink
 ):
     dataset = SimpleNamespace(id=uuid4(), name="ds", owner_id=uuid4())
@@ -177,9 +177,9 @@ async def test_run_tasks_opens_pipeline_scope_and_drains_once_after_terminal_log
     logs.complete.side_effect = lambda *args, **kwargs: order.append("complete")
     real_drain = capture.drain
 
-    async def spy_drain(timeout=5.0):
+    async def spy_drain(timeout=None):
         order.append("drain")
-        await real_drain(timeout)
+        return await real_drain(timeout)
 
     monkeypatch.setattr(capture, "drain", spy_drain)
 
@@ -187,6 +187,7 @@ async def test_run_tasks_opens_pipeline_scope_and_drains_once_after_terminal_log
 
     async def fake_item(*args, **kwargs):
         seen_scopes.append(capture.current_scope())
+        capture.emit(KIND_SUMMARY_GENERATED, "from a task", payload_kind="text")
         return {"run_info": "ok"}
 
     monkeypatch.setattr(run_tasks_module, "run_tasks_data_item", fake_item)
@@ -194,7 +195,9 @@ async def test_run_tasks_opens_pipeline_scope_and_drains_once_after_terminal_log
     events = await _drive(run_tasks_module, dataset)
     pipeline_run_id = events[0].pipeline_run_id
 
-    assert order == ["complete", "drain"]
+    # Events first, then — once that drain completed — the manifest, so its
+    # accounting describes what actually reached the sink.
+    assert order == ["complete", "drain", "drain"]
     [scope] = seen_scopes
     assert scope.kind == "pipeline"
     assert scope.run_id == pipeline_run_id
@@ -203,20 +206,29 @@ async def test_run_tasks_opens_pipeline_scope_and_drains_once_after_terminal_log
     assert scope.finished is True
     assert capture.current_scope() is None
 
-    # The run's own drain covered its manifest (finish() ran before it); the
-    # scope's exit — after the terminal yield — did not enqueue a duplicate.
+    # The scope's exit — after the terminal yield — did not enqueue a duplicate.
     assert not capture.hook._buffer
     [manifest] = _manifests(fake_capture_sink)
     assert manifest["run_id"] == str(pipeline_run_id)
     assert manifest["dataset_id"] == str(dataset.id)
-    assert manifest["payload"]["kind"] == "pipeline"
-    assert manifest["payload"]["sampled"] is True
+    payload = manifest["payload"]
+    assert payload["kind"] == "pipeline"
+    assert payload["sampled"] is True
+    # The pipeline log's attribution, mirrored like an operation manifest mirrors its row.
+    assert payload["pipeline_name"] == "cognify_pipeline"
+    assert payload["outcome"] == "succeeded"
+    assert payload["error_class"] is None
+    # Exact per-run accounting, taken after the run's events were delivered.
+    assert payload["events_emitted"] == 1
+    assert payload["events_delivered"] == 1
+    assert payload["events_dropped"] == 0
+    assert payload["capture_complete"] is True
     await real_drain()
     assert len(_manifests(fake_capture_sink)) == 1
 
 
 @pytest.mark.asyncio
-async def test_run_tasks_drains_once_on_the_error_path(
+async def test_run_tasks_reports_the_failure_on_the_error_path(
     monkeypatch, runner_plumbing, fake_capture_sink
 ):
     dataset = SimpleNamespace(id=uuid4(), name="ds", owner_id=uuid4())
@@ -226,9 +238,9 @@ async def test_run_tasks_drains_once_on_the_error_path(
     logs.error.side_effect = lambda *args, **kwargs: order.append("error")
     real_drain = capture.drain
 
-    async def spy_drain(timeout=5.0):
+    async def spy_drain(timeout=None):
         order.append("drain")
-        await real_drain(timeout)
+        return await real_drain(timeout)
 
     monkeypatch.setattr(capture, "drain", spy_drain)
 
@@ -240,13 +252,46 @@ async def test_run_tasks_drains_once_on_the_error_path(
     with pytest.raises(RuntimeError, match="item exploded"):
         await _drive(run_tasks_module, dataset)
 
-    assert order == ["error", "drain"]
+    assert order == ["error", "drain", "drain"]
     logs.complete.assert_not_awaited()
-    # The error path finishes the scope before draining too.
+    # A failed run is identifiable from its manifest alone: an eval must be able
+    # to exclude a cognify that died halfway without joining back to the logs.
     [manifest] = _manifests(fake_capture_sink)
     assert manifest["payload"]["kind"] == "pipeline"
+    assert manifest["payload"]["pipeline_name"] == "cognify_pipeline"
+    assert manifest["payload"]["outcome"] == "failed"
+    assert manifest["payload"]["error_class"] == "RuntimeError"
     await real_drain()
     assert len(_manifests(fake_capture_sink)) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_tasks_leaves_the_manifest_to_the_flusher_when_its_drain_did_not_finish(
+    monkeypatch, runner_plumbing, fake_capture_sink
+):
+    """Under a wedged sink the first drain runs out of budget; a second full
+    budget for the manifest would double the pipeline's tail latency, so the
+    manifest is finished but left to the flusher / atexit hook instead."""
+    dataset = SimpleNamespace(id=uuid4(), name="ds", owner_id=uuid4())
+    runner_plumbing(run_tasks_module, dataset)
+
+    drains = []
+
+    async def incomplete_drain(timeout=None):
+        drains.append(timeout)
+        return False
+
+    monkeypatch.setattr(capture, "drain", incomplete_drain)
+    monkeypatch.setattr(
+        run_tasks_module, "run_tasks_data_item", AsyncMock(return_value={"run_info": "ok"})
+    )
+
+    await _drive(run_tasks_module, dataset)
+
+    assert len(drains) == 1
+    # Finished (so exit will not emit a duplicate) and buffered, not delivered.
+    assert [event.kind for event in capture.hook._buffer] == [KIND_RUN_MANIFEST]
+    assert _manifests(fake_capture_sink) == []
 
 
 @pytest.mark.asyncio
@@ -286,6 +331,8 @@ async def test_run_tasks_manifest_is_in_the_sink_before_the_terminal_yield(
     # The task's event and the manifest share the run id: joinable offline.
     [event] = [r for r in fake_capture_sink.records if r["kind"] == KIND_SUMMARY_GENERATED]
     assert event["run_id"] == manifest["run_id"]
+    # And the event was delivered before the manifest counted it.
+    assert manifest["payload"]["events_delivered"] == manifest["payload"]["events_emitted"] == 1
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
+++ b/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
@@ -1537,3 +1537,66 @@ async def test_candidates_capture_failure_never_breaks_the_search(monkeypatch, f
     assert results == [edge]
     await capture.drain()
     assert _candidate_events(fake_capture_sink) == []
+
+
+@pytest.mark.asyncio
+async def test_missing_distances_fall_back_to_the_triplet_distance_penalty(fake_capture_sink):
+    """Every ``score`` fallback path, which the well-formed fixtures never exercise.
+
+    The penalty machinery exists because triplet endpoints frequently carry no
+    distance for a given query, so a regression that hardcoded the default or
+    returned 0.0 would silently corrupt the ranking-input score in every captured
+    record. Covered here: a missing ``vector_distance`` key, a list too short for
+    this query index, a non-numeric entry, and a pool row with no ``.score``.
+    """
+    edge = _capture_edge("a", "b", "knows", ([0.5], [1.5], [2.5]))
+    del edge.node2.attributes["vector_distance"]  # missing key -> penalty
+    edge.attributes["vector_distance"] = []  # too short for index 0 -> penalty
+
+    short = _capture_edge("c", "d", "likes", ([0.25], [0.25], [0.25]))
+    short.node1.attributes["vector_distance"] = ["not-a-number"]  # TypeError/ValueError -> penalty
+
+    class _NoScore:
+        id = "no-score"
+
+    engine = _capture_vector_engine(single={"Entity_name": [_NoScore()]})
+
+    results = await _capture_search(
+        engine,
+        _capture_fragment([edge, short]),
+        query="q",
+        node_name=None,
+        triplet_distance_penalty=9.0,
+    )
+    assert results == [edge, short]
+
+    await capture.drain()
+    [event] = _candidate_events(fake_capture_sink)
+    payload = event["payload"]
+
+    # node1 keeps its 0.5; edge and node2 both fall back to the explicit 9.0.
+    assert payload["top_k"][0]["score"] == pytest.approx(0.5 + 9.0 + 9.0)
+    # node1's entry is non-numeric -> penalty; the other two are real.
+    assert payload["top_k"][1]["score"] == pytest.approx(9.0 + 0.25 + 0.25)
+    # A pool row with no .score falls back to the same penalty.
+    assert payload["pool"] == [{"id": "no-score", "collection": "Entity_name", "score": 9.0}]
+
+
+@pytest.mark.asyncio
+async def test_the_default_penalty_is_used_when_none_is_passed(fake_capture_sink):
+    """``triplet_distance_penalty=None`` means the 6.5 retrieval default, not 0.0."""
+    edge = _capture_edge("a", "b", "knows", ([0.5], [1.5], [2.5]))
+    del edge.node2.attributes["vector_distance"]
+    engine = _capture_vector_engine(single={"Entity_name": [MockScoredResult("a", 0.1)]})
+
+    await _capture_search(
+        engine,
+        _capture_fragment([edge]),
+        query="q",
+        node_name=None,
+        triplet_distance_penalty=None,
+    )
+
+    await capture.drain()
+    [event] = _candidate_events(fake_capture_sink)
+    assert event["payload"]["top_k"][0]["score"] == pytest.approx(0.5 + 1.5 + 6.5)

--- a/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
+++ b/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
@@ -1,7 +1,11 @@
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
+from uuid import uuid4
 
 from cognee.exceptions import CogneeValidationError
+from cognee.modules.observability import capture
+from cognee.modules.observability.capture import KIND_RETRIEVAL_CANDIDATES
+from cognee.modules.retrieval.utils import brute_force_triplet_search as bfts_module
 from cognee.modules.retrieval.utils.brute_force_triplet_search import (
     brute_force_triplet_search,
     get_memory_fragment,
@@ -9,6 +13,7 @@ from cognee.modules.retrieval.utils.brute_force_triplet_search import (
 )
 from cognee.modules.graph.models.EdgeType import EdgeType
 from cognee.modules.graph.cognee_graph.CogneeGraph import CogneeGraph
+from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge, Node
 from cognee.modules.graph.exceptions.exceptions import EntityNotFoundError
 from cognee.infrastructure.databases.vector.exceptions.exceptions import CollectionNotFoundError
 
@@ -1262,3 +1267,273 @@ async def test_cognee_graph_mapping_batch_shapes():
     assert node1.attributes.get("vector_distance") == [0.95, 6.5]
     assert node2.attributes.get("vector_distance") == [6.5, 0.87]
     assert edge.attributes.get("vector_distance") == [0.92, 0.88]
+
+
+# ---------------------------------------------------------------------------
+# Eval capture (SDK-529): retrieval.candidates events and bounding-setting notes.
+# The vector engine and the memory fragment are faked exactly as above; the
+# fragment returns real CogneeGraph Edge objects so the flat payload is built
+# from the same attribute paths production uses. No LLM, no database.
+# ---------------------------------------------------------------------------
+
+
+def _capture_vector_engine(single=None, batch=None):
+    """A vector engine whose per-collection results are given as dicts."""
+    engine = AsyncMock()
+    engine.embedding_engine = AsyncMock()
+    engine.embedding_engine.embed_text = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+    if single is not None:
+        engine.search = AsyncMock(side_effect=lambda **kw: single.get(kw["collection_name"], []))
+    if batch is not None:
+        engine.batch_search = AsyncMock(
+            side_effect=lambda **kw: batch.get(
+                kw["collection_name"], [[] for _ in kw["query_texts"]]
+            )
+        )
+    return engine
+
+
+def _capture_edge(source, target, rel, distances):
+    """A real Edge whose source, edge, and target carry per-query vector distances."""
+    node1 = Node(source, {"name": source})
+    node2 = Node(target, {"name": target})
+    edge = Edge(node1, node2, attributes={"relationship_type": rel})
+    for element, element_distances in zip((node1, edge, node2), distances):
+        element.attributes["vector_distance"] = list(element_distances)
+    return edge
+
+
+def _capture_fragment(results):
+    return AsyncMock(
+        map_vector_distances_to_graph_nodes=AsyncMock(),
+        map_vector_distances_to_graph_edges=AsyncMock(),
+        calculate_top_triplet_importances=AsyncMock(return_value=results),
+    )
+
+
+async def _capture_search(engine, fragment, **kwargs):
+    with (
+        patch(
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
+            return_value=engine,
+        ),
+        patch(
+            "cognee.modules.retrieval.utils.brute_force_triplet_search.get_memory_fragment",
+            return_value=fragment,
+        ),
+    ):
+        return await brute_force_triplet_search(**kwargs)
+
+
+def _candidate_events(sink):
+    return [record for record in sink.records if record["kind"] == KIND_RETRIEVAL_CANDIDATES]
+
+
+def _assert_flat(value):
+    """Every leaf is a JSON scalar: no ScoredResult, Node, Edge, or other object leaks."""
+    if isinstance(value, dict):
+        for item in value.values():
+            _assert_flat(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_flat(item)
+    else:
+        assert value is None or isinstance(value, (str, int, float, bool)), repr(value)
+
+
+@pytest.mark.asyncio
+async def test_capture_off_builds_no_retrieval_payload(monkeypatch, capture_reset):
+    """(a) With capture off the search never constructs a payload or buffers an event."""
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+    builder = MagicMock(side_effect=AssertionError("payload built while capture is off"))
+    monkeypatch.setattr(bfts_module, "_retrieval_candidates_payload", builder)
+
+    edge = _capture_edge("a", "b", "knows", ([0.1], [0.2], [0.3]))
+    engine = _capture_vector_engine(single={"Entity_name": [MockScoredResult("a", 0.1)]})
+
+    results = await _capture_search(engine, _capture_fragment([edge]), query="q", node_name=None)
+
+    assert results == [edge]
+    assert capture.is_active() is False
+    builder.assert_not_called()
+    assert not capture.hook._buffer
+
+
+@pytest.mark.asyncio
+async def test_sampled_out_search_records_notes_without_event(monkeypatch, fake_capture_sink):
+    """(b) A run sampled out still records the bounding settings; no event, no payload."""
+    capture.hook._configure(sample_rate=0.0)
+    builder = MagicMock(side_effect=AssertionError("payload built for a sampled-out run"))
+    monkeypatch.setattr(bfts_module, "_retrieval_candidates_payload", builder)
+
+    edge = _capture_edge("a", "b", "knows", ([0.1], [0.2], [0.3]))
+    engine = _capture_vector_engine(single={"Entity_name": [MockScoredResult("a", 0.1)]})
+
+    with capture.run_scope(uuid4(), kind="operation") as scope:
+        assert scope.sampled is False
+        results = await _capture_search(
+            engine,
+            _capture_fragment([edge]),
+            query="q",
+            node_name=None,
+            top_k=3,
+            wide_search_top_k=7,
+            neighborhood_seed_top_k=4,
+            feedback_influence=0.2,
+            collections=["Entity_name"],
+        )
+
+    assert results == [edge]
+    assert scope.fields == {
+        "retrieval.top_k": 3,
+        "retrieval.wide_search_top_k": 7,
+        "retrieval.neighborhood_seed_top_k": 4,
+        "retrieval.feedback_influence": 0.2,
+        "retrieval.mode": "single",
+        "retrieval.collections": ["Entity_name", "EdgeType_relationship_name"],
+    }
+    builder.assert_not_called()
+    await capture.drain()
+    assert _candidate_events(fake_capture_sink) == []
+
+
+@pytest.mark.asyncio
+async def test_sampled_in_search_emits_flat_capped_candidates(fake_capture_sink):
+    """(c) One flat event: scalar-only pool/top_k, pool capped at 500, cut_size == len(top_k)."""
+    entity_rows = [MockScoredResult(f"n{i}", i / 1000) for i in range(600)]
+    edge_rows = [MockScoredResult(f"e{i}", 0.5 + i / 100) for i in range(3)]
+    engine = _capture_vector_engine(
+        single={"Entity_name": entity_rows, "EdgeType_relationship_name": edge_rows}
+    )
+    edges = [
+        _capture_edge("a", "b", "knows", ([0.1], [0.2], [0.3])),
+        _capture_edge("b", "c", "likes", ([0.4], [0.5], [0.6])),
+    ]
+
+    results = await _capture_search(
+        engine, _capture_fragment(edges), query="q", node_name=None, top_k=2
+    )
+    assert results == edges
+
+    await capture.drain()
+    [event] = _candidate_events(fake_capture_sink)
+    assert event["stage"] == "brute_force_triplet_search"
+    payload = event["payload"]
+    assert set(payload) == {
+        "query_index",
+        "pool",
+        "top_k",
+        "pool_size",
+        "pool_truncated",
+        "cut_size",
+    }
+    _assert_flat(payload)
+    assert payload["query_index"] == 0
+
+    # Pool: 600 entity + 3 edge candidates seen, 500 kept.
+    assert payload["pool_size"] == 603
+    assert payload["pool_truncated"] is True
+    assert len(payload["pool"]) == 500
+    for entry in payload["pool"]:
+        assert set(entry) == {"id", "collection", "score"}
+        assert isinstance(entry["id"], str)
+        assert isinstance(entry["collection"], str)
+        assert isinstance(entry["score"], float)
+    assert payload["pool"][0] == {"id": "n0", "collection": "Entity_name", "score": 0.0}
+    # The cap keeps the head of every collection, not just the first 500 seen.
+    edge_ids = [e["id"] for e in payload["pool"] if e["collection"] == "EdgeType_relationship_name"]
+    assert edge_ids == ["e0", "e1", "e2"]
+
+    # Cut: plain ids and the summed raw vector distance for this query.
+    assert payload["cut_size"] == len(payload["top_k"]) == 2
+    for entry in payload["top_k"]:
+        assert set(entry) == {"source", "target", "rel", "score"}
+    assert payload["top_k"][0] == {
+        "source": "a",
+        "target": "b",
+        "rel": "knows",
+        "score": pytest.approx(0.6),
+    }
+    assert payload["top_k"][1] == {
+        "source": "b",
+        "target": "c",
+        "rel": "likes",
+        "score": pytest.approx(1.5),
+    }
+
+
+@pytest.mark.asyncio
+async def test_batch_search_emits_one_candidates_event_per_query(fake_capture_sink):
+    """(d) Batch mode: one event per query index, each with its own pool and cut."""
+    batch = {
+        "Entity_name": [
+            [MockScoredResult("n1", 0.1), MockScoredResult("n2", 0.2)],
+            [MockScoredResult("n3", 0.3)],
+        ],
+        "EdgeType_relationship_name": [[MockScoredResult("e1", 0.4)], []],
+    }
+    engine = _capture_vector_engine(batch=batch)
+    edge_a = _capture_edge("a", "b", "knows", ([0.1, 1.0], [0.2, 2.0], [0.3, 3.0]))
+    edge_b = _capture_edge("b", "c", "likes", ([0.4, 4.0], [0.5, 5.0], [0.6, 6.0]))
+    run_id = uuid4()
+
+    with capture.run_scope(run_id, kind="operation") as scope:
+        assert scope.sampled is True
+        results = await _capture_search(
+            engine,
+            _capture_fragment([[edge_a], [edge_a, edge_b]]),
+            query_batch=["q1", "q2"],
+            collections=["Entity_name"],
+        )
+
+    assert results == [[edge_a], [edge_a, edge_b]]
+    assert scope.fields["retrieval.mode"] == "batch"
+
+    await capture.drain()
+    events = _candidate_events(fake_capture_sink)
+    assert [event["run_id"] for event in events] == [str(run_id), str(run_id)]
+    first, second = (event["payload"] for event in events)
+    _assert_flat(first)
+    _assert_flat(second)
+
+    assert first["query_index"] == 0
+    assert first["pool"] == [
+        {"id": "n1", "collection": "Entity_name", "score": 0.1},
+        {"id": "n2", "collection": "Entity_name", "score": 0.2},
+        {"id": "e1", "collection": "EdgeType_relationship_name", "score": 0.4},
+    ]
+    assert first["pool_size"] == 3
+    assert first["pool_truncated"] is False
+    assert first["top_k"] == [
+        {"source": "a", "target": "b", "rel": "knows", "score": pytest.approx(0.6)}
+    ]
+    assert first["cut_size"] == 1
+
+    assert second["query_index"] == 1
+    assert second["pool"] == [{"id": "n3", "collection": "Entity_name", "score": 0.3}]
+    assert second["pool_size"] == 1
+    assert second["cut_size"] == 2
+    # Scores are taken at this query's index of each element's distance list.
+    assert second["top_k"][0]["score"] == pytest.approx(6.0)
+    assert second["top_k"][1] == {
+        "source": "b",
+        "target": "c",
+        "rel": "likes",
+        "score": pytest.approx(15.0),
+    }
+
+
+@pytest.mark.asyncio
+async def test_candidates_capture_failure_never_breaks_the_search(monkeypatch, fake_capture_sink):
+    """A failing payload build is swallowed: the search returns normally, no event."""
+    monkeypatch.setattr(
+        bfts_module, "_retrieval_candidates_payload", MagicMock(side_effect=RuntimeError("boom"))
+    )
+    edge = _capture_edge("a", "b", "knows", ([0.1], [0.2], [0.3]))
+    engine = _capture_vector_engine(single={"Entity_name": [MockScoredResult("a", 0.1)]})
+
+    results = await _capture_search(engine, _capture_fragment([edge]), query="q", node_name=None)
+
+    assert results == [edge]
+    await capture.drain()
+    assert _candidate_events(fake_capture_sink) == []

--- a/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
+++ b/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
@@ -1356,7 +1356,7 @@ async def test_capture_off_builds_no_retrieval_payload(monkeypatch, capture_rese
     assert results == [edge]
     assert capture.is_active() is False
     builder.assert_not_called()
-    assert not capture.hook._buffer
+    assert not capture.hook._runtime.buffer
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
+++ b/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
@@ -1362,7 +1362,7 @@ async def test_capture_off_builds_no_retrieval_payload(monkeypatch, capture_rese
 @pytest.mark.asyncio
 async def test_sampled_out_search_records_notes_without_event(monkeypatch, fake_capture_sink):
     """(b) A run sampled out still records the bounding settings; no event, no payload."""
-    capture.hook._configure(sample_rate=0.0)
+    capture.hook._configure(retrieval_sample_rate=0.0)
     builder = MagicMock(side_effect=AssertionError("payload built for a sampled-out run"))
     monkeypatch.setattr(bfts_module, "_retrieval_candidates_payload", builder)
 

--- a/cognee/tests/unit/tasks/graph/conftest.py
+++ b/cognee/tests/unit/tasks/graph/conftest.py
@@ -1,0 +1,13 @@
+"""Eval-capture fixtures for the graph task tests (SDK-529).
+
+The canonical definitions live in ``cognee/tests/unit/modules/conftest.py``; they are
+re-exported here so the extraction emit-point tests can sit next to the task tests
+they cover. Importing a fixture function into a conftest registers it for this
+directory.
+"""
+
+from cognee.tests.unit.modules.conftest import (  # noqa: F401
+    FakeCaptureSink,
+    capture_reset,
+    fake_capture_sink,
+)

--- a/cognee/tests/unit/tasks/graph/test_extraction_capture.py
+++ b/cognee/tests/unit/tasks/graph/test_extraction_capture.py
@@ -45,6 +45,14 @@ class _UndumpableGraph(KnowledgeGraph):
         raise AssertionError("model_dump must not run while capture is off")
 
 
+class _RaisingDumpGraph(KnowledgeGraph):
+    """A graph whose ``model_dump(mode="json")`` blows up, as a cyclic or
+    arbitrary-typed caller-supplied graph_model does in practice."""
+
+    def model_dump(self, *args, **kwargs):
+        raise ValueError("Circular reference detected (id repeated)")
+
+
 class _PersonGraph(DataPoint):
     """A custom DataPoint-derived graph_model, as cognify accepts."""
 
@@ -436,3 +444,66 @@ async def test_extract_content_graph_fingerprints_per_call_and_only_inside_a_sco
 
     assert hashed == ["p", "p"]
     assert scope.fields["extraction.prompt_fingerprint"] == real_fingerprint("p")
+
+
+# ---------------------------------------------------------------------------
+# Capture never breaks the extraction it observes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_graph_that_cannot_be_dumped_costs_its_event_not_the_run(
+    fake_capture_sink, no_edge_lookup
+):
+    """A caller-supplied graph_model can hold a reference cycle or a non-JSON-native
+    value, and ``model_dump(mode="json")`` then raises. That must cost the one event,
+    never the extraction — turning capture on must not convert a working cognify into
+    a hard failure."""
+    chunks = [_make_chunk("first"), _make_chunk("second")]
+    graphs = [_RaisingDumpGraph(nodes=[], edges=[]), _clean_graph()]
+
+    result = await _run_extraction(chunks, graphs)
+
+    assert result == chunks
+    await capture.drain()
+
+    # The good chunk still reports; the undumpable one is simply absent.
+    events = _records(fake_capture_sink, KIND_EXTRACTION_CHUNK_GRAPH)
+    assert [event["payload"]["chunk_id"] for event in events] == [str(chunks[1].id)]
+    assert events[0]["payload"]["graph"]["nodes"][0]["name"] == "Dave"
+
+
+@pytest.mark.asyncio
+async def test_a_chunk_without_an_id_costs_its_event_not_the_run(fake_capture_sink, no_edge_lookup):
+    """extract_graph_from_data validates only ``.text`` on its chunks, so a duck-typed
+    chunk can reach the emit point without an ``id``."""
+    bad = MagicMock()
+    del bad.id  # everything else a chunk needs, but no id
+    bad.text = "no id here"
+    bad.contains = None
+    bad.belongs_to_set = []
+    good = _make_chunk("fine")
+
+    result = await _run_extraction([bad, good], [_clean_graph(), _clean_graph()])
+
+    assert result == [bad, good]
+    await capture.drain()
+    events = _records(fake_capture_sink, KIND_EXTRACTION_CHUNK_GRAPH)
+    assert [event["payload"]["chunk_id"] for event in events] == [str(good.id)]
+    assert not hasattr(bad, "id")
+
+
+@pytest.mark.asyncio
+async def test_ontology_mode_falls_back_to_the_configured_mode(
+    monkeypatch, fake_capture_sink, no_edge_lookup
+):
+    """A None per-call mode is reported as the configured ONTOLOGY_MODE, not as None."""
+    monkeypatch.setattr(egd_module, "get_configured_ontology_mode", lambda *a, **k: "strict")
+
+    with capture.run_scope(uuid4(), kind="pipeline") as scope:
+        await _run_extraction([_make_chunk()], [_clean_graph()], resolver=_StubResolver())
+
+    assert scope.fields["ontology.mode"] == "strict"
+    assert scope.fields["ontology.resolver"] == "_StubResolver"
+    assert scope.fields["ontology.matching_strategy"] == "FuzzyMatchingStrategy"
+    assert scope.fields["ontology.threshold"] == 0.9

--- a/cognee/tests/unit/tasks/graph/test_extraction_capture.py
+++ b/cognee/tests/unit/tasks/graph/test_extraction_capture.py
@@ -1,0 +1,339 @@
+"""Extraction emit points for eval capture (SDK-529): the raw per-chunk graph is
+snapshotted before dedup mutates it, dropped duplicate ids are reported once per
+chunk, and the extraction model / prompt fingerprint and the ontology configuration
+land on the run manifest — every one of them a structural no-op with capture off.
+
+``find_existing_edge_identities`` is stubbed and ``calculate_chunk_graphs`` replaces
+the LLM; the ``extract_content_graph`` tests stub ``LLMGateway``. No network, no
+database.
+"""
+
+import importlib
+import json
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from cognee.context_global_variables import llm_config as llm_config_ctx
+from cognee.infrastructure.llm.config import get_llm_config, get_llm_context_config
+from cognee.modules.observability import capture
+from cognee.modules.observability.capture import (
+    KIND_EXTRACTION_CHUNK_GRAPH,
+    KIND_EXTRACTION_DROPPED_DUPLICATES,
+    KIND_RUN_MANIFEST,
+)
+from cognee.modules.ontology.base_ontology_resolver import BaseOntologyResolver
+from cognee.modules.ontology.matching_strategies import FuzzyMatchingStrategy
+from cognee.shared.data_models import Edge as KGEdge
+from cognee.shared.data_models import KnowledgeGraph, Node
+from cognee.tasks.graph.extract_graph_from_data import extract_graph_from_data
+
+egd_module = importlib.import_module("cognee.tasks.graph.extract_graph_from_data")
+ecg_module = importlib.import_module(
+    "cognee.infrastructure.llm.extraction.knowledge_graph.extract_content_graph"
+)
+
+pytestmark = pytest.mark.usefixtures("capture_reset")
+
+
+class _UndumpableGraph(KnowledgeGraph):
+    """A graph whose serialization must never be reached while capture is off."""
+
+    def model_dump(self, *args, **kwargs):
+        raise AssertionError("model_dump must not run while capture is off")
+
+
+class _StubResolver(BaseOntologyResolver):
+    """Matches nothing; carries a fuzzy strategy with a distinctive cutoff."""
+
+    def __init__(self):
+        super().__init__(FuzzyMatchingStrategy(cutoff=0.9))
+
+    def build_lookup(self) -> None:
+        return None
+
+    def refresh_lookup(self) -> None:
+        return None
+
+    def find_closest_match(self, name: str, category: str):
+        return None
+
+    def get_subgraph(self, node_name: str, node_type: str = "individuals", directed: bool = True):
+        return [], [], None
+
+
+def _make_chunk(text="chunk text"):
+    chunk = MagicMock()
+    chunk.id = uuid4()
+    chunk.text = text
+    chunk.contains = None
+    chunk.belongs_to_set = []
+    return chunk
+
+
+def _graph_with_duplicate(graph_class=KnowledgeGraph):
+    return graph_class(
+        nodes=[
+            Node(id="dup", name="Alice", type="Person", description="first"),
+            Node(id="dup", name="Bob", type="Person", description="second"),
+            Node(id="n2", name="Carol", type="Person", description="third"),
+        ],
+        edges=[KGEdge(source_node_id="dup", target_node_id="n2", relationship_name="knows")],
+    )
+
+
+def _clean_graph(graph_class=KnowledgeGraph):
+    return graph_class(
+        nodes=[Node(id="n1", name="Dave", type="Person", description="desc")],
+        edges=[],
+    )
+
+
+def _records(sink, kind):
+    return [record for record in sink.records if record["kind"] == kind]
+
+
+@pytest.fixture
+def no_edge_lookup(monkeypatch):
+    monkeypatch.setattr(egd_module, "find_existing_edge_identities", AsyncMock(return_value=set()))
+
+
+async def _run_extraction(chunks, graphs, resolver=None, ontology_mode=None):
+    async def fake_calc(data_chunks, graph_model, custom_prompt, **kwargs):
+        return graphs
+
+    ontology_config = {"ontology_resolver": resolver}
+    if ontology_mode is not None:
+        ontology_config["ontology_mode"] = ontology_mode
+
+    return await extract_graph_from_data(
+        chunks,
+        type(graphs[0]),
+        config={"ontology_config": ontology_config},
+        calculate_chunk_graphs=fake_calc,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Off path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capture_off_never_dumps_buffers_or_starts_a_flusher(monkeypatch, no_edge_lookup):
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+    chunks = [_make_chunk(), _make_chunk()]
+    graphs = [_graph_with_duplicate(_UndumpableGraph), _clean_graph(_UndumpableGraph)]
+
+    await _run_extraction(chunks, graphs, resolver=_StubResolver())
+
+    assert capture.is_active() is False
+    assert not capture.hook._buffer
+    assert not capture.hook._flushers
+    # The dedup itself is unchanged: first node per id wins.
+    assert [(node.id, node.name) for node in graphs[0].nodes] == [("dup", "Alice"), ("n2", "Carol")]
+
+
+@pytest.mark.asyncio
+async def test_extract_content_graph_off_path_never_hashes(monkeypatch):
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+    monkeypatch.setattr(
+        ecg_module.LLMGateway, "acreate_structured_output", AsyncMock(return_value=_clean_graph())
+    )
+
+    def _boom(text):
+        raise AssertionError("prompt_fingerprint must not run while capture is off")
+
+    monkeypatch.setattr(capture, "prompt_fingerprint", _boom)
+
+    result = await ecg_module.extract_content_graph("text", KnowledgeGraph, custom_prompt="p")
+
+    assert isinstance(result, KnowledgeGraph)
+    assert capture.current_scope() is None
+    assert not capture.hook._buffer
+
+
+# ---------------------------------------------------------------------------
+# E1: raw per-chunk graph, snapshotted before dedup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chunk_graph_payload_is_the_pre_dedup_snapshot(fake_capture_sink, no_edge_lookup):
+    chunks = [_make_chunk("the first chunk"), _make_chunk("second")]
+    graphs = [_graph_with_duplicate(), _clean_graph()]
+
+    await _run_extraction(chunks, graphs)
+    await capture.drain()
+
+    events = _records(fake_capture_sink, KIND_EXTRACTION_CHUNK_GRAPH)
+    assert [event["payload"]["chunk_index"] for event in events] == [0, 1]
+    assert {event["stage"] for event in events} == {"extract_graph_from_data"}
+
+    first = events[0]["payload"]
+    assert first["chunk_id"] == str(chunks[0].id)
+    assert first["chunk_size_chars"] == len("the first chunk")
+    # Three nodes were extracted; the dedup that ran afterwards collapsed the live
+    # graph to two — the snapshot still shows all three, in extraction order.
+    assert [node["id"] for node in first["graph"]["nodes"]] == ["dup", "dup", "n2"]
+    assert [node["name"] for node in first["graph"]["nodes"]] == ["Alice", "Bob", "Carol"]
+    assert first["graph"]["edges"] == [
+        {
+            "source_node_id": "dup",
+            "target_node_id": "n2",
+            "relationship_name": "knows",
+            "description": None,
+        }
+    ]
+    assert [node.id for node in graphs[0].nodes] == ["dup", "n2"]
+    # Plain JSON, no model references.
+    json.dumps([event["payload"] for event in events])
+
+    second = events[1]["payload"]
+    assert second["chunk_id"] == str(chunks[1].id)
+    assert second["chunk_size_chars"] == len("second")
+    assert [node["id"] for node in second["graph"]["nodes"]] == ["n1"]
+
+
+@pytest.mark.asyncio
+async def test_chunk_graph_snapshot_survives_ontology_canonicalization(
+    fake_capture_sink, no_edge_lookup
+):
+    class _Canonicalizer(_StubResolver):
+        def get_subgraph(self, node_name, node_type="individuals", directed=True):
+            from cognee.modules.ontology.models import AttachedOntologyNode
+
+            if node_type == "individuals" and node_name == "dave":
+                root = AttachedOntologyNode("https://example.test/onto#david", "individuals")
+                return [root], [], root
+            return [], [], None
+
+    graphs = [_clean_graph()]
+
+    await _run_extraction([_make_chunk()], graphs, resolver=_Canonicalizer())
+    await capture.drain()
+
+    [event] = _records(fake_capture_sink, KIND_EXTRACTION_CHUNK_GRAPH)
+    # The live graph was renamed in place; the snapshot kept the extracted name.
+    assert graphs[0].nodes[0].name == "david"
+    assert event["payload"]["graph"]["nodes"][0]["name"] == "Dave"
+
+
+# ---------------------------------------------------------------------------
+# E6: dropped duplicates, one event per chunk graph that dropped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_dropped_duplicates_event_per_chunk_that_dropped(
+    fake_capture_sink, no_edge_lookup
+):
+    chunks = [_make_chunk(), _make_chunk(), _make_chunk()]
+    graphs = [
+        _graph_with_duplicate(),
+        _clean_graph(),
+        KnowledgeGraph(
+            nodes=[
+                Node(id="x", name="Eve", type="Person", description="1"),
+                Node(id="x", name="Frank", type="Person", description="2"),
+                Node(id="x", name="Grace", type="Person", description="3"),
+            ],
+            edges=[],
+        ),
+    ]
+    run_id = uuid4()
+
+    with capture.run_scope(run_id, uuid4(), kind="pipeline"):
+        await _run_extraction(chunks, graphs)
+    await capture.drain()
+
+    events = _records(fake_capture_sink, KIND_EXTRACTION_DROPPED_DUPLICATES)
+    assert [
+        (e["payload"]["chunk_index"], e["payload"]["dropped_node_ids"], e["payload"]["count"])
+        for e in events
+    ] == [(0, ["dup"], 1), (2, ["x", "x"], 2)]
+    assert {event["run_id"] for event in events} == {str(run_id)}
+    assert {event["stage"] for event in events} == {"extract_graph_from_data"}
+
+    [manifest] = _records(fake_capture_sink, KIND_RUN_MANIFEST)
+    assert manifest["payload"]["counters"]["extraction.dropped_duplicate_nodes"] == 3
+
+
+@pytest.mark.asyncio
+async def test_no_dropped_duplicates_event_when_nothing_was_dropped(
+    fake_capture_sink, no_edge_lookup
+):
+    await _run_extraction([_make_chunk()], [_clean_graph()])
+    await capture.drain()
+
+    assert _records(fake_capture_sink, KIND_EXTRACTION_DROPPED_DUPLICATES) == []
+    assert len(_records(fake_capture_sink, KIND_EXTRACTION_CHUNK_GRAPH)) == 1
+
+
+# ---------------------------------------------------------------------------
+# E5: ontology configuration on the manifest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manifest_carries_the_ontology_configuration(fake_capture_sink, no_edge_lookup):
+    with capture.run_scope(uuid4(), uuid4(), kind="pipeline"):
+        await _run_extraction(
+            [_make_chunk()], [_clean_graph()], resolver=_StubResolver(), ontology_mode="annotate"
+        )
+    await capture.drain()
+
+    [manifest] = _records(fake_capture_sink, KIND_RUN_MANIFEST)
+    payload = manifest["payload"]
+    assert payload["ontology.mode"] == "annotate"
+    assert payload["ontology.resolver"] == "_StubResolver"
+    assert payload["ontology.matching_strategy"] == "FuzzyMatchingStrategy"
+    assert payload["ontology.threshold"] == 0.9
+
+
+@pytest.mark.asyncio
+async def test_manifest_reports_a_run_without_an_ontology(fake_capture_sink, no_edge_lookup):
+    with capture.run_scope(uuid4(), uuid4(), kind="pipeline") as scope:
+        await _run_extraction([_make_chunk()], [_clean_graph()], ontology_mode="strict")
+
+    assert scope.fields["ontology.mode"] == "strict"
+    assert scope.fields["ontology.resolver"] is None
+    assert scope.fields["ontology.matching_strategy"] is None
+    assert scope.fields["ontology.threshold"] is None
+
+
+# ---------------------------------------------------------------------------
+# E2: extraction model and prompt fingerprint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_content_graph_notes_model_and_prompt_fingerprint(
+    monkeypatch, fake_capture_sink
+):
+    gateway = AsyncMock(return_value=_clean_graph())
+    monkeypatch.setattr(ecg_module.LLMGateway, "acreate_structured_output", gateway)
+
+    with capture.run_scope(uuid4(), uuid4(), kind="pipeline") as scope:
+        await ecg_module.extract_content_graph("text", KnowledgeGraph, custom_prompt="be brief")
+
+    gateway.assert_awaited_once()
+    assert scope.fields["extraction.prompt_fingerprint"] == capture.prompt_fingerprint("be brief")
+    assert scope.fields["extraction.model"] == get_llm_context_config().llm_model
+
+
+@pytest.mark.asyncio
+async def test_extract_content_graph_notes_the_stage_routed_model(monkeypatch, fake_capture_sink):
+    monkeypatch.setattr(
+        ecg_module.LLMGateway, "acreate_structured_output", AsyncMock(return_value=_clean_graph())
+    )
+    routed = get_llm_config().model_copy(update={"llm_model": "test/extraction-model"})
+    token = llm_config_ctx.set(routed)
+    try:
+        with capture.run_scope(uuid4(), uuid4(), kind="pipeline") as scope:
+            await ecg_module.extract_content_graph("text", KnowledgeGraph, custom_prompt="p")
+    finally:
+        llm_config_ctx.reset(token)
+
+    assert scope.fields["extraction.model"] == "test/extraction-model"

--- a/cognee/tests/unit/tasks/graph/test_extraction_capture.py
+++ b/cognee/tests/unit/tasks/graph/test_extraction_capture.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 import pytest
 
 from cognee.context_global_variables import llm_config as llm_config_ctx
+from cognee.infrastructure.engine import DataPoint
 from cognee.infrastructure.llm.config import get_llm_config, get_llm_context_config
 from cognee.modules.observability import capture
 from cognee.modules.observability.capture import (
@@ -42,6 +43,13 @@ class _UndumpableGraph(KnowledgeGraph):
 
     def model_dump(self, *args, **kwargs):
         raise AssertionError("model_dump must not run while capture is off")
+
+
+class _PersonGraph(DataPoint):
+    """A custom DataPoint-derived graph_model, as cognify accepts."""
+
+    name: str
+    metadata: dict = {"index_fields": ["name"]}
 
 
 class _StubResolver(BaseOntologyResolver):
@@ -99,7 +107,7 @@ def no_edge_lookup(monkeypatch):
     monkeypatch.setattr(egd_module, "find_existing_edge_identities", AsyncMock(return_value=set()))
 
 
-async def _run_extraction(chunks, graphs, resolver=None, ontology_mode=None):
+async def _run_extraction(chunks, graphs, resolver=None, ontology_mode=None, graph_model=None):
     async def fake_calc(data_chunks, graph_model, custom_prompt, **kwargs):
         return graphs
 
@@ -109,7 +117,7 @@ async def _run_extraction(chunks, graphs, resolver=None, ontology_mode=None):
 
     return await extract_graph_from_data(
         chunks,
-        type(graphs[0]),
+        graph_model or type(graphs[0]),
         config={"ontology_config": ontology_config},
         calculate_chunk_graphs=fake_calc,
     )
@@ -220,6 +228,41 @@ async def test_chunk_graph_snapshot_survives_ontology_canonicalization(
     assert event["payload"]["graph"]["nodes"][0]["name"] == "Dave"
 
 
+@pytest.mark.asyncio
+async def test_chunk_graph_snapshot_of_a_datapoint_graph_model_is_plain_json(fake_capture_sink):
+    """A custom DataPoint-derived graph_model is dumped before integrate_chunk_graphs
+    attaches the live instance to its chunk: the payload is acyclic JSON, not the
+    DataPoint (whose ``contains`` recursion the payload rules forbid)."""
+    chunk = _make_chunk("custom model")
+    graphs = [_PersonGraph(name="Dave")]
+
+    await _run_extraction([chunk], graphs)
+    await capture.drain()
+
+    [event] = _records(fake_capture_sink, KIND_EXTRACTION_CHUNK_GRAPH)
+    graph = event["payload"]["graph"]
+    assert isinstance(graph, dict)
+    assert graph["name"] == "Dave"
+    assert graph["type"] == "_PersonGraph"
+    assert graph["id"] == str(graphs[0].id)
+    assert "contains" not in graph
+    json.dumps(event["payload"])
+    # The live instance was attached afterwards; the snapshot is not it.
+    assert chunk.contains is graphs[0]
+
+
+@pytest.mark.asyncio
+async def test_chunk_graph_is_none_for_a_non_model_chunk_graph(fake_capture_sink):
+    chunk = _make_chunk()
+
+    await _run_extraction([chunk], [{"name": "Dave"}], graph_model=_PersonGraph)
+    await capture.drain()
+
+    [event] = _records(fake_capture_sink, KIND_EXTRACTION_CHUNK_GRAPH)
+    assert event["payload"]["chunk_id"] == str(chunk.id)
+    assert event["payload"]["graph"] is None
+
+
 # ---------------------------------------------------------------------------
 # E6: dropped duplicates, one event per chunk graph that dropped
 # ---------------------------------------------------------------------------
@@ -253,11 +296,37 @@ async def test_one_dropped_duplicates_event_per_chunk_that_dropped(
         (e["payload"]["chunk_index"], e["payload"]["dropped_node_ids"], e["payload"]["count"])
         for e in events
     ] == [(0, ["dup"], 1), (2, ["x", "x"], 2)]
+    assert [e["payload"]["chunk_id"] for e in events] == [str(chunks[0].id), str(chunks[2].id)]
     assert {event["run_id"] for event in events} == {str(run_id)}
     assert {event["stage"] for event in events} == {"extract_graph_from_data"}
 
     [manifest] = _records(fake_capture_sink, KIND_RUN_MANIFEST)
     assert manifest["payload"]["counters"]["extraction.dropped_duplicate_nodes"] == 3
+
+
+@pytest.mark.asyncio
+async def test_dropped_duplicates_carry_the_chunk_id_across_batches(
+    fake_capture_sink, no_edge_lookup
+):
+    """One run, two batches: chunk_index restarts at 0 for each, so only chunk_id joins a
+    dropped-duplicates event to its chunk_graph record."""
+    first_chunk, second_chunk = _make_chunk("batch one"), _make_chunk("batch two")
+
+    with capture.run_scope(uuid4(), uuid4(), kind="pipeline"):
+        await _run_extraction([first_chunk], [_graph_with_duplicate()])
+        await _run_extraction([second_chunk], [_graph_with_duplicate()])
+    await capture.drain()
+
+    dropped = _records(fake_capture_sink, KIND_EXTRACTION_DROPPED_DUPLICATES)
+    chunk_graphs = _records(fake_capture_sink, KIND_EXTRACTION_CHUNK_GRAPH)
+    assert [e["payload"]["chunk_index"] for e in dropped] == [0, 0]
+    assert [e["payload"]["chunk_id"] for e in dropped] == [
+        str(first_chunk.id),
+        str(second_chunk.id),
+    ]
+    assert [e["payload"]["chunk_id"] for e in dropped] == [
+        e["payload"]["chunk_id"] for e in chunk_graphs
+    ]
 
 
 @pytest.mark.asyncio
@@ -337,3 +406,33 @@ async def test_extract_content_graph_notes_the_stage_routed_model(monkeypatch, f
         llm_config_ctx.reset(token)
 
     assert scope.fields["extraction.model"] == "test/extraction-model"
+
+
+@pytest.mark.asyncio
+async def test_extract_content_graph_fingerprints_per_call_and_only_inside_a_scope(
+    monkeypatch, fake_capture_sink
+):
+    """No process-wide memo: a cached fingerprint would outlive runs and tests, so the
+    off-path "never hashes" stubs would stop biting for any prompt seen before. And with
+    no run scope open ``note()`` would discard the value, so nothing is hashed at all."""
+    monkeypatch.setattr(
+        ecg_module.LLMGateway, "acreate_structured_output", AsyncMock(return_value=_clean_graph())
+    )
+    real_fingerprint = capture.prompt_fingerprint
+    hashed = []
+
+    def _counting(text):
+        hashed.append(text)
+        return real_fingerprint(text)
+
+    monkeypatch.setattr(capture, "prompt_fingerprint", _counting)
+
+    await ecg_module.extract_content_graph("text", KnowledgeGraph, custom_prompt="p")
+    assert hashed == []
+
+    with capture.run_scope(uuid4(), uuid4(), kind="pipeline") as scope:
+        await ecg_module.extract_content_graph("text", KnowledgeGraph, custom_prompt="p")
+        await ecg_module.extract_content_graph("text", KnowledgeGraph, custom_prompt="p")
+
+    assert hashed == ["p", "p"]
+    assert scope.fields["extraction.prompt_fingerprint"] == real_fingerprint("p")

--- a/cognee/tests/unit/tasks/graph/test_extraction_capture.py
+++ b/cognee/tests/unit/tasks/graph/test_extraction_capture.py
@@ -10,6 +10,7 @@ database.
 
 import importlib
 import json
+from typing import ClassVar
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -473,15 +474,20 @@ async def test_a_graph_that_cannot_be_dumped_costs_its_event_not_the_run(
     assert events[0]["payload"]["graph"]["nodes"][0]["name"] == "Dave"
 
 
-@pytest.mark.asyncio
-async def test_a_chunk_without_an_id_costs_its_event_not_the_run(fake_capture_sink, no_edge_lookup):
+def _chunk_without_an_id(text="no id here"):
     """extract_graph_from_data validates only ``.text`` on its chunks, so a duck-typed
-    chunk can reach the emit point without an ``id``."""
+    chunk can reach every emit point without an ``id``."""
     bad = MagicMock()
     del bad.id  # everything else a chunk needs, but no id
-    bad.text = "no id here"
+    bad.text = text
     bad.contains = None
     bad.belongs_to_set = []
+    return bad
+
+
+@pytest.mark.asyncio
+async def test_a_chunk_without_an_id_costs_its_event_not_the_run(fake_capture_sink, no_edge_lookup):
+    bad = _chunk_without_an_id()
     good = _make_chunk("fine")
 
     result = await _run_extraction([bad, good], [_clean_graph(), _clean_graph()])
@@ -491,6 +497,65 @@ async def test_a_chunk_without_an_id_costs_its_event_not_the_run(fake_capture_si
     events = _records(fake_capture_sink, KIND_EXTRACTION_CHUNK_GRAPH)
     assert [event["payload"]["chunk_id"] for event in events] == [str(good.id)]
     assert not hasattr(bad, "id")
+
+
+@pytest.mark.asyncio
+async def test_a_chunk_without_an_id_costs_its_dropped_duplicates_event_not_the_run(
+    fake_capture_sink, no_edge_lookup
+):
+    """The dropped-duplicates emit point reads ``chunk.id`` too — and it is only
+    reached for a chunk whose graph actually lost nodes, which the test above never
+    triggers. Unguarded, it turned this working extraction into an AttributeError
+    the moment capture was switched on."""
+    bad = _chunk_without_an_id()
+    good = _make_chunk("fine")
+    graphs = [_graph_with_duplicate(), _graph_with_duplicate()]
+
+    result = await _run_extraction([bad, good], graphs)
+
+    assert result == [bad, good]
+    # Deduplication itself happened for both chunks, capture or not.
+    assert [node.id for node in graphs[0].nodes] == ["dup", "n2"]
+    assert [node.id for node in graphs[1].nodes] == ["dup", "n2"]
+    await capture.drain()
+    events = _records(fake_capture_sink, KIND_EXTRACTION_DROPPED_DUPLICATES)
+    # The good chunk still reports; the id-less one is simply absent.
+    assert [event["payload"]["chunk_id"] for event in events] == [str(good.id)]
+
+
+class _CountingDumpGraph(KnowledgeGraph):
+    """Counts ``model_dump`` calls: the snapshot must not be taken for an event
+    that ``emit()`` would drop on arrival."""
+
+    dumps: ClassVar[int] = 0
+
+    def model_dump(self, *args, **kwargs):
+        type(self).dumps += 1
+        return super().model_dump(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_no_snapshot_is_taken_for_a_chunk_graph_the_full_buffer_would_drop(
+    fake_capture_sink, no_edge_lookup
+):
+    """A default cognify batch is 2000 chunks and the snapshot loop is synchronous, so
+    a buffer smaller than the batch used to pay the full ~32 µs dump for every chunk
+    past the bound and then throw the result away. The build is lazy now: a full
+    buffer costs the drop counter only."""
+    from cognee.modules.observability.capture import hook
+
+    hook._configure(queue_size=1, flush_interval_s=60.0)
+    capture.emit(KIND_EXTRACTION_CHUNK_GRAPH, "fills the buffer", payload_kind="text")
+    assert capture.has_room() is False
+    _CountingDumpGraph.dumps = 0
+    chunks = [_make_chunk("a"), _make_chunk("b")]
+    graphs = [_CountingDumpGraph(nodes=[], edges=[]), _CountingDumpGraph(nodes=[], edges=[])]
+
+    result = await _run_extraction(chunks, graphs)
+
+    assert result == chunks
+    assert _CountingDumpGraph.dumps == 0
+    assert hook._dropped == 2  # both chunk graphs, accounted for, never built
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/tasks/graph/test_extraction_capture.py
+++ b/cognee/tests/unit/tasks/graph/test_extraction_capture.py
@@ -146,8 +146,8 @@ async def test_capture_off_never_dumps_buffers_or_starts_a_flusher(monkeypatch, 
     await _run_extraction(chunks, graphs, resolver=_StubResolver())
 
     assert capture.is_active() is False
-    assert not capture.hook._buffer
-    assert not capture.hook._flushers
+    assert not capture.hook._runtime.buffer
+    assert not capture.hook._runtime.flushers
     # The dedup itself is unchanged: first node per id wins.
     assert [(node.id, node.name) for node in graphs[0].nodes] == [("dup", "Alice"), ("n2", "Carol")]
 
@@ -168,7 +168,7 @@ async def test_extract_content_graph_off_path_never_hashes(monkeypatch):
 
     assert isinstance(result, KnowledgeGraph)
     assert capture.current_scope() is None
-    assert not capture.hook._buffer
+    assert not capture.hook._runtime.buffer
 
 
 # ---------------------------------------------------------------------------
@@ -555,7 +555,7 @@ async def test_no_snapshot_is_taken_for_a_chunk_graph_the_full_buffer_would_drop
 
     assert result == chunks
     assert _CountingDumpGraph.dumps == 0
-    assert hook._dropped == 2  # both chunk graphs, accounted for, never built
+    assert hook._runtime.dropped == 2  # both chunk graphs, accounted for, never built
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/tasks/storage/conftest.py
+++ b/cognee/tests/unit/tasks/storage/conftest.py
@@ -1,0 +1,10 @@
+"""Storage-task test fixtures.
+
+The eval-capture fixtures (SDK-529) — ``capture_reset`` and ``fake_capture_sink`` —
+are defined in the pipeline-runner conftest under ``tests/unit/modules/``, which
+pytest does not apply to this directory; re-exporting them here makes them
+available to the ``add_data_points`` tests without a second copy of the
+loop-ordering subtleties documented on ``capture_reset``.
+"""
+
+from cognee.tests.unit.modules.conftest import capture_reset, fake_capture_sink  # noqa: F401

--- a/cognee/tests/unit/tasks/storage/test_add_data_points.py
+++ b/cognee/tests/unit/tasks/storage/test_add_data_points.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 import sys
@@ -9,6 +10,7 @@ from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
 from cognee.modules.data.processing.document_types.Document import Document
 from cognee.modules.engine.models import Triplet
 from cognee.modules.graph.utils import ensure_default_edge_properties
+from cognee.modules.observability import capture
 from cognee.modules.pipelines.models import PipelineContext
 from cognee.tasks.storage.add_data_points import (
     add_data_points,
@@ -895,3 +897,188 @@ async def test_add_data_points_relational_upserts_happen_before_graph_and_vector
     )
     assert call_order[:3] == ["upsert_nodes", "upsert_edges", "upsert_edges"]
     assert first_graph_index >= 3
+
+
+# ---------------------------------------------------------------------------
+# Eval capture (SDK-529): one storage.delta per call, OTel counters wired
+# ---------------------------------------------------------------------------
+
+
+def _storage_deltas(sink):
+    return [record for record in sink.records if record["kind"] == capture.KIND_STORAGE_DELTA]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hybrid", [False, True])
+@patch.object(adp_module, "index_graph_edges")
+@patch.object(adp_module, "index_data_points")
+@patch.object(adp_module, "get_unified_engine")
+@patch.object(adp_module, "deduplicate_nodes_and_edges")
+@patch.object(adp_module, "get_graph_from_model")
+async def test_add_data_points_emits_one_storage_delta_per_call(
+    mock_get_graph,
+    mock_dedup,
+    mock_get_unified,
+    mock_index_nodes,
+    mock_index_edges,
+    hybrid,
+    fake_capture_sink,
+):
+    """Counts, a type histogram, string ids and the run id — the same event on
+    the default and the hybrid write path; the run-scope counters see the write."""
+    from cognee.infrastructure.databases.unified.capabilities import EngineCapability
+
+    dp1 = SimplePoint(text="first")
+    dp2 = NamedPoint(name="second")
+    edge1 = (str(dp1.id), str(dp2.id), "related_to", {"edge_text": "connects"})
+    custom_edges = [(str(dp2.id), str(dp1.id), "custom_edge", {})]
+
+    mock_get_graph.side_effect = [([dp1], [edge1]), ([dp2], [])]
+    mock_dedup.side_effect = lambda n, e: (n, e)
+    unified, _graph_engine = _graph_provenance_unified(mock_get_unified)
+    if hybrid:
+        unified.has_capability = MagicMock(
+            side_effect=lambda cap: cap == EngineCapability.HYBRID_WRITE
+        )
+    ctx = _provenance_ctx()
+
+    with capture.run_scope(ctx.pipeline_run_id, ctx.dataset.id, kind="pipeline") as scope:
+        await add_data_points([dp1, dp2], custom_edges=custom_edges, ctx=ctx)
+
+    assert scope.counters["storage.nodes_written"] == 2
+    assert scope.counters["storage.edges_written"] == 2  # 1 datapoint edge + 1 custom edge
+
+    await capture.drain()
+
+    [delta] = _storage_deltas(fake_capture_sink)
+    assert delta["stage"] == "add_data_points"
+    assert delta["run_id"] == str(ctx.pipeline_run_id)
+    assert delta["dataset_id"] == str(ctx.dataset.id)
+
+    payload = delta["payload"]
+    assert payload["node_count"] == 2
+    assert payload["edge_count"] == 1
+    assert payload["custom_edge_count"] == 1
+    assert payload["node_types"] == {"SimplePoint": 1, "NamedPoint": 1}
+    assert sorted(payload["node_ids"]) == sorted([str(dp1.id), str(dp2.id)])
+    assert payload["pipeline_run_id"] == str(ctx.pipeline_run_id)
+    # Plain scalars only — no DataPoint slipped into the event.
+    json.dumps(payload)
+
+
+@pytest.mark.asyncio
+@patch.object(adp_module, "index_graph_edges")
+@patch.object(adp_module, "index_data_points")
+@patch.object(adp_module, "get_unified_engine")
+@patch.object(adp_module, "deduplicate_nodes_and_edges")
+@patch.object(adp_module, "get_graph_from_model")
+async def test_add_data_points_storage_delta_drops_node_ids_past_the_cap(
+    mock_get_graph,
+    mock_dedup,
+    mock_get_unified,
+    mock_index_nodes,
+    mock_index_edges,
+    monkeypatch,
+    fake_capture_sink,
+):
+    monkeypatch.setattr(adp_module, "_STORAGE_DELTA_MAX_NODE_IDS", 1)
+    dp1 = SimplePoint(text="first")
+    dp2 = SimplePoint(text="second")
+    mock_get_graph.side_effect = [([dp1], []), ([dp2], [])]
+    mock_dedup.side_effect = lambda n, e: (n, e)
+    unified, _graph_engine, _vector_engine = _make_unified_mock()
+    mock_get_unified.return_value = unified
+
+    await add_data_points([dp1, dp2])  # no ctx: no pipeline run, no dataset
+    await capture.drain()
+
+    [delta] = _storage_deltas(fake_capture_sink)
+    assert delta["run_id"] is None
+    assert delta["dataset_id"] is None
+    payload = delta["payload"]
+    assert payload["node_ids"] is None
+    assert payload["node_count"] == 2
+    assert payload["node_types"] == {"SimplePoint": 2}
+    assert payload["edge_count"] == 0
+    assert payload["custom_edge_count"] == 0
+    assert payload["pipeline_run_id"] is None
+
+
+@pytest.mark.asyncio
+@patch.object(adp_module, "index_graph_edges")
+@patch.object(adp_module, "index_data_points")
+@patch.object(adp_module, "get_unified_engine")
+@patch.object(adp_module, "deduplicate_nodes_and_edges")
+@patch.object(adp_module, "get_graph_from_model")
+async def test_add_data_points_is_a_capture_no_op_when_off(
+    mock_get_graph,
+    mock_dedup,
+    mock_get_unified,
+    mock_index_nodes,
+    mock_index_edges,
+    monkeypatch,
+    capture_reset,
+):
+    """Structural no-op: neither the payload (id list, histogram) nor an event
+    nor a counter bump is built when no sink is registered."""
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+    payload_spy = MagicMock(wraps=adp_module._storage_delta_payload)
+    monkeypatch.setattr(adp_module, "_storage_delta_payload", payload_spy)
+    emit_spy = MagicMock(wraps=capture.emit)
+    monkeypatch.setattr(capture, "emit", emit_spy)
+    bump_spy = MagicMock(wraps=capture.bump)
+    monkeypatch.setattr(capture, "bump", bump_spy)
+
+    dp = SimplePoint(text="only")
+    mock_get_graph.side_effect = [([dp], [])]
+    mock_dedup.side_effect = lambda n, e: (n, e)
+    unified, _graph_engine, _vector_engine = _make_unified_mock()
+    mock_get_unified.return_value = unified
+
+    result = await add_data_points([dp])
+
+    assert result == [dp]
+    assert capture.is_active() is False
+    payload_spy.assert_not_called()
+    emit_spy.assert_not_called()
+    bump_spy.assert_not_called()
+    assert not capture.hook._buffer
+
+
+@pytest.mark.asyncio
+@patch.object(adp_module, "index_graph_edges")
+@patch.object(adp_module, "index_data_points")
+@patch.object(adp_module, "get_unified_engine")
+@patch.object(adp_module, "deduplicate_nodes_and_edges")
+@patch.object(adp_module, "get_graph_from_model")
+async def test_add_data_points_reports_graph_write_counters(
+    mock_get_graph,
+    mock_dedup,
+    mock_get_unified,
+    mock_index_nodes,
+    mock_index_edges,
+    monkeypatch,
+    capture_reset,
+):
+    """The OTel node/edge counters fire once per call, with the same attributes
+    cognify uses for its duration histogram — independent of eval capture."""
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+    nodes_counter = MagicMock()
+    edges_counter = MagicMock()
+    monkeypatch.setattr(adp_module, "increment_graph_nodes", nodes_counter)
+    monkeypatch.setattr(adp_module, "increment_graph_edges", edges_counter)
+
+    dp1 = SimplePoint(text="first")
+    dp2 = SimplePoint(text="second")
+    edge1 = (str(dp1.id), str(dp2.id), "related_to", {"edge_text": "connects"})
+    custom_edges = [(str(dp2.id), str(dp1.id), "custom_edge", {})]
+    mock_get_graph.side_effect = [([dp1], [edge1]), ([dp2], [])]
+    mock_dedup.side_effect = lambda n, e: (n, e)
+    unified, _graph_engine, _vector_engine = _make_unified_mock()
+    mock_get_unified.return_value = unified
+
+    await add_data_points([dp1, dp2], custom_edges=custom_edges)
+
+    attributes = {"memory.system": "cognee", "memory.operation": "process"}
+    nodes_counter.assert_called_once_with(2, attributes)
+    edges_counter.assert_called_once_with(2, attributes)  # 1 datapoint edge + 1 custom edge

--- a/cognee/tests/unit/tasks/storage/test_add_data_points.py
+++ b/cognee/tests/unit/tasks/storage/test_add_data_points.py
@@ -1078,7 +1078,7 @@ async def test_add_data_points_is_a_capture_no_op_when_off(
     payload_spy.assert_not_called()
     emit_spy.assert_not_called()
     bump_spy.assert_not_called()
-    assert not capture.hook._buffer
+    assert not capture.hook._runtime.buffer
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/tasks/storage/test_add_data_points.py
+++ b/cognee/tests/unit/tasks/storage/test_add_data_points.py
@@ -120,6 +120,42 @@ async def test_add_data_points_indexes_nodes_and_edges(
 @patch.object(adp_module, "get_unified_engine")
 @patch.object(adp_module, "deduplicate_nodes_and_edges")
 @patch.object(adp_module, "get_graph_from_model")
+async def test_add_data_points_capture_failure_never_breaks_the_write(
+    mock_get_graph,
+    mock_dedup,
+    mock_get_unified,
+    mock_index_nodes,
+    mock_index_edges,
+    monkeypatch,
+    fake_capture_sink,
+):
+    """Capture never breaks the write it observes (SDK-529): a payload build that
+    raises costs the storage.delta event, never the nodes and edges."""
+    from cognee.modules.observability.capture import KIND_STORAGE_DELTA
+
+    dp1 = SimplePoint(text="first")
+    mock_get_graph.side_effect = [([dp1], [])]
+    mock_dedup.side_effect = lambda n, e: (n, e)
+    unified, graph_engine, _vector_engine = _make_unified_mock()
+    mock_get_unified.return_value = unified
+    monkeypatch.setattr(
+        adp_module, "_storage_delta_payload", MagicMock(side_effect=RuntimeError("boom"))
+    )
+
+    result = await add_data_points([dp1])
+
+    assert result == [dp1]
+    graph_engine.add_nodes.assert_awaited_once()
+    await capture.drain()
+    assert [r for r in fake_capture_sink.records if r["kind"] == KIND_STORAGE_DELTA] == []
+
+
+@pytest.mark.asyncio
+@patch.object(adp_module, "index_graph_edges")
+@patch.object(adp_module, "index_data_points")
+@patch.object(adp_module, "get_unified_engine")
+@patch.object(adp_module, "deduplicate_nodes_and_edges")
+@patch.object(adp_module, "get_graph_from_model")
 async def test_add_data_points_indexes_triplets_when_enabled(
     mock_get_graph, mock_dedup, mock_get_unified, mock_index_nodes, mock_index_edges
 ):

--- a/cognee/tests/unit/tasks/summarization/conftest.py
+++ b/cognee/tests/unit/tasks/summarization/conftest.py
@@ -1,0 +1,51 @@
+"""Eval-capture fixtures for the summarization task tests (SDK-529).
+
+Mirrors ``capture_reset`` / ``fake_capture_sink`` / ``FakeCaptureSink`` from
+``cognee/tests/unit/modules/conftest.py``. That conftest lives in a directory
+without ``__init__.py``, so pytest loads it as a bare ``conftest`` module that
+cannot be imported from here; the fixtures are re-declared instead.
+"""
+
+import pytest
+
+
+class FakeCaptureSink:
+    """In-memory eval-capture sink: records every batch it receives."""
+
+    def __init__(self):
+        self.calls: list[list[dict]] = []
+
+    async def __call__(self, records):
+        self.calls.append(list(records))
+
+    @property
+    def records(self) -> list[dict]:
+        return [record for call in self.calls for record in call]
+
+
+@pytest.fixture
+def capture_reset(event_loop, monkeypatch):
+    """Reset eval-capture module state around a test.
+
+    Depends on ``event_loop`` so this teardown runs BEFORE pytest-asyncio closes
+    the loop (pytest-asyncio 0.21.x closes loops without cancelling tasks, and a
+    flusher task left behind would be destroyed while pending). Also detaches
+    ``CaptureConfig`` from the repo ``.env`` so a developer's ``COGNEE_CAPTURE_*``
+    settings cannot flip the off-path tests.
+    """
+    from cognee.modules.observability.capture import CaptureConfig, hook
+
+    monkeypatch.setitem(CaptureConfig.model_config, "env_file", None)
+    hook._reset_for_tests()
+    yield
+    hook._reset_for_tests()
+
+
+@pytest.fixture
+def fake_capture_sink(capture_reset):
+    """Register a FakeCaptureSink as the process-wide capture sink."""
+    from cognee.modules.observability import capture
+
+    sink = FakeCaptureSink()
+    capture.register_capture_sink(sink)
+    return sink

--- a/cognee/tests/unit/tasks/summarization/conftest.py
+++ b/cognee/tests/unit/tasks/summarization/conftest.py
@@ -1,51 +1,14 @@
 """Eval-capture fixtures for the summarization task tests (SDK-529).
 
-Mirrors ``capture_reset`` / ``fake_capture_sink`` / ``FakeCaptureSink`` from
-``cognee/tests/unit/modules/conftest.py``. That conftest lives in a directory
-without ``__init__.py``, so pytest loads it as a bare ``conftest`` module that
-cannot be imported from here; the fixtures are re-declared instead.
+The canonical definitions live in ``cognee/tests/unit/modules/conftest.py``; they are
+re-exported here (as the graph and storage task conftests do) so the summary emit-point
+tests can sit next to the task tests they cover without a second copy of the
+loop-ordering subtleties documented on ``capture_reset``. Importing a fixture function
+into a conftest registers it for this directory.
 """
 
-import pytest
-
-
-class FakeCaptureSink:
-    """In-memory eval-capture sink: records every batch it receives."""
-
-    def __init__(self):
-        self.calls: list[list[dict]] = []
-
-    async def __call__(self, records):
-        self.calls.append(list(records))
-
-    @property
-    def records(self) -> list[dict]:
-        return [record for call in self.calls for record in call]
-
-
-@pytest.fixture
-def capture_reset(event_loop, monkeypatch):
-    """Reset eval-capture module state around a test.
-
-    Depends on ``event_loop`` so this teardown runs BEFORE pytest-asyncio closes
-    the loop (pytest-asyncio 0.21.x closes loops without cancelling tasks, and a
-    flusher task left behind would be destroyed while pending). Also detaches
-    ``CaptureConfig`` from the repo ``.env`` so a developer's ``COGNEE_CAPTURE_*``
-    settings cannot flip the off-path tests.
-    """
-    from cognee.modules.observability.capture import CaptureConfig, hook
-
-    monkeypatch.setitem(CaptureConfig.model_config, "env_file", None)
-    hook._reset_for_tests()
-    yield
-    hook._reset_for_tests()
-
-
-@pytest.fixture
-def fake_capture_sink(capture_reset):
-    """Register a FakeCaptureSink as the process-wide capture sink."""
-    from cognee.modules.observability import capture
-
-    sink = FakeCaptureSink()
-    capture.register_capture_sink(sink)
-    return sink
+from cognee.tests.unit.modules.conftest import (  # noqa: F401
+    FakeCaptureSink,
+    capture_reset,
+    fake_capture_sink,
+)

--- a/cognee/tests/unit/tasks/summarization/test_summarize_text.py
+++ b/cognee/tests/unit/tasks/summarization/test_summarize_text.py
@@ -90,9 +90,7 @@ async def test_summarize_text_leaves_provenance_unset_when_capture_is_off(monkey
     [summary] = await summarize_text_module.summarize_text([_chunk()], summarization_model=object)
 
     assert capture.is_active() is False
-    assert summary.model is None
-    assert summary.prompt_fingerprint is None
-    assert summary.source_text_hash is None
+    assert summary.text == f"Summary of {summary.made_from.text}"
     hashing.assert_not_called()
     assert not capture.hook._buffer
 
@@ -107,10 +105,10 @@ async def test_summarize_text_populates_provenance_and_emits_one_event_per_chunk
 
     assert len(summaries) == 2
     for chunk, summary in zip(chunks, summaries):
-        assert summary.model == MODEL
-        assert summary.prompt_fingerprint == capture.prompt_fingerprint(PROMPT)
-        assert summary.source_text_hash == capture.prompt_fingerprint(chunk.text)
         assert summary.text == f"Summary of {chunk.text}"
+        # Provenance rides the event, never the persisted node.
+        for field in ("model", "prompt_fingerprint", "source_text_hash"):
+            assert not hasattr(summary, field)
 
     await capture.drain()
 
@@ -165,21 +163,19 @@ async def test_summarize_text_returns_empty_input_without_touching_capture(
     assert not capture.hook._buffer
 
 
-def test_text_summary_provenance_fields_are_not_embedded():
-    summary = TextSummary(
-        text="Short summary",
-        made_from=_chunk(),
-        model=MODEL,
-        prompt_fingerprint="sha256:0000000000000000",
-        source_text_hash="sha256:1111111111111111",
-    )
+def test_text_summary_node_carries_no_capture_provenance():
+    """Graph content must not depend on whether capture happened to be on.
+
+    The provenance the design partner needs is on the ``summary.generated`` event,
+    keyed by ``summary_id``; the node schema stays free of telemetry fields.
+    """
+    summary = TextSummary(text="Short summary", made_from=_chunk())
+
+    for name in ("model", "prompt_fingerprint", "source_text_hash"):
+        assert name not in TextSummary.model_fields
 
     # The embedding index is unchanged: only the summary text is embedded.
     assert TextSummary.model_fields["metadata"].default == {"index_fields": ["text"]}
     assert summary.metadata["index_fields"] == ["text"]
     assert DataPoint.get_embeddable_property_names(summary) == ["text"]
     assert DataPoint.get_embeddable_properties(summary) == ["Short summary"]
-    for name in ("model", "prompt_fingerprint", "source_text_hash"):
-        assert name in TextSummary.model_fields
-        assert TextSummary.model_fields[name].default is None
-        assert name not in summary.metadata["index_fields"]

--- a/cognee/tests/unit/tasks/summarization/test_summarize_text.py
+++ b/cognee/tests/unit/tasks/summarization/test_summarize_text.py
@@ -1,13 +1,29 @@
+"""summarize_text: source-chunk reference fields, and the eval-capture provenance
+(SDK-529) it adds to every TextSummary only while capture is active.
+
+``extract_summary_with_provenance`` is patched throughout — no LLM, no network.
+"""
+
 import importlib
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
 import pytest
 
+from cognee.infrastructure.engine import DataPoint
 from cognee.modules.chunking.models import DocumentChunk
 from cognee.modules.data.processing.document_types import TextDocument
+from cognee.modules.observability import capture
+from cognee.modules.observability.capture import KIND_RUN_MANIFEST, KIND_SUMMARY_GENERATED
+from cognee.tasks.summarization.models import TextSummary
 
 summarize_text_module = importlib.import_module("cognee.tasks.summarization.summarize_text")
+
+pytestmark = pytest.mark.usefixtures("capture_reset")
+
+PROMPT = "Summarize the following content."
+MODEL = "openai/gpt-test"
 
 
 def _document():
@@ -19,11 +35,11 @@ def _document():
     )
 
 
-def _chunk(text="Chunk text", document=None, belongs_to_set=None):
+def _chunk(text="Chunk text", document=None, belongs_to_set=None, chunk_index=0):
     return DocumentChunk(
         text=text,
         chunk_size=len(text.split()),
-        chunk_index=0,
+        chunk_index=chunk_index,
         cut_type="sentence_end",
         is_part_of=document or _document(),
         contains=[],
@@ -31,18 +47,139 @@ def _chunk(text="Chunk text", document=None, belongs_to_set=None):
     )
 
 
+@pytest.fixture
+def extract(monkeypatch):
+    """Stand-in for extract_summary_with_provenance: (llm_output, prompt_text, model_name)."""
+    mock = AsyncMock(
+        side_effect=lambda content, response_model: (
+            SimpleNamespace(summary=f"Summary of {content}"),
+            PROMPT,
+            MODEL,
+        )
+    )
+    monkeypatch.setattr(summarize_text_module, "extract_summary_with_provenance", mock)
+    return mock
+
+
+def _summary_events(sink):
+    return [record for record in sink.records if record["kind"] == KIND_SUMMARY_GENERATED]
+
+
 @pytest.mark.asyncio
-async def test_summarize_text_sets_source_chunk_reference_fields():
+async def test_summarize_text_sets_source_chunk_reference_fields(monkeypatch, extract):
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
     chunk = _chunk(belongs_to_set=["KEEP"])
 
-    with patch.object(
-        summarize_text_module,
-        "extract_summary",
-        new=AsyncMock(return_value=SimpleNamespace(summary="Short summary")),
-    ):
-        summaries = await summarize_text_module.summarize_text([chunk], summarization_model=object)
+    summaries = await summarize_text_module.summarize_text([chunk], summarization_model=object)
 
     assert len(summaries) == 1
     assert summaries[0].source_chunk_id == str(chunk.id)
     assert summaries[0].belongs_to_set == ["KEEP"]
     assert summaries[0].made_from == chunk
+    assert summaries[0].text == f"Summary of {chunk.text}"
+    extract.assert_awaited_once_with(chunk.text, object)
+
+
+@pytest.mark.asyncio
+async def test_summarize_text_leaves_provenance_unset_when_capture_is_off(monkeypatch, extract):
+    monkeypatch.delenv("COGNEE_CAPTURE_ENABLED", raising=False)
+    # A structural no-op when off: nothing is hashed, nothing is buffered.
+    hashing = MagicMock(side_effect=capture.prompt_fingerprint)
+    monkeypatch.setattr(capture, "prompt_fingerprint", hashing)
+
+    [summary] = await summarize_text_module.summarize_text([_chunk()], summarization_model=object)
+
+    assert capture.is_active() is False
+    assert summary.model is None
+    assert summary.prompt_fingerprint is None
+    assert summary.source_text_hash is None
+    hashing.assert_not_called()
+    assert not capture.hook._buffer
+
+
+@pytest.mark.asyncio
+async def test_summarize_text_populates_provenance_and_emits_one_event_per_chunk(
+    fake_capture_sink, extract
+):
+    chunks = [_chunk("First chunk text", chunk_index=0), _chunk("Second chunk text", chunk_index=1)]
+
+    summaries = await summarize_text_module.summarize_text(chunks, summarization_model=object)
+
+    assert len(summaries) == 2
+    for chunk, summary in zip(chunks, summaries):
+        assert summary.model == MODEL
+        assert summary.prompt_fingerprint == capture.prompt_fingerprint(PROMPT)
+        assert summary.source_text_hash == capture.prompt_fingerprint(chunk.text)
+        assert summary.text == f"Summary of {chunk.text}"
+
+    await capture.drain()
+
+    events = _summary_events(fake_capture_sink)
+    assert len(events) == 2
+    for chunk, summary, event in zip(chunks, summaries, events):
+        assert event["stage"] == "summarize_text"
+        # Exact payload: ids, fingerprints and a size — never the chunk or summary text.
+        assert event["payload"] == {
+            "chunk_id": str(chunk.id),
+            "summary_id": str(summary.id),
+            "model": MODEL,
+            "prompt_fingerprint": capture.prompt_fingerprint(PROMPT),
+            "source_text_hash": capture.prompt_fingerprint(chunk.text),
+            "summary_chars": len(summary.text),
+        }
+
+
+@pytest.mark.asyncio
+async def test_summarize_text_notes_model_and_prompt_once_per_run(fake_capture_sink, extract):
+    run_id, dataset_id = uuid4(), uuid4()
+    chunks = [_chunk("a", chunk_index=0), _chunk("b", chunk_index=1), _chunk("c", chunk_index=2)]
+
+    with capture.run_scope(run_id, dataset_id, kind="pipeline") as scope:
+        await summarize_text_module.summarize_text(chunks, summarization_model=object)
+
+    assert scope.fields["summarization.model"] == MODEL
+    assert scope.fields["summarization.prompt_fingerprint"] == capture.prompt_fingerprint(PROMPT)
+
+    await capture.drain()
+
+    [manifest] = [r for r in fake_capture_sink.records if r["kind"] == KIND_RUN_MANIFEST]
+    assert manifest["run_id"] == str(run_id)
+    assert manifest["payload"]["summarization.model"] == MODEL
+    assert manifest["payload"]["summarization.prompt_fingerprint"] == capture.prompt_fingerprint(
+        PROMPT
+    )
+    # Every event is attributed to the run; still exactly one per chunk.
+    events = _summary_events(fake_capture_sink)
+    assert len(events) == 3
+    assert {event["run_id"] for event in events} == {str(run_id)}
+    assert {event["dataset_id"] for event in events} == {str(dataset_id)}
+
+
+@pytest.mark.asyncio
+async def test_summarize_text_returns_empty_input_without_touching_capture(
+    fake_capture_sink, extract
+):
+    assert await summarize_text_module.summarize_text([], summarization_model=object) == []
+
+    extract.assert_not_awaited()
+    assert not capture.hook._buffer
+
+
+def test_text_summary_provenance_fields_are_not_embedded():
+    summary = TextSummary(
+        text="Short summary",
+        made_from=_chunk(),
+        model=MODEL,
+        prompt_fingerprint="sha256:0000000000000000",
+        source_text_hash="sha256:1111111111111111",
+    )
+
+    # The embedding index is unchanged: only the summary text is embedded.
+    assert TextSummary.model_fields["metadata"].default == {"index_fields": ["text"]}
+    assert summary.metadata["index_fields"] == ["text"]
+    assert DataPoint.get_embeddable_property_names(summary) == ["text"]
+    assert DataPoint.get_embeddable_properties(summary) == ["Short summary"]
+    for name in ("model", "prompt_fingerprint", "source_text_hash"):
+        assert name in TextSummary.model_fields
+        assert TextSummary.model_fields[name].default is None
+        assert name not in summary.metadata["index_fields"]

--- a/cognee/tests/unit/tasks/summarization/test_summarize_text.py
+++ b/cognee/tests/unit/tasks/summarization/test_summarize_text.py
@@ -96,6 +96,25 @@ async def test_summarize_text_leaves_provenance_unset_when_capture_is_off(monkey
 
 
 @pytest.mark.asyncio
+async def test_summarize_text_capture_failure_never_breaks_summarization(
+    monkeypatch, fake_capture_sink, extract
+):
+    """Capture never breaks the summarization it observes: a provenance hash that
+    raises costs that chunk's fingerprints (reported as None), never the summaries."""
+    monkeypatch.setattr(capture, "prompt_fingerprint", MagicMock(side_effect=RuntimeError("no")))
+    chunks = [_chunk("First chunk text", chunk_index=0), _chunk("Second chunk text", chunk_index=1)]
+
+    summaries = await summarize_text_module.summarize_text(chunks, summarization_model=object)
+
+    assert [summary.text for summary in summaries] == [f"Summary of {c.text}" for c in chunks]
+    await capture.drain()
+    events = _summary_events(fake_capture_sink)
+    assert [event["payload"]["chunk_id"] for event in events] == [str(c.id) for c in chunks]
+    assert all(event["payload"]["prompt_fingerprint"] is None for event in events)
+    assert all(event["payload"]["source_text_hash"] is None for event in events)
+
+
+@pytest.mark.asyncio
 async def test_summarize_text_populates_provenance_and_emits_one_event_per_chunk(
     fake_capture_sink, extract
 ):

--- a/cognee/tests/unit/tasks/summarization/test_summarize_text.py
+++ b/cognee/tests/unit/tasks/summarization/test_summarize_text.py
@@ -92,7 +92,7 @@ async def test_summarize_text_leaves_provenance_unset_when_capture_is_off(monkey
     assert capture.is_active() is False
     assert summary.text == f"Summary of {summary.made_from.text}"
     hashing.assert_not_called()
-    assert not capture.hook._buffer
+    assert not capture.hook._runtime.buffer
 
 
 @pytest.mark.asyncio
@@ -179,7 +179,7 @@ async def test_summarize_text_returns_empty_input_without_touching_capture(
     assert await summarize_text_module.summarize_text([], summarization_model=object) == []
 
     extract.assert_not_awaited()
-    assert not capture.hook._buffer
+    assert not capture.hook._runtime.buffer
 
 
 def test_text_summary_node_carries_no_capture_provenance():


### PR DESCRIPTION
## Description

Adds an opt-in **eval-capture** telemetry hook so extraction and retrieval can be evaluated separately, and wires it into the four stages that currently discard the evidence.

Closes part of SDK-529. Targets `dev`.

### What we verified is missing today

- The per-chunk LLM output in `extract_graph_from_data` is merged into the graph and **discarded** — merge decisions leave no trace.
- Retrieval logs **that** a search ran (`Query`: text, type, user, dataset, timestamps), never what it considered or picked.
- Summaries link to a source chunk but carry **no model or prompt**, and the chunk can change under them on re-ingest.
- There is **no prompt versioning anywhere** in the repo.
- `increment_graph_nodes` / `increment_graph_edges` were imported in `cognify.py` and **never called**.

Roughly half the plumbing already existed and is reused rather than rebuilt: `record_operation`/`pipeline_runs` (SDK-399), the provenance ledger (`source_ref_key` + `pipeline_run_id` on every node/edge), `record_llm_call`, `pipeline_stage`, and `StorageManager`.

## Design

**The hot path emits a reference. It never serializes and never awaits I/O.**

```
emit(kind, payload)  →  sink = _runtime.sink; if sink is None: return   ← ~30 ns, no allocation
                        append to a bounded deque                        ← drop-newest + per-run counter
                          └─► background flusher (per loop, asyncio.Event wake)
                                serialize off-loop → gzip + StorageManager.store() on a worker thread
```

- **Off by default.** Nothing registered → two reads. `register_capture_sink()` for programmatic use (cloud, Sesame); `COGNEE_CAPTURE_ENABLED=true` auto-registers the reference `StorageSink`.
- **Sinks are never called inline from `emit()`** — only from the flusher, `drain()` or `shutdown()`. Each sink write runs on a worker thread so `SINK_TIMEOUT_S` / `drain()`'s budget can actually cancel it (`LocalFileStorage.store` is an `async def` with no suspension point).
- **All hook state lives on one `CaptureRuntime`** (`hook._runtime`): knobs, sink, buffer, per-loop flushers, in-flight batches, drop counter. The public API is the module functions. Tests get a fresh instance per test instead of cleared globals.
- **`record_operation` never drains.** It wraps user-facing `recall`/`search`, and the buffer is process-global, so draining there would make a recall wait on a concurrent cognify's sink I/O. It **does** forward its dataset to the capture scope the moment the caller binds it, so events flushed mid-operation file under `<dataset>/`, not `nodataset/`. The `run_tasks` pipeline wiring drains its events, then finishes and drains its manifest.
- **Every record is versioned and identifiable**: `schema_version` and a stable `event_id` (assigned at emit — a requeued record keeps it, so consumers dedupe on it under at-least-once delivery).
- **Every manifest reports its own capture accounting**: `events_emitted` / `events_dropped` / `events_delivered` counted on the run the event was emitted under (from the emit path and from the flusher), and `capture_complete`. Pipeline manifests carry `pipeline_name` / `outcome` / `error_class` like operation manifests carry `operation` / `outcome` / `error_class`.
- **Three storage tiers by shape**: run metadata → per-run `manifest.json`; artifacts (raw chunk graphs, retrieval pools) → gzip'd JSONL in object storage; never the relational DB. Works over local FS and S3 through the existing `get_file_storage`.
- **Binding payload rules**: a payload is a back-reference-free model dump or plain scalars. Never `CogneeGraph` `Node`/`Edge`, `ScoredResult`, or `DataPoint` — those pin whole graph fragments in the buffer.

## ⚠️ What lands on disk

Capture writes **derived user content**, not just metrics: `extraction.chunk_graph` carries the raw per-chunk graph verbatim (entity names, descriptions, relationships), `extraction.fuzzy_match` the names looked up against the ontology, `retrieval.candidates` candidate ids and scores. It is filed under `<COGNEE_CAPTURE_DIR>/<dataset_id>/<run_id>/`, inherits that directory's permissions (`<DATA_ROOT_DIRECTORY>/capture` by default), and is **not removed when a dataset is forgotten**. A deployment that enables capture owns the same retention and access-control obligations for that directory as for the data root. `COGNEE_CAPTURE_RETRIEVAL_SAMPLE_RATE` samples only `retrieval.*`; the extraction kinds are always captured in full. `COGNEE_CAPTURE_DIR` must be absolute (or `s3://`), like every other storage root.

## What to look at first

1. **`cognee/modules/observability/capture/hook.py`** — `CaptureRuntime`, `emit()` / `emit_lazy()`, the flusher lifecycle, `drain()` / `shutdown()`, the per-run accounting. This is where the contract lives or dies.
2. **`capture_chunk_graphs`** in `extract_graph_from_data.py` — the snapshot must be taken *before* `_remove_duplicate_extracted_nodes_by_id` and ontology canonicalization mutate the graph, or E1 captures the post-merge result and is worthless. It is built lazily (`emit_lazy`) and the loop yields every 64 chunks.
3. **`add_data_points.py`** — this PR makes the **first-ever real calls** to the two dead OTel counters. In scope per SDK-529, but it is a behaviour change beyond capture; see the section below.
4. **`record_operation.py` / `run_tasks.py`** — the two wirings; confirm the OFF path constructs nothing, and the dataset reaches the scope on `set_dataset()`.
5. **`sinks.py`** — `run_coroutine_off_loop` and why the store runs off-loop.

## ⚠️ Behaviour change beyond capture (independent of the flag)

`add_data_points` now calls `increment_graph_nodes` / `increment_graph_edges` on **every** graph write, whether or not `COGNEE_CAPTURE_ENABLED` is set. Both counters existed in `cognee.modules.observability` but had no call site anywhere in the repo, so this is the first time they emit. Any deployment with an OTel meter provider configured will start seeing two new counters with constant attributes (`memory.system=cognee`, `memory.operation=process`); deployments without a meter provider hit the `_NullInstrument` no-ops and see nothing. Keep this line in the merge commit body so it is discoverable from the changelog.

## Second review round (last four commits)

An external review of the branch surfaced ten items; all are addressed, in four commits so each is reviewable on its own:

**`fix(observability): Keep capture correct and complete`** — five defects found by an independent multi-lens review:
- Every search's `retrieval.candidates` landed in `nodataset/` while its manifest landed in `<dataset>/` — the dataset was forwarded to the capture scope only in `record_operation`'s `finally`. `recall()` never bound one at all. Fixed on `OperationContext.set_dataset()`; `recall()` binds its single resolved dataset like `search()`.
- Default queue (512) was a quarter of cognify's default `chunks_per_batch` (2000) and the snapshot loop was synchronous: ~74% of chunk graphs dropped after paying the full snapshot cost. Default 2048, lazy build (`emit_lazy`), loop yields.
- `StorageSink` awaited `store()` on the loop, an `async def` with no suspension point: `SINK_TIMEOUT_S` and `drain()`'s budget could never cancel it, and a stalled filesystem pinned every coroutine. Write runs on a worker thread now.
- Two emit points (dropped duplicates, fuzzy matches) read `chunk.id` unguarded where the non-capture path never does — capture on turned a working extraction into an `AttributeError`. Every emit point is guarded and has a failure-injection test.
- `COGNEE_CAPTURE_DIR` was the only storage root not validated as absolute.

**`feat(observability): Version, identify and account every record`** — `schema_version` + `event_id`; `pipeline_name` / `outcome` / `error_class` on pipeline manifests; exact per-run `events_emitted` / `events_dropped` / `events_delivered` + `capture_complete` (replacing a process-wide counter delta that concurrent runs polluted); the pipeline drains before finishing its scope so sink failures are charged to the run before its manifest is written.

**`refactor(observability): Name the sampling knob for what it samples`** — `COGNEE_CAPTURE_SAMPLE_RATE` → `COGNEE_CAPTURE_RETRIEVAL_SAMPLE_RATE` (it only ever sampled `retrieval.*`, deliberately), plus the on-disk data-handling note above.

**`refactor(observability): Contain capture state in CaptureRuntime`** — the module globals moved onto one object; public API unchanged.

Deferred, by agreement: a true graph-version stamp (needs atomic cross-backend versioning), exact live new-vs-existing merge decisions (needs DB pre-reads or every upsert adapter returning insert/update), and a byte-based queue limit (the `pool_truncated` / `pool_size` indicators on retrieval records already exist; an emitted-bytes counter would be the cheap first step if a large corpus proves the need).

## Try it

```bash
export COGNEE_CAPTURE_ENABLED=true
# then run any cognify; artifacts land under <DATA_ROOT_DIRECTORY>/capture/
#   <dataset>/<run>/manifest.json
#   <dataset>/<run>/<kind>/batch-<ts>-<pid>-<seq>.jsonl.gz
```

Knobs (all in `.env.template`): `COGNEE_CAPTURE_DIR`, `_QUEUE_SIZE` (2048), `_BATCH_SIZE`, `_FLUSH_INTERVAL_S`, `_RETRIEVAL_SAMPLE_RATE`, `_SINK_TIMEOUT_S`, `_DRAIN_TIMEOUT_S` (the flush wait added at every pipeline completion while capture is on; default 5 s).

## Test evidence

- Capture suites (`modules/observability`, `modules/operations`, `tasks/{graph,summarization,storage}`, `modules/ontology`, `retrieval/test_brute_force_triplet_search.py`) + both import invariants → **425 passed, 25 skipped**.
- Broader sweep (`modules/pipelines`, `api`, `tasks`, `modules/{retrieval,search,recall}`, `shared`) → **1768 passed**; the 11 failures (`api/test_status_progress_router.py::test_status_progress_requires_authentication` and 10 order-dependent retriever tests in `graph_completion_retriever_cot_test.py`, `temporal_retriever_test.py`, `triplet_retriever_test.py`) **fail identically on the branch's base commit in the same sweep** and pass in isolation. Pre-existing, unrelated.
- `ruff check` and `ruff format --check` clean across every changed file.
- No `cognee_db_workers/` files touched (import-hygiene invariant intact); **no Alembic/schema migration**.
- `import cognee` does **not** import the capture package (asserted by a subprocess test).

## Not in this PR

- **E4 exact/new merge decisions** — derivable *offline* from the provenance ledger (a node whose only `source_ref_key` is this run is new). Doing it live needs a DB pre-read per chunk on the subprocess worker's 300 s budget.
- **R3 "graph version" stamp on queries** — no such concept exists yet; needs defining first (see CLO-652, where `computedAt` currently reports null on most datasets).
- **Cloud enablement** — sink registration, per-dataset opt-in, S3 lifecycle, MotherDuck views. Cloud team, separate PR. Capture stays **off** for every tenant until then.
- **Full graph-state replay** — dropped by agreement with Sesame: `personal_weights` and `feedback_influence` mutate retrieval at query time, so replaying a query needs the feedback state too, not just graph + vector index.

## Known limitations

- An operation run (search/recall) is never drained, so its manifest reports `events_delivered` as of manifest time; a sink failure after that is not reflected. Pipeline runs drain first, so theirs is exact. Consumers verify completeness offline by comparing the records under a run with its `events_emitted`.
- Fuzzy-match capture attributes a resolution to the **first** chunk that mentioned a name, because `_find_ontology_matches_for_extracted_graphs` dedups lookups across the whole batch.
- A loop closed *without* cancelling (pytest-asyncio 0.21) can strand an in-flight batch; the atexit hook and the next `drain()` recover what is still buffered.
- Under S3, the atexit drain still depends on the default executor (`S3FileStorage.store` → `run_async`), which is gone at interpreter exit; leftovers at that point are lost. Local storage persists them. Pre-existing storage-layer behaviour; noted rather than fixed here.
- `RunScope.dropped` is bumped from the emitting thread (buffer full) and the flusher's thread (sink failure); a simultaneous pair of unlocked increments can lose one. A lock on the emit path is not worth that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAbwzWoiSsSjTmFaQqSkN
