### PR TITLE
fix(retrieval): Rank temporal events and add adapter contract (SDK-544)

### DIFF
--- a/cognee/api/v1/recall/query_router.py
+++ b/cognee/api/v1/recall/query_router.py
@@ -135,7 +135,8 @@ _RULES: list[tuple[re.Pattern, SearchType, float]] = [
         4.0,
     ),
     (
-        re.compile(r"\b\d{4}s?\b"),
+        # Plausible years only (1000-2099), so "port 8080" or "error 4040" stay put.
+        re.compile(r"\b(1[0-9]{3}|20[0-9]{2})s?\b"),
         SearchType.TEMPORAL,
         3.0,
     ),

--- a/cognee/infrastructure/databases/graph/graph_db_interface.py
+++ b/cognee/infrastructure/databases/graph/graph_db_interface.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 from abc import abstractmethod, ABC
-from typing import Optional, Dict, Any, List, Tuple, Type, Union
+from typing import TYPE_CHECKING, Optional, Dict, Any, List, Tuple, Type, Union
 from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.engine import DataPoint
 from cognee.infrastructure.databases.exceptions import UnsupportedProvenanceCapability
@@ -9,6 +9,9 @@ from cognee.infrastructure.databases.provenance import (
     EdgeIdentity,
     NodeDeleteData,
 )
+
+if TYPE_CHECKING:
+    from cognee.tasks.temporal_graph.models import Timestamp
 
 logger = get_logger()
 
@@ -693,6 +696,63 @@ class GraphDBInterface(ABC):
             - bool: True if the node existed and was updated, False if not found.
         """
         raise NotImplementedError("update_node is not implemented for this adapter")
+
+    async def collect_time_ids(
+        self,
+        time_from: Optional["Timestamp"] = None,
+        time_to: Optional["Timestamp"] = None,
+    ) -> List[str]:
+        """
+        Return the ids of ``Timestamp`` nodes whose ``time_at`` lies inside the window.
+
+        Both bounds are inclusive and optional; an open side means "unbounded". With
+        neither bound given the result is an empty list. Backs ``SearchType.TEMPORAL``
+        together with ``collect_events``.
+
+        Optional extension — implemented by LadybugAdapter and Neo4jAdapter. Adapters
+        that raise here make ``TemporalRetriever`` fall back to triplet search.
+
+        Parameters:
+        -----------
+
+            - time_from (Optional[Timestamp]): Inclusive lower bound.
+            - time_to (Optional[Timestamp]): Inclusive upper bound.
+
+        Returns:
+        --------
+
+            - List[str]: Ids of the matching ``Timestamp`` nodes.
+        """
+        raise NotImplementedError(
+            f"collect_time_ids is not implemented for {type(self).__name__}; "
+            "SearchType.TEMPORAL time filtering is unavailable on this backend"
+        )
+
+    async def collect_events(self, ids: List[str]) -> List[Dict[str, Any]]:
+        """
+        Return the ``Event`` nodes reachable within two hops of the given ``Timestamp``
+        node ids (one hop through ``at``, two hops through ``during`` -> ``Interval``).
+
+        Every event is a flat dict with ``id``, ``name`` and ``description``, plus
+        ``location`` when set and its time anchors when linked: ``time_at`` (ms epoch)
+        for point events, ``time_from`` / ``time_to`` (ms epoch) for interval events.
+
+        Optional extension — implemented by LadybugAdapter and Neo4jAdapter.
+
+        Parameters:
+        -----------
+
+            - ids (List[str]): ``Timestamp`` node ids, typically from ``collect_time_ids``.
+
+        Returns:
+        --------
+
+            - List[Dict[str, Any]]: One dict per distinct event, in no particular order.
+        """
+        raise NotImplementedError(
+            f"collect_events is not implemented for {type(self).__name__}; "
+            "SearchType.TEMPORAL time filtering is unavailable on this backend"
+        )
 
     async def get_edge_feedback_weights(self, edge_object_ids: List[str]) -> Dict[str, float]:
         """

--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -3585,54 +3585,99 @@ class LadybugAdapter(GraphDBInterface):
         result = await self.query(query)
         return [record[0] for record in result] if result else []
 
-    def _normalize_temporal_ids(self, ids: Union[List[str], str]) -> List[str]:
-        if isinstance(ids, str):
-            return [uid.strip().strip("'\"") for uid in ids.split(",") if uid.strip()]
-
-        return ids
-
-    async def collect_events(self, ids: Union[List[str], str]) -> Any:
+    async def collect_events(self, ids: List[str]) -> List[Dict[str, Any]]:
         """
-        Collect all Event-type nodes reachable within 1..2 hops
-        from the given node IDs.
+        Collect the Event nodes reachable within 1..2 hops of the given Timestamp ids,
+        each with its time anchors attached. See ``GraphDBInterface.collect_events``.
 
         Args:
-            graph_engine: Object exposing an async .query(str) -> Any
-            ids: List of node IDs (strings)
+            ids: Timestamp node ids (from ``collect_time_ids``).
 
         Returns:
-            List of events
+            One flat dict per distinct event: ``id``, ``name``, ``description``,
+            optional ``location``, and ``time_at`` or ``time_from`` / ``time_to``
+            in ms epoch when the event is linked to a Timestamp / Interval.
         """
+        ids = [str(uid) for uid in ids if uid]
+        if not ids:
+            return []
 
-        event_collection_cypher = """UNWIND $ids AS uid
-            MATCH (start {id: uid})
-            MATCH (start)-[*1..2]-(event)
+        event_rows = await self.query(
+            """
+            UNWIND $ids AS uid
+            MATCH (start:Node {id: uid})
+            MATCH (start)-[*1..2]-(event:Node)
             WHERE event.type = 'Event'
-            WITH DISTINCT event
-            RETURN collect(event) AS events;
-        """
+            RETURN DISTINCT event.id, event.name, event.properties
+            """,
+            {"ids": ids},
+        )
 
