### PR TITLE
COG-6309 feat(retrieval): expose vector score from SummariesRetriever, document score semantics (stacked on #4891)

### DIFF
--- a/cognee/modules/retrieval/chunks_retriever.py
+++ b/cognee/modules/retrieval/chunks_retriever.py
@@ -66,7 +66,10 @@ class ChunksRetriever(BaseRetriever):
         """
         # TODO: Do we want to generate a completion using LLM here?
         if retrieved_objects:
-            chunk_payloads = [found_chunk.payload for found_chunk in retrieved_objects]
+            chunk_payloads = [
+                {**found_chunk.payload, "score": found_chunk.score}
+                for found_chunk in retrieved_objects
+            ]
             return chunk_payloads
         else:
             return []

--- a/cognee/modules/retrieval/chunks_retriever.py
+++ b/cognee/modules/retrieval/chunks_retriever.py
@@ -62,12 +62,14 @@ class ChunksRetriever(BaseRetriever):
         Returns:
         --------
 
-            - List[dict]: A list of payloads of found chunks.
+            - List[dict]: A list of payloads of found chunks. Each payload carries the
+              vector search ``score`` of the chunk: the raw backend distance (cosine
+              distance for built-in adapters), where a lower value is a better match.
         """
         # TODO: Do we want to generate a completion using LLM here?
         if retrieved_objects:
             chunk_payloads = [
-                {**found_chunk.payload, "score": found_chunk.score}
+                {**(found_chunk.payload or {}), "score": found_chunk.score}
                 for found_chunk in retrieved_objects
             ]
             return chunk_payloads

--- a/cognee/modules/retrieval/summaries_retriever.py
+++ b/cognee/modules/retrieval/summaries_retriever.py
@@ -105,11 +105,15 @@ class SummariesRetriever(BaseRetriever):
         Returns:
         --------
 
-            - List[dict]: A list of payloads of found summaries.
+            - List[dict]: A list of payloads of found summaries. Each payload carries the
+              vector search ``score`` of the summary: the raw backend distance (cosine
+              distance for built-in adapters), where a lower value is a better match.
         """
         # TODO: Do we want to generate a completion using LLM here?
         if retrieved_objects:
-            summary_payloads = [summary.payload for summary in retrieved_objects]
+            summary_payloads = [
+                {**(summary.payload or {}), "score": summary.score} for summary in retrieved_objects
+            ]
             logger.info(f"Returning {len(summary_payloads)} summary payloads")
             return summary_payloads
         else:

--- a/cognee/tests/unit/modules/recall/test_normalize_search_payload.py
+++ b/cognee/tests/unit/modules/recall/test_normalize_search_payload.py
@@ -210,3 +210,46 @@ def test_only_context_prompt_format_without_a_prompt_keeps_text_readable():
     assert items[0].text == "chunk-a\n---\nchunk-b"
     assert not items[0].text.startswith("{")
     assert items[0].raw["session_context"] == "## Active session guidance\n- be terse"
+
+
+def test_chunk_result_surfaces_retriever_score():
+    """The ``score`` ChunksRetriever attaches to each payload lands on
+    ``SearchResultItem.score`` so callers can rank/fuse across retrievers."""
+    payload = SearchResultPayload(
+        completion=[
+            {"id": "chunk-1", "text": "closest", "score": 0.12},
+            {"id": "chunk-2", "text": "farther", "score": 0.34},
+        ],
+        search_type=SearchType.CHUNKS,
+    )
+
+    items = normalize_search_payload(payload)
+
+    assert [item.score for item in items] == [0.12, 0.34]
+    # raw still carries the score alongside the original payload fields.
+    assert items[0].raw["score"] == 0.12
+
+
+def test_summary_result_surfaces_retriever_score():
+    """SUMMARIES payloads carry the same ``score`` key and normalize the same way."""
+    payload = SearchResultPayload(
+        completion=[{"text": "A summary.", "made_from": "chunk-1", "score": 0.2}],
+        search_type=SearchType.SUMMARIES,
+    )
+
+    items = normalize_search_payload(payload)
+
+    assert items[0].kind == SearchResultKind.SUMMARY
+    assert items[0].score == 0.2
+
+
+def test_chunk_result_without_score_has_none_score():
+    """Payloads that never carried a score (legacy or non-numeric) stay ``None``."""
+    payload = SearchResultPayload(
+        completion=[{"text": "no score"}, {"text": "bad score", "score": "0.5"}],
+        search_type=SearchType.CHUNKS,
+    )
+
+    items = normalize_search_payload(payload)
+
+    assert [item.score for item in items] == [None, None]

--- a/cognee/tests/unit/modules/retrieval/chunks_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/chunks_retriever_test.py
@@ -241,3 +241,19 @@ async def test_get_context_empty_payload(mock_vector_engine):
         )
 
     assert context == ""
+
+
+@pytest.mark.asyncio
+async def test_get_completion_from_context_none_payload_still_returns_score():
+    """A ScoredResult with payload=None yields a dict carrying only the score, not a TypeError."""
+    result = MagicMock()
+    result.payload = None
+    result.score = 0.42
+
+    retriever = ChunksRetriever()
+
+    completion = await retriever.get_completion_from_context(
+        query="test query", retrieved_objects=[result], context=None
+    )
+
+    assert completion == [{"score": 0.42}]

--- a/cognee/tests/unit/modules/retrieval/chunks_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/chunks_retriever_test.py
@@ -55,6 +55,47 @@ async def test_get_context_success(mock_vector_engine):
 
 
 @pytest.mark.asyncio
+async def test_get_completion_from_context_includes_score(mock_vector_engine):
+    """Test that get_completion_from_context attaches each chunk's score to its payload."""
+    mock_result1 = MagicMock()
+    mock_result1.payload = {"text": "Steve Rodger", "chunk_index": 0}
+    mock_result1.score = 0.12
+    mock_result2 = MagicMock()
+    mock_result2.payload = {"text": "Mike Broski", "chunk_index": 1}
+    mock_result2.score = 0.34
+
+    mock_vector_engine.search.return_value = [mock_result1, mock_result2]
+
+    retriever = ChunksRetriever(top_k=5)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_unified_engine",
+        return_value=_make_unified_mock(mock_vector_engine),
+    ):
+        retrieved_objects = await retriever.get_retrieved_objects("test query")
+        completion = await retriever.get_completion_from_context(
+            query="test query", retrieved_objects=retrieved_objects, context=None
+        )
+
+    assert completion[0]["score"] == 0.12
+    assert completion[0]["text"] == "Steve Rodger"
+    assert completion[1]["score"] == 0.34
+    assert completion[1]["text"] == "Mike Broski"
+
+
+@pytest.mark.asyncio
+async def test_get_completion_from_context_empty_returns_empty_list():
+    """Test that get_completion_from_context returns [] when there are no retrieved objects."""
+    retriever = ChunksRetriever()
+
+    completion = await retriever.get_completion_from_context(
+        query="test query", retrieved_objects=[], context=None
+    )
+
+    assert completion == []
+
+
+@pytest.mark.asyncio
 async def test_get_context_collection_not_found_error(mock_vector_engine):
     """Test that CollectionNotFoundError is converted to NoDataError."""
     mock_vector_engine.search.side_effect = CollectionNotFoundError("Collection not found")

