### PR TITLE
CLO-556: Format streaming tests so pre-commit passes on dev

### DIFF
--- a/cognee/tests/unit/api/recall/test_recall_streaming.py
+++ b/cognee/tests/unit/api/recall/test_recall_streaming.py
@@ -352,9 +352,7 @@ def test_a_failure_after_output_arrives_as_a_single_error_event(client, monkeypa
     assert kinds[-1] == "error"
 
 
-def test_a_failure_after_output_still_reports_the_status_it_would_have_had(
-    client, monkeypatch
-):
+def test_a_failure_after_output_still_reports_the_status_it_would_have_had(client, monkeypatch):
     """Credit exhaustion is the failure this most needs to survive the transport.
 
     The 200 is already committed by the time the answer call runs, so a client

--- a/cognee/tests/unit/infrastructure/llm/test_adapter_streaming.py
+++ b/cognee/tests/unit/infrastructure/llm/test_adapter_streaming.py
@@ -210,7 +210,10 @@ async def test_include_usage_survives_caller_supplied_stream_options():
     with (
         _flag(True),
         _active(sink),
-        patch(f"{STREAM_MODULE}.litellm.acompletion", new=_streaming_completion([_chunk("hi")], seen=seen)),
+        patch(
+            f"{STREAM_MODULE}.litellm.acompletion",
+            new=_streaming_completion([_chunk("hi")], seen=seen),
+        ),
     ):
         await _stream(sink, [_chunk("hi")], stream_options={"other_key": "value"})
 

--- a/cognee/tests/unit/infrastructure/llm/test_streaming_capability.py
+++ b/cognee/tests/unit/infrastructure/llm/test_streaming_capability.py
@@ -14,9 +14,15 @@ from unittest.mock import patch
 import pytest
 
 from cognee.infrastructure.llm.LLMGateway import LLMGateway
-from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.azure_openai.adapter import AzureOpenAIAdapter
-from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.gemini.adapter import GeminiAdapter
-from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mcp_sampling.adapter import MCPSamplingAdapter
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.azure_openai.adapter import (
+    AzureOpenAIAdapter,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.gemini.adapter import (
+    GeminiAdapter,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mcp_sampling.adapter import (
+    MCPSamplingAdapter,
+)
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.bedrock.adapter import (
     BedrockAdapter,
 )

--- a/cognee/tests/unit/infrastructure/llm/test_token_sink.py
+++ b/cognee/tests/unit/infrastructure/llm/test_token_sink.py
@@ -492,4 +492,3 @@ async def test_a_failure_without_a_status_still_reports_the_error():
 
     errors = [e for e in await _drain(sink) if e.type == "error"]
     assert len(errors) == 1 and errors[0].status is None
-


### PR DESCRIPTION
## What this is

`dev` is red since `612b38674` (CLO-556 streaming, #4538): the **Lockfile and Pre-commit Hooks** job fails because four new unit test files are not formatted the way the repo's hooks want them. `ruff-format` rewrites three of them and `end-of-file-fixer` strips a trailing blank line from the fourth. Every PR whose merge ref includes that commit inherits the failure (see #4874's `pull_request` run).

## Change

The hooks' own output applied to the four files, nothing else:

- `cognee/tests/unit/api/recall/test_recall_streaming.py`
- `cognee/tests/unit/infrastructure/llm/test_adapter_streaming.py`
- `cognee/tests/unit/infrastructure/llm/test_streaming_capability.py`
- `cognee/tests/unit/infrastructure/llm/test_token_sink.py`

14 insertions, 8 deletions; formatting only. `pre-commit run --all-files` is clean on a second pass and the four files still pass.

## Also seen on dev

The run before this one (`5d80c60dc`) failed only on the Windows 3.13 unit job, in `test_ladybug_subprocess_lock_race.py::test_close_waits_for_worker_process_exit` ("worker pid still alive after close"). It has flaked on several runs today across branches and passes on rerun; it is not touched here and deserves its own look.

https://claude.ai/code/session_01EzVVTVg7nGagvcEoWZuoaq
