### PR TITLE
COG-6542 fix(frontend): Skip tenant permission grant for local sentinel

### DIFF
--- a/cognee-frontend/src/modules/datasets/createDataset.ts
+++ b/cognee-frontend/src/modules/datasets/createDataset.ts
@@ -15,8 +15,11 @@ export default async function createDataset(
   });
   const created = await response.json();
 
-  // Grant tenant-level read+write so all tenant members can see this dataset
-  if (tenantId && created.id) {
+  // Grant tenant-level read+write so all tenant members can see this dataset.
+  // Skip in local (self-hosted) mode, where tenantId is the "local" sentinel
+  // rather than a real UUID — there's no multi-tenant sharing to set up there.
+  const isRealTenantId = !!tenantId && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(tenantId);
+  if (isRealTenantId && created.id) {
     const body = JSON.stringify([created.id]);
     try {
       await Promise.all([


### PR DESCRIPTION
Creating a dataset in self-hosted mode sent the "local" tenant_id sentinel as principal_id to POST /permissions/datasets/{principal_id}, which expects a UUID, causing a 400. Single-user local mode has no one else to share the dataset with anyway, so skip the grant when tenantId isn't a real UUID.