--- a/cognee/tests/unit/modules/retrieval/summaries_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/summaries_retriever_test.py
@@ -194,3 +194,58 @@ async def test_get_completion_with_session_id(mock_vector_engine):
 
     assert len(completion) == 1
     assert completion[0]["text"] == "S.R."
+
+
+@pytest.mark.asyncio
+async def test_get_completion_from_context_includes_score(mock_vector_engine):
+    """Test that get_completion_from_context attaches each summary's score to its payload."""
+    mock_result1 = MagicMock()
+    mock_result1.payload = {"text": "S.R.", "made_from": "chunk1"}
+    mock_result1.score = 0.12
+    mock_result2 = MagicMock()
+    mock_result2.payload = {"text": "M.B.", "made_from": "chunk2"}
+    mock_result2.score = 0.34
+
+    mock_vector_engine.search.return_value = [mock_result1, mock_result2]
+
+    retriever = SummariesRetriever(top_k=5)
+
+    with patch(
+        "cognee.modules.retrieval.summaries_retriever.get_unified_engine",
+        return_value=_make_unified_mock(mock_vector_engine),
+    ):
+        retrieved_objects = await retriever.get_retrieved_objects("test query")
+        completion = await retriever.get_completion_from_context(
+            query="test query", retrieved_objects=retrieved_objects, context=None
+        )
+
+    assert completion[0] == {"text": "S.R.", "made_from": "chunk1", "score": 0.12}
+    assert completion[1] == {"text": "M.B.", "made_from": "chunk2", "score": 0.34}
+
+
+@pytest.mark.asyncio
+async def test_get_completion_from_context_empty_returns_empty_list():
+    """Test that get_completion_from_context returns [] when there are no retrieved objects."""
+    retriever = SummariesRetriever()
+
+    completion = await retriever.get_completion_from_context(
+        query="test query", retrieved_objects=[], context=None
+    )
+
+    assert completion == []
+
+
+@pytest.mark.asyncio
+async def test_get_completion_from_context_none_payload_still_returns_score():
+    """A ScoredResult with payload=None yields a dict carrying only the score, not a TypeError."""
+    result = MagicMock()
+    result.payload = None
+    result.score = 0.42
+
+    retriever = SummariesRetriever()
+
+    completion = await retriever.get_completion_from_context(
+        query="test query", retrieved_objects=[result], context=None
+    )
+
+    assert completion == [{"score": 0.42}]


