### PR TITLE
refactor: Propagate session API write errors

### DIFF
--- a/cognee/api/v1/session/session.py
+++ b/cognee/api/v1/session/session.py
@@ -117,21 +117,31 @@ async def add_feedback(
     feedback_score: Optional[int] = None,
     user: Optional[User] = None,
 ) -> bool:
+    """Add or update feedback for a QA entry.
+
+    Args:
+        session_id: Session identifier.
+        qa_id: QA entry identifier.
+        feedback_text: Optional free-text feedback.
+        feedback_score: Optional numeric feedback score.
+        user: User that owns the session. If None, uses session/context user or default user.
+
+    Returns:
+        True if the entry was updated, False if the QA entry was not found or
+        caching is disabled. Any other failure (unreachable cache, misconfigured
+        backend, invalid parameters) raises instead of being reported as False.
+    """
     resolved_user = await _resolve_user(user)
     user_id = str(resolved_user.id)
 
-    try:
-        sm = get_session_manager()
-        return await sm.add_feedback(
-            user_id=user_id,
-            session_id=session_id,
-            qa_id=qa_id,
-            feedback_text=feedback_text,
-            feedback_score=feedback_score,
-        )
-    except Exception as e:
-        logger.warning("add_feedback: error from SessionManager: %s", e)
-        return False
+    sm = get_session_manager()
+    return await sm.add_feedback(
+        user_id=user_id,
+        session_id=session_id,
+        qa_id=qa_id,
+        feedback_text=feedback_text,
+        feedback_score=feedback_score,
+    )
 
 
 async def add_frequency_weights(
@@ -158,7 +168,9 @@ async def add_frequency_weights(
         user: User that owns the session. If None, uses session/context user or default user.
 
     Returns:
-        True if updated, False if QA not found or cache unavailable.
+        True if the entry was updated, False if the QA entry was not found or
+        caching is disabled. Any other failure (unreachable cache, misconfigured
+        backend, invalid parameters) raises instead of being reported as False.
     """
     from cognee.tasks.memify.frequency_weights_constants import (
         MEMIFY_METADATA_FREQUENCY_WEIGHTS_APPLIED_KEY,
@@ -173,18 +185,14 @@ async def add_frequency_weights(
     if edge_ids:
         used_graph_element_ids["edge_ids"] = edge_ids
 
-    try:
-        sm = get_session_manager()
-        return await sm.update_qa(
-            user_id=user_id,
-            session_id=session_id,
-            qa_id=qa_id,
-            used_graph_element_ids=used_graph_element_ids if used_graph_element_ids else None,
-            memify_metadata={MEMIFY_METADATA_FREQUENCY_WEIGHTS_APPLIED_KEY: False},
-        )
-    except Exception as e:
-        logger.warning("add_frequency_weights: error from SessionManager: %s", e)
-        return False
+    sm = get_session_manager()
+    return await sm.update_qa(
+        user_id=user_id,
+        session_id=session_id,
+        qa_id=qa_id,
+        used_graph_element_ids=used_graph_element_ids if used_graph_element_ids else None,
+        memify_metadata={MEMIFY_METADATA_FREQUENCY_WEIGHTS_APPLIED_KEY: False},
+    )
 
 
 async def delete_feedback(
@@ -203,18 +211,16 @@ async def delete_feedback(
         user: User that owns the session. If None, uses session/context user or default user.
 
     Returns:
-        True if feedback was cleared, False if QA not found or cache unavailable.
+        True if feedback was cleared, False if the QA entry was not found or
+        caching is disabled. Any other failure (unreachable cache, misconfigured
+        backend, invalid parameters) raises instead of being reported as False.
     """
     resolved_user = await _resolve_user(user)
     user_id = str(resolved_user.id)
 
-    try:
-        sm = get_session_manager()
-        return await sm.delete_feedback(
-            user_id=user_id,
-            session_id=session_id,
-            qa_id=qa_id,
-        )
-    except Exception as e:
-        logger.warning("delete_feedback: error from SessionManager: %s", e)
-        return False
+    sm = get_session_manager()
+    return await sm.delete_feedback(
+        user_id=user_id,
+        session_id=session_id,
+        qa_id=qa_id,
+    )

--- a/cognee/cli/commands/feedback_command.py
+++ b/cognee/cli/commands/feedback_command.py
@@ -51,43 +51,65 @@ Subcommands:
             fmt.error("Provide at least --text or --score.")
             raise CliCommandException("No feedback content provided", error_code=1)
 
-        async def run():
+        sid = args.session_id
+
+        async def run() -> bool:
             from cognee.api.v1.session import add_feedback
             from cognee.cli.user_resolution import resolve_cli_user
 
             user = await resolve_cli_user(getattr(args, "user_id", None))
-            sid = args.session_id
-
-            ok = await add_feedback(
+            return await add_feedback(
                 session_id=sid,
                 qa_id=args.qa_id,
                 feedback_text=args.text,
                 feedback_score=args.score,
                 user=user,
             )
-            if ok:
-                fmt.success(f"Feedback added to entry {args.qa_id} in session {sid}.")
-            else:
-                fmt.error("Failed to add feedback. Check session/qa IDs.")
 
-        asyncio.run(run())
+        ok = self._run(run(), "Error adding feedback")
+        if not ok:
+            raise CliCommandException(
+                _not_found_message("Feedback not added", args.qa_id, sid), error_code=1
+            )
+        fmt.success(f"Feedback added to entry {args.qa_id} in session {sid}.")
 
     def _delete(self, args: argparse.Namespace) -> None:
-        async def run():
+        sid = args.session_id
+
+        async def run() -> bool:
             from cognee.api.v1.session import delete_feedback
             from cognee.cli.user_resolution import resolve_cli_user
 
             user = await resolve_cli_user(getattr(args, "user_id", None))
-            sid = args.session_id
-
-            ok = await delete_feedback(
+            return await delete_feedback(
                 session_id=sid,
                 qa_id=args.qa_id,
                 user=user,
             )
-            if ok:
-                fmt.success(f"Feedback cleared from entry {args.qa_id} in session {sid}.")
-            else:
-                fmt.error("Failed to clear feedback. Check session/qa IDs.")
 
-        asyncio.run(run())
+        ok = self._run(run(), "Error clearing feedback")
+        if not ok:
+            raise CliCommandException(
+                _not_found_message("Feedback not cleared", args.qa_id, sid), error_code=1
+            )
+        fmt.success(f"Feedback cleared from entry {args.qa_id} in session {sid}.")
+
+    @staticmethod
+    def _run(coro, error_prefix: str) -> bool:
+        """Run the session call, surfacing infrastructure failures as CLI errors.
+
+        The session API raises on anything that is not a plain "not found"
+        (unreachable cache, misconfigured backend, invalid ids), so a failure
+        here is a real error and must not be reported as a missing entry.
+        """
+        try:
+            return asyncio.run(coro)
+        except Exception as e:
+            raise CliCommandException(f"{error_prefix}: {str(e)}", error_code=1) from e
+
+
+def _not_found_message(prefix: str, qa_id: str, session_id: str) -> str:
+    return (
+        f"{prefix}: no Q&A entry {qa_id} in session {session_id}, or caching is disabled. "
+        "Check the session and qa IDs and the CACHING setting."
+    )

--- a/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
@@ -828,3 +828,138 @@ class TestConfigGetSetPersistence:
             os.chdir(original_cwd)
             get_chunk_config.cache_clear()
             get_chunk_config().chunk_size = original_chunk_size
+
+
+class TestFeedbackCommand:
+    """Tests for FeedbackCommand: a missing Q&A entry and a broken cache are
+    different failures, and both must exit non-zero."""
+
+    def _add_args(self, **overrides):
+        base = dict(feedback_action="add", session_id="s1", qa_id="q1", text="good", score=None)
+        base.update(overrides)
+        return argparse.Namespace(**base)
+
+    def _delete_args(self):
+        return argparse.Namespace(feedback_action="delete", session_id="s1", qa_id="q1")
+
+    def test_command_properties(self):
+        from cognee.cli.commands.feedback_command import FeedbackCommand
+
+        command = FeedbackCommand()
+        assert command.command_string == "feedback"
+        assert "feedback" in command.help_string.lower()
+
+    def test_configure_parser(self):
+        from cognee.cli.commands.feedback_command import FeedbackCommand
+
+        parser = argparse.ArgumentParser()
+        FeedbackCommand().configure_parser(parser)
+        add_args = parser.parse_args(["add", "s1", "q1", "--score", "5"])
+        assert add_args.feedback_action == "add"
+        assert add_args.score == 5
+        del_args = parser.parse_args(["delete", "s1", "q1"])
+        assert del_args.feedback_action == "delete"
+
+    def test_add_requires_text_or_score(self):
+        from cognee.cli.commands.feedback_command import FeedbackCommand
+
+        with pytest.raises(CliCommandException) as exc_info:
+            FeedbackCommand().execute(self._add_args(text=None, score=None))
+        assert exc_info.value.error_code == 1
+
+    @patch(_RESOLVE_USER_PATCH, new_callable=lambda: AsyncMock(return_value=_mock_user()))
+    @patch("cognee.cli.commands.feedback_command.fmt.success")
+    @patch("cognee.cli.commands.feedback_command.asyncio.run", side_effect=_mock_run)
+    def test_add_success(self, _mock_asyncio_run, mock_success, _mock_resolve):
+        from cognee.cli.commands.feedback_command import FeedbackCommand
+
+        with patch(
+            "cognee.api.v1.session.add_feedback", new_callable=lambda: AsyncMock(return_value=True)
+        ) as mock_add:
+            FeedbackCommand().execute(self._add_args(score=4))
+
+        mock_add.assert_awaited_once_with(
+            session_id="s1", qa_id="q1", feedback_text="good", feedback_score=4, user=ANY
+        )
+        mock_success.assert_called_once()
+
+    @patch(_RESOLVE_USER_PATCH, new_callable=lambda: AsyncMock(return_value=_mock_user()))
+    @patch("cognee.cli.commands.feedback_command.asyncio.run", side_effect=_mock_run)
+    def test_add_not_found_exits_non_zero(self, _mock_asyncio_run, _mock_resolve):
+        """False from the SDK means "no such entry" (or caching off), not a crash."""
+        from cognee.cli.commands.feedback_command import FeedbackCommand
+
+        with patch(
+            "cognee.api.v1.session.add_feedback", new_callable=lambda: AsyncMock(return_value=False)
+        ):
+            with pytest.raises(CliCommandException) as exc_info:
+                FeedbackCommand().execute(self._add_args())
+
+        assert exc_info.value.error_code == 1
+        assert "no Q&A entry q1 in session s1" in str(exc_info.value)
+
+    @patch(_RESOLVE_USER_PATCH, new_callable=lambda: AsyncMock(return_value=_mock_user()))
+    @patch("cognee.cli.commands.feedback_command.asyncio.run", side_effect=_mock_run)
+    def test_add_infrastructure_error_is_reported_as_error(self, _mock_asyncio_run, _mock_resolve):
+        """A cache failure surfaces with its own message, not as "check your IDs"."""
+        from cognee.cli.commands.feedback_command import FeedbackCommand
+        from cognee.infrastructure.databases.exceptions import CacheConnectionError
+
+        with patch(
+            "cognee.api.v1.session.add_feedback",
+            new_callable=lambda: AsyncMock(side_effect=CacheConnectionError("redis down")),
+        ):
+            with pytest.raises(CliCommandException) as exc_info:
+                FeedbackCommand().execute(self._add_args())
+
+        assert exc_info.value.error_code == 1
+        assert "redis down" in str(exc_info.value)
+        assert "no Q&A entry" not in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, CacheConnectionError)
+
+    @patch(_RESOLVE_USER_PATCH, new_callable=lambda: AsyncMock(return_value=_mock_user()))
+    @patch("cognee.cli.commands.feedback_command.fmt.success")
+    @patch("cognee.cli.commands.feedback_command.asyncio.run", side_effect=_mock_run)
+    def test_delete_success(self, _mock_asyncio_run, mock_success, _mock_resolve):
+        from cognee.cli.commands.feedback_command import FeedbackCommand
+
+        with patch(
+            "cognee.api.v1.session.delete_feedback",
+            new_callable=lambda: AsyncMock(return_value=True),
+        ) as mock_delete:
+            FeedbackCommand().execute(self._delete_args())
+
+        mock_delete.assert_awaited_once_with(session_id="s1", qa_id="q1", user=ANY)
+        mock_success.assert_called_once()
+
+    @patch(_RESOLVE_USER_PATCH, new_callable=lambda: AsyncMock(return_value=_mock_user()))
+    @patch("cognee.cli.commands.feedback_command.asyncio.run", side_effect=_mock_run)
+    def test_delete_not_found_exits_non_zero(self, _mock_asyncio_run, _mock_resolve):
+        from cognee.cli.commands.feedback_command import FeedbackCommand
+
+        with patch(
+            "cognee.api.v1.session.delete_feedback",
+            new_callable=lambda: AsyncMock(return_value=False),
+        ):
+            with pytest.raises(CliCommandException) as exc_info:
+                FeedbackCommand().execute(self._delete_args())
+
+        assert exc_info.value.error_code == 1
+        assert "no Q&A entry q1 in session s1" in str(exc_info.value)
+
+    @patch(_RESOLVE_USER_PATCH, new_callable=lambda: AsyncMock(return_value=_mock_user()))
+    @patch("cognee.cli.commands.feedback_command.asyncio.run", side_effect=_mock_run)
+    def test_delete_infrastructure_error_is_reported_as_error(
+        self, _mock_asyncio_run, _mock_resolve
+    ):
+        from cognee.cli.commands.feedback_command import FeedbackCommand
+
+        with patch(
+            "cognee.api.v1.session.delete_feedback",
+            new_callable=lambda: AsyncMock(side_effect=RuntimeError("cache exploded")),
+        ):
+            with pytest.raises(CliCommandException) as exc_info:
+                FeedbackCommand().execute(self._delete_args())
+
+        assert exc_info.value.error_code == 1
+        assert "cache exploded" in str(exc_info.value)

--- a/cognee/tests/unit/api/v1/session/test_session_api.py
+++ b/cognee/tests/unit/api/v1/session/test_session_api.py
@@ -411,12 +411,27 @@ class TestAddFeedback:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_session_manager_exception(self, session_user_ctx, sm):
+    async def test_session_manager_exception_propagates(self, session_user_ctx, sm):
+        """A failed write is an error, not a missing QA entry."""
         from cognee.api.v1.session.session import add_feedback
 
         sm.add_feedback.side_effect = RuntimeError("cache error")
-        result = await add_feedback(session_id="s1", qa_id="q1", feedback_text="ok")
-        assert result is False
+        with pytest.raises(RuntimeError, match="cache error"):
+            await add_feedback(session_id="s1", qa_id="q1", feedback_text="ok")
+
+    @pytest.mark.asyncio
+    async def test_session_manager_factory_exception_propagates(self, session_user_ctx):
+        """A misconfigured cache backend is an error, not a missing QA entry."""
+        from cognee.api.v1.session.session import add_feedback
+        from cognee.infrastructure.databases.exceptions import CacheConnectionError
+
+        with patch.object(
+            _session_module(),
+            "get_session_manager",
+            side_effect=CacheConnectionError("bad backend"),
+        ):
+            with pytest.raises(CacheConnectionError, match="bad backend"):
+                await add_feedback(session_id="s1", qa_id="q1", feedback_text="ok")
 
     @pytest.mark.asyncio
     async def test_passes_optional_feedback_params(self, session_user_ctx, sm):
@@ -492,12 +507,13 @@ class TestAddFrequencyWeights:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_session_manager_exception(self, session_user_ctx, sm):
+    async def test_session_manager_exception_propagates(self, session_user_ctx, sm):
+        """A failed write is an error, not a missing QA entry."""
         from cognee.api.v1.session.session import add_frequency_weights
 
         sm.update_qa.side_effect = RuntimeError("cache error")
-        result = await add_frequency_weights(session_id="s1", qa_id="q1", node_ids=["n1"])
-        assert result is False
+        with pytest.raises(RuntimeError, match="cache error"):
+            await add_frequency_weights(session_id="s1", qa_id="q1", node_ids=["n1"])
 
     @pytest.mark.asyncio
     async def test_uses_explicit_user(self, session_user_ctx, sm):
@@ -551,12 +567,13 @@ class TestDeleteFeedback:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_session_manager_exception(self, session_user_ctx, sm):
+    async def test_session_manager_exception_propagates(self, session_user_ctx, sm):
+        """A failed write is an error, not a missing QA entry."""
         from cognee.api.v1.session.session import delete_feedback
 
         sm.delete_feedback.side_effect = RuntimeError("cache error")
-        result = await delete_feedback(session_id="s1", qa_id="q1")
-        assert result is False
+        with pytest.raises(RuntimeError, match="cache error"):
+            await delete_feedback(session_id="s1", qa_id="q1")
 
     @pytest.mark.asyncio
     async def test_uses_explicit_user(self, session_user_none, sm):


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->
`add_feedback`, `add_frequency_weights`, and `delete_feedback` in `cognee/api/v1/session/session.py` wrapped their bodies in `except Exception: return False`, so a not-found QA, caching disabled, and a broken cache all looked the same to callers. A user recording feedback while Redis hiccups got `False` and the signal was silently lost.

The wrappers are removed and errors propagate, following the same fix already applied to `get_session`. `False` now means only "QA not found" or "caching disabled"; the SessionManager already returns that by design.

## Changes

- Remove the three catch-alls and document the new return contract.
- Flip the three `False`-on-error unit tests to assert propagation, plus one new test for a failing session-manager factory.
- `cognee-cli feedback add/delete` now reports not-found and infrastructure errors separately and exits non-zero on both (previously exited 0 with a generic message).
- Add `TestFeedbackCommand` covering the CLI paths.

## Behavior changes

- Empty `qa_id`/`session_id` raise `SessionParameterValidationError` instead of returning `False`.
- CLI exits 1 when the entry is not found.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
