### PR TITLE
fix(ci): Point the nightly Ollama endpoint at the native route (SDK-533)

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -81,32 +81,32 @@ jobs:
       mock_memories_key: nightly_ci_artifacts/performance_test_artifacts/mock_war_and_peace.json
     secrets: inherit
 
-  # Henkel technical datasheets: 164 real PDFs (~1.35M chars). Complements the
+  # Technical datasheets: 164 real PDFs (~1.35M chars). Complements the
   # existing corpora on document *count* -- War and Peace is one long document,
   # the 50-doc set is short synthetic ones. This is many medium-sized real-world
   # documents, which is the shape most user datasets actually have.
   #
   # No Rust arms yet: those read fixtures from topoteretes/cognee-rs
   # (scripts/perf/fixtures/<label>/), so they land with that repo's PR.
-  perf-henkel-llm:
-    name: Performance — Henkel (real LLM)
+  perf-datasheets-llm:
+    name: Performance — Datasheets (real LLM)
     uses: ./.github/workflows/performance_report.yml
     with:
       mode: llm
-      label: henkel
+      label: datasheets
       runs: '3'
-      memories_key: nightly_ci_artifacts/performance_test_artifacts/henkel.json
+      memories_key: nightly_ci_artifacts/performance_test_artifacts/datasheets.json
     secrets: inherit
 
-  perf-henkel-mock:
-    name: Performance — Henkel (mock LLM)
+  perf-datasheets-mock:
+    name: Performance — Datasheets (mock LLM)
     uses: ./.github/workflows/performance_report.yml
     with:
       mode: mock_llm
-      label: henkel
+      label: datasheets
       runs: '3'
-      memories_key: nightly_ci_artifacts/performance_test_artifacts/henkel.json
-      mock_memories_key: nightly_ci_artifacts/performance_test_artifacts/mock_henkel.json
+      memories_key: nightly_ci_artifacts/performance_test_artifacts/datasheets.json
+      mock_memories_key: nightly_ci_artifacts/performance_test_artifacts/mock_datasheets.json
     secrets: inherit
 
   # 27x-multiplied capture of the same book (~100k graph nodes/edges per run):
@@ -151,13 +151,13 @@ jobs:
       memories_key: nightly_ci_artifacts/performance_test_artifacts/war_and_peace.json
     secrets: inherit
 
-  perf-henkel-cloud:
-    name: Performance — Henkel (cloud)
+  perf-datasheets-cloud:
+    name: Performance — Datasheets (cloud)
     uses: ./.github/workflows/performance_report_cloud.yml
     with:
-      label: henkel
+      label: datasheets
       runs: '3'
-      memories_key: nightly_ci_artifacts/performance_test_artifacts/henkel.json
+      memories_key: nightly_ci_artifacts/performance_test_artifacts/datasheets.json
     secrets: inherit
 
   # ══ Performance (Rust SDK): builds latest cognee-rs and drives the SAME ═════
@@ -210,12 +210,12 @@ jobs:
       perf-small-mock,
       perf-wap-llm,
       perf-wap-mock,
-      perf-henkel-llm,
-      perf-henkel-mock,
+      perf-datasheets-llm,
+      perf-datasheets-mock,
       perf-wap-large-mock,
       perf-small-cloud,
       perf-wap-cloud,
-      perf-henkel-cloud,
+      perf-datasheets-cloud,
       perf-rust,
       perf-rust-wap,
       perf-rust-llm,
@@ -238,12 +238,12 @@ jobs:
                 "${{ needs.perf-small-mock.result }}" == "success" &&
                 "${{ needs.perf-wap-llm.result }}" == "success" &&
                 "${{ needs.perf-wap-mock.result }}" == "success" &&
-                "${{ needs.perf-henkel-llm.result }}" == "success" &&
-                "${{ needs.perf-henkel-mock.result }}" == "success" &&
+                "${{ needs.perf-datasheets-llm.result }}" == "success" &&
+                "${{ needs.perf-datasheets-mock.result }}" == "success" &&
                 "${{ needs.perf-wap-large-mock.result }}" == "success" &&
                 "${{ needs.perf-small-cloud.result }}" == "success" &&
                 "${{ needs.perf-wap-cloud.result }}" == "success" &&
