### PR TITLE
fix(mcp): redact the API token in the entrypoint launch echo

### DIFF
--- a/cognee-mcp/entrypoint.sh
+++ b/cognee-mcp/entrypoint.sh
@@ -128,7 +128,15 @@ else
     echo "Direct mode: Using local cognee instance"
 fi
 
-echo "calling cognee-mcp" "${ARGS[@]}"
+# Echo the launch command with the API token redacted: the container log is
+# readable by anyone with docker access, and the token is a long-lived credential.
+LOG_ARGS=("${ARGS[@]}")
+for i in "${!LOG_ARGS[@]}"; do
+    if [ "${LOG_ARGS[$i]}" = "--api-token" ] && [ $((i + 1)) -lt ${#LOG_ARGS[@]} ]; then
+        LOG_ARGS[$((i + 1))]="<redacted>"
+    fi
+done
+echo "calling cognee-mcp" "${LOG_ARGS[@]}"
 
 if [ "$DEBUG" = "true" ] && { [ "$ENV" = "dev" ] || [ "$ENV" = "local" ]; }; then
     DEBUG_PORT=${DEBUG_PORT:-5678}


### PR DESCRIPTION
Fixes #4910

## Description
`cognee-mcp/entrypoint.sh` echoes the full launch command at start, including the value of `API_TOKEN`, so a long-lived credential lands in `docker logs` for the container's lifetime. This echoes the same command with the token value replaced by `<redacted>`; the `ARGS` array handed to `cognee-mcp` is unchanged.

## Acceptance Criteria
- Startup log shows `--api-token <redacted>`; the process still receives the real token.
- No behaviour change when `API_TOKEN` is unset.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
```
$ bash -n cognee-mcp/entrypoint.sh && echo OK
OK
$ ARGS=(--host 0.0.0.0 --port 8000 --api-url http://x --api-token SECRETVALUE); <redaction loop>; echo "calling cognee-mcp" "${LOG_ARGS[@]}"
calling cognee-mcp --host 0.0.0.0 --port 8000 --api-url http://x --api-token <redacted>
$ echo "${ARGS[*]}" | grep -c SECRETVALUE
1
$ uvx pre-commit run --files cognee-mcp/entrypoint.sh
Trim Trailing Whitespace / Fix End of Files / Check for added large files ... Passed
```

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests (shell entrypoint; the repo has no harness for it)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

