### PR TITLE
fix(serve): Proxy update() to remote instance and carry pinned data ids

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -88,6 +88,28 @@ jobs:
       - name: Run Migration/Model Lockstep Guard
         run: uv run pytest cognee/tests/e2e/migrations/test_migration_model_lockstep.py -v
 
+  run-serve-remote-routing-e2e:
+    name: serve() remote routing e2e
+    runs-on: ubuntu-22.04
+    container: ${{ inputs.ci-image != '' && fromJSON(format('{{"image":"{0}","credentials":{{"username":"{1}","password":"{2}"}}}}', inputs.ci-image, github.actor, github.token)) || null }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+
+      # Real API server in a subprocess + the SDK after cognee.serve(url=...):
+      # remember → datasets.list_data → update (chunk-level and full paths, by
+      # id and by name) must all land on the server, never the SDK's local
+      # store. Mocked LLM and embeddings: no secrets.
+      - name: Run serve() remote routing suite
+        env:
+          ENV: 'dev'
+        run: uv run pytest cognee/tests/e2e/serve/ -v
+
   run-telemetry-test:
     name: Run Telemetry Test
     runs-on: ubuntu-22.04

--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -208,7 +208,13 @@ async def add(
 
     client = get_remote_client()
     if client is not None:
-        result = await client.add(data, dataset_name)
+        result = await client.add(
+            data,
+            dataset_name,
+            dataset_id=dataset_id,
+            node_set=node_set,
+            run_in_background=run_in_background,
+        )
         # Wrap in a simple namespace so callers expecting .model_dump() still work
         from types import SimpleNamespace
 

--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -208,6 +208,23 @@ async def add(
 
     client = get_remote_client()
     if client is not None:
+        dropped = [
+            name
+            for name, value, default in (
+                ("incremental_loading", incremental_loading, True),
+                ("data_cache", data_cache, True),
+                ("preferred_loaders", preferred_loaders, None),
+                ("vector_db_config", vector_db_config, None),
+                ("graph_db_config", graph_db_config, None),
+            )
+            if value is not default
+        ]
+        if dropped:
+            logger.warning(
+                "add() is proxied to the remote instance; POST /api/v1/add has no slot for "
+                "%s — the server applies its own defaults",
+                ", ".join(dropped),
+            )
         result = await client.add(
             data,
             dataset_name,

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -10,6 +10,7 @@ from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.tasks.ingestion.data_item import (
     pair_labels_with_data,
+    parse_data_ids,
     parse_external_metadata,
     parse_labels,
 )
@@ -67,6 +68,19 @@ def get_add_router() -> APIRouter:
                 "file), and one entry per file is required when any is given. Merged into "
                 "the file's stored external_metadata (your keys win over loader-derived "
                 "ones; 'node_set' is reserved) and returned when listing dataset data."
+            ),
+        ),
+        data_ids: Optional[str] = Form(
+            default=None,
+            examples=[""],
+            description=(
+                "JSON array of per-file UUIDs to pin as each file's data id, e.g. "
+                '["9c4e4a4b-2b1a-4f6e-9d3a-1c2b3d4e5f6a", null]. Paired positionally '
+                "like labels: the Nth entry applies to the Nth uploaded file (null skips "
+                "that file and the server mints an id), one entry per file when any is "
+                "given. An id already present in the dataset updates that document in "
+                "place; an id owned by another dataset is refused. Pin ids to keep a "
+                "stable handle for PATCH /api/v1/update."
             ),
         ),
         datasetName: Optional[str] = Form(
@@ -156,7 +170,10 @@ def get_add_router() -> APIRouter:
         # store them on each file's Data record. Invalid JSON or a count
         # mismatch raises a CogneeApiError (400), returned by the global handler.
         data = pair_labels_with_data(
-            data, parse_labels(labels), parse_external_metadata(external_metadata)
+            data,
+            parse_labels(labels),
+            parse_external_metadata(external_metadata),
+            parse_data_ids(data_ids),
         )
 
         try:

--- a/cognee/api/v1/datasets/datasets.py
+++ b/cognee/api/v1/datasets/datasets.py
@@ -130,6 +130,18 @@ class datasets:
     async def list_data(dataset_id: UUID, user: Optional[User] = None):
         from cognee.modules.data.methods import get_dataset_data
 
+        # Route to the remote instance if connected via serve(): the dataset
+        # lives on the server, so the local store would report it empty or
+        # missing. Rows come back as attribute-accessible namespaces so the
+        # usual ``item.id`` / ``item.name`` reads keep working.
+        from cognee.api.v1.serve.state import get_remote_client
+
+        client = get_remote_client()
+        if client is not None:
+            from types import SimpleNamespace
+
+            return [SimpleNamespace(**row) for row in await client.list_data(dataset_id)]
+
         if not user:
             user = await get_default_user()
 

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -13,6 +13,7 @@ from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.tasks.ingestion.data_item import (
     pair_labels_with_data,
+    parse_data_ids,
     parse_external_metadata,
     parse_labels,
 )
@@ -143,6 +144,19 @@ def get_remember_router() -> APIRouter:
                 "the file's stored external_metadata (your keys win over loader-derived "
                 "ones; 'node_set' is reserved). Only supported for normal ingestion — "
                 "rejected when combined with session_id or content_type."
+            ),
+        ),
+        data_ids: Optional[str] = Form(
+            default=None,
+            examples=[""],
+            description=(
+                "JSON array of per-file UUIDs to pin as each file's data id, e.g. "
+                '["9c4e4a4b-2b1a-4f6e-9d3a-1c2b3d4e5f6a", null]. Paired positionally '
+                "like labels (null skips that file and the server mints an id). An id "
+                "already present in the dataset updates that document in place; an id "
+                "owned by another dataset is refused. Pin ids to keep a stable handle for "
+                "PATCH /api/v1/update. Only supported for normal ingestion — rejected "
+                "when combined with session_id or content_type."
             ),
         ),
         datasetName: Optional[str] = Form(
@@ -366,26 +380,30 @@ def get_remember_router() -> APIRouter:
         # Invalid JSON raises a CogneeApiError (400) via the global handler.
         parsed_labels = parse_labels(labels)
         parsed_metadata = parse_external_metadata(external_metadata)
+        parsed_data_ids = parse_data_ids(data_ids)
 
-        # Labels and metadata live on the Data records that normal add+cognify
-        # ingestion creates. The session-cache, skills, and archive paths never
-        # create those records, so they would be silently dropped — reject
-        # instead.
-        if (any(parsed_labels or []) or any(entry for entry in (parsed_metadata or []))) and (
-            session_id or content_type
-        ):
+        # Labels, metadata and pinned ids live on the Data records that normal
+        # add+cognify ingestion creates. The session-cache, skills, and archive
+        # paths never create those records, so they would be silently dropped —
+        # reject instead.
+        has_item_attributes = (
+            any(parsed_labels or [])
+            or any(entry for entry in (parsed_metadata or []))
+            or any(parsed_data_ids or [])
+        )
+        if has_item_attributes and (session_id or content_type):
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    "labels and external_metadata are only supported for normal ingestion — "
-                    "remove session_id and content_type to use them."
+                    "labels, external_metadata and data_ids are only supported for normal "
+                    "ingestion — remove session_id and content_type to use them."
                 ),
             )
 
-        # Labels and metadata ride on DataItems, which ingestion unwraps to
-        # store them on each file's Data record. A count mismatch raises a
-        # CogneeApiError (400), returned by the global handler.
-        data = pair_labels_with_data(data, parsed_labels, parsed_metadata)
+        # Labels, metadata and pinned ids ride on DataItems, which ingestion
+        # unwraps to store them on each file's Data record. A count mismatch
+        # raises a CogneeApiError (400), returned by the global handler.
+        data = pair_labels_with_data(data, parsed_labels, parsed_metadata, parsed_data_ids)
 
         if content_type == "cogx-archive":
             if not data:

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -1,6 +1,7 @@
 """Remote HTTP client that proxies V2 operations to a Cognee Cloud instance."""
 
 import io
+import json
 from pathlib import Path
 from typing import Any, Optional
 from uuid import UUID