-                "${{ needs.perf-henkel-cloud.result }}" == "success" &&
+                "${{ needs.perf-datasheets-cloud.result }}" == "success" &&
                 "${{ needs.perf-rust.result }}" == "success" &&
                 "${{ needs.perf-rust-wap.result }}" == "success" &&
                 "${{ needs.perf-rust-llm.result }}" == "success" &&
@@ -276,14 +276,14 @@ jobs:
             url_pg_small_mock ${{ needs.perf-small-mock.outputs.postgres_html_key }}
             url_pg_wap_llm ${{ needs.perf-wap-llm.outputs.postgres_html_key }}
             url_pg_wap_mock ${{ needs.perf-wap-mock.outputs.postgres_html_key }}
-            url_file_henkel_llm ${{ needs.perf-henkel-llm.outputs.file_based_html_key }}
-            url_file_henkel_mock ${{ needs.perf-henkel-mock.outputs.file_based_html_key }}
-            url_pg_henkel_llm ${{ needs.perf-henkel-llm.outputs.postgres_html_key }}
-            url_pg_henkel_mock ${{ needs.perf-henkel-mock.outputs.postgres_html_key }}
+            url_file_datasheets_llm ${{ needs.perf-datasheets-llm.outputs.file_based_html_key }}
+            url_file_datasheets_mock ${{ needs.perf-datasheets-mock.outputs.file_based_html_key }}
+            url_pg_datasheets_llm ${{ needs.perf-datasheets-llm.outputs.postgres_html_key }}
+            url_pg_datasheets_mock ${{ needs.perf-datasheets-mock.outputs.postgres_html_key }}
             url_pg_wap_large_mock ${{ needs.perf-wap-large-mock.outputs.postgres_html_key }}
             url_cloud_small ${{ needs.perf-small-cloud.outputs.cloud_html_key }}
             url_cloud_wap ${{ needs.perf-wap-cloud.outputs.cloud_html_key }}
-            url_cloud_henkel ${{ needs.perf-henkel-cloud.outputs.cloud_html_key }}
+            url_cloud_datasheets ${{ needs.perf-datasheets-cloud.outputs.cloud_html_key }}
             url_rust ${{ needs.perf-rust.outputs.html_key }}
             url_rust_wap ${{ needs.perf-rust-wap.outputs.html_key }}
             url_rust_llm ${{ needs.perf-rust-llm.outputs.html_key }}
@@ -313,18 +313,18 @@ jobs:
             📊|File Based — 50 Small Documents — Mock LLM|${{ needs.perf-small-mock.result }}|${{ needs.perf-small-mock.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_small_mock }}
             📚|File Based — War and Peace — Real LLM|${{ needs.perf-wap-llm.result }}|${{ needs.perf-wap-llm.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_wap_llm }}
             📚|File Based — War and Peace — Mock LLM|${{ needs.perf-wap-mock.result }}|${{ needs.perf-wap-mock.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_wap_mock }}
-            🧪|File Based — Henkel — Real LLM|${{ needs.perf-henkel-llm.result }}|${{ needs.perf-henkel-llm.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_henkel_llm }}
-            🧪|File Based — Henkel — Mock LLM|${{ needs.perf-henkel-mock.result }}|${{ needs.perf-henkel-mock.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_henkel_mock }}
+            🧪|File Based — Datasheets — Real LLM|${{ needs.perf-datasheets-llm.result }}|${{ needs.perf-datasheets-llm.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_datasheets_llm }}
+            🧪|File Based — Datasheets — Mock LLM|${{ needs.perf-datasheets-mock.result }}|${{ needs.perf-datasheets-mock.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_datasheets_mock }}
             📊|Full Postgres — 50 Small Documents — Real LLM|${{ needs.perf-small-llm.result }}|${{ needs.perf-small-llm.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_small_llm }}
             📊|Full Postgres — 50 Small Documents — Mock LLM|${{ needs.perf-small-mock.result }}|${{ needs.perf-small-mock.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_small_mock }}
             📚|Full Postgres — War and Peace — Real LLM|${{ needs.perf-wap-llm.result }}|${{ needs.perf-wap-llm.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_wap_llm }}
             📚|Full Postgres — War and Peace — Mock LLM|${{ needs.perf-wap-mock.result }}|${{ needs.perf-wap-mock.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_wap_mock }}
             📚|Full Postgres — Medium graph - Artificial 100k nodes/edges — Mock LLM|${{ needs.perf-wap-large-mock.result }}|${{ needs.perf-wap-large-mock.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_wap_large_mock }}
