### PR TITLE
chore(ci): Move nightly-only tests to release tests (SDK-533)

### DIFF
--- a/.github/scripts/build_nightly_slack_blocks.py
+++ b/.github/scripts/build_nightly_slack_blocks.py
@@ -13,8 +13,8 @@ Input (env):
                `metrics` output; empty/unparseable is treated as `{}`, which is
                what a failed job produces. A `tenant_create` key adds the
                cloud-only tenant row.
-  STATUS_*     header fields (emoji, summary, ran_at, ollama, llamacpp,
-               branch, cadence, sha — the last three fall back if unset).
+  STATUS_*     header fields (emoji, summary, ran_at, branch, cadence,
+               sha — the last three fall back if unset).
   RUN_URL      link target for the footer.
 
 Output: `blocks=<compact JSON>` appended to $GITHUB_OUTPUT (stdout if unset).
@@ -98,8 +98,6 @@ def main():
         f"{env.get('STATUS_SUMMARY', '')}\n"
         f"*Ran at:* `{env.get('STATUS_RAN_AT', '')}`  •  "
         f"*Branch:* `{branch}` (`{cadence}`)  •  *Commit:* `{sha}`\n"
-        f"*Ollama:* `{env.get('STATUS_OLLAMA', '')}`  •  "
-        f"*Llama-cpp:* `{env.get('STATUS_LLAMACPP', '')}`\n"
     )
 
     blocks = [header]

--- a/.github/scripts/build_nightly_slack_blocks.py
+++ b/.github/scripts/build_nightly_slack_blocks.py
@@ -99,8 +99,7 @@ def main():
         f"*Ran at:* `{env.get('STATUS_RAN_AT', '')}`  •  "
         f"*Branch:* `{branch}` (`{cadence}`)  •  *Commit:* `{sha}`\n"
         f"*Ollama:* `{env.get('STATUS_OLLAMA', '')}`  •  "
-        f"*Llama-cpp:* `{env.get('STATUS_LLAMACPP', '')}`  •  "
-        f"*Unit 3.11-3.13:* `{env.get('STATUS_UNIT_MID', '') or 'n/a'}`\n"
+        f"*Llama-cpp:* `{env.get('STATUS_LLAMACPP', '')}`\n"
     )
 
     blocks = [header]

--- a/.github/workflows/nightly_scheduler.yml
+++ b/.github/workflows/nightly_scheduler.yml
@@ -12,8 +12,8 @@ name: Nightly Scheduler
 #     window either side of the DST switch, so the cloud perf arms measure
 #     the platform under real peak load)
 #   * weekly Sun 06:00 UTC -> dev   (in-development code keeps nightly-only
-#     coverage: the 3.11-3.13 unit matrix, the search-DB version sweep, and
-#     anything else that runs only here)
+#     coverage: the search-DB version sweep and anything else that runs
+#     only here)
 #
 # It works because workflow_dispatch is one of only two events GITHUB_TOKEN may
 # raise that still creates a workflow run:

--- a/.github/workflows/nightly_scheduler.yml
+++ b/.github/workflows/nightly_scheduler.yml
@@ -11,8 +11,8 @@ name: Nightly Scheduler
 #     hours: 18:00 UTC = 19:00 CET / 20:00 CEST, inside the 17:00-22:00 CET
 #     window either side of the DST switch, so the cloud perf arms measure
 #     the platform under real peak load)
-#   * weekly Sun 06:00 UTC -> dev   (in-development code keeps nightly-only
-#     coverage: the Ollama and llama-cpp suites and the perf arms)
+#   * weekly Sun 06:00 UTC -> dev   (in-development code keeps the perf
+#     arms' coverage, which only run here)
 #
 # It works because workflow_dispatch is one of only two events GITHUB_TOKEN may
 # raise that still creates a workflow run:

--- a/.github/workflows/nightly_scheduler.yml
+++ b/.github/workflows/nightly_scheduler.yml
@@ -12,8 +12,7 @@ name: Nightly Scheduler
 #     window either side of the DST switch, so the cloud perf arms measure
 #     the platform under real peak load)
 #   * weekly Sun 06:00 UTC -> dev   (in-development code keeps nightly-only