### PR DESCRIPTION
## Summary

Stacked on #4891 (external contribution by @GrowDev1), which attaches `score` to each `ChunksRetriever` payload. This PR rebases that commit onto current `dev` and adds the follow-ups a review of #4891 surfaced. Merge #4891 first; this PR then reduces to the single follow-up commit.

Related: COG-6309 (hybrid BM25+vector RRF fusion) needs per-lane scores on the wire, which is what these payloads now carry.

### Analysis of #4891

- The change is correct and minimal, and mirrors the existing idiom in `temporal_retriever.py`.
- `normalize_search_payload._score_from` already reads a `score` key, so CHUNKS results now populate `SearchResultItem.score` with no normalizer change.
- `DocumentChunk` has no `score` field, so the spread cannot clobber a real payload attribute.
- It merges cleanly onto `dev` (base was July `dev`, 1500+ commits behind, no conflicts).
- The all-red CI on #4891 is unrelated: every job dies in ~5s with zero steps, which is the fork-PR secrets problem, not a test failure.

### What this adds

- **`SummariesRetriever` parity.** It has the identical shape and is also routed through the normalizer, but #4891 left it without a score. Now spreads `score` the same way.
- **`None` payload guard.** `ScoredResult.payload` is typed `Optional`; `{**None}` would raise `TypeError`. Both retrievers now use `payload or {}`.
- **Score semantics documented.** `ScoredResult.score` is the raw backend distance (cosine for built-in adapters), lower is better. The retriever docstrings now say so, since a fusion caller that assumes higher-is-better would invert the ranking.
- **Normalizer tests.** CHUNKS and SUMMARIES scores reach `SearchResultItem.score`; missing or non-numeric scores stay `None`.

### Not in scope (noted for follow-up)

`CHUNKS_LEXICAL` (`BM25ChunksRetriever`) is built with `with_scores=False`, and its `with_scores=True` mode returns `(payload, score)` tuples rather than dicts, so `_score_from` returns `None` for it. Making the lexical lane emit a `score` key is a shape change worth its own PR under COG-6309.

## Test plan

- [x] `pytest cognee/tests/unit/modules/retrieval cognee/tests/unit/modules/recall cognee/tests/unit/modules/search` → 678 passed, 1 skipped
- [x] `ruff check` / `ruff format --check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