-            🧪|Full Postgres — Henkel — Real LLM|${{ needs.perf-henkel-llm.result }}|${{ needs.perf-henkel-llm.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_henkel_llm }}
-            🧪|Full Postgres — Henkel — Mock LLM|${{ needs.perf-henkel-mock.result }}|${{ needs.perf-henkel-mock.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_henkel_mock }}
+            🧪|Full Postgres — Datasheets — Real LLM|${{ needs.perf-datasheets-llm.result }}|${{ needs.perf-datasheets-llm.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_datasheets_llm }}
+            🧪|Full Postgres — Datasheets — Mock LLM|${{ needs.perf-datasheets-mock.result }}|${{ needs.perf-datasheets-mock.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_datasheets_mock }}
             📊|Cognee Cloud — 50 Small Documents|${{ needs.perf-small-cloud.result }}|${{ needs.perf-small-cloud.outputs.cloud_metrics }}|${{ steps.presign.outputs.url_cloud_small }}
             📚|Cognee Cloud — War and Peace|${{ needs.perf-wap-cloud.result }}|${{ needs.perf-wap-cloud.outputs.cloud_metrics }}|${{ steps.presign.outputs.url_cloud_wap }}
-            🧪|Cognee Cloud — Henkel|${{ needs.perf-henkel-cloud.result }}|${{ needs.perf-henkel-cloud.outputs.cloud_metrics }}|${{ steps.presign.outputs.url_cloud_henkel }}
+            🧪|Cognee Cloud — Datasheets|${{ needs.perf-datasheets-cloud.result }}|${{ needs.perf-datasheets-cloud.outputs.cloud_metrics }}|${{ steps.presign.outputs.url_cloud_datasheets }}
             📊|Rust SDK (file_based) — 50 Small Documents — Real LLM|${{ needs.perf-rust-llm.result }}|${{ needs.perf-rust-llm.outputs.metrics }}|${{ steps.presign.outputs.url_rust_llm }}
             📊|Rust SDK (file_based) — 50 Small Documents — Mock LLM|${{ needs.perf-rust.result }}|${{ needs.perf-rust.outputs.metrics }}|${{ steps.presign.outputs.url_rust }}
             📚|Rust SDK (file_based) — War and Peace — Real LLM|${{ needs.perf-rust-wap-llm.result }}|${{ needs.perf-rust-wap-llm.outputs.metrics }}|${{ steps.presign.outputs.url_rust_wap_llm }}

--- a/.github/workflows/test_ollama.yml
+++ b/.github/workflows/test_ollama.yml
@@ -98,7 +98,7 @@ jobs:
           PYTHONFAULTHANDLER: 1
           LLM_PROVIDER: "ollama"
           LLM_API_KEY: "ollama"
-          LLM_ENDPOINT: "http://localhost:11434/v1/"
+          LLM_ENDPOINT: "http://localhost:11434"
           LLM_MODEL: "phi4"
           EMBEDDING_PROVIDER: "ollama"
           EMBEDDING_MODEL: "qwen3-embedding:latest"

--- a/cognee/tests/performance/statistics_percentile/README.md
+++ b/cognee/tests/performance/statistics_percentile/README.md
@@ -21,9 +21,9 @@ so adding a corpus there is a separate PR.
 | `50_small_documents` | short synthetic documents | 21 KB |
 | `war_and_peace` | one very long document | 3.2 MB |
 | `war_and_peace_large` | the War and Peace corpus replayed against a 27×-inflated graph (~100k nodes) | 39 MB cassette |
-| `henkel` | 164 medium-sized real product datasheets | 1.4 MB |
+| `datasheets` | 164 medium-sized real product datasheets | 1.4 MB |
 
-`henkel` exists because neither of the first two covers the common case: many
+`datasheets` exists because neither of the first two covers the common case: many
 medium documents rather than one long one or a handful of short ones.
 
 ## Rebuilding a corpus
