### PR TITLE
fix(recall): ignore operation records in graph warm-up

### DIFF
--- a/cognee/modules/recall/methods/graph_warmup.py
+++ b/cognee/modules/recall/methods/graph_warmup.py
@@ -150,8 +150,19 @@ async def get_graph_build_status(user, dataset_ids: list[UUID] | None) -> Warmup
                 error_message=latest_errored[1],
             )
 
+        # Operation records also use pipeline_runs, but intentionally leave
+        # pipeline_name NULL. They are activity evidence, not graph readiness.
         any_run = (
-            await session.execute(select(exists().where(PipelineRun.dataset_id.in_(ids))))
+            await session.execute(
+                select(
+                    exists().where(
+                        and_(
+                            PipelineRun.dataset_id.in_(ids),
+                            PipelineRun.pipeline_name.isnot(None),
+                        )
+                    )
+                )
+            )
         ).scalar()
 
     if any_run:

--- a/cognee/tests/integration/retrieval/test_graph_warmup_probe.py
+++ b/cognee/tests/integration/retrieval/test_graph_warmup_probe.py
@@ -15,9 +15,11 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import select
 
 import cognee
 from cognee.infrastructure.databases.relational import create_db_and_tables, get_relational_engine
+from cognee.modules.operations import record_operation
 from cognee.modules.pipelines.models import PipelineRun
 from cognee.modules.pipelines.models.PipelineRun import PipelineRunStatus
 from cognee.modules.recall.methods.graph_warmup import (
@@ -108,6 +110,37 @@ async def test_errored_staging_run_keeps_failsafe_warm(clean_test_environment, m
 
     probe = await get_graph_build_status(_USER, [dataset_id])
     assert probe.state == STATE_WARM
+
+
+@pytest.mark.asyncio
+async def test_operation_record_does_not_make_unbuilt_dataset_warm(
+    clean_test_environment, monkeypatch
+):
+    """A session-only remember record is not evidence of a built graph."""
+    dataset_id = uuid4()
+    _permit(monkeypatch, [dataset_id])
+
+    # This is the row produced by remember(..., session_id=...): it carries
+    # the dataset for attribution, but has no pipeline_name or status.
+    async with record_operation("remember", dataset_id=dataset_id, session_id="session-1"):
+        pass
+
+    async with get_relational_engine().get_async_session() as session:
+        rows = (
+            (await session.execute(select(PipelineRun).where(PipelineRun.dataset_id == dataset_id)))
+            .scalars()
+            .all()
+        )
+
+    assert len(rows) == 1
+    operation_row = rows[0]
+    assert operation_row.dataset_id == dataset_id
+    assert operation_row.operation_name == "remember"
+    assert operation_row.pipeline_name is None
+    assert operation_row.status is None
+
+    probe = await get_graph_build_status(_USER, [dataset_id])
+    assert probe.state == STATE_NEVER_BUILT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Operation records and pipeline runs share the `pipeline_runs` table. Operation rows have `pipeline_name = NULL` and `status = NULL`, but the graph warm-up fallback previously treated any row for a dataset as evidence that its graph was ready.

This change requires a non-null `pipeline_name` in that fallback query. It keeps the existing behavior for named pipeline rows, including the conservative fallback used for staged data and custom pipelines. It also adds a regression test that creates an operation row through `record_operation()` and verifies that an otherwise unbuilt dataset remains `never_built`.

Fixes #4879

## Acceptance Criteria
- Operation-only activity rows return `never_built`.
- Named pipeline rows retain their existing warm fallback behavior.
- A regression test verifies both the stored operation-row shape and the resulting warm-up state.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->
N/A

## Test Results

```text
uv run --no-sync pytest cognee/tests/unit/api/v1/recall/test_recall_warmup.py -q
21 passed

uv run --no-sync ruff format --check \
  cognee/modules/recall/methods/graph_warmup.py \
  cognee/tests/integration/retrieval/test_graph_warmup_probe.py
uv run --no-sync ruff check \
  cognee/modules/recall/methods/graph_warmup.py \
  cognee/tests/integration/retrieval/test_graph_warmup_probe.py
All checks passed!
2 files already formatted
```

The following integration test did not complete locally because async SQLite initialization hung before the test body:

```text
uv run --no-sync pytest \
  cognee/tests/integration/retrieval/test_graph_warmup_probe.py -q
```

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
