### PR TITLE
fix: Initialize logging exactly once per process (SDK-564)

### DIFF
--- a/cognee/shared/logging_utils.py
+++ b/cognee/shared/logging_utils.py
@@ -354,6 +354,17 @@ def setup_logging(log_level=None, name=None) -> bool:
     """
     global _is_structlog_configured
 
+    # Logging is process-global state: configure it exactly once. setup_logging
+    # is called from several import-time sites (cognee/__init__, api/client,
+    # embeddings utils) plus server startup; without this guard every call
+    # appended another root-logger file handler (each record written N times to
+    # the same log file) and re-emitted the startup banner — a server start
+    # logged the "Cognee 1.0 changes" warning four times. Later callers just
+    # get a logger; the first caller's handlers, excepthook, and log file stay
+    # authoritative.
+    if _is_structlog_configured:
+        return structlog.get_logger(name if name else __name__)
+
     # Regular detailed logging for non-CLI usage
     log_level = log_level if log_level else log_levels[os.getenv("LOG_LEVEL", "INFO").upper()]
 


### PR DESCRIPTION
## Description

A server start logged the "Cognee 1.0 changes" startup banner **four times**. Root cause: `setup_logging()` has no idempotency guard, and it runs from four places during a server start — `cognee/__init__.py` (import), `cognee/api/client.py` module level, `cognee/infrastructure/databases/vector/embeddings/utils.py` (import), and the server-startup call in `api/client.py`. Every call redid the whole configuration.

The noise was the visible symptom; the real bug underneath: **each call appended another `PlainFileHandler` to the root logger**, all pointing at the same log file (shared via `LOG_FILE_NAME`), so every log record was written to the file once per initialization.

### Fix

Early-return in `setup_logging()` on the existing `_is_structlog_configured` flag: the first call configures handlers, the excepthook, and the log file; later calls just return a structlog logger. One deliberate behavior change rides along: repeat callers passing `log_level` (e.g. `setup_logging(log_level=ERROR)` in visualization paths) no longer retune the global handlers mid-run — that was the same reconfiguration bug in different clothes.

Subprocesses are unaffected: a fresh interpreter starts with the flag unset and configures its own handlers, still appending to the shared `LOG_FILE_NAME` file as designed.

### Verification

- Import chain (`import cognee` + `import cognee.api.client`) plus an explicit `setup_logging()` re-call: banner emitted **once**, exactly **one** file handler on the root logger (previously 2+ banners, one handler per call).
- Real `uvicorn cognee.api.client:app` start: banner logged exactly once, startup completes normally.
- `cognee/tests/unit/shared/` (incl. the pinned excepthook contract tests): 59 passed. The excepthook stays installed by the first call; nothing in-tree uninstalls it.

https://claude.ai/code/session_0183ggfG9S2GXQqkFpwrbQCw