@@ -24,6 +25,167 @@ def _text_upload_filename(text: str) -> str:
     (FileContentHashingError 409s).
     """
     return create_text_data(text).get_metadata()["name"]
+
+
+def _is_data_item(value: Any) -> bool:
+    """A ``DataItem`` wrapper (duck-typed to avoid importing the tasks package here)."""
+    return (
+        hasattr(value, "data")
+        and hasattr(value, "data_id")
+        and not hasattr(value, "read")
+        and not isinstance(value, (str, Path))
+    )
+
+
+def _local_file_path(value: Any) -> Optional[Path]:
+    """The local file a ``/abs/path`` / ``file://`` / ``Path`` value names, else None."""
+    if isinstance(value, Path):
+        return value.expanduser()
+    if isinstance(value, str) and (value.startswith("file://") or value.startswith("/")):
+        raw = value[len("file://") :] if value.startswith("file://") else value
+        return Path(raw).expanduser()
+    return None
+
+
+def _upload_field(form: "aiohttp.FormData", item: Any, *, strict_paths: bool) -> None:
+    """Add one payload to ``form`` as a multipart ``data`` field.
+
+    File-like objects stream as-is. A local path (``/abs/path``,
+    ``file://...``, ``Path``) is read and its bytes uploaded — the server
+    cannot see the caller's filesystem. With ``strict_paths`` a path that
+    names no file raises; otherwise the string falls back to raw text, which
+    is what add()/remember() always did with strings. Any other string is raw
+    text, named by content hash like local ingestion names it.
+    """
+    if hasattr(item, "read"):
+        name = Path(getattr(item, "name", "upload")).name or "upload"
+        form.add_field("data", item, filename=name)
+        return
+
+    path = _local_file_path(item)
+    if path is not None:
+        if path.is_file():
+            form.add_field("data", path.open("rb"), filename=path.name)
+            return
+        if strict_paths:
+            raise FileNotFoundError(f"Upload source not found: {item}")
+
+    text = str(item)
+    form.add_field(
+        "data",
+        io.BytesIO(text.encode("utf-8")),
+        filename=_text_upload_filename(text),
+        content_type="text/plain",
+    )
+
+
+def _attach_upload(form: "aiohttp.FormData", data: Any) -> None:
+    """Add exactly one document to ``form`` for the update route.
+
+    Accepts what the local ``update()`` accepts: a ``DataItem`` (unwrapped to
+    its payload — its id is pinned by the route's query param and it has no
+    slot for label/external_metadata), a file-like object, a local path, or
+    raw text. A single-item list is unwrapped; anything longer is a caller
+    error, as it is locally.
+    """
+    if isinstance(data, list):
+        if len(data) != 1:
+            raise ValueError(f"update() replaces exactly one document; got {len(data)} items.")
+        data = data[0]
+    if _is_data_item(data):
+        data = data.data
+    _upload_field(form, data, strict_paths=True)
+
+
+def _attach_uploads(form: "aiohttp.FormData", data: Any) -> list:
+    """Add every payload in ``data`` to ``form`` and carry DataItem attributes along.
+
+    ``DataItem`` wrappers are unwrapped for the upload; their ``label``,
+    ``external_metadata`` and ``data_id`` are sent as the positional JSON
+    array fields the add/remember routes accept (one entry per file, null to
+    skip), so a pinned id survives the wire and the server stores the document
+    under it. Returns the pinned ids in upload order (None where unpinned).
+    """
+    items = data if isinstance(data, list) else [data]
+    labels, metadata, data_ids = [], [], []
+    for item in items:
+        if _is_data_item(item):
+            labels.append(item.label)
+            metadata.append(item.external_metadata)
+            data_ids.append(str(item.data_id) if item.data_id is not None else None)
+            item = item.data
+        else:
+            labels.append(None)
+            metadata.append(None)
+            data_ids.append(None)
+        _upload_field(form, item, strict_paths=False)
+
+    if any(labels):
+        form.add_field("labels", json.dumps(labels))
+    if any(metadata):
+        form.add_field("external_metadata", json.dumps(metadata))
+    if any(data_ids):
+        form.add_field("data_ids", json.dumps(data_ids))
+    return data_ids
+
+
+def _returned_data_ids(response: Any) -> set:
+    """Data ids an add/remember response reports, as strings.
+
+    remember() responses list them as ``items[].id``; add() responses (a
+    pipeline run) as ``data_ingestion_info[].data_id``. Empty when the shape
+    carries none (background runs, older servers).
+    """
+    found = set()
+    if not isinstance(response, dict):
+        return found
+    for entry in response.get("items") or []:
+        if isinstance(entry, dict) and entry.get("id") is not None:
+            found.add(str(entry["id"]))
+    for entry in response.get("data_ingestion_info") or []:
+        if isinstance(entry, dict) and entry.get("data_id") is not None:
+            found.add(str(entry["data_id"]))
+    return found
+
+
+def _verify_pinned_ids(response: Any, pinned: list, operation: str) -> None:
+    """Fail loudly if the server minted its own ids instead of honoring the pins.
+
+    An older server without the ``data_ids`` field ignores it silently
+    (FastAPI drops unknown form fields), and the caller would go on to
+    ``update()`` an id that does not exist remotely. When the response
+    reports ids and a pin is missing from them, that is what happened.
+    A response that reports no ids at all cannot be checked; it is logged.
+    """
+    requested = [pin for pin in pinned if pin]
+    if not requested:
+        return
+    returned = _returned_data_ids(response)
+    if not returned:
+        logger.warning(
+            "Remote %s response reports no data ids; cannot confirm the pinned data_id(s) %s "
+            "were honored (background run, or a server without data_ids support)",
+            operation,
+            ", ".join(requested),
+        )
+        return
+    missing = [pin for pin in requested if pin not in returned]
+    if missing:
+        raise RuntimeError(
+            f"Remote {operation} did not honor pinned data_id(s) {', '.join(missing)}: the "
+            f"server stored the document(s) under {', '.join(sorted(returned))}. The remote "
+            "instance is probably older than this SDK and lacks the data_ids field on "
+            f"POST /api/v1/{operation}; upgrade it or use the server-assigned id."
+        )
+
+
+def _node_set_tags(node_set: Any) -> list:
+    """node_set as repeated-form-field values: a str is one tag, a list many."""
+    if not node_set:
+        return []
+    if isinstance(node_set, str):
+        return [node_set]
+    return [str(tag) for tag in node_set if tag]
 
 
 class CloudClient:
@@ -110,7 +272,10 @@ class CloudClient:
             form.add_field("content_type", str(content_type_kw))
         if kwargs.get("import_mode") is not None:
             form.add_field("import_mode", str(kwargs["import_mode"]))
+        for tag in _node_set_tags(kwargs.get("node_set")):
+            form.add_field("node_set", tag)
 
+        pinned_ids: list = []
         # Code repos travel as spec strings in the 'repositories' form field —
         # the server clones git URLs itself and reads local paths from its own
         # filesystem (only useful when it shares the caller's filesystem).
@@ -142,29 +307,10 @@ class CloudClient:
                 # the SKILL.md layout when writing to its tempdir.
                 rel = skill_path.relative_to(base).as_posix()
                 form.add_field("data", skill_path.open("rb"), filename=rel)
-        # Handle data — string or file-like objects
-        elif isinstance(data, str):
-            form.add_field(
-                "data",
-                io.BytesIO(data.encode("utf-8")),
-                filename=_text_upload_filename(data),
-                content_type="text/plain",
-            )
-        elif isinstance(data, list):
-            for item in data:
-                if isinstance(item, str):
-                    form.add_field(
-                        "data",
-                        io.BytesIO(item.encode("utf-8")),
-                        filename=_text_upload_filename(item),
-                        content_type="text/plain",
-                    )
-                elif hasattr(item, "read"):
-                    name = getattr(item, "name", "upload")
-                    form.add_field("data", item, filename=name)
-        elif hasattr(data, "read"):
-            name = getattr(data, "name", "upload")
-            form.add_field("data", data, filename=name)
+        # Normal ingestion — strings, local paths, file-like objects, or
+        # DataItems carrying label / external_metadata / a pinned data_id.
+        else:
+            pinned_ids = _attach_uploads(form, data)
 
         # Code ingestion can block on a clone + whole-repo parse; the archive
         # timeout (no total cap) fits both. Prefer run_in_background=True for
@@ -180,7 +326,9 @@ class CloudClient:
             if resp.status >= 400:
                 body = await resp.text()
                 raise RuntimeError(f"Remote remember failed ({resp.status}): {body}")