-#     coverage: the search-DB version sweep and anything else that runs
-#     only here)
+#     coverage: the Ollama and llama-cpp suites and the perf arms)
 #
 # It works because workflow_dispatch is one of only two events GITHUB_TOKEN may
 # raise that still creates a workflow run:

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -40,16 +40,6 @@ env:
   ENV: 'dev'
 
 jobs:
-  ollama-tests:
-    name: Ollama Tests
-    uses: ./.github/workflows/test_ollama.yml
-    secrets: inherit
-
-  llamacpp-tests:
-    name: Llama-cpp Tests
-    uses: ./.github/workflows/test_llamacpp.yml
-    secrets: inherit
-
   # ══ Performance: each caller runs BOTH file_based and postgres backends ════
   perf-small-llm:
     name: Performance — 50 Small Documents (real LLM)
@@ -218,8 +208,6 @@ jobs:
   notify:
     name: Test Completion Status
     needs: [
-      ollama-tests,
-      llamacpp-tests,
       perf-small-llm,
       perf-small-mock,
       perf-wap-llm,
@@ -250,9 +238,7 @@ jobs:
           # and inline interpolation would splice it into this shell script.
           CADENCE: ${{ inputs.cadence }}
         run: |
-          if [[ "${{ needs.ollama-tests.result }}" == "success" &&
-                "${{ needs.llamacpp-tests.result }}" == "success" &&
-                "${{ needs.perf-small-llm.result }}" == "success" &&
+          if [[ "${{ needs.perf-small-llm.result }}" == "success" &&
                 "${{ needs.perf-small-mock.result }}" == "success" &&
                 "${{ needs.perf-wap-llm.result }}" == "success" &&
                 "${{ needs.perf-wap-mock.result }}" == "success" &&
@@ -327,8 +313,6 @@ jobs:
           STATUS_BRANCH: ${{ github.ref_name }}
           STATUS_CADENCE: ${{ steps.status.outputs.cadence }}
           STATUS_SHA: ${{ github.sha }}
-          STATUS_OLLAMA: ${{ needs.ollama-tests.result }}
-          STATUS_LLAMACPP: ${{ needs.llamacpp-tests.result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           # One arm per line: emoji|title|result|metrics-json|report-url.
           # Adding a benchmark arm is a line here plus its REPORT_KEYS entry.

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -50,58 +50,6 @@ jobs:
     uses: ./.github/workflows/test_llamacpp.yml
     secrets: inherit
 
-  # The PR gate runs the unit suite on the interpreter edges (3.10, 3.14) and
-  # on windows/macos 3.13 -- the four environments with version- or OS-specific
-  # fixes in the history. The three middle Linux versions run here instead.
-  # Same reusable workflow, same extras as the PR gate's ubuntu legs.
-  unit-matrix-mid:
-    name: Unit Tests (3.11-3.13 ubuntu)
-    uses: ./.github/workflows/test_different_operating_systems.yml
-    with:
-      python-versions: '["3.11.x", "3.12.x", "3.13.x"]'
-      os: '["ubuntu-22.04"]'
-      extra-dependencies: 'postgres aws neptune langchain dlt'
-    secrets: inherit
-
-  # Restored here after being cut from the PR gate. It runs the same
-  # test_library.py the OS matrix runs, but writes .anon_id first, so the
-  # pipeline executes with telemetry ON -- a code path nothing else on the
-  # gate covers. It has no telemetry assertion (it only proves the pipeline
-  # does not crash with telemetry enabled), which is why it is nightly rather
-  # than pre-merge, but it is not zero coverage and should not have been
-  # deleted outright.
-  run-telemetry-pipeline-test:
-    name: Run Telemetry Pipeline Test
-    runs-on: ubuntu-22.04
-    # No container: the nightly is not a reusable workflow, so there is no
-    # ci-image input to resolve. Runs on the bare runner like every other
-    # job in this file.
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-
-      - name: Cognee Setup
-        uses: ./.github/actions/cognee_setup
-        with:
-          python-version: '3.11.x'
-
-      - name: Add telemetry identifier
-        run: |
-          echo "test-machine" > .anon_id
-
-      - name: Run default basic pipeline with telemetry on
-        env:
-          ENV: 'local'
-          LLM_MODEL: ${{ secrets.LLM_MODEL }}
-          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
-          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-          LLM_ARGS: ${{ secrets.LLM_ARGS }}
-          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
-          EMBEDDING_DIMENSIONS: 300
-          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
-          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
-        run: uv run python ./cognee/tests/test_library.py
-
   # The PR gate runs the search suite on one Python per backend combo. The
   # two bare Neo4j jobs are the only ones where the Python dimension was ever
   # real (the container jobs pin 3.11), so their version sweep runs here.
@@ -281,7 +229,6 @@ jobs:
     name: Test Completion Status
     needs: [
       ollama-tests,
-      unit-matrix-mid,
       search-db-versions,
       llamacpp-tests,
       perf-small-llm,
@@ -316,7 +263,6 @@ jobs:
         run: |
           if [[ "${{ needs.ollama-tests.result }}" == "success" &&
                 "${{ needs.llamacpp-tests.result }}" == "success" &&
-                "${{ needs.unit-matrix-mid.result }}" == "success" &&
                 "${{ needs.search-db-versions.result }}" == "success" &&
                 "${{ needs.perf-small-llm.result }}" == "success" &&
                 "${{ needs.perf-small-mock.result }}" == "success" &&
@@ -395,7 +341,6 @@ jobs:
           STATUS_SHA: ${{ github.sha }}
           STATUS_OLLAMA: ${{ needs.ollama-tests.result }}
           STATUS_LLAMACPP: ${{ needs.llamacpp-tests.result }}
-          STATUS_UNIT_MID: ${{ needs.unit-matrix-mid.result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           # One arm per line: emoji|title|result|metrics-json|report-url.
           # Adding a benchmark arm is a line here plus its REPORT_KEYS entry.

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -50,16 +50,6 @@ jobs:
     uses: ./.github/workflows/test_llamacpp.yml
     secrets: inherit
 
-  # The PR gate runs the search suite on one Python per backend combo. The
-  # two bare Neo4j jobs are the only ones where the Python dimension was ever
-  # real (the container jobs pin 3.11), so their version sweep runs here.
-  search-db-versions:
-    name: Search DB version sweep
-    uses: ./.github/workflows/search_db_tests.yml
-    with:
-      python-versions: '["3.10", "3.12", "3.13"]'
-    secrets: inherit
-
   # ══ Performance: each caller runs BOTH file_based and postgres backends ════
   perf-small-llm:
     name: Performance — 50 Small Documents (real LLM)
@@ -229,7 +219,6 @@ jobs:
     name: Test Completion Status
     needs: [
       ollama-tests,
-      search-db-versions,
       llamacpp-tests,
       perf-small-llm,
       perf-small-mock,
@@ -263,7 +252,6 @@ jobs:
         run: |
           if [[ "${{ needs.ollama-tests.result }}" == "success" &&
                 "${{ needs.llamacpp-tests.result }}" == "success" &&
-                "${{ needs.search-db-versions.result }}" == "success" &&
                 "${{ needs.perf-small-llm.result }}" == "success" &&
                 "${{ needs.perf-small-mock.result }}" == "success" &&
                 "${{ needs.perf-wap-llm.result }}" == "success" &&

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -78,8 +78,8 @@ jobs:
   # ══ Moved out of the PR gate and the nightly (SDK-533) ═══════════════════
   # These jobs used to run on every PR (e2e_tests.yml) or in nightly_tests.yml.
   # None of them earns a PR-gate slot, and the nightly report is for the
-  # Ollama/llama-cpp suites and the perf arms, so they run here: before a
-  # release, and on demand. They test the checked-out source -- cognee_setup
+  # perf arms, so they run here: before a release, and on demand. They
+  # test the checked-out source -- cognee_setup
   # installs from the local tree -- so the `cognee_version` input does not
   # apply to them.
 
@@ -106,6 +106,20 @@ jobs:
     uses: ./.github/workflows/search_db_tests.yml
     with:
       python-versions: '["3.10", "3.12", "3.13"]'
+    secrets: inherit
+
+  # Local-model suites: each pulls a model into a container on the runner,
+  # which is why neither has ever been on the PR gate.
+  ollama-tests:
+    name: Ollama Tests
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/test_ollama.yml
+    secrets: inherit
+
+  llamacpp-tests:
+    name: Llama-cpp Tests
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/test_llamacpp.yml
     secrets: inherit
 
   # The only job that runs the pipeline with telemetry ON; every other job in

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -75,6 +75,139 @@ jobs:
         run: |
           uv run pytest cognee/tests/integration/retrieval/test_graph_completion_retriever_cot.py -v --timeout=300
 
+  # ══ Moved out of the PR gate and the nightly (SDK-533) ═══════════════════
+  # These jobs used to run on every PR (e2e_tests.yml) or in nightly_tests.yml.
+  # None of them earns a PR-gate slot, and the nightly report is for the
+  # Ollama/llama-cpp suites and the perf arms, so they run here: before a
+  # release, and on demand. They test the checked-out source -- cognee_setup
+  # installs from the local tree -- so the `cognee_version` input does not
+  # apply to them.
+
+  # The PR gate runs the unit suite on the interpreter edges (3.10, 3.14) and
+  # on windows/macos 3.13 -- the four environments with version- or OS-specific
+  # fixes in the history. The three middle Linux versions run here instead.
+  # Same reusable workflow, same extras as the PR gate's ubuntu legs.
+  unit-matrix-mid:
+    name: Unit Tests (3.11-3.13 ubuntu)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/test_different_operating_systems.yml
+    with:
+      python-versions: '["3.11.x", "3.12.x", "3.13.x"]'
+      os: '["ubuntu-22.04"]'
+      extra-dependencies: 'postgres aws neptune langchain dlt'
+    secrets: inherit
+
+  # The only job that runs the pipeline with telemetry ON; every other job in
+  # CI disables it. It writes .anon_id first and runs the same test_library.py
+  # the OS matrix runs. It has no telemetry assertion (it proves the pipeline
+  # does not crash with telemetry enabled), which is why it is not pre-merge.
+  run-telemetry-pipeline-test:
+    name: Run Telemetry Pipeline Test
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+
+      - name: Add telemetry identifier
+        run: |
+          echo "test-machine" > .anon_id
+
+      - name: Run default basic pipeline with telemetry on
+        env:
+          ENV: 'local'
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_ARGS: ${{ secrets.LLM_ARGS }}
+          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
+          EMBEDDING_DIMENSIONS: 300
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+        run: uv run python ./cognee/tests/test_library.py
+
+  test-deletion-on-default-graph:
+    name: Delete default graph data test
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          fetch-depth: 0
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+
+      - name: Run deletion on default graph
+        env:
+          ENV: 'dev'
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_ARGS: ${{ secrets.LLM_ARGS }}
+          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+        run: uv run python ./cognee/tests/test_delete_default_graph.py
+
+  test-deletion-on-custom-graph:
+    name: Delete custom graph data test
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          fetch-depth: 0
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+
+      - name: Run deletion on custom graph
+        env:
+          ENV: 'dev'
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_ARGS: ${{ secrets.LLM_ARGS }}
+          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+        run: uv run python ./cognee/tests/test_delete_custom_graph.py
+
+  run_agent_registry_tests:
+    name: Agent Registry Tests
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+
+      - name: Run Agent Registry Tests
+        env:
+          ENV: 'dev'
+        run: uv run pytest cognee/tests/unit/modules/agents/test_agent_registry.py -v
+
   # 10 parallel users against a live HTTP server with access control enabled:
   # per-user dataset isolation, add/cognify/search verification via sentinel chunks
   # (LLM-free CHUNKS search), delete + recreate, forget + recreate-same-name.

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -97,6 +97,17 @@ jobs:
       extra-dependencies: 'postgres aws neptune langchain dlt'
     secrets: inherit
 
+  # The PR gate runs the search suite on one Python per backend combo. The
+  # two bare Neo4j jobs are the only ones where the Python dimension was ever
+  # real (the container jobs pin 3.11), so their version sweep runs here.
+  search-db-versions:
+    name: Search DB version sweep
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/search_db_tests.yml
+    with:
+      python-versions: '["3.10", "3.12", "3.13"]'
+    secrets: inherit
+
   # The only job that runs the pipeline with telemetry ON; every other job in
   # CI disables it. It writes .anon_id first and runs the same test_library.py
   # the OS matrix runs. It has no telemetry assertion (it proves the pipeline

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -175,7 +175,7 @@ jobs:
     with:
       # The interpreter edges only. Every version-specific fix on dev since
       # 2025-06 was 3.10 (5) or 3.14 (1); none was 3.11/3.12/3.13-only. Those
-      # three run nightly instead. The unit suite is byte-identical across the
+      # three run in release_test.yml instead. The unit suite is byte-identical across the
       # legs, so this cuts three of eight copies with no change in what a
       # passing run proves.
       python-versions: '["3.10.x", "3.14.x"]'

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -265,7 +265,7 @@ jobs:
       # job labelled "Python 3.13" logged "Python 3.11.14". So those were the
       # same run four times. The Python dimension is the unit matrix's job;
       # this workflow's value is the four backend combos, which all stay.
-      # The full version sweep for the two bare Neo4j jobs runs nightly.
+      # The full version sweep for the two bare Neo4j jobs runs in release_test.yml.
       python-versions: '["3.11"]'
     secrets: inherit
 


### PR DESCRIPTION
Review follow-up for #4876, addressing the two review comments there plus the follow-up asks to move the search-DB sweep and the Ollama/llama-cpp suites as well.

## What moves

Into `release_test.yml` (runs on PRs to `main` and on `workflow_dispatch`):

- **`unit-matrix-mid`** (3.11/3.12/3.13 on ubuntu) — out of `nightly_tests.yml`. Same reusable workflow and extras as before.
- **`search-db-versions`** (3.10/3.12/3.13 sweep of the four search backend combos) — out of `nightly_tests.yml`.
- **`ollama-tests`** and **`llamacpp-tests`** — out of `nightly_tests.yml`. With these gone the nightly is the perf arms only, which is what its Slack report and the MotherDuck load are built around.
- **`run-telemetry-pipeline-test`** — out of `nightly_tests.yml`. This is the only CI job that runs the pipeline with telemetry on; everything else disables it.
- **`test-deletion-on-default-graph`**, **`test-deletion-on-custom-graph`**, **`run_agent_registry_tests`** — restored from the `e2e_tests.yml` jobs the parent PR deleted outright, until it is confirmed their coverage exists elsewhere.

The moved jobs carry the same `if:` guard as the rest of the file (fork PRs skipped). They install from the checked-out source via `cognee_setup`, so the `cognee_version` input does not apply to them; noted in the block comment.

## Nightly cleanup

- `nightly_tests.yml`: the five jobs removed, plus their `needs:` entries, the status-gate lines, and the `STATUS_OLLAMA` / `STATUS_LLAMACPP` / `STATUS_UNIT_MID` env. What remains is the perf arms and the notify job.
- `build_nightly_slack_blocks.py`: the header's suite-status line is gone; the header is now emoji, summary, ran-at, branch, cadence, and commit.
- Comments in `nightly_scheduler.yml` and `test_suites.yml` that pointed at the nightly for these suites now point at the release tests.

## Verification

- YAML parses; pre-commit (yaml check, ruff, ruff format) passes on all changed files.
- Slack builder smoke-tested with the reduced header.
- `release_test.yml` dispatched manually on this branch: run 33766754503 went green on attempt 2 (47 passed, 2 skipped by design); every moved job passed on the first attempt. Details in the PR comment.