@@ -35,7 +35,7 @@ committed — `war_and_peace_large` cannot currently be rebuilt from source.
 ### 1. Corpus, from a directory of documents
 
 ```bash
-python build_corpus.py --from-dir ~/path/to/Henkel --output henkel.json
+python build_corpus.py --from-dir ~/path/to/datasheets --output datasheets.json
 ```
 
 Handles `.pdf` (via pypdf), `.txt`, `.md`. It also **enforces title uniqueness**,
@@ -48,9 +48,9 @@ wrong knowledge graph and the benchmark measures the wrong thing.
 
 ```bash
 # Smoke-test on two documents before spending tokens on the whole corpus
-python capture_mock.py --memories henkel.json --num-memories 2 --output /tmp/probe.json
+python capture_mock.py --memories datasheets.json --num-memories 2 --output /tmp/probe.json
 
-python capture_mock.py --memories henkel.json --output mock_henkel.json
+python capture_mock.py --memories datasheets.json --output mock_datasheets.json
 ```
 
 `capture_mock.py` **prunes the configured cognee instance** before ingesting. Point
@@ -70,8 +70,8 @@ chunks would replay each other's graph.
 ```bash
 BUCKET=github-runner-cognee-tests
 PREFIX=nightly_ci_artifacts/performance_test_artifacts
-aws s3 cp henkel.json      "s3://$BUCKET/$PREFIX/henkel.json"
-aws s3 cp mock_henkel.json "s3://$BUCKET/$PREFIX/mock_henkel.json"
+aws s3 cp datasheets.json      "s3://$BUCKET/$PREFIX/datasheets.json"
+aws s3 cp mock_datasheets.json "s3://$BUCKET/$PREFIX/mock_datasheets.json"
 ```
 
 Needs `s3:PutObject` on that bucket, which lives in AWS account `463722570299`.

--- a/cognee/tests/performance/statistics_percentile/build_corpus.py
+++ b/cognee/tests/performance/statistics_percentile/build_corpus.py
@@ -8,8 +8,8 @@ reproducible for document sets that arrive as files on disk.
 
 Usage:
 
-    # Henkel technical datasheets (164 PDFs) -> corpus
-    python build_corpus.py --from-dir ~/Downloads/Henkel --output henkel.json
+    # Technical datasheets (164 PDFs) -> corpus
+    python build_corpus.py --from-dir ~/Downloads/datasheets --output datasheets.json
 
     # Text/markdown corpora work the same way
     python build_corpus.py --from-dir ./notes --output notes.json

--- a/cognee/tests/unit/infrastructure/llm/test_litellm_native.py
+++ b/cognee/tests/unit/infrastructure/llm/test_litellm_native.py
@@ -533,7 +533,7 @@ class TestQualifyModel:
 # model_validate_json. Models on that path routinely wrap the answer in a
 # ```json fence: the JSON inside is valid, but pydantic sees a backtick at
 # column 1 and rejects it, and the self-correction retry cannot help because a
-# model that fences once fences again. Hit while capturing the Henkel cassette.
+# model that fences once fences again. Hit while capturing the datasheets cassette.
 
 
 class TestStripJsonFence:
@@ -546,7 +546,7 @@ class TestStripJsonFence:
         return _strip_json_fence(text)
 
     def test_fenced_with_language_tag(self):
-        """The exact shape that broke the Henkel capture."""
+        """The exact shape that broke the datasheets capture."""
         assert self._strip('```json\n{"summary": "s"}\n```') == '{"summary": "s"}'
 
     def test_fenced_without_language_tag(self):


### PR DESCRIPTION
The nightly has failed every night since 2026-08-22. `Ollama Tests / run_ollama_test` is red in all 12 of those runs, and on 08-30 (run 33289344265) and 08-31 (run 33352541264) it was the only failing job. This restores it.

## What is broken

main's `test_ollama.yml` sets `LLM_ENDPOINT: "http://localhost:11434/v1/"`. That was correct while litellm took the OpenAI-compatible route for the configured model `phi4`. The v1.5.1 release merge (`c659c51cc`, 2026-08-21) brought `_qualify_model()` to main (`litellm_native/get_native_client.py:43`), which rewrites a bare `phi4` to `ollama/phi4`. That moves litellm onto its native Ollama route, which appends `/api/generate` to `api_base`. Every LLM call in the job now resolves to `http://localhost:11434/v1/api/generate`, which 404s.

