### PR TITLE
ci: Raise the docs planning turn cap to 50

### DIFF
--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -217,7 +217,7 @@ jobs:
 
             - **Prepared documentation edit scope** (`./${{ steps.branch_paths.outputs.docs_edit_scope_markdown }}`): Curated source files, docs candidates, assessment summary, and out-of-scope files.
             - **Prepared documentation edit scope JSON** (`./${{ steps.branch_paths.outputs.docs_edit_scope_json }}`): Machine-readable copy of the prepared scope.
-          claude_args: "--allowed-tools Read,Write,Glob,Grep --max-turns 35"
+          claude_args: "--allowed-tools Read,Write,Glob,Grep --max-turns 50"
 
       # The action fails a step whose reported turn count overshoots the cap even
       # when the agent finished cleanly, which throws away completed work. So judge


### PR DESCRIPTION
## What this PR does

Raises the `--max-turns` cap on the **Plan docs changes with Claude** step of `dev_previous_day_commits.yml` from 35 to 50, matching the cap the editing step already uses.

## Why

The nightly docs-draft run for 2026-09-02 ([run 33698785986](https://github.com/topoteretes/cognee/actions/runs/33698785986)) lost both of its large branches at the planning step:

- **PR #4538** (LLM answer streaming, ~2,900 changed lines) hit a genuine `error_max_turns` at turn 36 — a branch that size needs more exploration than 35 turns allow.
- **PR #4867** (frontend sync) finished its plan cleanly at 42 turns but was failed post-hoc by the action's turn accounting. That failure mode is already fixed on dev by RES-30's finished-agent checks (`33abfd378`), which **main has not received yet** — the schedule runs the workflow from main, so until the next dev → main sync the nightly run keeps the old behavior for both issues.

## Notes

- One-line change; no behavior change for branches that plan within the old cap.
- The docs drafts the failed run should have produced were created manually: [cognee-docs#1586](https://github.com/topoteretes/cognee-docs/pull/1586) for PR #4538, and no docs were needed for PR #4867 (frontend-only sync, nothing the docs describe changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)