### PR TITLE
Expose similarity score from ChunksRetriever.get_completion_from_context

### DIFF
--- a/cognee/modules/retrieval/chunks_retriever.py
+++ b/cognee/modules/retrieval/chunks_retriever.py
@@ -66,7 +66,10 @@ class ChunksRetriever(BaseRetriever):
         """
         # TODO: Do we want to generate a completion using LLM here?
         if retrieved_objects:
-            chunk_payloads = [found_chunk.payload for found_chunk in retrieved_objects]
+            chunk_payloads = [
+                {**found_chunk.payload, "score": found_chunk.score}
+                for found_chunk in retrieved_objects
+            ]
             return chunk_payloads
         else:
             return []

--- a/cognee/tests/unit/modules/retrieval/chunks_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/chunks_retriever_test.py
@@ -55,6 +55,47 @@ async def test_get_context_success(mock_vector_engine):
 
 
 @pytest.mark.asyncio
+async def test_get_completion_from_context_includes_score(mock_vector_engine):
+    """Test that get_completion_from_context attaches each chunk's score to its payload."""
+    mock_result1 = MagicMock()
+    mock_result1.payload = {"text": "Steve Rodger", "chunk_index": 0}
+    mock_result1.score = 0.12
+    mock_result2 = MagicMock()
+    mock_result2.payload = {"text": "Mike Broski", "chunk_index": 1}
+    mock_result2.score = 0.34
+
+    mock_vector_engine.search.return_value = [mock_result1, mock_result2]
+
+    retriever = ChunksRetriever(top_k=5)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_unified_engine",
+        return_value=_make_unified_mock(mock_vector_engine),
+    ):
+        retrieved_objects = await retriever.get_retrieved_objects("test query")
+        completion = await retriever.get_completion_from_context(
+            query="test query", retrieved_objects=retrieved_objects, context=None
+        )
+
+    assert completion[0]["score"] == 0.12
+    assert completion[0]["text"] == "Steve Rodger"
+    assert completion[1]["score"] == 0.34
+    assert completion[1]["text"] == "Mike Broski"
+
+
+@pytest.mark.asyncio
+async def test_get_completion_from_context_empty_returns_empty_list():
+    """Test that get_completion_from_context returns [] when there are no retrieved objects."""
+    retriever = ChunksRetriever()
+
+    completion = await retriever.get_completion_from_context(
+        query="test query", retrieved_objects=[], context=None
+    )
+
+    assert completion == []
+
+
+@pytest.mark.asyncio
 async def test_get_context_collection_not_found_error(mock_vector_engine):
     """Test that CollectionNotFoundError is converted to NoDataError."""
     mock_vector_engine.search.side_effect = CollectionNotFoundError("Collection not found")


### PR DESCRIPTION
## Summary

`ChunksRetriever` already computes a similarity score for each result on `ScoredResult`, but `get_completion_from_context` never returns it in the chunk payload — so a caller doing hybrid/fusion ranking across retrievers has no way to see it.

This spreads `found_chunk.score` into the returned chunk dict, matching the existing idiom already used in `temporal_retriever.py`, and matching what `normalize_search_payload.py`'s `_score_from()` already expects to find when present.

`completion_retriever.py` is intentionally left untouched — it returns LLM-generated text, not chunk dicts, so injecting a score there would corrupt the prompt rather than add metadata.

## Test plan

- [x] Added `test_get_completion_from_context_includes_score`
- [x] Added `test_get_completion_from_context_empty_returns_empty_list`
- [x] Existing `chunks_retriever_test.py` suite passes (12/12)
- [x] `ruff check` / `ruff format --check` clean
- [x] Full retrieval test directory run — no new failures introduced (pre-existing unrelated failures confirmed via `git stash`/re-run: missing LLM key and no live Postgres in this environment)