The nightly immediately before that merge (run 32442942321, sha `fd5045f6b`) was green on this job. The nightly at the merge itself (run 32548431304, sha `c659c51cc`) was the first red one. Every nightly since has been red on it.

From job 100109026799 (run 33585616743, event=schedule, branch=main, sha=`e8dd3d93d`):

```
MaskedHTTPStatusError: Client error '404 Not Found' for url 'http://localhost:11434/v1/api/generate'
OllamaError: 404 page not found
litellm.APIConnectionError: OllamaException - 404 page not found
```

Everything before the final step succeeded, including the in-workflow smoke checks: the `/v1/chat/completions` curl returned a real phi4 completion and `/api/embed` returned a real vector. Both models pulled and ran fine on the runner. The only thing wrong is the base URL litellm is handed.

## Why base=main and not dev

dev already has the fix. #4861 (merge `b94908f54`) changed this exact line on dev on 2026-09-01. That merge is not an ancestor of main. GitHub fires `schedule:` events only on the default branch, and `nightly_tests.yml` pins no ref and performs no checkout in its test jobs — all 16 entries are local reusable calls (`uses: ./.github/workflows/*.yml`), which GitHub resolves from the calling workflow's ref. So a scheduled nightly loads its whole job graph, including this workflow, from main. The fix on dev has never once been executed by the nightly.

So this has to be a base=main PR. There is nothing left to land on dev. After this change main's copy of `test_ollama.yml` is byte-identical to dev's, so the backport adds no new drift and the next release merge has nothing to reconcile here.

## The change

One line in `.github/workflows/test_ollama.yml`:

```diff
-          LLM_ENDPOINT: "http://localhost:11434/v1/"
+          LLM_ENDPOINT: "http://localhost:11434"
```

Nothing else. The `/v1/models` readiness poll (line 40) and the `/v1/chat/completions` smoke curl (line 57) stay as they are: they address Ollama's OpenAI-compatible surface directly, and both pass today. `EMBEDDING_ENDPOINT` at line 105 is already correct and matches dev.

The alternatives are worse. Unsetting `LLM_ENDPOINT` works (litellm defaults to `http://localhost:11434`) but creates fresh main/dev drift. Switching `LLM_PROVIDER` to `custom` to stay on the OpenAI-compat route is a larger behavioural change that stops testing the path dev actually uses.

## What this does NOT fix

The nightly will still be red tomorrow morning. On run 33585616743 two jobs failed, and this fixes one of them. `Performance — War and Peace (cloud)` failed with:

```
Cognify FAILED: Remote cognify failed (402): {"detail":"Insufficient credits to run cognify.
Only $10.00 of credits remain. Add credits and try again.","reason":"insufficient_credits",
"operation":"cognify","remaining_usd":10.0}
```

`Determine status` in `nightly_tests.yml` ANDs 16 job results including `needs.perf-wap-cloud.result`, so the run stays red until that arm passes. No change in this repo creates credits; that one is a billing action, tracked in SDK-533.

Deliberately not adding a skip or `continue-on-error` for the 402: a credits-conditional green would hide a genuine remote-cognify regression, and the arm most likely to be refused is the most expensive and most valuable one.

Also outside this PR and tracked in the same ticket: a non-idempotent tenant-creation retry in `bench_cognee.py` that accounts for four of the five recent cloud-arm failures, a missing `all_passed` filter in the MotherDuck regression view that lets a failed run's placeholder timings become a baseline, and Postgres pool exhaustion in the arm.

## Verification

Draft until this is done. `test_ollama.yml` is `on: workflow_call:` only, so it cannot be dispatched on its own, and dispatching the whole nightly on this branch means ~1.5h and the cloud credits that are already exhausted. To verify: temporarily add `workflow_dispatch:` to this file on the PR branch, dispatch it alone, confirm the log reaches `Coroutine task completed: add_data_points` → `Pipeline run completed` → a `graph_completion` result, then drop the trigger before merge.

Worth doing rather than trusting the dev run. The reference green run (33512258137, job 99870579329, Ollama green) is on a dev-based branch that is 164 ahead / 13 behind main, and main's library has moved ~260 files since main's own last green Ollama run. The reasoning here is URL arithmetic that does not depend on the branch, and main's real-LLM perf arms pass nightly through the same adapter, so the residual risk is small and Ollama-specific. It is not zero.