-        ids = self._normalize_temporal_ids(ids)
-        result = await self.query(event_collection_cypher, {"ids": ids})
-        events = []
-        if not result or not result[0] or not result[0][0]:
-            return [{"events": events}]
-
-        for node in result[0][0]:
-            props = json.loads(node["properties"])
-
-            event = {
-                "id": node["id"],
-                "name": node["name"],
+        events: Dict[str, Dict[str, Any]] = {}
+        for event_id, name, properties_json in event_rows:
+            props = json.loads(properties_json) if properties_json else {}
+            event: Dict[str, Any] = {
+                "id": event_id,
+                "name": name,
                 "description": props.get("description"),
             }
-
             if props.get("location"):
                 event["location"] = props["location"]
+            events[event_id] = event
 
-            events.append(event)
+        if not events:
+            return []
 
-        return [{"events": events}]
+        # Time anchors: Event -[at]-> Timestamp, or Event -[during]-> Interval
+        # -[time_from|time_to]-> Timestamp. time_at lives in the JSON blob.
+        anchor_rows = await self.query(
+            """
+            UNWIND $ids AS eid
+            MATCH (event:Node {id: eid})-[r:EDGE]->(t:Node)
+            WHERE t.type = 'Timestamp' OR t.type = 'Interval'
+            RETURN event.id, r.relationship_name, t.id, t.type, t.properties
+            """,
+            {"ids": list(events.keys())},
+        )
+
+        interval_to_event: Dict[str, str] = {}
+        for event_id, relationship_name, target_id, target_type, properties_json in anchor_rows:
+            if target_type == "Timestamp":
+                time_at = self._time_at_from_properties(properties_json)
+                if time_at is not None:
+                    events[event_id]["time_at"] = time_at
+            elif target_type == "Interval":
+                interval_to_event[target_id] = event_id
+
+        if interval_to_event:
+            bound_rows = await self.query(
+                """
+                UNWIND $ids AS iid
+                MATCH (interval:Node {id: iid})-[r:EDGE]->(t:Node)
+                WHERE t.type = 'Timestamp'
+                RETURN interval.id, r.relationship_name, t.properties
+                """,
+                {"ids": list(interval_to_event.keys())},
+            )
+            for interval_id, relationship_name, properties_json in bound_rows:
+                if relationship_name not in ("time_from", "time_to"):
+                    continue
+                time_at = self._time_at_from_properties(properties_json)
+                if time_at is not None:
+                    events[interval_to_event[interval_id]][relationship_name] = time_at
+
+        return list(events.values())
+
+    @staticmethod
+    def _time_at_from_properties(properties_json: Optional[str]) -> Optional[int]:
+        """Read the ms-epoch ``time_at`` out of a Timestamp node's JSON blob."""
+        if not properties_json:
+            return None
+        try:
+            value = json.loads(properties_json).get("time_at")
+            return int(value) if value not in (None, "") else None
+        except (ValueError, TypeError):
+            return None
 
     async def collect_time_ids(
         self,
@@ -3640,79 +3685,43 @@ class LadybugAdapter(GraphDBInterface):
         time_to: Optional[Timestamp] = None,
     ) -> List[str]:
         """
-        Collect IDs of Timestamp nodes between time_from and time_to.
+        Collect the ids of Timestamp nodes whose ``time_at`` lies inside the inclusive
+        window. See ``GraphDBInterface.collect_time_ids``.
 
         Args:
-            graph_engine: Object exposing an async .query(query, params) -> list[dict]
-            time_from: Lower bound int (inclusive), optional
-            time_to: Upper bound int (inclusive), optional
+            time_from: Inclusive lower bound, optional.
+            time_to: Inclusive upper bound, optional.
 
         Returns:
-            A list of timestamp node IDs.
+            A list of Timestamp node ids; empty when no bound is given.
+        """
+        conditions = []
+        params: Dict[str, Any] = {}
+        if time_from:
+            conditions.append("t >= $time_from")
+            params["time_from"] = date_to_int(time_from)
+        if time_to:
+            conditions.append("t <= $time_to")
+            params["time_to"] = date_to_int(time_to)
+        if not conditions:
+            return []
+
+        cypher = f"""
+        MATCH (n:Node)
+        WHERE n.type = 'Timestamp'
+        // time_at lives in the JSON blob; extract and cast to INT64
+        WITH n, json_extract(n.properties, '$.time_at') AS t_str
+        WITH n,
+             CASE
+               WHEN t_str IS NULL OR t_str = '' THEN NULL
+               ELSE CAST(t_str AS INT64)
+             END AS t
+        WHERE {" AND ".join(conditions)}
+        RETURN n.id AS id
         """
 
-        ids: List[str] = []
-
-        if time_from and time_to:
-            time_from = date_to_int(time_from)
-            time_to = date_to_int(time_to)
-
-            cypher = f"""
-            MATCH (n:Node)
-            WHERE n.type = 'Timestamp'
-            // Extract time_at from the JSON string and cast to INT64
-            WITH n, json_extract(n.properties, '$.time_at') AS t_str
-            WITH n,
-                 CASE
-                   WHEN t_str IS NULL OR t_str = '' THEN NULL
-                   ELSE CAST(t_str AS INT64)
-                 END AS t
-            WHERE t >= {time_from}
-            AND t <= {time_to}
-            RETURN n.id as id
-            """
-
-        elif time_from:
-            time_from = date_to_int(time_from)
-
-            cypher = f"""
-            MATCH (n:Node)
-            WHERE n.type = 'Timestamp'
-            // Extract time_at from the JSON string and cast to INT64
-            WITH n, json_extract(n.properties, '$.time_at') AS t_str
-            WITH n,
-                 CASE
-                   WHEN t_str IS NULL OR t_str = '' THEN NULL
-                   ELSE CAST(t_str AS INT64)
-                 END AS t
-            WHERE t >= {time_from}
-            RETURN n.id as id
-            """
-
-        elif time_to:
-            time_to = date_to_int(time_to)
-
-            cypher = f"""
-            MATCH (n:Node)
-            WHERE n.type = 'Timestamp'
-            // Extract time_at from the JSON string and cast to INT64
-            WITH n, json_extract(n.properties, '$.time_at') AS t_str
-            WITH n,
-                 CASE
-                   WHEN t_str IS NULL OR t_str = '' THEN NULL
-                   ELSE CAST(t_str AS INT64)
-                 END AS t
-            WHERE t <= {time_to}
-            RETURN n.id as id
-            """
-
-        else:
-            return ids
-
-        time_nodes = await self.query(cypher)
-        time_ids_list = [item[0] for item in time_nodes]
-
-        return time_ids_list
+        time_nodes = await self.query(cypher, params)
+        return [row[0] for row in time_nodes if row and row[0]]
 
     async def get_triplets_batch(self, offset: int, limit: int) -> list[dict[str, Any]]:
         """

--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -2395,92 +2395,127 @@ class Neo4jAdapter(GraphDBInterface):
         result = await self.query(query)
         return [record["n"] for record in result] if result else []
 
-    async def collect_events(self, ids: List[str]) -> Any:
+    async def collect_events(self, ids: List[str]) -> List[Dict[str, Any]]:
         """
-        Collect all Event-type nodes reachable within 1..2 hops
-        from the given node IDs.
+        Collect the Event nodes reachable within 1..2 hops of the given Timestamp ids,
+        each with its time anchors attached. See ``GraphDBInterface.collect_events``.
 
         Args:
-            graph_engine: Object exposing an async .query(str) -> Any
-            ids: List of node IDs (strings)
+            ids: Timestamp node ids (from ``collect_time_ids``).
 
         Returns:
-            List of events
+            One flat dict per distinct event: ``id``, ``name``, ``description``,
+            optional ``location``, and ``time_at`` or ``time_from`` / ``time_to``
+            in ms epoch when the event is linked to a Timestamp / Interval.
         """
+        ids = [str(uid) for uid in ids if uid]
+        if not ids:
+            return []
 
-        event_collection_cypher = """UNWIND [{quoted}] AS uid
-            MATCH (start {{id: uid}})
+        event_rows = await self.query(
+            """
+            UNWIND $ids AS uid
+            MATCH (start {id: uid})
             MATCH (start)-[*1..2]-(event)
             WHERE event.type = 'Event'
-            WITH DISTINCT event
-            RETURN collect(event) AS events;
-        """
+            RETURN DISTINCT event.id AS id, event.name AS name,
+                   event.description AS description, event.location AS location
+            """,
+            {"ids": ids},
+        )
 
-        query = event_collection_cypher.format(quoted=ids)
-        return await self.query(query)
+        events: Dict[str, Dict[str, Any]] = {}
+        for row in event_rows:
+            event: Dict[str, Any] = {
+                "id": row["id"],
+                "name": row.get("name"),
+                "description": row.get("description"),
+            }
+            if row.get("location"):
+                event["location"] = row["location"]
+            events[row["id"]] = event
+
+        if not events:
+            return []
+
+        # Time anchors: Event -[at]-> Timestamp, or Event -[during]-> Interval
+        # -[time_from|time_to]-> Timestamp. The relationship type is the
+        # relationship name, and time_at is a native property.
+        anchor_rows = await self.query(
+            """
+            UNWIND $ids AS eid
+            MATCH (event {id: eid})-[r]->(t)
+            WHERE t.type IN ['Timestamp', 'Interval']
+            RETURN event.id AS event_id, type(r) AS relationship_name,
+                   t.id AS target_id, t.type AS target_type, t.time_at AS time_at
+            """,
+            {"ids": list(events.keys())},
+        )
+
+        interval_to_event: Dict[str, str] = {}
+        for row in anchor_rows:
+            if row["target_type"] == "Timestamp":
+                if row.get("time_at") is not None:
+                    events[row["event_id"]]["time_at"] = int(row["time_at"])
+            elif row["target_type"] == "Interval":
+                interval_to_event[row["target_id"]] = row["event_id"]
+
+        if interval_to_event:
+            bound_rows = await self.query(
+                """
+                UNWIND $ids AS iid
+                MATCH (interval {id: iid})-[r]->(t)
+                WHERE t.type = 'Timestamp'
+                RETURN interval.id AS interval_id, type(r) AS relationship_name,
+                       t.time_at AS time_at
+                """,
+                {"ids": list(interval_to_event.keys())},
+            )
+            for row in bound_rows:
+                relationship_name = row["relationship_name"]
+                if relationship_name in ("time_from", "time_to") and row.get("time_at") is not None:
+                    events[interval_to_event[row["interval_id"]]][relationship_name] = int(
+                        row["time_at"]
+                    )
+
+        return list(events.values())
 
     async def collect_time_ids(
         self,
         time_from: Optional[Timestamp] = None,
         time_to: Optional[Timestamp] = None,
-    ) -> str:
+    ) -> List[str]:
         """
-        Collect IDs of Timestamp nodes between time_from and time_to.
+        Collect the ids of Timestamp nodes whose ``time_at`` lies inside the inclusive
+        window. See ``GraphDBInterface.collect_time_ids``.
 
         Args:
-            graph_engine: Object exposing an async .query(query, params) -> list[dict]
-            time_from: Lower bound int (inclusive), optional
-            time_to: Upper bound int (inclusive), optional
+            time_from: Inclusive lower bound, optional.
+            time_to: Inclusive upper bound, optional.
 
         Returns:
-            A string of quoted IDs:  "'id1', 'id2', 'id3'"
-            (ready for use in a Cypher UNWIND clause).
+            A list of Timestamp node ids; empty when no bound is given.
+        """
+        conditions = []
+        params: Dict[str, Any] = {}
+        if time_from:
+            conditions.append("n.time_at >= $time_from")
+            params["time_from"] = date_to_int(time_from)
+        if time_to:
+            conditions.append("n.time_at <= $time_to")
+            params["time_to"] = date_to_int(time_to)
+        if not conditions:
+            return []
+
+        cypher = f"""
+        MATCH (n)
+        WHERE n.type = 'Timestamp'
+          AND {" AND ".join(conditions)}
+        RETURN n.id AS id
         """
 
-        ids: List[str] = []
-
-        if time_from and time_to:
-            time_from = date_to_int(time_from)
-            time_to = date_to_int(time_to)
-
-            cypher = """
-            MATCH (n)
-            WHERE n.type = 'Timestamp'
-              AND n.time_at >= $time_from
-              AND n.time_at <= $time_to
-            RETURN n.id AS id
-            """
-            params = {"time_from": time_from, "time_to": time_to}
-
-        elif time_from:
-            time_from = date_to_int(time_from)
-
-            cypher = """
-            MATCH (n)
-            WHERE n.type = 'Timestamp'
-              AND n.time_at >= $time_from
-            RETURN n.id AS id
-            """
-            params = {"time_from": time_from}
-
-        elif time_to:
-            time_to = date_to_int(time_to)
-
-            cypher = """
-            MATCH (n)
-            WHERE n.type = 'Timestamp'
-              AND n.time_at <= $time_to
-            RETURN n.id AS id
-            """
-            params = {"time_to": time_to}
-
-        else:
-            return ids
-
         time_nodes = await self.query(cypher, params)
-        time_ids_list = [item["id"] for item in time_nodes if "id" in item]
-
-        return ", ".join(f"'{uid}'" for uid in time_ids_list)
+        return [row["id"] for row in time_nodes if row.get("id")]
 
     async def get_triplets_batch(self, offset: int, limit: int) -> list[dict[str, Any]]:
         """

--- a/cognee/infrastructure/llm/prompts/extract_query_time.txt
+++ b/cognee/infrastructure/llm/prompts/extract_query_time.txt
@@ -11,3 +11,4 @@ Extraction rules:
 6. "Who is" and "Who was" questions: These imply a general identity or biographical inquiry without a specific temporal scope. Set both starts_at and ends_at to None.
 7. Ordering rule: Always ensure the earlier date is assigned to starts_at and the later date to ends_at.
 8. No temporal information: If no valid or inferable time reference is found, set both starts_at and ends_at to None.
+9. Precision: on every timestamp you return, set `precision` to the most specific unit the query actually states ("1996" → year, "March 1996" → month, "5 March 1996" → day). Never invent a month or day the query did not give; leave the defaults and let `precision` say how coarse the bound is.

--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -1,9 +1,8 @@
 import os
-import asyncio
-from typing import Any, Dict, List, Optional, Type
-from datetime import datetime
+import calendar
+from typing import Any, Dict, List, Optional, Tuple, Type
+from datetime import datetime, timezone
 
-from operator import itemgetter
 from cognee.base_config import get_base_config
 from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.infrastructure.llm.prompts import render_prompt
@@ -12,25 +11,110 @@ from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionR
 from cognee.modules.retrieval.utils.used_graph_elements import extract_from_temporal_dict
 from cognee.shared.logging_utils import get_logger
 
-from cognee.tasks.temporal_graph.models import QueryInterval
+from cognee.tasks.temporal_graph.models import QueryInterval, Timestamp
 
 logger = get_logger()
+
+# Precision ladder used to widen an upper bound to the end of the unit the user gave.
+_PRECISION_ORDER = ("year", "month", "day", "hour", "minute", "second")
+
+
+def _infer_precision(ts: Timestamp) -> str:
+    """Return the explicit ``precision`` or infer it from the default-valued fields.
+
+    The extraction model defaults month/day to 1 and the clock to 0, so a bare year
+    arrives as Jan 1 00:00:00. Without an explicit ``precision`` that is the only
+    signal we have; a genuine "January 1st" query is treated as a year, which widens
+    the window rather than narrowing it.
+    """
+    if ts.precision:
+        return ts.precision
+    if ts.second:
+        return "second"
+    if ts.minute:
+        return "minute"
+    if ts.hour:
+        return "hour"
+    if ts.day != 1:
+        return "day"
+    if ts.month != 1:
+        return "month"
+    return "year"
+
+
+def expand_to_period_end(ts: Optional[Timestamp]) -> Optional[Timestamp]:
+    """Widen an upper bound to the last second of the unit it was stated in.
+
+    "before 1996" / "between 1994 and 1996" / "in 1996" all end at 1996-12-31 23:59:59
+    instead of 1996-01-01 00:00:00, so events later in that year are not excluded.
+    """
+    if ts is None:
+        return None
+
+    precision = _infer_precision(ts)
+    values = ts.model_dump()
+    values["precision"] = precision
+
+    if precision == "year":
+        values.update(month=12, day=31, hour=23, minute=59, second=59)
+    elif precision == "month":
+        values.update(day=calendar.monthrange(ts.year, ts.month)[1], hour=23, minute=59, second=59)
+    elif precision == "day":
+        values.update(hour=23, minute=59, second=59)
+    elif precision == "hour":
+        values.update(minute=59, second=59)
+    elif precision == "minute":
+        values.update(second=59)
+
+    return Timestamp(**values)
+
+
+def _event_time_key(event: Dict[str, Any]) -> Tuple[int, int]:
+    """Chronological sort key; events without any time anchor sort last."""
+    anchor = event.get("time_at", event.get("time_from", event.get("time_to")))
+    return (0, int(anchor)) if anchor is not None else (1, 0)
+
+
+def _format_ms(value: Any) -> str:
+    try:
+        return datetime.fromtimestamp(int(value) / 1000, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+    except (ValueError, TypeError, OverflowError, OSError):
+        return str(value)
+
+
+def _event_time_label(event: Dict[str, Any]) -> Optional[str]:
+    if event.get("time_at") is not None:
+        return _format_ms(event["time_at"])
+    time_from, time_to = event.get("time_from"), event.get("time_to")
+    if time_from is not None and time_to is not None:
+        return f"{_format_ms(time_from)} to {_format_ms(time_to)}"
+    if time_from is not None:
+        return f"from {_format_ms(time_from)}"
+    if time_to is not None:
+        return f"until {_format_ms(time_to)}"
+    return None
 
 
 class TemporalRetriever(GraphCompletionRetriever):
     """
-    Handles graph completion by generating responses based on a series of interactions with
-    a language model. This class extends from GraphCompletionRetriever and is designed to
-    manage the retrieval and validation process for user queries, integrating follow-up
-    questions based on reasoning. The public methods are:
+    Time-aware graph completion.
+
+    A query is first parsed into a time window (one structured LLM call). The window
+    selects ``Timestamp`` nodes, the events anchored to them are collected from the
+    graph, and those events are ranked by vector similarity to the question. The
+    top-k events, rendered chronologically, form the LLM context. With no usable
+    window (or on a backend without temporal queries) it falls back to the parent's
+    triplet search. The public methods are:
 
     - get_completion
+    - get_retrieved_objects
+    - get_context_from_objects
 
     Instance variables include:
-    - validation_system_prompt_path
-    - validation_user_prompt_path
-    - followup_system_prompt_path
-    - followup_user_prompt_path
+    - time_extraction_prompt_path
+    - wide_search_top_k (size of the vector candidate pool used for ranking)
     """
 
     def __init__(
@@ -76,13 +160,20 @@ class TemporalRetriever(GraphCompletionRetriever):
             return extract_from_temporal_dict(retrieved_objects)
         return None
 
-    def descriptions_to_string(self, results):
-        descs = []
-        for entry in results:
-            d = entry.get("description")
-            if d:
-                descs.append(d.strip())
-        return "\n#####################\n".join(descs)
+    def descriptions_to_string(self, results: List[Dict[str, Any]]) -> str:
+        """Render events chronologically, one block each, prefixed with their time."""
+        blocks = []
+        for event in sorted(results, key=_event_time_key):
+            text = (event.get("description") or event.get("name") or "").strip()
+            if not text:
+                continue
+            label = _event_time_label(event)
+            if label:
+                text = f"[{label}] {text}"
+            if event.get("location"):
+                text = f"{text} (location: {event['location']})"
+            blocks.append(text)
+        return "\n#####################\n".join(blocks)
 
     async def extract_time_from_query(self, query: str):
         prompt_path = self.time_extraction_prompt_path
@@ -102,75 +193,91 @@ class TemporalRetriever(GraphCompletionRetriever):
         interval = await LLMGateway.acreate_structured_output(query, system_prompt, QueryInterval)
 
         time_from = interval.starts_at
-        time_to = interval.ends_at
+        # A year-only "1996" parses as 1996-01-01; the user meant the whole year.
+        time_to = expand_to_period_end(interval.ends_at)
 
         return time_from, time_to
 
-    async def filter_top_k_events(self, relevant_events, scored_results):
-        # Build a score lookup from vector search results.
-        # ScoredResult.id is a UUID while event["id"] arrives from the graph as a string,
-        # so both sides must be normalized to str or every lookup misses and all events
-        # collapse to float("inf"), discarding the vector-similarity ranking.
+    async def filter_top_k_events(
+        self, relevant_events: List[Dict[str, Any]], scored_results
+    ) -> List[Dict[str, Any]]:
+        """Rank the time-window events by vector similarity and keep the top k.
+
+        Events that the vector search scored come first, best (lowest distance)
+        first. Events the candidate pool did not reach are kept after them in
+        chronological order rather than dropped, so a sparse pool still yields a
+        full, deterministic top-k.
+        """
+        # ScoredResult.id is a UUID while event["id"] arrives from the graph as a
+        # string, so both sides are normalized to str or every lookup misses.
         score_lookup = {str(res.id): res.score for res in scored_results}
 
-        events_with_scores = []
-        for event in relevant_events[0]["events"]:
-            score = score_lookup.get(str(event["id"]), float("inf"))
-            events_with_scores.append({**event, "score": score})
+        scored, unscored = [], []
+        for event in relevant_events:
+            score = score_lookup.get(str(event["id"]))
+            if score is None:
+                unscored.append({**event, "score": float("inf")})
+            else:
+                scored.append({**event, "score": score})
 
-        events_with_scores.sort(key=itemgetter("score"))
+        scored.sort(key=lambda event: event["score"])
+        unscored.sort(key=_event_time_key)
 
-        return events_with_scores[: self.top_k]
+        return (scored + unscored)[: self.top_k]
 
     async def get_retrieved_objects(self, query: str) -> dict:
         time_from, time_to = await self.extract_time_from_query(query)
 
-        unified = await get_unified_engine()
-        graph_engine = unified.graph
-
-        if time_from and time_to:
-            ids = await graph_engine.collect_time_ids(time_from=time_from, time_to=time_to)
-        elif time_from:
-            ids = await graph_engine.collect_time_ids(time_from=time_from)
-        elif time_to:
-            ids = await graph_engine.collect_time_ids(time_to=time_to)
-        else:
+        if not time_from and not time_to:
             logger.info(
                 "No timestamps identified based on the query, performing retrieval using triplet search on events and entities."
             )
-            triplets = await self.get_triplets(query)
-            return {"triplets": triplets}
+            return {"triplets": await self.get_triplets(query)}
 
-        if ids:
-            relevant_events = await graph_engine.collect_events(ids=ids)
-        else:
+        unified = await get_unified_engine()
+        graph_engine = unified.graph
+
+        try:
+            ids = await graph_engine.collect_time_ids(time_from=time_from, time_to=time_to)
+            relevant_events = await graph_engine.collect_events(ids) if ids else []
+        except NotImplementedError as error:
+            logger.warning(
+                "%s. Falling back to triplet search for this TEMPORAL query.", str(error)
+            )
+            return {"triplets": await self.get_triplets(query)}
+
+        if not relevant_events:
             logger.info(
                 "No events identified based on timestamp filtering, performing retrieval using triplet search on events and entities."
             )
-            triplets = await self.get_triplets(query)
-            return {"triplets": triplets}
+            return {"triplets": await self.get_triplets(query)}
 
         vector_engine = unified.vector
         query_vector = (await vector_engine.embedding_engine.embed_text([query]))[0]
 
+        # The candidate pool must be wider than top_k: the search runs over every
+        # event in the collection, and only the hits that fall inside the time
+        # window can be ranked. A pool of top_k would leave most window events
+        # unscored and the ranking would collapse to graph order.
+        candidate_pool = max(self.wide_search_top_k, self.top_k, len(relevant_events))
         vector_search_results = await vector_engine.search(
-            collection_name="Event_name", query_vector=query_vector, limit=self.top_k
+            collection_name="Event_name", query_vector=query_vector, limit=candidate_pool
         )
 
         return {"relevant_events": relevant_events, "vector_search_results": vector_search_results}
 
     async def get_context_from_objects(self, query: str, retrieved_objects: Any) -> Any:
         """Retrieves context based on the query."""
-        if retrieved_objects.get("relevant_events", None) and retrieved_objects.get(
-            "vector_search_results", None
-        ):
+        relevant_events = retrieved_objects.get("relevant_events")
+        if relevant_events:
             top_k_events = await self.filter_top_k_events(
-                retrieved_objects.get("relevant_events"),
-                retrieved_objects.get("vector_search_results", None),
+                relevant_events, retrieved_objects.get("vector_search_results") or []
             )
+            # Record what actually reached the prompt so provenance / feedback
+            # attribute the answer to these events, not the whole candidate pool.
+            retrieved_objects["selected_events"] = top_k_events
             return self.descriptions_to_string(top_k_events)
-        else:
-            # In case no events were found, fall back to triplet context
-            triplets = retrieved_objects.get("triplets", [])
-            context_text = await self.resolve_edges_to_text(triplets)
-            return context_text
+
+        # In case no events were found, fall back to triplet context
+        triplets = retrieved_objects.get("triplets", [])
+        return await self.resolve_edges_to_text(triplets)

--- a/cognee/modules/retrieval/utils/used_graph_elements.py
+++ b/cognee/modules/retrieval/utils/used_graph_elements.py
@@ -69,14 +69,24 @@ def extract_from_scored_results(results: List[Any]) -> Optional[Dict[str, List[s
 
 def extract_from_temporal_dict(obj: Dict[str, Any]) -> Optional[Dict[str, List[str]]]:
     """
-    From temporal retriever dict: triplets -> extract_from_edges; events path -> extract_from_scored_results.
-    Returns None if nothing extracted.
+    From temporal retriever dict: triplets -> extract_from_edges; events path -> the
+    ``selected_events`` that reached the prompt, else extract_from_scored_results over
+    the vector candidate pool. Returns None if nothing extracted.
     """
     if not isinstance(obj, dict):
         return None
     triplets = obj.get("triplets")
     if triplets is not None and is_edge_list(triplets):
         return extract_from_edges(triplets)
+    selected_events = obj.get("selected_events")
+    if isinstance(selected_events, list) and selected_events:
+        node_ids = {
+            str(event["id"])
+            for event in selected_events
+            if isinstance(event, dict) and event.get("id") is not None
+        }
+        if node_ids:
+            return {"node_ids": sorted(node_ids)}
     scored_results = obj.get("vector_search_results")
     if isinstance(scored_results, list) and scored_results:
         return extract_from_scored_results(scored_results)

--- a/cognee/tasks/temporal_graph/models.py
+++ b/cognee/tasks/temporal_graph/models.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Literal, Optional, List
 from pydantic import BaseModel, Field
 
 
@@ -14,6 +14,13 @@ class Timestamp(BaseModel):
     hour: int = Field(0, ge=0, le=23, description="If unknown, default to 0")
     minute: int = Field(0, ge=0, le=59, description="If unknown, default to 0")
     second: int = Field(0, ge=0, le=59, description="If unknown, default to 0")
+    precision: Optional[Literal["year", "month", "day", "hour", "minute", "second"]] = Field(
+        None,
+        description=(
+            "The most specific unit actually stated in the text: 'year' for '1996', "
+            "'month' for 'March 1996', 'day' for '5 March 1996'. Leave null if unsure."
+        ),
+    )
 
 
 class Interval(BaseModel):

--- a/cognee/tests/unit/api/v2/test_query_router.py
+++ b/cognee/tests/unit/api/v2/test_query_router.py
@@ -128,6 +128,13 @@ class TestTemporal:
     def test_specific_year(self):
         assert route_query("What was discovered in 1915?").search_type == SearchType.TEMPORAL
 
+    def test_four_digit_number_is_not_a_year(self):
+        """Port numbers and error codes must not pull a query toward TEMPORAL."""
+        assert route_query("Why does the server listen on port 8080?").search_type != (
+            SearchType.TEMPORAL
+        )
+        assert route_query("What does error 4040 mean?").search_type != SearchType.TEMPORAL
+
 
 class TestNegation:
     def test_not_related_suppresses_graph(self):

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_temporal.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_temporal.py
@@ -1,38 +1,140 @@
+"""Unit tests for the Ladybug temporal queries behind ``SearchType.TEMPORAL``.
+
+``collect_time_ids`` / ``collect_events`` are the ``GraphDBInterface`` extension the
+``TemporalRetriever`` relies on. These tests pin the contract: parameterised Cypher,
+list results, and a flat event dict that carries the event's time anchors.
+"""
+
+import json
 from unittest.mock import AsyncMock
 
 import pytest
 
+from cognee.infrastructure.databases.graph.graph_db_interface import GraphDBInterface
 from cognee.infrastructure.databases.graph.ladybug.adapter import LadybugAdapter
 from cognee.tasks.temporal_graph.models import Timestamp
 
 
-@pytest.mark.asyncio
-async def test_collect_time_ids_returns_list_for_unwind_params():
+def _adapter(query_side_effect):
     adapter = LadybugAdapter.__new__(LadybugAdapter)
-    adapter.query = AsyncMock(return_value=[["timestamp-1"], ["timestamp-2"]])
+    adapter.query = AsyncMock(side_effect=query_side_effect)
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_collect_time_ids_returns_list_and_binds_bounds_as_params():
+    adapter = _adapter([[["timestamp-1"], ["timestamp-2"]]])
+
+    ids = await adapter.collect_time_ids(
+        time_from=Timestamp(year=1900), time_to=Timestamp(year=1980)
+    )
+
+    assert ids == ["timestamp-1", "timestamp-2"]
+    cypher, params = adapter.query.await_args.args
+    assert set(params) == {"time_from", "time_to"}
+    assert params["time_from"] < params["time_to"]
+    # Bounds travel as parameters, never interpolated into the query text.
+    assert str(params["time_from"]) not in cypher
+    assert "t >= $time_from" in cypher and "t <= $time_to" in cypher
+
+
+@pytest.mark.asyncio
+async def test_collect_time_ids_single_bound_only_emits_that_condition():
+    adapter = _adapter([[["timestamp-1"]]])
 
     ids = await adapter.collect_time_ids(time_to=Timestamp(year=1980))
 
-    assert ids == ["timestamp-1", "timestamp-2"]
+    assert ids == ["timestamp-1"]
+    cypher, params = adapter.query.await_args.args
+    assert set(params) == {"time_to"}
+    assert "$time_from" not in cypher
 
 
 @pytest.mark.asyncio
-async def test_collect_events_binds_ids_as_list():
-    adapter = LadybugAdapter.__new__(LadybugAdapter)
-    adapter.query = AsyncMock(return_value=[])
+async def test_collect_time_ids_without_bounds_does_not_query():
+    adapter = _adapter([])
 
-    await adapter.collect_events(ids=["timestamp-1", "timestamp-2"])
+    assert await adapter.collect_time_ids() == []
+    adapter.query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_collect_events_binds_ids_as_list_and_returns_empty_for_no_events():
+    adapter = _adapter([[]])
+
+    assert await adapter.collect_events(ids=["timestamp-1", "timestamp-2"]) == []
 
     _, params = adapter.query.await_args.args
     assert params == {"ids": ["timestamp-1", "timestamp-2"]}
 
 
 @pytest.mark.asyncio
-async def test_collect_events_accepts_legacy_quoted_id_string():
-    adapter = LadybugAdapter.__new__(LadybugAdapter)
-    adapter.query = AsyncMock(return_value=[])
+async def test_collect_events_with_no_ids_does_not_query():
+    adapter = _adapter([])
 
-    await adapter.collect_events(ids="'timestamp-1', 'timestamp-2'")
+    assert await adapter.collect_events(ids=[]) == []
+    adapter.query.assert_not_awaited()
 
-    _, params = adapter.query.await_args.args
-    assert params == {"ids": ["timestamp-1", "timestamp-2"]}
+
+@pytest.mark.asyncio
+async def test_collect_events_returns_flat_events_with_time_anchors():
+    event_rows = [
+        ["ev-1", "Launch", json.dumps({"description": "Project launched", "location": "Oslo"})],
+        ["ev-2", "Build phase", json.dumps({"description": "Building"})],
+        ["ev-3", "Undated", json.dumps({"description": "No time link"})],
+    ]
+    anchor_rows = [
+        ["ev-1", "at", "ts-1", "Timestamp", json.dumps({"time_at": 1000})],
+        ["ev-2", "during", "iv-1", "Interval", json.dumps({})],
+    ]
+    bound_rows = [
+        ["iv-1", "time_from", json.dumps({"time_at": 2000})],
+        ["iv-1", "time_to", json.dumps({"time_at": 3000})],
+    ]
+    adapter = _adapter([event_rows, anchor_rows, bound_rows])
+
+    events = {e["id"]: e for e in await adapter.collect_events(ids=["ts-1", "ts-2"])}
+
+    assert events["ev-1"] == {
+        "id": "ev-1",
+        "name": "Launch",
+        "description": "Project launched",
+        "location": "Oslo",
+        "time_at": 1000,
+    }
+    assert events["ev-2"] == {
+        "id": "ev-2",
+        "name": "Build phase",
+        "description": "Building",
+        "time_from": 2000,
+        "time_to": 3000,
+    }
+    assert events["ev-3"] == {"id": "ev-3", "name": "Undated", "description": "No time link"}
+    # Interval bounds are fetched only when an interval was actually linked.
+    assert adapter.query.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_collect_events_skips_interval_lookup_without_intervals():
+    event_rows = [["ev-1", "Launch", json.dumps({"description": "d"})]]
+    anchor_rows = [["ev-1", "at", "ts-1", "Timestamp", json.dumps({"time_at": "1000"})]]
+    adapter = _adapter([event_rows, anchor_rows])
+
+    events = await adapter.collect_events(ids=["ts-1"])
+
+    assert events[0]["time_at"] == 1000  # string time_at is coerced
+    assert adapter.query.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_interface_default_raises_not_implemented():
+    class BareAdapter(GraphDBInterface):
+        pass
+
+    BareAdapter.__abstractmethods__ = frozenset()
+    adapter = BareAdapter()
+
+    with pytest.raises(NotImplementedError, match="collect_time_ids"):
+        await adapter.collect_time_ids(time_from=Timestamp(year=2000))
+    with pytest.raises(NotImplementedError, match="collect_events"):
+        await adapter.collect_events(["x"])

--- a/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
@@ -4,7 +4,7 @@ import os
 from unittest.mock import AsyncMock, patch, MagicMock
 from datetime import datetime
 
-from cognee.modules.retrieval.temporal_retriever import TemporalRetriever
+from cognee.modules.retrieval.temporal_retriever import TemporalRetriever, expand_to_period_end
 from cognee.tasks.temporal_graph.models import QueryInterval, Timestamp
 from cognee.infrastructure.llm import LLMGateway
 
@@ -56,13 +56,9 @@ async def test_filter_top_k_events_sorts_and_limits():
     tr = TemporalRetriever(top_k=2)
 
     relevant_events = [
-        {
-            "events": [
-                {"id": "e1", "description": "E1"},
-                {"id": "e2", "description": "E2"},
-                {"id": "e3", "description": "E3 - not in vector results"},
-            ]
-        }
+        {"id": "e1", "description": "E1"},
+        {"id": "e2", "description": "E2"},
+        {"id": "e3", "description": "E3 - not in vector results"},
     ]
 
     scored_results = [
@@ -84,13 +80,9 @@ async def test_filter_top_k_events_includes_unknown_as_infinite_but_not_in_top_k
     tr = TemporalRetriever(top_k=2)
 
     relevant_events = [
-        {
-            "events": [
-                {"id": "known1", "description": "Known 1"},
-                {"id": "unknown", "description": "Unknown"},
-                {"id": "known2", "description": "Known 2"},
-            ]
-        }
+        {"id": "known1", "description": "Known 1"},
+        {"id": "unknown", "description": "Unknown"},
+        {"id": "known2", "description": "Known 2"},
     ]
 
     scored_results = [
@@ -121,13 +113,9 @@ async def test_filter_top_k_events_matches_uuid_scored_results_against_str_event
 
     # Event ids come from the graph as strings (str() of the node UUID).
     relevant_events = [
-        {
-            "events": [
-                {"id": str(id_third), "description": "Third - not scored"},
-                {"id": str(id_second), "description": "Second"},
-                {"id": str(id_first), "description": "First"},
-            ]
-        }
+        {"id": str(id_third), "description": "Third - not scored"},
+        {"id": str(id_second), "description": "Second"},
+        {"id": str(id_first), "description": "First"},
     ]
 
     # Real ScoredResult objects: .id is a UUID (not a str).
@@ -163,7 +151,7 @@ def test_descriptions_to_string_unicode_and_newlines():
 @pytest.mark.asyncio
 async def test_filter_top_k_events_limits_when_top_k_exceeds_events():
     tr = TemporalRetriever(top_k=10)
-    relevant_events = [{"events": [{"id": "a"}, {"id": "b"}]}]
+    relevant_events = [{"id": "a"}, {"id": "b"}]
     scored_results = [
         SimpleNamespace(id="a", payload={"id": "a"}, score=0.1),
         SimpleNamespace(id="b", payload={"id": "b"}, score=0.2),
@@ -176,7 +164,7 @@ async def test_filter_top_k_events_limits_when_top_k_exceeds_events():
 @pytest.mark.asyncio
 async def test_filter_top_k_events_handles_empty_scored_results():
     tr = TemporalRetriever(top_k=2)
-    relevant_events = [{"events": [{"id": "x"}, {"id": "y"}]}]
+    relevant_events = [{"id": "x"}, {"id": "y"}]
     scored_results = []
     out = await tr.filter_top_k_events(relevant_events, scored_results)
     assert [e["id"] for e in out] == ["x", "y"]
@@ -225,12 +213,8 @@ async def test_get_context_with_time_range(mock_graph_engine, mock_vector_engine
 
     mock_graph_engine.collect_time_ids.return_value = ["e1", "e2"]
     mock_graph_engine.collect_events.return_value = [
-        {
-            "events": [
-                {"id": "e1", "description": "Event 1"},
-                {"id": "e2", "description": "Event 2"},
-            ]
-        }
+        {"id": "e1", "description": "Event 1"},
+        {"id": "e2", "description": "Event 2"},
     ]
 
     mock_result1 = SimpleNamespace(id="e2", payload={"id": "e2"}, score=0.05)
@@ -331,11 +315,7 @@ async def test_get_context_time_from_only(mock_graph_engine, mock_vector_engine)
 
     mock_graph_engine.collect_time_ids.return_value = ["e1"]
     mock_graph_engine.collect_events.return_value = [
-        {
-            "events": [
-                {"id": "e1", "description": "Event 1"},
-            ]
-        }
+        {"id": "e1", "description": "Event 1"},
     ]
 
     mock_result = SimpleNamespace(id="e1", payload={"id": "e1"}, score=0.05)
@@ -364,11 +344,7 @@ async def test_get_context_time_to_only(mock_graph_engine, mock_vector_engine):
 
     mock_graph_engine.collect_time_ids.return_value = ["e1"]
     mock_graph_engine.collect_events.return_value = [
-        {
-            "events": [
-                {"id": "e1", "description": "Event 1"},
-            ]
-        }
+        {"id": "e1", "description": "Event 1"},
     ]
 
     mock_result = SimpleNamespace(id="e1", payload={"id": "e1"}, score=0.05)
@@ -397,11 +373,7 @@ async def test_get_completion_without_context(mock_graph_engine, mock_vector_eng
 
     mock_graph_engine.collect_time_ids.return_value = ["e1"]
     mock_graph_engine.collect_events.return_value = [
-        {
-            "events": [
-                {"id": "e1", "description": "Event 1"},
-            ]
-        }
+        {"id": "e1", "description": "Event 1"},
     ]
 
     mock_result = SimpleNamespace(id="e1", payload={"id": "e1"}, score=0.05)
@@ -478,11 +450,7 @@ async def test_get_completion_with_session(mock_graph_engine, mock_vector_engine
 
     mock_graph_engine.collect_time_ids.return_value = ["e1"]
     mock_graph_engine.collect_events.return_value = [
-        {
-            "events": [
-                {"id": "e1", "description": "Event 1"},
-            ]
-        }
+        {"id": "e1", "description": "Event 1"},
     ]
 
     mock_result = SimpleNamespace(id="e1", payload={"id": "e1"}, score=0.05)
@@ -540,11 +508,7 @@ async def test_get_completion_with_session_no_user_id(mock_graph_engine, mock_ve
 
     mock_graph_engine.collect_time_ids.return_value = ["e1"]
     mock_graph_engine.collect_events.return_value = [
-        {
-            "events": [
-                {"id": "e1", "description": "Event 1"},
-            ]
-        }
+        {"id": "e1", "description": "Event 1"},
     ]
 
     mock_result = SimpleNamespace(id="e1", payload={"id": "e1"}, score=0.05)
@@ -599,11 +563,7 @@ async def test_get_completion_with_response_model(mock_graph_engine, mock_vector
 
     mock_graph_engine.collect_time_ids.return_value = ["e1"]
     mock_graph_engine.collect_events.return_value = [
-        {
-            "events": [
-                {"id": "e1", "description": "Event 1"},
-            ]
-        }
+        {"id": "e1", "description": "Event 1"},
     ]
 
     mock_result = SimpleNamespace(id="e1", payload={"id": "e1"}, score=0.05)
@@ -671,7 +631,14 @@ async def test_extract_time_from_query_relative_path():
         time_from, time_to = await retriever.extract_time_from_query("What happened in 2024?")
 
     assert time_from == mock_timestamp_from
-    assert time_to == mock_timestamp_to
+    # The upper bound is widened to the end of the stated day (SDK-544).
+    assert (time_to.year, time_to.month, time_to.day, time_to.hour, time_to.second) == (
+        2024,
+        12,
+        31,
+        23,
+        59,
+    )
 
 
 @pytest.mark.asyncio
@@ -712,7 +679,14 @@ async def test_extract_time_from_query_absolute_path():
         time_from, time_to = await retriever.extract_time_from_query("What happened in 2024?")
 
     assert time_from == mock_timestamp_from
-    assert time_to == mock_timestamp_to
+    # The upper bound is widened to the end of the stated day (SDK-544).
+    assert (time_to.year, time_to.month, time_to.day, time_to.hour, time_to.second) == (
+        2024,
+        12,
+        31,
+        23,
+        59,
+    )
 
 
 @pytest.mark.asyncio
@@ -742,3 +716,180 @@ async def test_extract_time_from_query_with_none_values():
 
     assert time_from is None
     assert time_to is None
+
+
+# ---------------------------------------------------------------------------
+# Ranking regression (SDK-544): the vector candidate pool must be wider than
+# top_k, unscored window events must survive in chronological order, and the
+# rendered context must be chronological with time labels.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_candidate_pool_is_at_least_wide_search_top_k(mock_graph_engine, mock_vector_engine):
+    """A pool of top_k would leave most window events unscored (the old bug)."""
+    retriever = TemporalRetriever(top_k=3, wide_search_top_k=100)
+
+    mock_graph_engine.collect_time_ids.return_value = ["t1"]
+    mock_graph_engine.collect_events.return_value = [
+        {"id": f"e{i}", "description": f"Event {i}", "time_at": i * 1000} for i in range(10)
+    ]
+    mock_vector_engine.search.return_value = []
+
+    unified_mock = _make_unified_mock(mock_graph_engine, mock_vector_engine)
+    with (
+        patch.object(retriever, "extract_time_from_query", return_value=("from", "to")),
+        patch(
+            "cognee.modules.retrieval.temporal_retriever.get_unified_engine",
+            return_value=unified_mock,
+        ),
+    ):
+        await retriever.get_retrieved_objects("What happened?")
+
+    assert mock_vector_engine.search.await_args.kwargs["limit"] >= 100
+
+
+@pytest.mark.asyncio
+async def test_candidate_pool_grows_with_the_time_window(mock_graph_engine, mock_vector_engine):
+    retriever = TemporalRetriever(top_k=3, wide_search_top_k=10)
+
+    mock_graph_engine.collect_time_ids.return_value = ["t1"]
+    mock_graph_engine.collect_events.return_value = [{"id": f"e{i}"} for i in range(250)]
+    mock_vector_engine.search.return_value = []
+
+    unified_mock = _make_unified_mock(mock_graph_engine, mock_vector_engine)
+    with (
+        patch.object(retriever, "extract_time_from_query", return_value=("from", "to")),
+        patch(
+            "cognee.modules.retrieval.temporal_retriever.get_unified_engine",
+            return_value=unified_mock,
+        ),
+    ):
+        await retriever.get_retrieved_objects("What happened?")
+
+    assert mock_vector_engine.search.await_args.kwargs["limit"] == 250
+
+
+@pytest.mark.asyncio
+async def test_filter_top_k_events_keeps_unscored_events_chronologically_after_scored():
+    tr = TemporalRetriever(top_k=4)
+    relevant_events = [
+        {"id": "late", "time_at": 3000},
+        {"id": "scored_worse", "time_at": 500},
+        {"id": "early", "time_at": 1000},
+        {"id": "scored_best", "time_at": 2000},
+        {"id": "undated"},
+    ]
+    scored_results = [
+        SimpleNamespace(id="scored_best", score=0.1),
+        SimpleNamespace(id="scored_worse", score=0.4),
+    ]
+
+    top = await tr.filter_top_k_events(relevant_events, scored_results)
+
+    # Scored by relevance first, then the unscored ones oldest-first; the undated
+    # event is the last candidate and falls outside top_k.
+    assert [e["id"] for e in top] == ["scored_best", "scored_worse", "early", "late"]
+
+
+def test_descriptions_to_string_is_chronological_with_time_labels():
+    tr = TemporalRetriever()
+    results = [
+        {"description": "Second", "time_at": 946684800000},  # 2000-01-01
+        {
+            "description": "Interval",
+            "time_from": 631152000000,
+            "time_to": 662688000000,
+        },  # 1990-1991
+        {"description": "Undated"},
+        {"description": "First", "time_at": 0, "location": "Oslo"},
+        {"name": "Only a name", "time_at": 1},
+    ]
+
+    s = tr.descriptions_to_string(results)
+    blocks = s.split("\n#####################\n")
+
+    assert blocks[0] == "[1970-01-01 00:00:00] First (location: Oslo)"
+    assert blocks[1] == "[1970-01-01 00:00:00] Only a name"
+    assert blocks[2] == "[1990-01-01 00:00:00 to 1991-01-01 00:00:00] Interval"
+    assert blocks[3] == "[2000-01-01 00:00:00] Second"
+    assert blocks[4] == "Undated"
+
+
+@pytest.mark.asyncio
+async def test_get_retrieved_objects_falls_back_when_backend_lacks_temporal_queries(
+    mock_graph_engine,
+):
+    """A backend without collect_time_ids must degrade to triplet search, not crash."""
+    retriever = TemporalRetriever()
+    mock_graph_engine.collect_time_ids.side_effect = NotImplementedError("collect_time_ids ...")
+    unified_mock = _make_unified_mock(mock_graph_engine)
+
+    with (
+        patch.object(retriever, "extract_time_from_query", return_value=("from", "to")),
+        patch(
+            "cognee.modules.retrieval.temporal_retriever.get_unified_engine",
+            return_value=unified_mock,
+        ),
+        patch.object(retriever, "get_triplets", return_value=["triplet"]) as mock_get_triplets,
+    ):
+        objects = await retriever.get_retrieved_objects("What happened in 2024?")
+
+    assert objects == {"triplets": ["triplet"]}
+    mock_get_triplets.assert_awaited_once_with("What happened in 2024?")
+
+
+# ---------------------------------------------------------------------------
+# Query bound expansion: "1996" means the whole of 1996, not its first second.
+# ---------------------------------------------------------------------------
+
+
+class TestExpandToPeriodEnd:
+    def test_none_passes_through(self):
+        assert expand_to_period_end(None) is None
+
+    def test_year_only_expands_to_end_of_year(self):
+        ts = expand_to_period_end(Timestamp(year=1996))
+        assert (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second) == (
+            1996,
+            12,
+            31,
+            23,
+            59,
+            59,
+        )
+        assert ts.precision == "year"
+
+    def test_month_only_expands_to_end_of_month_including_leap_day(self):
+        ts = expand_to_period_end(Timestamp(year=2024, month=2))
+        assert (ts.month, ts.day, ts.hour, ts.minute, ts.second) == (2, 29, 23, 59, 59)
+
+    def test_day_expands_to_end_of_day(self):
+        ts = expand_to_period_end(Timestamp(year=2022, month=3, day=5))
+        assert (ts.day, ts.hour, ts.minute, ts.second) == (5, 23, 59, 59)
+
+    def test_explicit_precision_wins_over_heuristic(self):
+        # Jan 1st stated as a day stays a day; the heuristic alone would call it a year.
+        ts = expand_to_period_end(Timestamp(year=2022, month=1, day=1, precision="day"))
+        assert (ts.month, ts.day, ts.hour) == (1, 1, 23)
+
+    def test_full_timestamp_is_unchanged(self):
+        ts = expand_to_period_end(
+            Timestamp(year=2022, month=3, day=5, hour=10, minute=30, second=15)
+        )
+        assert (ts.hour, ts.minute, ts.second) == (10, 30, 15)
+
+
+@pytest.mark.asyncio
+async def test_extract_time_from_query_expands_only_the_upper_bound():
+    retriever = TemporalRetriever()
+    interval = QueryInterval(starts_at=Timestamp(year=1994), ends_at=Timestamp(year=1996))
+
+    with (
+        patch("cognee.modules.retrieval.temporal_retriever.render_prompt", return_value="p"),
+        patch.object(LLMGateway, "acreate_structured_output", AsyncMock(return_value=interval)),
+    ):
+        time_from, time_to = await retriever.extract_time_from_query("between 1994 and 1996")
+
+    assert (time_from.year, time_from.month, time_from.day) == (1994, 1, 1)
+    assert (time_to.year, time_to.month, time_to.day, time_to.second) == (1996, 12, 31, 59)

--- a/cognee/tests/unit/modules/retrieval/test_used_graph_elements.py
+++ b/cognee/tests/unit/modules/retrieval/test_used_graph_elements.py
@@ -1,4 +1,5 @@
 import pytest
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from cognee.modules.retrieval.utils.used_graph_elements import (
@@ -143,3 +144,21 @@ def test_extract_from_temporal_dict_empty_returns_none():
     assert extract_from_temporal_dict({}) is None
     assert extract_from_temporal_dict({"other": []}) is None
     assert extract_from_temporal_dict({"vector_search_results": []}) is None
+
+
+def test_extract_from_temporal_dict_prefers_selected_events_over_candidate_pool():
+    """Only the events that reached the prompt count as used, not the wide vector pool."""
+    obj = {
+        "relevant_events": [{"id": "e1"}, {"id": "e2"}, {"id": "e3"}],
+        "vector_search_results": [
+            SimpleNamespace(id="e1", payload=None),
+            SimpleNamespace(id="pool-only", payload=None),
+        ],
+        "selected_events": [{"id": "e2"}, {"id": "e1"}, {"no_id": True}],
+    }
+    assert extract_from_temporal_dict(obj) == {"node_ids": ["e1", "e2"]}
+
+
+def test_extract_from_temporal_dict_falls_back_to_scored_results_without_selection():
+    obj = {"vector_search_results": [SimpleNamespace(id="e1", payload=None)]}
+    assert extract_from_temporal_dict(obj) == {"node_ids": ["e1"]}


### PR DESCRIPTION
## Summary

Phase 1 of the temporal cleanup (after #4886). Fixes correctness and backend parity for `SearchType.TEMPORAL`, no schema change.

**Ranking was a no-op.** `TemporalRetriever` searched the whole `Event_name` collection with `limit=top_k`, then scored the time-window events against that tiny set. Almost every window event got `float("inf")`, so the sort did nothing and the answer came from an arbitrary `top_k` slice of the window. Now:
- the candidate pool is `max(wide_search_top_k, top_k, len(window events))`,
- scored events rank first by similarity, unscored ones follow chronologically instead of being dropped,
- the context is rendered oldest-first with a `[time]` label, location included, name as fallback when there is no description.

**Adapter contract.** `collect_time_ids(time_from, time_to) -> list[str]` and `collect_events(ids) -> list[dict]` are now declared on `GraphDBInterface` (optional extension, `NotImplementedError` default). Both Ladybug and Neo4j return the same flat event shape (`id`, `name`, `description`, `location?`, `time_at?` / `time_from?` / `time_to?` in ms epoch) and bind bounds and ids as parameters. Neo4j previously built Cypher with `str.format` and returned a quoted-id string; Ladybug's `_normalize_temporal_ids` shim is gone. Backends without the extension (Neptune, `postgres_demo`) fall back to triplet search with a warning instead of raising `AttributeError`.

**Query bound precision.** A year-only bound parsed as Jan 1 00:00:00, so "between 1994 and 1996" excluded almost all of 1996. `extract_time_from_query` now widens the upper bound to the end of the stated unit (year / month / day / …). The extraction `Timestamp` model gains an optional `precision` field and the prompt asks for it; a default-values heuristic covers responses without it.

**Router.** The year regex is `\b(1[0-9]{3}|20[0-9]{2})s?\b`, so "port 8080" or "error 4040" no longer score toward TEMPORAL.

**Provenance.** `extract_from_temporal_dict` prefers the `selected_events` that actually reached the prompt over the wide vector pool.

## Test plan

- [x] `pytest cognee/tests/unit/modules/retrieval cognee/tests/unit/infrastructure/databases/graph cognee/tests/unit/api/v2/test_query_router.py cognee/tests/unit/modules/search cognee/tests/unit/modules/graph` — 926 passed
- [x] New unit tests: candidate-pool size, unscored-after-scored ranking, chronological rendering, `NotImplementedError` fallback, `expand_to_period_end` (year / month incl. leap day / day / explicit precision), Ladybug `collect_events` flat shape with `at` and `during` anchors, interface default raises, router non-year numbers
- [ ] `temporal_graph_tests.yml` (Kuzu + Neo4j, LanceDB + PGVector) runs in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
