### PR TITLE
fix: Pass max_completion_tokens to litellm (SDK-538)

### DIFF
--- a/cognee/infrastructure/llm/structured_output_framework/litellm_native/native_adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_native/native_adapter.py
@@ -371,6 +371,13 @@ class NativeLiteLLMAdapter:
         fallback model before raising ``ContentPolicyFilterError``.
         """
         merged_kwargs = {**self.llm_args, **kwargs}
+        # The stored cap is min(model limit, llm_max_completion_tokens) — see
+        # get_native_client. Without it in the request, a reasoning model bills
+        # unbounded reasoning output. Inject it as the base layer unless the
+        # caller already caps via either alias: sending max_tokens AND
+        # max_completion_tokens together is an API error on some providers.
+        if not ({"max_completion_tokens", "max_tokens"} & merged_kwargs.keys()):
+            merged_kwargs["max_completion_tokens"] = self.max_completion_tokens
 
         # A plain string needs no schema — skip structured output entirely.
         if response_model is str:

--- a/cognee/tests/unit/infrastructure/llm/test_litellm_native.py
+++ b/cognee/tests/unit/infrastructure/llm/test_litellm_native.py
@@ -586,3 +586,90 @@ class TestStripJsonFence:
 
         raw = '```json\n{"summary": "a summary", "description": ""}\n```'
         assert SummarizedContent.model_validate_json(self._strip(raw)).summary == "a summary"
+
+
+# ---- max_completion_tokens actually reaching litellm (SDK-538) ----
+
+
+def _call_kwargs(mock_acompletion):
+    return mock_acompletion.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_stored_cap_reaches_litellm_on_schema_path():
+    """The constructor-stored cap must be sent — unsent, a reasoning model
+    bills unbounded reasoning output (the CLO-679 COGS gap)."""
+    from cognee.infrastructure.llm.structured_output_framework.litellm_native.native_adapter import (
+        NativeLiteLLMAdapter,
+    )
+
+    adapter = NativeLiteLLMAdapter(
+        api_key="test-key", model="openai/gpt-5-mini", max_completion_tokens=4096
+    )
+    mock = AsyncMock(return_value=_make_mock_response(json.dumps({"name": "A", "age": 1})))
+    with patch("litellm.acompletion", mock):
+        await adapter.acreate_structured_output(
+            text_input="x", system_prompt="y", response_model=PersonModel
+        )
+    assert _call_kwargs(mock)["max_completion_tokens"] == 4096
+
+
+@pytest.mark.asyncio
+async def test_stored_cap_reaches_litellm_on_plain_str_path():
+    from cognee.infrastructure.llm.structured_output_framework.litellm_native.native_adapter import (
+        NativeLiteLLMAdapter,
+    )
+
+    adapter = NativeLiteLLMAdapter(
+        api_key="test-key", model="openai/gpt-5-mini", max_completion_tokens=4096
+    )
+    mock = AsyncMock(return_value=_make_mock_response("plain text"))
+    with patch("litellm.acompletion", mock):
+        await adapter.acreate_structured_output(
+            text_input="x", system_prompt="y", response_model=str
+        )
+    assert _call_kwargs(mock)["max_completion_tokens"] == 4096
+
+
+@pytest.mark.asyncio
+async def test_no_injection_when_llm_args_cap_via_max_tokens():
+    """Cloud charts cap via LLM_ARGS max_tokens; sending both aliases is an API
+    error on some providers, so the stored cap must stand down."""
+    from cognee.infrastructure.llm.structured_output_framework.litellm_native.native_adapter import (
+        NativeLiteLLMAdapter,
+    )
+
+    adapter = NativeLiteLLMAdapter(
+        api_key="test-key",
+        model="openai/gpt-5-mini",
+        max_completion_tokens=4096,
+        llm_args={"max_tokens": 24000},
+    )
+    mock = AsyncMock(return_value=_make_mock_response(json.dumps({"name": "A", "age": 1})))
+    with patch("litellm.acompletion", mock):
+        await adapter.acreate_structured_output(
+            text_input="x", system_prompt="y", response_model=PersonModel
+        )
+    kwargs = _call_kwargs(mock)
+    assert "max_completion_tokens" not in kwargs
+    assert kwargs["max_tokens"] == 24000
+
+
+@pytest.mark.asyncio
+async def test_explicit_call_kwarg_beats_stored_cap():
+    from cognee.infrastructure.llm.structured_output_framework.litellm_native.native_adapter import (
+        NativeLiteLLMAdapter,
+    )
+
+    adapter = NativeLiteLLMAdapter(
+        api_key="test-key", model="openai/gpt-5-mini", max_completion_tokens=4096
+    )
+    mock = AsyncMock(return_value=_make_mock_response(json.dumps({"name": "A", "age": 1})))
+    with patch("litellm.acompletion", mock):
+        await adapter.acreate_structured_output(
+            text_input="x",
+            system_prompt="y",
+            response_model=PersonModel,
+            max_completion_tokens=99,
+        )
+    assert _call_kwargs(mock)["max_completion_tokens"] == 99


### PR DESCRIPTION
## Problem

[SDK-538](https://linear.app/cognee/issue/SDK-538/pass-max-completion-tokens-to-litellm-in-the-native-adapter). `NativeLiteLLMAdapter` accepts and stores `max_completion_tokens` — `get_native_client` computes it as `min(model limit, llm_max_completion_tokens)` (default 16384) — but **never sends it**: all three `litellm.acompletion` call sites pass only `{**self.llm_args, **kwargs}`.

On reasoning models (`gpt-5-mini` — the OSS default and cloud's OpenAI bridge) nothing caps output, and reasoning tokens bill as output. The CLO-679 COGS analysis (adversarially verified against the repo's own `estimator.py` calibration, a ~20× reasoning-output multiplier measured on a real default-config run) put default-config cognify at **~$21–24 per 1M ingested tokens** vs a **~$1.72 floor** with output bounded. This unsent cap is most of that gap, and it gates $1/1M (CLO-679) being margin-positive on the OpenAI path.

## Change

One guarded line at the adapter's single kwargs-merge origin (`acreate_structured_output`), covering every call path (plain-str, schema-native, prompted-JSON fallback):

```python
if not ({"max_completion_tokens", "max_tokens"} & merged_kwargs.keys()):
    merged_kwargs["max_completion_tokens"] = self.max_completion_tokens
```

The stand-down matters: cloud tenant charts cap via `LLM_ARGS max_tokens` (24000 / 48000), and sending both aliases is an API error on some providers. Explicit `llm_args` / call kwargs always win.

## Verification

- 4 new tests assert the kwargs **actually received** by a patched `litellm.acompletion`: stored cap on the schema-native and plain-str paths, no injection when `max_tokens` is present, explicit override wins — 32/32 green
- Mutation-checked: replacing the injection with `pass` turns exactly the two direct-assertion tests red
- Behaviour change to expect after deploy: structured outputs can now be truncated at 16384 completion tokens where they previously ran unbounded — at the default chunk size the expected output is far below the cap, but flagging it for review
