### PR TITLE
fix(mcp): redact the API token in the entrypoint launch echo

### DIFF
--- a/cognee-mcp/entrypoint.sh
+++ b/cognee-mcp/entrypoint.sh
@@ -128,7 +128,15 @@ else
     echo "Direct mode: Using local cognee instance"
 fi
 
-echo "calling cognee-mcp" "${ARGS[@]}"
+# Echo the launch command with the API token redacted: the container log is
+# readable by anyone with docker access, and the token is a long-lived credential.
+LOG_ARGS=("${ARGS[@]}")
+for i in "${!LOG_ARGS[@]}"; do
+    if [ "${LOG_ARGS[$i]}" = "--api-token" ] && [ $((i + 1)) -lt ${#LOG_ARGS[@]} ]; then
+        LOG_ARGS[$((i + 1))]="<redacted>"
+    fi
+done
+echo "calling cognee-mcp" "${LOG_ARGS[@]}"
 
 if [ "$DEBUG" = "true" ] && { [ "$ENV" = "dev" ] || [ "$ENV" = "local" ]; }; then
     DEBUG_PORT=${DEBUG_PORT:-5678}


### PR DESCRIPTION
## What this is

Internal copy of #4908 by @nagelm so the full CI matrix (which needs repository secrets and does not run on fork PRs) runs on the change. The commit is the contributor's own, unchanged, with their sign-off; only the branch is new.

Fixes #4910.

## Change

`cognee-mcp/entrypoint.sh` echoed the complete launch command at start, including the value of `API_TOKEN`, so a long-lived credential was written to `docker logs` for the container's lifetime. The echo now prints the same command with the token value replaced by `<redacted>`; the argument array handed to `cognee-mcp` is unchanged.

## Verified locally

Run against a stub `cognee-mcp` that records the arguments it receives:

- API mode with a token: the log line reads `--api-token <redacted>`, the secret does not appear in the output, and the process receives the real token.
- API mode without a token, and plain stdio mode: log line and arguments identical to before.
- `bash -n` clean; pre-commit hooks pass on the file. The one shellcheck warning in the file is on a pre-existing line this change does not touch.

Branch is one commit ahead of `dev` and rebases cleanly.
