### PR TITLE
fix: replace expired discord invite in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Discord Community
-    url: https://discord.gg/NQtRemgQVD
+    url: https://discord.gg/NQPKmU5CCg
     about: Join our Discord community for questions, discussions, and support
   - name: 📖 Documentation
     url: https://docs.cognee.ai


### PR DESCRIPTION
The Discord link offered to everyone opening a GitHub issue pointed at an expired invite. Point it at the same invite the README uses, which is live.

issue - 

https://github.com/user-attachments/assets/c23ec4c8-3e20-47b8-bf69-a9e981e3d786


link added -

https://discord.gg/NQPKmU5CCg
