### PR TITLE
fix(agents): named connection lookup finds a deactivated connection

### DIFF
--- a/cognee/modules/agents/operations.py
+++ b/cognee/modules/agents/operations.py
@@ -189,10 +189,13 @@ async def get_agent_connection_detail(
     agent_id: UUIDType,
     agent_session_name: Optional[str] = None,
 ) -> Optional[AgentDetailResponse]:
+    # A lookup by name must still find a connection that unregister has
+    # deactivated; only the unnamed lookup keeps the active-only default.
     response = await list_agent_connections(
         user=user,
         agent_id=agent_id,
         include_sources=True,
+        active_only=not agent_session_name,
         limit=10000,
         offset=0,
     )

--- a/cognee/tests/unit/modules/agents/test_agent_connection_detail.py
+++ b/cognee/tests/unit/modules/agents/test_agent_connection_detail.py
@@ -1,0 +1,41 @@
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.agents.agent_mode import register_agent, unregister_agent
+from cognee.modules.agents.models import RegisterAgentRequest, UnregisterAgentRequest
+from cognee.modules.agents.operations import (
+    get_agent_connection_detail,
+    list_agent_connections,
+)
+from cognee.modules.agents.registry import clear_registered_agent_connections
+from cognee.modules.users.methods import get_default_user
+
+
+@pytest.mark.asyncio
+async def test_connection_detail_by_name_survives_deactivation():
+    """A client looking up its own connection by name must find it after
+    unregister deactivated the persisted copy; the unnamed / listing paths
+    keep hiding inactive connections."""
+    clear_registered_agent_connections()
+    user = await get_default_user()
+    name = f"conn_{uuid4().hex}"
+
+    await register_agent(user, RegisterAgentRequest(agent_session_name=name, type="api"))
+
+    detail = await get_agent_connection_detail(user=user, agent_id=user.id, agent_session_name=name)
+    assert detail is not None
+    assert detail.agent.agent_session_name == name
+    assert detail.agent.status == "active"
+
+    await unregister_agent(user, UnregisterAgentRequest(agent_session_name=name))
+
+    detail = await get_agent_connection_detail(user=user, agent_id=user.id, agent_session_name=name)
+    assert detail is not None, "named lookup must not 404 an existing, inactive connection"
+    assert detail.agent.agent_session_name == name
+    assert detail.agent.status == "inactive"
+
+    listing = await list_agent_connections(user=user, agent_id=user.id)
+    assert all(agent.agent_session_name != name for agent in listing.agents), (
+        "the default listing still excludes inactive connections"
+    )


### PR DESCRIPTION
Fixes #4909

## Description
`get_agent_connection_detail()` lists connections with the default `active_only=True` before filtering by `agent_session_name`, so `GET /api/v1/agents/connections/me?agent_session_name=<name>` answers 404 for a connection that `/agents/unregister` has deactivated — even though `GET /api/v1/agents/connections?active_only=false` still lists it. A client polling for its own connection by name (the Claude Code plugin does, on every hook) gets a permanent 404 after the first deactivation.

This passes `active_only=False` only when a name is given. The unnamed lookup and the listing endpoint keep their active-only behaviour.

## Acceptance Criteria
- Named lookup returns the connection after deactivation, with `status: inactive`.
- `GET /api/v1/agents/connections` (default `active_only=true`) still hides it.
- The new test fails on `dev` (`AssertionError: named lookup must not 404 an existing, inactive connection`) and passes with the fix.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
```
$ .venv/Scripts/python.exe -m pytest cognee/tests/unit/modules/agents -q
20 passed, 12 warnings in 0.72s
$ uvx pre-commit run --files cognee/modules/agents/operations.py cognee/tests/unit/modules/agents/test_agent_connection_detail.py
Trim Trailing Whitespace / Fix End of Files / Check for added large files / ruff / ruff format ... Passed
```
(Windows 11, Python 3.12, `uv sync` on `dev` @ e6a847f.)

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