-            return await resp.json()
+            result = await resp.json()
+        _verify_pinned_ids(result, pinned_ids, "remember")
+        return result
 
     async def remember_entry(
         self,
@@ -295,35 +443,79 @@ class CloudClient:
         session = await self._get_session()
 
         form = aiohttp.FormData()
-        form.add_field("datasetName", dataset_name)
+        if dataset_name:
+            form.add_field("datasetName", dataset_name)
+        if kwargs.get("dataset_id"):
+            form.add_field("datasetId", str(kwargs["dataset_id"]))
+        for tag in _node_set_tags(kwargs.get("node_set")):
+            form.add_field("node_set", tag)
+        if kwargs.get("run_in_background"):
+            form.add_field("run_in_background", "true")
 
-        if isinstance(data, str):
-            form.add_field(
-                "data",
-                io.BytesIO(data.encode("utf-8")),
-                filename=_text_upload_filename(data),
-                content_type="text/plain",
-            )
-        elif isinstance(data, list):
-            for item in data:
-                if isinstance(item, str):
-                    form.add_field(
-                        "data",
-                        io.BytesIO(item.encode("utf-8")),
-                        filename=_text_upload_filename(item),
-                        content_type="text/plain",
-                    )
-                elif hasattr(item, "read"):
-                    name = getattr(item, "name", "upload")
-                    form.add_field("data", item, filename=name)
-        elif hasattr(data, "read"):
-            name = getattr(data, "name", "upload")
-            form.add_field("data", data, filename=name)
+        pinned_ids = _attach_uploads(form, data)
 
         async with session.post(f"{self.service_url}/api/v1/add", data=form) as resp:
             if resp.status >= 400:
                 body = await resp.text()
                 raise RuntimeError(f"Remote add failed ({resp.status}): {body}")
+            result = await resp.json()
+        _verify_pinned_ids(result, pinned_ids, "add")
+        return result
+
+    async def update(
+        self,
+        data_id: UUID,
+        data: Any,
+        dataset_id: Optional[UUID] = None,
+        node_set: Optional[list] = None,
+        chunk_level_diff: bool = True,
+        dataset_name: Optional[str] = None,
+    ) -> dict:
+        """PATCH /api/v1/update — replace one document in place on the remote.
+
+        Mirrors the server route: ``data_id``, the dataset (``dataset_id`` or
+        ``dataset_name``, exactly one) and ``chunk_level_diff`` travel as query
+        params, the new content as the multipart ``data`` file, ``node_set`` as
+        repeated form fields. The server keeps the document's id across the
+        update, so this is a real replace — never a local delete plus a remote
+        add, which would mint a fresh id on the remote and leave the original
+        in place.
+        """
+        if (dataset_id is None) == (dataset_name is None):
+            raise ValueError("update() takes exactly one of dataset_id or dataset_name.")
+
+        session = await self._get_session()
+
+        form = aiohttp.FormData()
+        _attach_upload(form, data)
+        for tag in _node_set_tags(node_set):
+            form.add_field("node_set", tag)
+
+        params = {
+            "data_id": str(data_id),
+            "chunk_level_diff": "true" if chunk_level_diff else "false",
+        }
+        if dataset_id is not None:
+            params["dataset_id"] = str(dataset_id)
+        else:
+            params["dataset_name"] = dataset_name
+
+        async with session.patch(
+            f"{self.service_url}/api/v1/update", params=params, data=form
+        ) as resp:
+            if resp.status >= 400:
+                body = await resp.text()
+                raise RuntimeError(f"Remote update failed ({resp.status}): {body}")
+            return await resp.json()
+
+    async def list_data(self, dataset_id: UUID) -> list:
+        """GET /api/v1/datasets/{dataset_id}/data — list the documents in a dataset."""
+        session = await self._get_session()
+
+        async with session.get(f"{self.service_url}/api/v1/datasets/{dataset_id}/data") as resp:
+            if resp.status >= 400:
+                body = await resp.text()
+                raise RuntimeError(f"Remote list_data failed ({resp.status}): {body}")
             return await resp.json()
 
     async def cognify(self, datasets: Any = None, **kwargs) -> dict:

--- a/cognee/api/v1/update/incremental.py
+++ b/cognee/api/v1/update/incremental.py
@@ -37,6 +37,7 @@ update instead, and can tell a permanent misconfiguration from a first
 ingestion in the logs. Permission errors are NOT refusals: they propagate.
 """
 
+import re
 import json
 from enum import Enum
 from pathlib import PureWindowsPath
@@ -120,6 +121,11 @@ PIPELINE_NAME = "cognify_pipeline"  # attribute to the cognify pipeline's status
 RUN_PIPELINE_NAME = "incremental_update_pipeline"
 # Matches cognify's own fallback when chunks_per_batch is unset.
 DEFAULT_CHUNKS_PER_BATCH = 2000
+
+
+# The name ``TextData`` gives raw text (``text_<md5>.txt``); an upload named this
+# way is raw text that traveled over HTTP, not a user-named file.
+_CONTENT_NAMED_TEXT_UPLOAD = re.compile(r"^text_[0-9a-f]{32}(\.txt)?$")
 
 
 class RefusalReason(str, Enum):
@@ -455,8 +461,16 @@ def _changed_staged_metadata(data, old_data: Data, staged: StagedContent) -> lis
     ]
     # Direct text gets an internal content-derived filename, so its name is
     # expected to change with its text. User-named uploads and streams are not.
+    # Raw text sent over HTTP (the SDK after serve(), the CLI against a server)
+    # arrives as an upload carrying that same content-derived name — see
+    # cloud_client._text_upload_filename — so it is direct text too, not a
+    # renamed document; treating it as one would send every remote text
+    # update down the full-rebuild path.
     source_data = data.data if isinstance(data, DataItem) else data
-    if hasattr(source_data, "filename") or hasattr(source_data, "name"):
+    upload_name = getattr(source_data, "filename", None) or getattr(source_data, "name", None)
+    if (hasattr(source_data, "filename") or hasattr(source_data, "name")) and not (
+        isinstance(upload_name, str) and _CONTENT_NAMED_TEXT_UPLOAD.match(upload_name)
+    ):
         fields.append("name")
     return [
         field for field in fields if getattr(old_data, field, None) != getattr(staged, field, None)

--- a/cognee/api/v1/update/routers/get_update_router.py
+++ b/cognee/api/v1/update/routers/get_update_router.py
@@ -55,10 +55,21 @@ def get_update_router() -> APIRouter:
             ),
             examples=["9c4e4a4b-2b1a-4f6e-9d3a-1c2b3d4e5f6a"],
         ),
-        dataset_id: UUID = Query(
-            ...,
-            description="UUID of the dataset containing the document to update.",
+        dataset_id: Optional[UUID] = Query(
+            default=None,
+            description=(
+                "UUID of the dataset containing the document to update. "
+                "Required unless dataset_name is provided."
+            ),
             examples=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+        ),
+        dataset_name: Optional[str] = Query(
+            default=None,
+            description=(
+                "Name of the dataset containing the document to update, resolved among "
+                "the datasets you may write to. Alternative to dataset_id."
+            ),
+            examples=["main_dataset"],
         ),
         data: List[UploadFile] = File(
             ...,
@@ -92,7 +103,10 @@ def get_update_router() -> APIRouter:
 
         ## Request Parameters
         - **data_id** (UUID, required, query): UUID of the existing document to update (returned by GET /api/v1/datasets/{dataset_id}/data)
-        - **dataset_id** (UUID, required, query): UUID of the dataset containing the document to update
+        - **dataset_id** (UUID, query): UUID of the dataset containing the document to update.
+                 Exactly one of dataset_id / dataset_name is required.
+        - **dataset_name** (str, query): Name of the dataset containing the document, resolved
+                 among the datasets the caller may write to. Alternative to dataset_id.
         - **data** (List[UploadFile]): New version of the document that replaces the existing one.
         - **node_set** (Optional[List[str]]): List of node identifiers for graph organization and access control.
                  Used for grouping related data points in the knowledge graph.
@@ -108,7 +122,8 @@ def get_update_router() -> APIRouter:
         pipeline run information for the delete + re-add + cognify operation.
 
         ## Error Codes
-        - **422 Unprocessable Entity**: data_id or dataset_id missing or not a valid UUID
+        - **422 Unprocessable Entity**: data_id missing or not a valid UUID, or neither/both of
+                 dataset_id and dataset_name given
         - **403 Forbidden**: User lacks write permission on the dataset
         - **500 Internal Server Error**: Pipeline run errored or an unexpected error occurred during the update
 
@@ -116,12 +131,21 @@ def get_update_router() -> APIRouter:
         - Chunk-level updates keep unaffected chunks, their entities, and their summaries
           untouched; only the edited region is re-extracted.
         """
+        if (dataset_id is None) == (dataset_name is None):
+            return JSONResponse(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                content=ErrorResponse(
+                    error="Provide exactly one of dataset_id or dataset_name.",
+                ).model_dump(),
+            )
+
         send_telemetry(
             "Update API Endpoint Invoked",
             user,
             additional_properties={
                 "endpoint": "PATCH /v1/update",
                 "dataset_id": str(dataset_id),
+                "dataset_name": dataset_name,
                 "data_id": str(data_id),
                 "node_set": str(node_set),
                 "cognee_version": cognee_version,
@@ -135,6 +159,7 @@ def get_update_router() -> APIRouter:
                 data_id=data_id,
                 data=data,
                 dataset_id=dataset_id,
+                dataset_name=dataset_name,
                 user=user,
                 node_set=node_set if node_set and node_set != [""] else None,
                 chunk_level_diff=chunk_level_diff,

--- a/cognee/api/v1/update/update.py
+++ b/cognee/api/v1/update/update.py
@@ -173,6 +173,10 @@ async def update(
                 ("custom_prompt", custom_prompt, None),
                 ("chunker", chunker, TextChunker),
                 ("policy", policy, DEFAULT_CHUNK_POLICY),
+                # No route field for either: the server runs its defaults (both
+                # True), so a caller disabling them locally must hear about it.
+                ("incremental_loading", incremental_loading, True),
+                ("data_cache", data_cache, True),
             )
             if value is not default
         ]

--- a/cognee/api/v1/update/update.py
+++ b/cognee/api/v1/update/update.py
@@ -56,7 +56,7 @@ async def _restore_row_lineage(
 async def update(
     data_id: UUID,
     data: Union[BinaryIO, list[BinaryIO], str, list[str]],
-    dataset_id: UUID,
+    dataset_id: Optional[UUID] = None,
     user: User = None,
     node_set: Optional[List[str]] = None,
     vector_db_config: dict = None,
@@ -69,6 +69,7 @@ async def update(
     custom_prompt: Optional[str] = None,
     chunker: type = TextChunker,
     policy: ChunkPolicy = DEFAULT_CHUNK_POLICY,
+    dataset_name: Optional[str] = None,
 ) -> Union[Dict[str, PipelineRunInfo], List[PipelineRunInfo], dict]:
     """
     Update existing data in Cognee.
@@ -107,7 +108,11 @@ async def update(
             - File URL: "file:///absolute/path/to/document.pdf" or "file://relative/path.txt"
             - S3 path: "s3://my-bucket/documents/file.pdf"
             - Binary file object: open("file.txt", "rb")
-        dataset_id: UUID of the dataset holding the document (required).
+        dataset_id: UUID of the dataset holding the document. Exactly one of
+              dataset_id / dataset_name is required.
+        dataset_name: Name of the dataset holding the document, resolved among the
+              datasets the user may write to. Alternative to dataset_id; the
+              dataset must already exist — update() never creates datasets.
         user: User object for authentication and permissions. Uses default user if None.
               Default user: "default_user@example.com" (created automatically on first use).
               Users can only access datasets they have permissions for.
@@ -144,8 +149,62 @@ async def update(
             - Processing status and any errors
             - Execution timestamps and metadata
     """
+    # Route to the remote instance if connected via serve(). This must come
+    # before any local work: the fallback path below deletes locally and
+    # re-adds, which against a remote dataset id fails with "Dataset not
+    # found" after resolving the LOCAL default user — and even a remote
+    # re-add would mint a new id rather than replace the document.
+    from cognee.api.v1.serve.state import get_remote_client
+
+    if (dataset_id is None) == (dataset_name is None):
+        from cognee.modules.ingestion.exceptions import IngestionError
+
+        raise IngestionError("update() takes exactly one of dataset_id or dataset_name.")
+
+    client = get_remote_client()
+    if client is not None:
+        dropped = [
+            name
+            for name, value, default in (
+                ("vector_db_config", vector_db_config, None),
+                ("graph_db_config", graph_db_config, None),
+                ("preferred_loaders", preferred_loaders, None),
+                ("graph_model", graph_model, KnowledgeGraph),
+                ("custom_prompt", custom_prompt, None),
+                ("chunker", chunker, TextChunker),
+                ("policy", policy, DEFAULT_CHUNK_POLICY),
+            )
+            if value is not default
+        ]
+        if dropped:
+            logger.warning(
+                "update() is proxied to the remote instance; PATCH /api/v1/update has no "
+                "slot for %s — the server applies its own configuration",
+                ", ".join(dropped),
+            )
+        return await client.update(
+            data_id=data_id,
+            data=data,
+            dataset_id=dataset_id,
+            dataset_name=dataset_name,
+            node_set=node_set,
+            chunk_level_diff=chunk_level_diff,
+        )
+
     if not user:
         user = await get_default_user()
+
+    if dataset_id is None:
+        # A name resolves only among datasets this user may write to, and only
+        # to an existing one: update() replaces documents, it never creates
+        # the dataset the way add()/remember() do.
+        from cognee.modules.data.exceptions import DatasetNotFoundError
+        from cognee.modules.data.methods import get_authorized_existing_datasets
+
+        matches = await get_authorized_existing_datasets([dataset_name], "write", user)
+        if not matches:
+            raise DatasetNotFoundError(f"Dataset '{dataset_name}' not found.")
+        dataset_id = matches[0].id
 
     from cognee.infrastructure.databases.relational import get_relational_engine
     from cognee.modules.data.methods import resolve_data_id

--- a/cognee/tasks/ingestion/data_item.py
+++ b/cognee/tasks/ingestion/data_item.py
@@ -4,7 +4,9 @@ from typing import Any, List, Optional
 from uuid import UUID
 
 from cognee.tasks.ingestion.exceptions import (
+    DataIdCountMismatchError,
     ExternalMetadataCountMismatchError,
+    InvalidDataIdsError,
     InvalidExternalMetadataError,
     InvalidLabelsError,
     LabelCountMismatchError,
@@ -87,30 +89,73 @@ def parse_external_metadata(
     return parsed
 
 
+def parse_data_ids(data_ids: Optional[str]) -> Optional[List[Optional[UUID]]]:
+    """Parse the ``data_ids`` form field: a JSON array of UUID strings.
+
+    Same wire convention as ``labels``: one JSON-encoded string, paired
+    positionally with the uploaded files, ``null`` (or ``""``) to let the
+    server mint an id for that file. A pinned id becomes the file's
+    ``Data.id`` — ingestion resolves it inside the target dataset (updating
+    the row in place when it exists, creating it under that id otherwise)
+    and refuses ids that belong to another dataset. Sending an id is what
+    lets a remote caller hold a stable handle for a later ``update()``.
+
+    Returns None when the field is absent or blank.
+
+    Raises:
+        InvalidDataIdsError: If the value is not a JSON array, or an entry is
+            neither null nor a valid UUID string.
+    """
+    if data_ids is None or not data_ids.strip():
+        return None
+    try:
+        parsed = json.loads(data_ids)
+    except json.JSONDecodeError as error:
+        raise InvalidDataIdsError(f"data_ids is not valid JSON: {error}")
+    if not isinstance(parsed, list):
+        raise InvalidDataIdsError()
+    result: List[Optional[UUID]] = []
+    for entry in parsed:
+        if entry is None or entry == "":
+            result.append(None)
+            continue
+        if not isinstance(entry, str):
+            raise InvalidDataIdsError()
+        try:
+            result.append(UUID(entry))
+        except ValueError:
+            raise InvalidDataIdsError(f"data_ids entry {entry!r} is not a valid UUID.")
+    return result
+
+
 def pair_labels_with_data(
     data: Optional[list],
     labels: Optional[List[Optional[str]]],
     external_metadata: Optional[List[Optional[dict]]] = None,
+    data_ids: Optional[List[Optional[UUID]]] = None,
 ) -> Optional[list]:
-    """Pair per-item labels and external metadata with data items as DataItems.
+    """Pair per-item labels, external metadata and pinned ids with data items as DataItems.
 
-    Both attribute lists pair positionally: the Nth entry applies to the Nth
-    data item. An empty label (``""``/``None``) or empty metadata entry
-    (``{}``/``None``) leaves that item's attribute unset, and either list may
-    be omitted entirely. With no non-empty entry in either list the data is
-    returned unchanged; otherwise each provided list's length must match the
-    item count — a partial list is ambiguous.
+    All attribute lists pair positionally: the Nth entry applies to the Nth
+    data item. An empty label (``""``/``None``), empty metadata entry
+    (``{}``/``None``) or ``None`` id leaves that item's attribute unset, and
+    any list may be omitted entirely. With no non-empty entry in any list the
+    data is returned unchanged; otherwise each provided list's length must
+    match the item count — a partial list is ambiguous.
 
     Raises:
         LabelCountMismatchError: If any label is provided and the counts differ.
         ExternalMetadataCountMismatchError: If any metadata entry is provided
             and the counts differ.
+        DataIdCountMismatchError: If any id is provided and the counts differ.
     """
     normalized_labels = [(entry or None) for entry in (labels or [])]
     normalized_metadata = [(entry or None) for entry in (external_metadata or [])]
+    normalized_ids = [(entry or None) for entry in (data_ids or [])]
     has_labels = any(normalized_labels)
     has_metadata = any(normalized_metadata)
-    if not has_labels and not has_metadata:
+    has_ids = any(normalized_ids)
+    if not has_labels and not has_metadata and not has_ids:
         return data
 
     item_count = len(data or [])
@@ -124,12 +169,21 @@ def pair_labels_with_data(
             f"Provide one external_metadata entry per uploaded file: got "
             f"{len(normalized_metadata)} entries for {item_count} files."
         )
+    if has_ids and len(normalized_ids) != item_count:
+        raise DataIdCountMismatchError(
+            f"Provide one data_ids entry per uploaded file: got {len(normalized_ids)} "
+            f"ids for {item_count} files."
+        )
 
     if not has_labels:
         normalized_labels = [None] * item_count
     if not has_metadata:
         normalized_metadata = [None] * item_count
+    if not has_ids:
+        normalized_ids = [None] * item_count
     return [
-        DataItem(data=item, label=label, external_metadata=metadata)
-        for item, label, metadata in zip(data, normalized_labels, normalized_metadata)
+        DataItem(data=item, label=label, external_metadata=metadata, data_id=data_id)
+        for item, label, metadata, data_id in zip(
+            data, normalized_labels, normalized_metadata, normalized_ids
+        )
     ]

--- a/cognee/tasks/ingestion/exceptions/__init__.py
+++ b/cognee/tasks/ingestion/exceptions/__init__.py
@@ -11,4 +11,6 @@ from .exceptions import (
     InvalidLabelsError,
     InvalidExternalMetadataError,
     ExternalMetadataCountMismatchError,
+    InvalidDataIdsError,
+    DataIdCountMismatchError,
 )

--- a/cognee/tasks/ingestion/exceptions/exceptions.py
+++ b/cognee/tasks/ingestion/exceptions/exceptions.py
@@ -74,6 +74,29 @@ class InvalidExternalMetadataError(CogneeValidationError):
         super().__init__(message, name, status_code)
 
 
+class InvalidDataIdsError(CogneeValidationError):
+    def __init__(
+        self,
+        message: str = (
+            "data_ids must be a JSON array of UUID strings, e.g. "
+            '["9c4e4a4b-2b1a-4f6e-9d3a-1c2b3d4e5f6a", null].'
+        ),
+        name: str = "InvalidDataIdsError",
+        status_code: int = status.HTTP_400_BAD_REQUEST,
+    ):
+        super().__init__(message, name, status_code)
+
+
+class DataIdCountMismatchError(CogneeValidationError):
+    def __init__(
+        self,
+        message: str = "data_ids count does not match data item count.",
+        name: str = "DataIdCountMismatchError",
+        status_code: int = status.HTTP_400_BAD_REQUEST,
+    ):
+        super().__init__(message, name, status_code)
+
+
 class ExternalMetadataCountMismatchError(CogneeValidationError):
     def __init__(
         self,

--- a/cognee/tests/e2e/serve/server_runner.py
+++ b/cognee/tests/e2e/serve/server_runner.py
@@ -1,0 +1,107 @@
+"""Boot a real cognee API server for the ``serve()`` e2e suite.
+
+Run as a subprocess by ``test_serve_remote_routing.py``::
+
+    python -m cognee.tests.e2e.serve.server_runner <port> <env-overrides.json>
+
+A separate process is not a convenience, it is the point: the SDK under test
+sets a process-global remote client, and the server's own handlers call the
+same SDK functions. In one process every handler would see that client and
+forward the request back to itself. Two processes are also what a real
+deployment looks like — the SDK's local store and the server's store are
+different directories, so the test can prove the SDK never touched its own.
+
+LLM structured output and embeddings are mocked the same way the
+incremental-update e2e suite mocks them: no API keys, deterministic graph.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _clear_config_caches() -> None:
+    import importlib
+
+    for module_name, factory_name in [
+        ("cognee.base_config", "get_base_config"),
+        ("cognee.infrastructure.databases.relational.config", "get_relational_config"),
+        (
+            "cognee.infrastructure.databases.relational.get_relational_engine",
+            "get_relational_engine",
+        ),
+        ("cognee.infrastructure.databases.graph.config", "get_graph_config"),
+        ("cognee.infrastructure.databases.vector.config", "get_vectordb_config"),
+        ("cognee.infrastructure.databases.cache.config", "get_cache_config"),
+        ("cognee.infrastructure.databases.cache.get_cache_engine", "create_cache_engine"),
+        ("cognee.infrastructure.databases.vector.embeddings.config", "get_embedding_config"),
+        (
+            "cognee.infrastructure.databases.vector.embeddings.get_embedding_engine",
+            "create_embedding_engine",
+        ),
+        ("cognee.infrastructure.llm.config", "get_llm_config"),
+    ]:
+        try:
+            getattr(importlib.import_module(module_name), factory_name).cache_clear()
+        except (ImportError, AttributeError):
+            pass
+
+
+def _install_llm_mock() -> None:
+    import re
+
+    from cognee.infrastructure.llm.LLMGateway import LLMGateway
+    from cognee.shared.data_models import KnowledgeGraph, Node, SummarizedContent
+
+    marker = re.compile(r"ENT[A-Z0-9]+")
+
+    @staticmethod
+    async def _mock_acreate(text_input, system_prompt, response_model, **kwargs):
+        if isinstance(response_model, type) and issubclass(response_model, KnowledgeGraph):
+            names = sorted(set(marker.findall(str(text_input))))
+            return KnowledgeGraph(
+                nodes=[Node(id=n, name=n, type="Marker", description=f"marker {n}") for n in names],
+                edges=[],
+            )
+        if isinstance(response_model, type) and issubclass(response_model, SummarizedContent):
+            return SummarizedContent(summary="Mock summary.", description="")
+        if response_model is str:
+            return "mock answer"
+        return response_model()
+
+    LLMGateway.acreate_structured_output = _mock_acreate
+
+
+def main() -> None:
+    port = int(sys.argv[1])
+    overrides = json.loads(Path(sys.argv[2]).read_text())
+    os.environ.update(overrides)
+
+    # ``import cognee`` runs load_dotenv(override=True), which would let a repo
+    # .env (say ENABLE_BACKEND_ACCESS_CONTROL=true) silently replace the
+    # suite's explicit environment — and the auth posture is fixed at import
+    # time. Keep .env as a fallback for anything unset, never an override.
+    import dotenv
+
+    original_load_dotenv = dotenv.load_dotenv
+
+    def _load_dotenv_without_override(*args, **kwargs):
+        kwargs["override"] = False
+        return original_load_dotenv(*args, **kwargs)
+
+    dotenv.load_dotenv = _load_dotenv_without_override
+
+    import cognee  # noqa: F401
+
+    os.environ.update(overrides)
+    _clear_config_caches()
+    _install_llm_mock()
+
+    from cognee.api.client import start_api_server
+
+    start_api_server(host="127.0.0.1", port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/cognee/tests/e2e/serve/test_serve_remote_routing.py
+++ b/cognee/tests/e2e/serve/test_serve_remote_routing.py
@@ -1,0 +1,224 @@
+"""Functional test: after ``cognee.serve(url=...)`` the SDK's write/read path
+runs on the remote instance, not the local store.
+
+Regression suite for the report "``cognee.update()`` after ``cognee.serve()``
+runs against the local store": ``update()`` resolved the LOCAL default user,
+ran a local ``datasets.delete_data`` against the remote dataset UUID and
+failed with ``Dataset '<uuid>' not found`` while the remote document stayed
+untouched. The same report listed two gaps on the path — a ``DataItem``'s
+pinned ``data_id`` never left the SDK, and ``datasets.list_data()`` read the
+local store.
+
+Setup: a real cognee API server in a subprocess (mocked LLM + embeddings, no
+API keys, ``ENABLE_BACKEND_ACCESS_CONTROL=false`` so the default user answers
+without a key), its own scratch data root; the SDK in this process with a
+*different* scratch root that must stay empty. The scenario drives the public
+SDK — ``remember`` → ``datasets.list_data`` → ``update`` (both the chunk-level
+and the full-rebuild path, by id and by name) — and checks the server's raw
+document after each step. Everything runs in one test coroutine: cognee's
+cached engines and the aiohttp session bind to the running event loop.
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+STARTUP_TIMEOUT_SECONDS = 240
+DATASET = "serve_e2e"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _paragraph(i: int, tag: str = "") -> str:
+    words = " ".join(f"w{i}{j:02d}" for j in range(30))
+    return f"Paragraph {i}{tag} ENTP{i} ENTSHARED. {words}.\n"
+
+
+TEXT_V1 = "".join(_paragraph(i) for i in range(6))
+# One paragraph edited: the chunk-level update path replaces just that region.
+TEXT_V2 = TEXT_V1.replace(_paragraph(3), _paragraph(3, " revised ENTNEW"))
+TEXT_V3 = "A different document altogether ENTFINAL. " + "".join(
+    _paragraph(i) for i in range(10, 13)
+)
+
+
+def _env_overrides(root: Path) -> dict:
+    return {
+        "GRAPH_DATABASE_PROVIDER": "kuzu",
+        "VECTOR_DB_PROVIDER": "lancedb",
+        "DB_PROVIDER": "sqlite",
+        "CACHE_BACKEND": "sqlite",
+        "MOCK_EMBEDDING": "true",
+        "TELEMETRY_DISABLED": "1",
+        "COGNEE_SKIP_CONNECTION_TEST": "true",
+        "DATA_ROOT_DIRECTORY": str(root / "data"),
+        "SYSTEM_ROOT_DIRECTORY": str(root / "system"),
+    }
+
+
+@pytest.fixture(scope="module")
+def remote_server():
+    """A real API server in a subprocess, plus an isolated root for this SDK process."""
+    root = Path(tempfile.mkdtemp(prefix="cognee_serve_e2e_"))
+    server_root = root / "server"
+    sdk_root = root / "sdk"
+    server_root.mkdir()
+    sdk_root.mkdir()
+
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    server_env = {
+        **_env_overrides(server_root),
+        # Single-user server: no API key needed, the default user answers.
+        "ENABLE_BACKEND_ACCESS_CONTROL": "false",
+        "REQUIRE_AUTHENTICATION": "false",
+        "LLM_API_KEY": os.environ.get("LLM_API_KEY", "mock-key"),
+    }
+    env_file = root / "server_env.json"
+    env_file.write_text(json.dumps(server_env))
+    log_path = root / "server.log"
+
+    with log_path.open("wb") as log:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "cognee.tests.e2e.serve.server_runner",
+                str(port),
+                str(env_file),
+            ],
+            env={**os.environ, **server_env},
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            cwd=str(root),
+        )
+
+    try:
+        deadline = time.monotonic() + STARTUP_TIMEOUT_SECONDS
+        while True:
+            if process.poll() is not None:
+                raise RuntimeError(
+                    f"server exited early ({process.returncode}):\n{log_path.read_text()[-4000:]}"
+                )
+            try:
+                if httpx.get(f"{base_url}/health", timeout=2).status_code == 200:
+                    break
+            except httpx.HTTPError:
+                pass
+            if time.monotonic() > deadline:
+                raise RuntimeError(
+                    f"server not healthy after {STARTUP_TIMEOUT_SECONDS}s:\n"
+                    f"{log_path.read_text()[-4000:]}"
+                )
+            time.sleep(0.5)
+
+        # The SDK side: its own empty root. If anything below ran locally it
+        # would land here — the final assertion checks it never did.
+        import cognee  # noqa: F401  (cognee's import runs load_dotenv(override=True))
+
+        os.environ.update(_env_overrides(sdk_root))
+        from cognee.tests.e2e.serve.server_runner import _clear_config_caches
+
+        _clear_config_caches()
+
+        yield {"base_url": base_url, "sdk_root": sdk_root, "log_path": log_path}
+    finally:
+        # Captured by pytest, shown only when a test fails: the server-side
+        # story (refusals, tracebacks) is otherwise lost with the scratch root.
+        if log_path.exists():
+            print("----- server log (tail) -----")
+            print(log_path.read_text(errors="replace")[-8000:])
+        process.terminate()
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+        shutil.rmtree(root, ignore_errors=True)
+
+
+async def _raw_document(base_url: str, dataset_id: str, data_id: UUID) -> str:
+    async with httpx.AsyncClient(timeout=30) as http:
+        response = await http.get(f"{base_url}/api/v1/datasets/{dataset_id}/data/{data_id}/raw")
+        response.raise_for_status()
+        return response.text
+
+
+@pytest.mark.asyncio
+async def test_sdk_writes_and_reads_go_to_the_remote_instance(remote_server):
+    import cognee
+    from cognee.api.v1.serve import state as serve_state
+    from cognee.api.v1.serve import credentials as serve_credentials
+    from cognee.tasks.ingestion.data_item import DataItem
+
+    base_url = remote_server["base_url"]
+    pinned = uuid4()
+
+    # serve() persists credentials under ~/.cognee; keep the suite out of $HOME.
+    with patch.object(serve_credentials, "save_credentials"):
+        await cognee.serve(url=base_url)
+    try:
+        assert serve_state.is_remote_mode()
+
+        # --- remember: the pinned id must be the id the server stores ---
+        stored = await cognee.remember(
+            DataItem(data=TEXT_V1, data_id=pinned),
+            dataset_name=DATASET,
+            node_set=["serve"],
+        )
+        assert stored["status"] == "completed", stored
+        assert [item["id"] for item in stored["items"]] == [str(pinned)]
+        dataset_id = stored["dataset_id"]
+        assert dataset_id
+
+        # --- list_data: routed to the server, reports the pinned document ---
+        rows = await cognee.datasets.list_data(UUID(dataset_id))
+        assert [str(row.id) for row in rows] == [str(pinned)]
+        assert await _raw_document(base_url, dataset_id, pinned) == TEXT_V1
+
+        # --- update by id: chunk-level path, in place ---
+        result = await cognee.update(data_id=pinned, data=TEXT_V2, dataset_id=UUID(dataset_id))
+        assert result["status"] == "incremental", result
+        assert await _raw_document(base_url, dataset_id, pinned) == TEXT_V2
+        rows = await cognee.datasets.list_data(UUID(dataset_id))
+        assert [str(row.id) for row in rows] == [str(pinned)], "update must replace, not duplicate"
+
+        # --- update by name, with node_set: full-rebuild path keeps the id ---
+        result = await cognee.update(
+            data_id=pinned, data=TEXT_V3, dataset_name=DATASET, node_set=["serve"]
+        )
+        assert isinstance(result, dict) and result, result
+        assert "status" not in result or result["status"] not in ("incremental", "unchanged")
+        assert await _raw_document(base_url, dataset_id, pinned) == TEXT_V3
+        rows = await cognee.datasets.list_data(UUID(dataset_id))
+        assert [str(row.id) for row in rows] == [str(pinned)], "fallback must keep the id"
+
+        # --- the original failure mode: an unknown id is the REMOTE's 404, not a
+        # local "Dataset not found" from a store that never had the dataset ---
+        with pytest.raises(RuntimeError, match=r"Remote update failed \(404\)"):
+            await cognee.update(data_id=uuid4(), data="nope", dataset_id=UUID(dataset_id))
+
+        # --- nothing ran locally ---
+        local_files = [p for p in remote_server["sdk_root"].rglob("*") if p.is_file()]
+        assert local_files == [], f"SDK touched its local store: {local_files}"
+    finally:
+        await cognee.disconnect()
+
+    assert not serve_state.is_remote_mode()

--- a/cognee/tests/e2e/serve/test_serve_remote_routing.py
+++ b/cognee/tests/e2e/serve/test_serve_remote_routing.py
@@ -193,6 +193,21 @@ async def test_sdk_writes_and_reads_go_to_the_remote_instance(remote_server):
         assert [str(row.id) for row in rows] == [str(pinned)]
         assert await _raw_document(base_url, dataset_id, pinned) == TEXT_V1
 
+        # --- incremental load over the wire: re-sending the identical pinned
+        # document resolves to the same row (no duplicate, content untouched) ---
+        again = await cognee.remember(
+            DataItem(data=TEXT_V1, data_id=pinned), dataset_name=DATASET, node_set=["serve"]
+        )
+        assert again["status"] == "completed", again
+        rows = await cognee.datasets.list_data(UUID(dataset_id))
+        assert [str(row.id) for row in rows] == [str(pinned)], "pinned re-ingest must not duplicate"
+        assert await _raw_document(base_url, dataset_id, pinned) == TEXT_V1
+
+        # --- identical content through update(): the chunk-level path is a no-op ---
+        unchanged = await cognee.update(data_id=pinned, data=TEXT_V1, dataset_id=UUID(dataset_id))
+        assert unchanged["status"] == "unchanged", unchanged
+        assert unchanged["added_chunks"] == 0 and unchanged["deleted_chunks"] == 0, unchanged
+
         # --- update by id: chunk-level path, in place ---
         result = await cognee.update(data_id=pinned, data=TEXT_V2, dataset_id=UUID(dataset_id))
         assert result["status"] == "incremental", result

--- a/cognee/tests/unit/api/test_incremental_refusals.py
+++ b/cognee/tests/unit/api/test_incremental_refusals.py
@@ -667,3 +667,38 @@ async def test_undecodable_stored_text_is_a_refusal_not_a_crash(tmp_path):
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def _text_baseline(name):
+    return SimpleNamespace(
+        name=name,
+        extension="txt",
+        mime_type="text/plain",
+        original_extension="txt",
+        original_mime_type="text/plain",
+        loader_engine="text_loader",
+    )
+
+
+def test_content_hash_named_text_upload_is_direct_text_not_a_rename():
+    """Raw text over HTTP arrives as an upload named ``text_<md5>.txt`` by the
+    cloud client (mirroring TextData). Its name changes with its content by
+    construction, so it must not trip the rename refusal — otherwise every
+    remote text update takes the full-rebuild path."""
+    old_hash, new_hash = "a" * 32, "b" * 32
+    old = _text_baseline(f"text_{old_hash}")
+    staged = SimpleNamespace(**vars(old))
+    staged.name = f"text_{new_hash}"
+
+    upload = SimpleNamespace(filename=f"text_{new_hash}.txt")
+    assert _changed_staged_metadata(upload, old, staged) == []
+    assert _changed_staged_metadata(DataItem(data=upload), old, staged) == []
+
+
+def test_user_file_that_merely_starts_with_text_is_still_a_rename():
+    old = _text_baseline("text_notes")
+    staged = SimpleNamespace(**vars(old))
+    staged.name = "text_notes_v2"
+
+    upload = SimpleNamespace(filename="text_notes_v2.txt")
+    assert _changed_staged_metadata(upload, old, staged) == ["name"]

--- a/cognee/tests/unit/api/v1/serve/test_cloud_client_pinned_ids.py
+++ b/cognee/tests/unit/api/v1/serve/test_cloud_client_pinned_ids.py
@@ -1,0 +1,169 @@
+"""After ``serve()``, a ``DataItem``'s pinned ``data_id`` must reach the server.
+
+``CloudClient.add()``/``remember()`` used to drop ``DataItem`` wrappers on the
+floor (neither a string nor file-like), so the id, label and metadata never
+left the SDK and the server minted its own UUID — callers had no stable
+handle for a later ``update()``. They now unwrap the payload and send the
+attributes as the positional JSON array fields the routes accept
+(``labels`` / ``external_metadata`` / ``data_ids``), plus ``node_set`` and
+``datasetId``, which were dropped as well. A server too old to know
+``data_ids`` ignores the field silently, so the client checks the ids the
+response reports against the pins and fails loudly on a mismatch.
+"""
+
+import io
+import json
+import logging
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from cognee.api.v1.serve.cloud_client import CloudClient, _verify_pinned_ids
+from cognee.tasks.ingestion.data_item import DataItem
+
+
+class _Response:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return str(self._payload)
+
+
+class _Session:
+    def __init__(self, payload):
+        self.calls = []
+        self._payload = payload
+
+    def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return _Response(self._payload)
+
+
+def _fields(form):
+    return [(opts["name"], opts.get("filename"), value) for opts, _h, value in form._fields]
+
+
+def _form_values(form, name):
+    return [value for field, _, value in _fields(form) if field == name]
+
+
+@pytest.mark.asyncio
+async def test_add_sends_pinned_ids_labels_metadata_node_set_and_dataset_id():
+    pinned, dataset_id = uuid4(), uuid4()
+    client = CloudClient("https://example.test", "key")
+    session = _Session(
+        {
+            "status": "PipelineRunCompleted",
+            "data_ingestion_info": [{"data_id": str(pinned)}, {"data_id": str(uuid4())}],
+        }
+    )
+    client._get_session = AsyncMock(return_value=session)
+
+    await client.add(
+        [
+            DataItem(
+                data="pinned text", label="finance", external_metadata={"k": 1}, data_id=pinned
+            ),
+            "plain",
+        ],
+        "repro",
+        dataset_id=dataset_id,
+        node_set=["a", "b"],
+    )
+
+    ((url, kwargs),) = session.calls
+    assert url == "https://example.test/api/v1/add"
+    form = kwargs["data"]
+    assert _form_values(form, "datasetName") == ["repro"]
+    assert _form_values(form, "datasetId") == [str(dataset_id)]
+    assert _form_values(form, "node_set") == ["a", "b"]
+    assert json.loads(_form_values(form, "data_ids")[0]) == [str(pinned), None]
+    assert json.loads(_form_values(form, "labels")[0]) == ["finance", None]
+    assert json.loads(_form_values(form, "external_metadata")[0]) == [{"k": 1}, None]
+    uploads = [(fn, v.read()) for name, fn, v in _fields(form) if name == "data"]
+    assert [body for _, body in uploads] == [b"pinned text", b"plain"]
+
+
+@pytest.mark.asyncio
+async def test_remember_sends_pinned_ids_and_node_set():
+    pinned = uuid4()
+    client = CloudClient("https://example.test", "key")
+    session = _Session({"status": "completed", "items": [{"id": str(pinned)}]})
+    client._get_session = AsyncMock(return_value=session)
+
+    await client.remember(DataItem(data="hello", data_id=pinned), "repro", node_set=["repro"])
+
+    ((url, kwargs),) = session.calls
+    assert url == "https://example.test/api/v1/remember"
+    form = kwargs["data"]
+    assert json.loads(_form_values(form, "data_ids")[0]) == [str(pinned)]
+    assert _form_values(form, "node_set") == ["repro"]
+    assert "labels" not in [name for name, _, _ in _fields(form)]
+
+
+@pytest.mark.asyncio
+async def test_unpinned_uploads_send_no_attribute_fields():
+    client = CloudClient("https://example.test", "key")
+    session = _Session({"status": "completed"})
+    client._get_session = AsyncMock(return_value=session)
+    handle = io.BytesIO(b"bytes")
+    handle.name = "/somewhere/notes.txt"
+
+    await client.add(["text", handle], "repro")
+
+    ((_, kwargs),) = session.calls
+    names = [name for name, _, _ in _fields(kwargs["data"])]
+    assert names == ["datasetName", "data", "data"]
+    assert [fn for name, fn, _ in _fields(kwargs["data"]) if name == "data"][1] == "notes.txt"
+
+
+@pytest.mark.asyncio
+async def test_add_uploads_local_file_bytes_for_path_strings(tmp_path):
+    source = tmp_path / "doc.md"
+    source.write_text("on disk")
+    client = CloudClient("https://example.test", "key")
+    session = _Session({"status": "completed"})
+    client._get_session = AsyncMock(return_value=session)
+
+    await client.add(str(source), "repro")
+
+    ((_, kwargs),) = session.calls
+    ((_, filename, value),) = [f for f in _fields(kwargs["data"]) if f[0] == "data"]
+    assert filename == "doc.md"
+    assert value.read() == b"on disk"
+    value.close()
+
+
+@pytest.mark.asyncio
+async def test_add_raises_when_server_ignores_the_pin():
+    pinned, minted = uuid4(), uuid4()
+    client = CloudClient("https://example.test", "key")
+    client._get_session = AsyncMock(
+        return_value=_Session({"data_ingestion_info": [{"data_id": str(minted)}]})
+    )
+
+    with pytest.raises(RuntimeError, match=f"did not honor pinned data_id.*{pinned}"):
+        await client.add(DataItem(data="x", data_id=pinned), "repro")
+
+
+def test_verify_pinned_ids_warns_when_response_reports_no_ids(caplog):
+    pinned = str(uuid4())
+    with caplog.at_level(logging.WARNING):
+        _verify_pinned_ids({"status": "PipelineRunStarted"}, [pinned], "add")
+    assert any(pinned in record.getMessage() for record in caplog.records)
+
+    # Nothing pinned → nothing to verify, whatever the response says.
+    _verify_pinned_ids({}, [None, None], "add")
+    _verify_pinned_ids("not a dict", [], "remember")

--- a/cognee/tests/unit/api/v1/serve/test_update_remote_routing.py
+++ b/cognee/tests/unit/api/v1/serve/test_update_remote_routing.py
@@ -1,0 +1,338 @@
+"""``cognee.update()`` and ``datasets.list_data()`` must proxy after ``serve()``.
+
+Before this, ``update()`` never consulted the remote client: it resolved the
+LOCAL default user, ran a local ``datasets.delete_data`` against the remote
+dataset UUID (``Dataset '<uuid>' not found``), and never touched the server.
+The server already exposes ``PATCH /api/v1/update``; the SDK must call it
+with the fields that route accepts — a real in-place replace, never a local
+delete plus a remote add (which would mint a new id on the remote).
+"""
+
+import io
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+import cognee.api.v1.update.update  # noqa: F401  (bind the real submodule)
+from cognee.api.v1.serve import state as serve_state
+from cognee.api.v1.serve.cloud_client import CloudClient, _attach_upload
+from cognee.tasks.ingestion.data_item import DataItem
+
+update_module = sys.modules["cognee.api.v1.update.update"]
+
+
+class _Response:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return str(self._payload)
+
+
+class _Session:
+    def __init__(self, payload=None, status=200):
+        self.calls = []
+        self._payload = payload
+        self._status = status
+
+    def _record(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return _Response(self._payload, self._status)
+
+    def patch(self, url, **kwargs):
+        return self._record("PATCH", url, **kwargs)
+
+    def get(self, url, **kwargs):
+        return self._record("GET", url, **kwargs)
+
+
+def _fields(form):
+    """(name, filename, value) triples from an aiohttp FormData."""
+    return [(opts["name"], opts.get("filename"), value) for opts, _headers, value in form._fields]
+
+
+# ----- CloudClient.update wire format -----
+
+
+@pytest.mark.asyncio
+async def test_cloud_client_update_patches_the_update_route_with_query_and_multipart():
+    client = CloudClient("https://example.test", "key")
+    session = _Session(payload={"status": "incremental", "regions": 1})
+    client._get_session = AsyncMock(return_value=session)
+    data_id, dataset_id = uuid4(), uuid4()
+
+    result = await client.update(
+        data_id=data_id,
+        data="hello, updated",
+        dataset_id=dataset_id,
+        node_set=["repro", "second"],
+        chunk_level_diff=False,
+    )
+
+    assert result == {"status": "incremental", "regions": 1}
+    ((method, url, kwargs),) = session.calls
+    assert method == "PATCH"
+    assert url == "https://example.test/api/v1/update"
+    assert kwargs["params"] == {
+        "data_id": str(data_id),
+        "dataset_id": str(dataset_id),
+        "chunk_level_diff": "false",
+    }
+    fields = _fields(kwargs["data"])
+    names = [name for name, _, _ in fields]
+    assert names.count("data") == 1
+    assert [value for name, _, value in fields if name == "node_set"] == ["repro", "second"]
+    ((_, filename, body),) = [f for f in fields if f[0] == "data"]
+    assert filename.startswith("text_") and filename.endswith(".txt")
+    assert body.read() == b"hello, updated"
+
+
+@pytest.mark.asyncio
+async def test_cloud_client_update_raises_on_server_error():
+    client = CloudClient("https://example.test", "key")
+    client._get_session = AsyncMock(return_value=_Session(payload="nope", status=404))
+
+    with pytest.raises(RuntimeError, match="Remote update failed \\(404\\)"):
+        await client.update(data_id=uuid4(), data="x", dataset_id=uuid4())
+
+
+def test_attach_upload_unwraps_data_item_and_uploads_local_file_bytes(tmp_path):
+    import aiohttp
+
+    source = tmp_path / "note.md"
+    source.write_text("from disk")
+
+    form = aiohttp.FormData()
+    _attach_upload(form, DataItem(data=str(source), data_id=uuid4()))
+    ((name, filename, value),) = _fields(form)
+    assert name == "data"
+    assert filename == "note.md"
+    assert value.read() == b"from disk"
+    value.close()
+
+    form = aiohttp.FormData()
+    _attach_upload(form, [f"file://{source}"])
+    ((_, filename, value),) = _fields(form)
+    assert filename == "note.md"
+    value.close()
+
+    form = aiohttp.FormData()
+    handle = io.BytesIO(b"stream")
+    handle.name = "/tmp/somewhere/stream.txt"
+    _attach_upload(form, handle)
+    ((_, filename, value),) = _fields(form)
+    assert filename == "stream.txt"
+    assert value is handle
+
+
+def test_attach_upload_rejects_missing_path_and_multi_item_lists():
+    import aiohttp
+
+    with pytest.raises(FileNotFoundError):
+        _attach_upload(aiohttp.FormData(), "/definitely/not/here.txt")
+    with pytest.raises(ValueError, match="exactly one document"):
+        _attach_upload(aiohttp.FormData(), ["a", "b"])
+
+
+# ----- SDK routing -----
+
+
+@pytest.mark.asyncio
+async def test_update_proxies_to_remote_and_does_no_local_work():
+    import cognee
+
+    data_id, dataset_id = uuid4(), uuid4()
+    client = MagicMock()
+    client.update = AsyncMock(return_value={"status": "unchanged"})
+    local = {
+        "get_default_user": AsyncMock(),
+        "incremental_update": AsyncMock(),
+        "datasets": SimpleNamespace(delete_data=AsyncMock()),
+        "add": AsyncMock(),
+        "cognify": AsyncMock(),
+    }
+
+    with (
+        patch.object(serve_state, "get_remote_client", return_value=client),
+        patch.object(update_module, "get_default_user", local["get_default_user"]),
+        patch.object(update_module, "incremental_update", local["incremental_update"]),
+        patch.object(update_module, "datasets", local["datasets"]),
+        patch.object(update_module, "add", local["add"]),
+        patch.object(update_module, "cognify", local["cognify"]),
+    ):
+        result = await cognee.update(
+            data_id=data_id,
+            data="hello, updated",
+            dataset_id=dataset_id,
+            node_set=["repro"],
+        )
+
+    assert result == {"status": "unchanged"}
+    client.update.assert_awaited_once_with(
+        data_id=data_id,
+        data="hello, updated",
+        dataset_id=dataset_id,
+        dataset_name=None,
+        node_set=["repro"],
+        chunk_level_diff=True,
+    )
+    local["get_default_user"].assert_not_awaited()
+    local["incremental_update"].assert_not_awaited()
+    local["datasets"].delete_data.assert_not_awaited()
+    local["add"].assert_not_awaited()
+    local["cognify"].assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_stays_local_without_a_remote_client():
+    """No client → the existing local path runs, starting with user resolution."""
+    data_methods_module = sys.modules["cognee.modules.data.methods"]
+
+    with (
+        patch.object(serve_state, "get_remote_client", return_value=None),
+        patch.object(update_module, "get_default_user", AsyncMock()) as get_default_user,
+        patch.object(
+            data_methods_module, "resolve_data_id", AsyncMock(return_value=None)
+        ) as resolve,
+    ):
+        with pytest.raises(Exception):
+            await update_module.update(data_id=uuid4(), data="x", dataset_id=uuid4())
+
+    get_default_user.assert_awaited_once()
+    resolve.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_list_data_proxies_to_remote_with_attribute_access():
+    from cognee.api.v1.datasets.datasets import datasets
+
+    dataset_id, data_id = uuid4(), uuid4()
+    client = MagicMock()
+    client.list_data = AsyncMock(
+        return_value=[{"id": str(data_id), "name": "hello", "dataset_id": str(dataset_id)}]
+    )
+
+    with (
+        patch.object(serve_state, "get_remote_client", return_value=client),
+        patch.object(
+            sys.modules["cognee.api.v1.datasets.datasets"], "get_default_user", AsyncMock()
+        ) as gdu,
+    ):
+        rows = await datasets.list_data(dataset_id)
+
+    client.list_data.assert_awaited_once_with(dataset_id)
+    gdu.assert_not_awaited()
+    assert [row.id for row in rows] == [str(data_id)]
+    assert rows[0].name == "hello"
+
+
+@pytest.mark.asyncio
+async def test_cloud_client_list_data_hits_dataset_data_route():
+    client = CloudClient("https://example.test/", "key")
+    session = _Session(payload=[{"id": "abc"}])
+    client._get_session = AsyncMock(return_value=session)
+    dataset_id = uuid4()
+
+    assert await client.list_data(dataset_id) == [{"id": "abc"}]
+    ((method, url, _),) = session.calls
+    assert method == "GET"
+    assert url == f"https://example.test/api/v1/datasets/{dataset_id}/data"
+
+
+@pytest.mark.asyncio
+async def test_cloud_client_update_sends_dataset_name_instead_of_id():
+    client = CloudClient("https://example.test", "key")
+    session = _Session(payload={"status": "unchanged"})
+    client._get_session = AsyncMock(return_value=session)
+    data_id = uuid4()
+
+    await client.update(data_id=data_id, data="x", dataset_name="repro_update")
+
+    ((_, _, kwargs),) = session.calls
+    assert kwargs["params"] == {
+        "data_id": str(data_id),
+        "chunk_level_diff": "true",
+        "dataset_name": "repro_update",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cloud_client_update_requires_exactly_one_dataset_selector():
+    client = CloudClient("https://example.test", "key")
+    client._get_session = AsyncMock()
+
+    with pytest.raises(ValueError, match="exactly one"):
+        await client.update(data_id=uuid4(), data="x")
+    with pytest.raises(ValueError, match="exactly one"):
+        await client.update(data_id=uuid4(), data="x", dataset_id=uuid4(), dataset_name="n")
+
+
+@pytest.mark.asyncio
+async def test_update_forwards_dataset_name_to_remote():
+    client = MagicMock()
+    client.update = AsyncMock(return_value={"status": "unchanged"})
+    data_id = uuid4()
+
+    with (
+        patch.object(serve_state, "get_remote_client", return_value=client),
+        patch.object(update_module, "get_default_user", AsyncMock()) as gdu,
+    ):
+        await update_module.update(data_id=data_id, data="x", dataset_name="repro_update")
+
+    gdu.assert_not_awaited()
+    assert client.update.await_args.kwargs["dataset_name"] == "repro_update"
+    assert client.update.await_args.kwargs["dataset_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_neither_or_both_dataset_selectors():
+    with patch.object(serve_state, "get_remote_client", return_value=MagicMock()):
+        with pytest.raises(Exception, match="exactly one"):
+            await update_module.update(data_id=uuid4(), data="x")
+        with pytest.raises(Exception, match="exactly one"):
+            await update_module.update(
+                data_id=uuid4(), data="x", dataset_id=uuid4(), dataset_name="n"
+            )
+
+
+@pytest.mark.asyncio
+async def test_local_update_resolves_dataset_name_among_writable_datasets():
+    """Locally a name resolves via the write-ACL lookup and never creates a dataset."""
+    data_methods_module = sys.modules["cognee.modules.data.methods"]
+    dataset_id = uuid4()
+    lookup = AsyncMock(return_value=[SimpleNamespace(id=dataset_id)])
+
+    with (
+        patch.object(serve_state, "get_remote_client", return_value=None),
+        patch.object(update_module, "get_default_user", AsyncMock(return_value="user")),
+        patch.object(data_methods_module, "get_authorized_existing_datasets", lookup),
+        patch.object(data_methods_module, "resolve_data_id", AsyncMock(return_value=None)),
+    ):
+        with pytest.raises(Exception, match="No document found to update"):
+            await update_module.update(data_id=uuid4(), data="x", dataset_name="repro")
+
+    lookup.assert_awaited_once_with(["repro"], "write", "user")
+
+    from cognee.modules.data.exceptions import DatasetNotFoundError
+
+    lookup.return_value = []
+    with (
+        patch.object(serve_state, "get_remote_client", return_value=None),
+        patch.object(update_module, "get_default_user", AsyncMock(return_value="user")),
+        patch.object(data_methods_module, "get_authorized_existing_datasets", lookup),
+    ):
+        with pytest.raises(DatasetNotFoundError):
+            await update_module.update(data_id=uuid4(), data="x", dataset_name="missing")

--- a/cognee/tests/unit/api/v1/serve/test_update_remote_routing.py
+++ b/cognee/tests/unit/api/v1/serve/test_update_remote_routing.py
@@ -336,3 +336,29 @@ async def test_local_update_resolves_dataset_name_among_writable_datasets():
     ):
         with pytest.raises(DatasetNotFoundError):
             await update_module.update(data_id=uuid4(), data="x", dataset_name="missing")
+
+
+@pytest.mark.asyncio
+async def test_update_warns_when_incremental_flags_cannot_travel(caplog):
+    """PATCH /api/v1/update has no field for incremental_loading / data_cache: the
+    server runs its defaults. Disabling them locally must not be silent."""
+    import logging
+
+    client = MagicMock()
+    client.update = AsyncMock(return_value={"status": "unchanged"})
+
+    with (
+        patch.object(serve_state, "get_remote_client", return_value=client),
+        caplog.at_level(logging.WARNING),
+    ):
+        await update_module.update(
+            data_id=uuid4(),
+            data="x",
+            dataset_id=uuid4(),
+            incremental_loading=False,
+            data_cache=False,
+        )
+
+    messages = " ".join(record.getMessage() for record in caplog.records)
+    assert "incremental_loading" in messages and "data_cache" in messages
+    client.update.assert_awaited_once()

--- a/cognee/tests/unit/api/v1/test_add_remember_data_ids.py
+++ b/cognee/tests/unit/api/v1/test_add_remember_data_ids.py
@@ -1,0 +1,228 @@
+"""The add and remember endpoints accept a ``data_ids`` form field.
+
+Same wire convention as ``labels`` / ``external_metadata``: one JSON array,
+paired positionally with the uploaded files, ``null`` to let the server mint
+that file's id. A pinned id lands on the file's DataItem so ingestion stores
+the document under it — the handle a remote SDK caller needs for a later
+``PATCH /api/v1/update``. Malformed entries, a count mismatch, and pins
+combined with session_id / content_type on remember are rejected with 400.
+"""
+
+import importlib
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cognee.api.client import app
+from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunCompleted
+from cognee.modules.users.methods import get_authenticated_user
+from cognee.tasks.ingestion.data_item import DataItem, pair_labels_with_data, parse_data_ids
+from cognee.tasks.ingestion.exceptions import DataIdCountMismatchError, InvalidDataIdsError
+
+add_pkg = importlib.import_module("cognee.api.v1.add")
+remember_pkg = importlib.import_module("cognee.api.v1.remember")
+
+UPLOADS = [
+    ("data", ("first.txt", b"first", "text/plain")),
+    ("data", ("second.txt", b"second", "text/plain")),
+]
+
+
+@pytest.fixture(scope="session")
+def test_client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def client(test_client):
+    async def override_get_authenticated_user():
+        return SimpleNamespace(
+            id=str(uuid.uuid4()),
+            email="test@example.com",
+            is_active=True,
+            tenant_id=str(uuid.uuid4()),
+        )
+
+    app.dependency_overrides[get_authenticated_user] = override_get_authenticated_user
+    yield test_client
+    app.dependency_overrides.pop(get_authenticated_user, None)
+
+
+def pipeline_run_completed():
+    return PipelineRunCompleted(
+        pipeline_run_id=uuid.uuid4(), dataset_id=uuid.uuid4(), dataset_name="test_dataset"
+    )
+
+
+# ----- parsing / pairing -----
+
+
+def test_parse_data_ids_accepts_uuids_and_null_entries():
+    pinned = uuid.uuid4()
+    assert parse_data_ids(f'["{pinned}", null, ""]') == [pinned, None, None]
+    assert parse_data_ids(None) is None
+    assert parse_data_ids("   ") is None
+
+
+@pytest.mark.parametrize("raw", ['["not-a-uuid"]', "[1]", '{"a": 1}', "not json"])
+def test_parse_data_ids_rejects_malformed_values(raw):
+    with pytest.raises(InvalidDataIdsError):
+        parse_data_ids(raw)
+
+
+def test_pair_sets_data_id_on_each_item_and_checks_count():
+    pinned = uuid.uuid4()
+    paired = pair_labels_with_data(["a", "b"], None, None, [pinned, None])
+    assert [type(item) for item in paired] == [DataItem, DataItem]
+    assert [item.data_id for item in paired] == [pinned, None]
+    assert [item.label for item in paired] == [None, None]
+
+    assert pair_labels_with_data(["a"], None, None, [None]) == ["a"]
+    with pytest.raises(DataIdCountMismatchError):
+        pair_labels_with_data(["a", "b"], None, None, [pinned])
+
+
+# ----- add route -----
+
+
+def test_add_pins_each_id_to_its_upload(client):
+    pinned = uuid.uuid4()
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        mock_add.return_value = pipeline_run_completed()
+
+        response = client.post(
+            "/api/v1/add",
+            files=UPLOADS,
+            data={"datasetName": "test_dataset", "data_ids": f'["{pinned}", null]'},
+        )
+
+        assert response.status_code == 200, response.text
+        sent = mock_add.call_args.args[0]
+        assert [type(item) for item in sent] == [DataItem, DataItem]
+        assert [item.data_id for item in sent] == [pinned, None]
+        assert [item.data.filename for item in sent] == ["first.txt", "second.txt"]
+
+
+def test_add_pins_ids_alongside_labels(client):
+    pinned = uuid.uuid4()
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        mock_add.return_value = pipeline_run_completed()
+
+        response = client.post(
+            "/api/v1/add",
+            files=UPLOADS,
+            data={
+                "datasetName": "test_dataset",
+                "labels": '["finance", ""]',
+                "data_ids": f'[null, "{pinned}"]',
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        sent = mock_add.call_args.args[0]
+        assert [item.label for item in sent] == ["finance", None]
+        assert [item.data_id for item in sent] == [None, pinned]
+
+
+@pytest.mark.parametrize(
+    "data_ids",
+    [f'["{uuid.uuid4()}"]', '["nope", null]', "[1, 2]"],
+    ids=["count_mismatch", "not_a_uuid", "not_strings"],
+)
+def test_add_rejects_bad_data_ids(client, data_ids):
+    with patch.object(add_pkg, "add", new_callable=AsyncMock) as mock_add:
+        response = client.post(
+            "/api/v1/add",
+            files=UPLOADS,
+            data={"datasetName": "test_dataset", "data_ids": data_ids},
+        )
+
+        assert response.status_code == 400, response.text
+        mock_add.assert_not_called()
+
+
+# ----- remember route -----
+
+
+def test_remember_pins_each_id_to_its_upload(client):
+    pinned = uuid.uuid4()
+    with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
+        mock_remember.return_value = SimpleNamespace(
+            status="completed", to_dict=lambda: {"status": "completed"}
+        )
+
+        response = client.post(
+            "/api/v1/remember",
+            files=UPLOADS,
+            data={"datasetName": "test_dataset", "data_ids": f'["{pinned}", null]'},
+        )
+
+        assert response.status_code == 200, response.text
+        sent = mock_remember.call_args.args[0]
+        assert [item.data_id for item in sent] == [pinned, None]
+
+
+@pytest.mark.parametrize(
+    "extra_form",
+    [{"session_id": "s1"}, {"content_type": "skills"}],
+    ids=["session_id", "content_type"],
+)
+def test_remember_rejects_pins_outside_normal_ingestion(client, extra_form):
+    with patch.object(remember_pkg, "remember", new_callable=AsyncMock) as mock_remember:
+        response = client.post(
+            "/api/v1/remember",
+            files=UPLOADS,
+            data={
+                "datasetName": "test_dataset",
+                "data_ids": f'["{uuid.uuid4()}", null]',
+                **extra_form,
+            },
+        )
+
+        assert response.status_code == 400, response.text
+        assert "data_ids" in response.json()["detail"]
+        mock_remember.assert_not_called()
+
+
+# ----- update route: dataset_name -----
+
+
+def test_update_route_accepts_dataset_name_and_requires_exactly_one_selector(client):
+    data_id = uuid.uuid4()
+    update_pkg = importlib.import_module("cognee.api.v1.update")
+    with patch.object(update_pkg, "update", new_callable=AsyncMock) as mock_update:
+        mock_update.return_value = {
+            "status": "unchanged",
+            "regions": 0,
+            "deleted_chunks": 0,
+            "added_chunks": 0,
+            "reused_chunks": 0,
+            "kept_chunks": 0,
+            "reindexed_chunks": 0,
+        }
+
+        response = client.patch(
+            "/api/v1/update",
+            params={"data_id": str(data_id), "dataset_name": "repro"},
+            files=UPLOADS[:1],
+        )
+        assert response.status_code == 200, response.text
+        assert mock_update.call_args.kwargs["dataset_name"] == "repro"
+        assert mock_update.call_args.kwargs["dataset_id"] is None
+
+        mock_update.reset_mock()
+        response = client.patch(
+            "/api/v1/update", params={"data_id": str(data_id)}, files=UPLOADS[:1]
+        )
+        assert response.status_code == 422, response.text
+        response = client.patch(
+            "/api/v1/update",
+            params={"data_id": str(data_id), "dataset_id": str(uuid.uuid4()), "dataset_name": "x"},
+            files=UPLOADS[:1],
+        )
+        assert response.status_code == 422, response.text
+        mock_update.assert_not_called()


### PR DESCRIPTION
## Summary

After `cognee.serve(url=..., api_key=...)`, `update()` ran against the **local** store: it resolved the local default user, ran a local `datasets.delete_data` against the remote dataset UUID, and failed with `PipelineRunFailedError: Dataset '<uuid>' not found` while the remote document stayed untouched. `datasets.list_data()` had the same gap. This PR closes both, plus the two related `serve()` gaps from the report.

### 1. `update()` and `list_data()` proxy to the remote
- `CloudClient.update()` sends `PATCH /api/v1/update` exactly as the route expects: `data_id` / dataset / `chunk_level_diff` as query params, the new content as the multipart `data` file, `node_set` as repeated form fields. It is an in-place replace — never a local delete + remote add, which would mint a new id.
- `CloudClient.list_data()` wraps `GET /api/v1/datasets/{id}/data`; `datasets.list_data()` routes through it and returns attribute-accessible rows.
- The remote branch runs **before** any local work in `update()`; parameters the route has no slot for (`graph_model`, `custom_prompt`, store configs, …) log a warning instead of being dropped silently.

### 2. `DataItem.data_id` reaches the server
- New `data_ids` form field on `POST /api/v1/add` and `POST /api/v1/remember`, same positional JSON-array convention as `labels` / `external_metadata` (`null` = let the server mint). Ingestion already resolves pins inside the target dataset and refuses foreign ones, so this is wiring only.
- `CloudClient.add()` / `remember()` previously dropped `DataItem` wrappers entirely. They now unwrap the payload and send `data_ids` / `labels` / `external_metadata`, plus `node_set` and `datasetId` (also dropped before). Local `/abs/path` and `file://` strings upload the file bytes, since the server can't see the caller's filesystem.
- **Old-server safety:** FastAPI ignores unknown form fields, so a server without `data_ids` would silently mint its own id. The client compares the ids the response reports against the pins and raises with an actionable message on a mismatch; a response with no ids (background run) logs a warning.

### 3. `dataset_name` on `update()`
- SDK `update()` and `PATCH /api/v1/update` accept `dataset_name` as an alternative to `dataset_id` (exactly one required; 422 on the route otherwise), matching every other entry point. Locally a name resolves only among datasets the caller may **write** to and never creates one. `dataset_id` stays optional-with-default so existing positional callers are unchanged.

## Test plan
- [x] `cognee/tests/unit/api/v1/serve/test_update_remote_routing.py` — wire format, upload helper, remote mode does zero local work, `dataset_name` forwarding and local resolution
- [x] `cognee/tests/unit/api/v1/serve/test_cloud_client_pinned_ids.py` — `data_ids`/labels/metadata/node_set/datasetId on add+remember, path uploads, pin-mismatch error and no-ids warning
- [x] `cognee/tests/unit/api/v1/test_add_remember_data_ids.py` — route parsing/pairing, 400s on malformed/mismatched ids and on pins with `session_id`/`content_type`, update route `dataset_name` + exactly-one check
- [x] All unit tests touching the changed modules: 603 passed, 7 skipped; `pre-commit run` clean
- [ ] Not exercised against a live remote instance from this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
