### PR TITLE
SDK-552 fix(provenance): declare evidence_kind's server default on the model, as its migration does

### DIFF
--- a/cognee/modules/provenance/edge_evidence/models.py
+++ b/cognee/modules/provenance/edge_evidence/models.py
@@ -33,7 +33,11 @@ class ProvenanceEdgeEvidence(Base):
     destination_node_id = Column(UUID, nullable=False)
     relationship_name = Column(Text, nullable=False)
 
-    evidence_kind = Column(String(32), nullable=False, default="extracted")
+    # server_default too: migration f3a7b9c1d2e4 gives the column a database-side
+    # DEFAULT, and the model must describe the same table the chain builds.
+    evidence_kind = Column(
+        String(32), nullable=False, default="extracted", server_default="extracted"
+    )
     source_task = Column(String(255), nullable=True)
     confidence = Column(Float, nullable=True)
     created_at = Column(


### PR DESCRIPTION
**Linear:** [SDK-552](https://linear.app/cognee/issue/SDK-552)

Migration `f3a7b9c1d2e4_add_provenance_edge_evidence` (#4108) creates `provenance_edge_evidence.evidence_kind` with `server_default="extracted"` — a database-side DEFAULT. The model (`cognee/modules/provenance/edge_evidence/models.py`) declared only `default="extracted"`, the Python-side default the ORM applies at insert time, which the database never sees. So a chain-built table carried a DEFAULT the model does not describe, and a `create_all`-built one (tests) carried none.

One-line fix: the model column now declares `server_default="extracted"` as well (the Python-side default stays, for ORM inserts).

Found by the deep schema comparison in the chain-born reconcile tests (SDK-551 / #4869): the name-level lockstep guard compares tables and columns only and cannot see defaults. Harmless at runtime under chain-born creation — every real database has the migration's shape — but the model should describe the table the chain builds.

Verified: reflecting `provenance_edge_evidence` from a chain-built SQLite database and from a `create_all`-built one now yields identical columns (type, nullability, default); provenance unit tests 119 passed, plus the edge-evidence contract and graph-expansion tests.