### PR TITLE
fix: Read EMBEDDING_API_BASE as endpoint alias (SDK-539)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -102,7 +102,7 @@ STRUCTURED_OUTPUT_FRAMEWORK="litellm_native"
 #  Tune these when using non-default embedding providers.
 ################################################################################
 
-#EMBEDDING_ENDPOINT=""
+#EMBEDDING_ENDPOINT=""   # EMBEDDING_API_BASE is accepted as an alias
 #EMBEDDING_API_VERSION=""
 #EMBEDDING_MAX_COMPLETION_TOKENS=8191
 #EMBEDDING_BATCH_SIZE=36

--- a/cognee/infrastructure/databases/vector/embeddings/config.py
+++ b/cognee/infrastructure/databases/vector/embeddings/config.py
@@ -1,5 +1,6 @@
 from typing import Optional
 from functools import lru_cache
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from cognee.shared.logging_utils import get_logger
@@ -75,7 +76,15 @@ class EmbeddingConfig(BaseSettings):
     # embedder by causing a Vector(3072) / 384-dim (etc.) mismatch on first
     # write into the vector store.
     embedding_dimensions: Optional[int] = None
-    embedding_endpoint: Optional[str] = None
+    # Also accepted as EMBEDDING_API_BASE — the name the litellm/OpenAI
+    # ecosystem uses (issue #4871: with only EMBEDDING_ENDPOINT recognized and
+    # extra="allow" swallowing unknowns, a custom base set via API_BASE was
+    # silently ignored and requests 404'd against api.openai.com).
+    # EMBEDDING_ENDPOINT wins when both are set.
+    embedding_endpoint: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("EMBEDDING_ENDPOINT", "EMBEDDING_API_BASE"),
+    )
     embedding_api_key: Optional[str] = None
     embedding_api_version: Optional[str] = None
     embedding_max_completion_tokens: Optional[int] = 8191
@@ -96,7 +105,7 @@ class EmbeddingConfig(BaseSettings):
     embedding_rate_limit_requests: int = 60
     embedding_rate_limit_interval: int = 60  # in seconds (default is 60 requests per minute)
     embedding_rate_limit_tokens: int = 0  # max tokens per interval (0 = disabled)
-    model_config = SettingsConfigDict(env_file=".env", extra="allow")
+    model_config = SettingsConfigDict(env_file=".env", extra="allow", populate_by_name=True)
 
     def model_post_init(self, __context) -> None:
         if self.embedding_dimensions is None:

--- a/cognee/tests/unit/infrastructure/databases/vector/test_embedding_config.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_embedding_config.py
@@ -91,3 +91,47 @@ def test_config_falls_back_when_unresolvable(monkeypatch):
         embedding_dimensions=None,
     )
     assert cfg.embedding_dimensions == 3072
+
+
+# ---- EMBEDDING_API_BASE alias (SDK-539 / issue #4871) ----
+
+
+def _fresh_config(monkeypatch, **env):
+    """Build EmbeddingConfig from a controlled environment (no .env leakage
+    for the two endpoint vars)."""
+    from cognee.infrastructure.databases.vector.embeddings.config import EmbeddingConfig
+
+    for var in ("EMBEDDING_ENDPOINT", "EMBEDDING_API_BASE"):
+        monkeypatch.delenv(var, raising=False)
+    for var, value in env.items():
+        monkeypatch.setenv(var, value)
+    return EmbeddingConfig(_env_file=None)
+
+
+def test_embedding_api_base_alone_populates_endpoint(monkeypatch):
+    """The exact repro from issue #4871: API_BASE set, ENDPOINT not."""
+    config = _fresh_config(monkeypatch, EMBEDDING_API_BASE="https://api.siliconflow.cn/v1")
+    assert config.embedding_endpoint == "https://api.siliconflow.cn/v1"
+
+
+def test_embedding_endpoint_wins_over_api_base(monkeypatch):
+    config = _fresh_config(
+        monkeypatch,
+        EMBEDDING_ENDPOINT="https://endpoint.example/v1",
+        EMBEDDING_API_BASE="https://api-base.example/v1",
+    )
+    assert config.embedding_endpoint == "https://endpoint.example/v1"
+
+
+def test_embedding_endpoint_env_still_works_alone(monkeypatch):
+    config = _fresh_config(monkeypatch, EMBEDDING_ENDPOINT="https://endpoint.example/v1")
+    assert config.embedding_endpoint == "https://endpoint.example/v1"
+
+
+def test_programmatic_field_name_construction_still_works(monkeypatch):
+    from cognee.infrastructure.databases.vector.embeddings.config import EmbeddingConfig
+
+    for var in ("EMBEDDING_ENDPOINT", "EMBEDDING_API_BASE"):
+        monkeypatch.delenv(var, raising=False)
+    config = EmbeddingConfig(_env_file=None, embedding_endpoint="https://kwarg.example/v1")
+    assert config.embedding_endpoint == "https://kwarg.example/v1"


### PR DESCRIPTION
Fixes #4871 · [SDK-539](https://linear.app/cognee/issue/SDK-539/accept-embedding-api-base-as-an-alias-for-embedding-endpoint)

## Problem

Configuring a custom OpenAI-compatible embedding endpoint via `EMBEDDING_API_BASE` (SiliconFlow, local vLLM — the name the litellm/OpenAI ecosystem uses) was **silently ignored**: requests routed to `api.openai.com` and 404'd.

Verified root cause: the engine is innocent — `LiteLLMEmbeddingEngine` forwards `api_base=self.endpoint` unconditionally, so custom bases already work under `EMBEDDING_PROVIDER=openai`. The whole failure is that `EMBEDDING_API_BASE` was not a name cognee reads anywhere, and `EmbeddingConfig`'s `extra="allow"` swallowed it without a warning — endpoint stayed `None`, litellm defaulted to OpenAI. A config mistake surfaced as a confusing 404 on the wrong host.

## Change

- `embedding_endpoint` accepts both names via `AliasChoices("EMBEDDING_ENDPOINT", "EMBEDDING_API_BASE")` — first alias wins when both are set
- `populate_by_name=True` so programmatic `EmbeddingConfig(embedding_endpoint=...)` construction keeps working (used by preflight/doctor tests)
- `.env.template` documents the alias

## Verification

- 4 new tests drive **real env parsing** (monkeypatched environment, `_env_file=None`), including the issue's exact repro: `EMBEDDING_API_BASE=https://api.siliconflow.cn/v1` alone → endpoint populated
- 72/72 green across the embedding-config, preflight, context-globals and LLM-config suites (the field-name construction consumers)
- Mutation-checked: removing `"EMBEDDING_API_BASE"` from the alias turns the repro test red

## Follow-up candidates (out of scope, noted on SDK-539)

Same alias for `LLM_ENDPOINT`/`LLM_API_BASE`, and a startup warning for unknown `EMBEDDING_*`/`LLM_*` vars so `extra="allow"` stops eating typos silently.
