### PR TITLE
feat: Install the dlt extra in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     for extra in ${COGNEE_EXTRAS}; do \
         set -- "$@" --extra "$extra"; \
     done; \
-    uv sync "$@" --extra fastembed --extra debug --extra api --extra postgres --extra neo4j --extra llama-index --extra aws --extra ollama --extra mistral --extra groq --extra anthropic --frozen --no-install-project --no-dev --no-editable
+    uv sync "$@" --extra fastembed --extra debug --extra api --extra postgres --extra neo4j --extra llama-index --extra aws --extra dlt --extra ollama --extra mistral --extra groq --extra anthropic --frozen --no-install-project --no-dev --no-editable
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
@@ -63,7 +63,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     for extra in ${COGNEE_EXTRAS}; do \
         set -- "$@" --extra "$extra"; \
     done; \
-    uv sync "$@" --extra fastembed --extra debug --extra aws --extra api --extra postgres --extra neo4j --extra llama-index --extra ollama --extra mistral --extra groq --extra anthropic --frozen --no-dev --no-editable
+    uv sync "$@" --extra fastembed --extra debug --extra aws --extra api --extra postgres --extra neo4j --extra llama-index --extra dlt --extra ollama --extra mistral --extra groq --extra anthropic --frozen --no-dev --no-editable
 
 FROM python:3.12-slim-bookworm
 


### PR DESCRIPTION
## Description

CSV ingestion has two paths:

- **structured** — `resolve_dlt_sources` turns the CSV into a DLT source (rows become graph/vector nodes via the dedicated DLT cognify pipeline);
- **plain** — the file is treated as a document through `csv_loader`.

`resolve_dlt_sources` takes the structured path only when `dlt` is importable. Otherwise it logs `"dlt is not installed: N structured input(s)…"` and falls back to the document path.

The Docker image never installed the `dlt` extra, so **every CSV uploaded to a containerised cognee silently took the document path**. Nothing surfaces this to the caller — `POST /api/v1/add` returns 200 either way.

This adds `--extra dlt` to both `uv sync` invocations in the Dockerfile: the dependency-cache layer and the final layer. Both must list the same extras, or the cached layer is discarded on every build.

## Acceptance Criteria

- The image can `import dlt`, so CSV inputs take the structured DLT path instead of silently falling back.

**Verified end to end by running a CSV through a container built from this branch**, not just by importing the package:

| | current image | this branch |
|---|---|---|
| `import dlt` | `ModuleNotFoundError` | `dlt 1.30.0` |
| `import pandas` | absent | `pandas 2.3.3` |
| `loader_engine` for an uploaded CSV | `csv_loader` | `dlt_csv_loader` |
| `system_metadata` | `null` | `{"source": "dlt_source", "source_name": "employees", "dlt_db_name": "dlt_database_dlt_csv", "tables": ["employees"], "row_count": 5}` |
| dlt working dir | absent | `/app/.dlt` created |

The structured path resolved the 5-row CSV into a DLT source, and the rows are queryable afterwards — `POST /api/v1/search` (GRAPH_COMPLETION) on the resulting dataset answers *"Katherine Johnson works in the Flight Dynamics department in Hampton"*, which is a fact that exists only as a row in that CSV.

Found during release validation of the containerised server: the same CSV on the current image is stored with `loader_engine=csv_loader` and no DLT artifacts.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Notes for review

- **Image size**: `dlt[sqlalchemy]` plus `pandas` are not small. If the image budget is tight, the alternative is leaving `dlt` out and making the fallback loud (surface it on the response rather than only in logs), so CSV behaviour is at least not silently different from a local install. Flagging the trade-off rather than assuming.
- The `gmail` extra pins the same `dlt[sqlalchemy]>=1.9.0,<2` and `pandas`, so this introduces no new dependency line, only installs an existing one.

## Pre-submission Checklist
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

https://claude.ai/code/session_0183ggfG9S2GXQqkFpwrbQCw
