### PR TITLE
fix(ci): Name the arm's own cassette when it drifts (CLO-706)

### DIFF
--- a/.github/workflows/performance_report_rust.yml
+++ b/.github/workflows/performance_report_rust.yml
@@ -159,7 +159,8 @@ jobs:
       # reports (empty-graph timings are cheap but not representative), and the
       # nightly stays green. The warning surfaces as a GitHub annotation + step
       # summary so it is visible without red-failing the whole nightly. Re-record
-      # cognee-rs/scripts/perf/fixtures/cassette.json to clear it (see its README).
+      # the arm's own cassette — `inputs.cassette`, which the warning names — to
+      # clear it (see cognee-rs/scripts/perf/README.md).
       #
       # LOG_LEVEL=info is pinned so the log-scraping check is deterministic
       # regardless of any RUST_LOG/LOG_LEVEL inherited by the runner.
@@ -182,7 +183,12 @@ jobs:
                       | grep -oE '[0-9]+' | head -1 || true)"
           echo "entity-type nodes created on replay: ${entities:-0}"
           if [ -z "${entities:-}" ] || [ "${entities:-0}" -lt 1 ]; then
-            msg="cognee-rs perf cassette looks STALE — replay produced no entity-type nodes (EmptyGraph fallback). Timings below are NOT representative. Re-record cognee-rs/scripts/perf/fixtures/cassette.json (see its README)."
+            # Name the cassette THIS arm replays. Every mock arm shares this
+            # step, so a hardcoded path sends whoever reads the annotation to
+            # re-record a different arm's fixture — and because the guard only
+            # warns, this arm goes on reporting empty-graph timings as "success"
+            # while the drift it reported stays uncleared.
+            msg="cognee-rs perf cassette looks STALE — replay produced no entity-type nodes (EmptyGraph fallback). Timings below are NOT representative. Re-record cognee-rs/${{ inputs.cassette }} (see cognee-rs/scripts/perf/README.md)."
             echo "::warning::$msg"
             echo "⚠️ $msg" >> "$GITHUB_STEP_SUMMARY"
             cat "$log" >&2


### PR DESCRIPTION
The "Verify cassette freshness" step in `performance_report_rust.yml` replays whatever cassette its caller passed (`${{ inputs.cassette }}`), but the warning it prints hardcoded one fixture path. Every mock Rust arm shares that step, so a drifting War-and-Peace cassette told whoever read the annotation to re-record the 50-small-documents fixture.

The guard warns rather than fails — deliberately, so a stale cassette does not redden the whole nightly. That is exactly what makes the misdirection expensive: the arm keeps reporting empty-graph timings as `success` while the wrong fixture gets re-recorded, so the drift it reported never gets cleared.

The message now interpolates the input, and points at the fixtures README instead of one fixture's own. Rendered for each caller today:

```
perf-rust      → Re-record cognee-rs/scripts/perf/fixtures/cassette.json (see cognee-rs/scripts/perf/README.md).
perf-rust-wap  → Re-record cognee-rs/scripts/perf/fixtures/war_and_peace/cassette.json (see …).
```

The comment above the step carried the same hardcoded path and is corrected with it.

Comment-and-string only — no change to what the guard runs or when it warns. YAML parses, the guard step's `run` block no longer contains a literal fixture path (the only remaining occurrence is the `cassette` input's default, which is correct), and `pre-commit run --files .github/workflows/performance_report_rust.yml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKqcwkpSRocWQtACWtLPhV