### PR TITLE
ci: Give every workflow a least-privilege GITHUB_TOKEN (SDK-567)

### DIFF
--- a/.github/workflows/backend_docker_build_test.yml
+++ b/.github/workflows/backend_docker_build_test.yml
@@ -1,9 +1,12 @@
 name: build test | Docker image
 
 # Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
-# only narrow this further; nothing in this workflow writes to the repository.
+# only narrow this further. packages: read is required: the jobs run inside the
+# private ghcr.io CI image (and pull ghcr.io service images), which the runner
+# fetches with this token before the first step. Nothing here writes.
 permissions:
   contents: read
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/backend_docker_build_test.yml
+++ b/.github/workflows/backend_docker_build_test.yml
@@ -1,5 +1,10 @@
 name: build test | Docker image
 
+# Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
+# only narrow this further; nothing in this workflow writes to the repository.
+permissions:
+  contents: read
+
 on:
   workflow_call:
 

--- a/.github/workflows/basic_tests.yml
+++ b/.github/workflows/basic_tests.yml
@@ -1,9 +1,12 @@
 name: Reusable Basic Tests
 
 # Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
-# only narrow this further; nothing in this workflow writes to the repository.
+# only narrow this further. packages: read is required: the jobs run inside the
+# private ghcr.io CI image (and pull ghcr.io service images), which the runner
+# fetches with this token before the first step. Nothing here writes.
 permissions:
   contents: read
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/basic_tests.yml
+++ b/.github/workflows/basic_tests.yml
@@ -1,5 +1,10 @@
 name: Reusable Basic Tests
 
+# Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
+# only narrow this further; nothing in this workflow writes to the repository.
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -1,9 +1,12 @@
 name: test | cli
 
 # Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
-# only narrow this further; nothing in this workflow writes to the repository.
+# only narrow this further. packages: read is required: the jobs run inside the
+# private ghcr.io CI image (and pull ghcr.io service images), which the runner
+# fetches with this token before the first step. Nothing here writes.
 permissions:
   contents: read
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -1,5 +1,10 @@
 name: test | cli
 
+# Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
+# only narrow this further; nothing in this workflow writes to the repository.
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/community_greetings.yml
+++ b/.github/workflows/community_greetings.yml
@@ -5,10 +5,12 @@ on:
     types: [opened]
 
 permissions:
-  issues: write
+  contents: read
 
 jobs:
   greeting:
+    permissions:
+      issues: write
     if: github.actor != 'github-actions[bot]' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -17,10 +17,12 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   mirror:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/notebooks_tests.yml
+++ b/.github/workflows/notebooks_tests.yml
@@ -1,5 +1,10 @@
 name: Reusable Notebook Tests
 
+# Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
+# only narrow this further; nothing in this workflow writes to the repository.
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/notebooks_tests.yml
+++ b/.github/workflows/notebooks_tests.yml
@@ -1,9 +1,12 @@
 name: Reusable Notebook Tests
 
 # Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
-# only narrow this further; nothing in this workflow writes to the repository.
+# only narrow this further. packages: read is required: the jobs run inside the
+# private ghcr.io CI image (and pull ghcr.io service images), which the runner
+# fetches with this token before the first step. Nothing here writes.
 permissions:
   contents: read
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/performance_report.yml
+++ b/.github/workflows/performance_report.yml
@@ -1,10 +1,12 @@
 name: performance report
 
 # Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
-# only narrow this further; nothing in this workflow writes to the repository.
+# only narrow this further. packages: read is required: the jobs run inside the
+# private ghcr.io CI image (and pull ghcr.io service images), which the runner
+# fetches with this token before the first step. Nothing here writes.
 permissions:
   contents: read
-  packages: read  # pull the ghcr.io service images
+  packages: read
 
 # Reusable workflow: runs the percentile performance report once for a given
 # dataset + mode, uploads the JSON + HTML artifacts to S3, and exposes the

--- a/.github/workflows/performance_report.yml
+++ b/.github/workflows/performance_report.yml
@@ -1,5 +1,11 @@
 name: performance report
 
+# Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
+# only narrow this further; nothing in this workflow writes to the repository.
+permissions:
+  contents: read
+  packages: read  # pull the ghcr.io service images
+
 # Reusable workflow: runs the percentile performance report once for a given
 # dataset + mode, uploads the JSON + HTML artifacts to S3, and exposes the
 # headline metrics + HTML object key as outputs for the caller (the Slack bot in

--- a/.github/workflows/relational_db_migration_tests.yml
+++ b/.github/workflows/relational_db_migration_tests.yml
@@ -1,5 +1,11 @@
 name: Relational DB Migration Tests
 
+# Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
+# only narrow this further; nothing in this workflow writes to the repository.
+permissions:
+  contents: read
+  packages: read  # pull the ghcr.io service images
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/relational_db_migration_tests.yml
+++ b/.github/workflows/relational_db_migration_tests.yml
@@ -1,10 +1,12 @@
 name: Relational DB Migration Tests
 
 # Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
-# only narrow this further; nothing in this workflow writes to the repository.
+# only narrow this further. packages: read is required: the jobs run inside the
+# private ghcr.io CI image (and pull ghcr.io service images), which the runner
+# fetches with this token before the first step. Nothing here writes.
 permissions:
   contents: read
-  packages: read  # pull the ghcr.io service images
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/reusable_notebook.yml
+++ b/.github/workflows/reusable_notebook.yml
@@ -1,5 +1,10 @@
 name: test-notebook
 
+# Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
+# only narrow this further; nothing in this workflow writes to the repository.
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/reusable_notebook.yml
+++ b/.github/workflows/reusable_notebook.yml
@@ -1,9 +1,12 @@
 name: test-notebook
 
 # Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
-# only narrow this further; nothing in this workflow writes to the repository.
+# only narrow this further. packages: read is required: the jobs run inside the
+# private ghcr.io CI image (and pull ghcr.io service images), which the runner
+# fetches with this token before the first step. Nothing here writes.
 permissions:
   contents: read
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/router_docstring_sync.yml
+++ b/.github/workflows/router_docstring_sync.yml
@@ -44,8 +44,7 @@ on:
     - cron: "0 5 * * 3"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 # Queue rather than cancel: a run cancelled between the branch push and the
 # PR update would leave the fix PR half-refreshed.
@@ -55,6 +54,9 @@ concurrency:
 
 jobs:
   sync-docstrings:
+    permissions:
+      contents: write
+      pull-requests: write
     name: Detect and fix router docstring drift
     runs-on: ubuntu-22.04
     timeout-minutes: 30
@@ -203,6 +205,9 @@ jobs:
           fi
 
   describe-params:
+    permissions:
+      contents: write
+      pull-requests: write
     name: Generate missing parameter descriptions with Claude
     runs-on: ubuntu-22.04
     timeout-minutes: 15

--- a/.github/workflows/spec_extras_sync.yml
+++ b/.github/workflows/spec_extras_sync.yml
@@ -76,8 +76,7 @@ on:
     - cron: "0 6 * * 3"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 env:
   # `inputs` is empty outside workflow_dispatch, so the weekly schedule always
@@ -92,6 +91,9 @@ concurrency:
 
 jobs:
   sync-spec-extras:
+    permissions:
+      contents: write
+      pull-requests: write
     name: Detect and fix spec extras drift
     runs-on: ubuntu-22.04
     timeout-minutes: 30

--- a/.github/workflows/telemetry-insights.yml
+++ b/.github/workflows/telemetry-insights.yml
@@ -27,8 +27,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
 
 concurrency:
   group: telemetry-insights
@@ -36,6 +34,10 @@ concurrency:
 
 jobs:
   telemetry-insights:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test_llamacpp.yml
+++ b/.github/workflows/test_llamacpp.yml
@@ -1,9 +1,12 @@
 name: test | ollama
 
 # Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
-# only narrow this further; nothing in this workflow writes to the repository.
+# only narrow this further. packages: read is required: the jobs run inside the
+# private ghcr.io CI image (and pull ghcr.io service images), which the runner
+# fetches with this token before the first step. Nothing here writes.
 permissions:
   contents: read
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/test_llamacpp.yml
+++ b/.github/workflows/test_llamacpp.yml
@@ -1,5 +1,10 @@
 name: test | ollama
 
+# Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
+# only narrow this further; nothing in this workflow writes to the repository.
+permissions:
+  contents: read
+
 on:
   workflow_call:
 

--- a/.github/workflows/test_mcp.yml
+++ b/.github/workflows/test_mcp.yml
@@ -1,5 +1,10 @@
 name: test | mcp
 
+# Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
+# only narrow this further; nothing in this workflow writes to the repository.
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/test_mcp.yml
+++ b/.github/workflows/test_mcp.yml
@@ -1,9 +1,12 @@
 name: test | mcp
 
 # Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
-# only narrow this further; nothing in this workflow writes to the repository.
+# only narrow this further. packages: read is required: the jobs run inside the
+# private ghcr.io CI image (and pull ghcr.io service images), which the runner
+# fetches with this token before the first step. Nothing here writes.
 permissions:
   contents: read
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/test_ollama.yml
+++ b/.github/workflows/test_ollama.yml
@@ -1,9 +1,12 @@
 name: test | ollama
 
 # Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
-# only narrow this further; nothing in this workflow writes to the repository.
+# only narrow this further. packages: read is required: the jobs run inside the
+# private ghcr.io CI image (and pull ghcr.io service images), which the runner
+# fetches with this token before the first step. Nothing here writes.
 permissions:
   contents: read
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/test_ollama.yml
+++ b/.github/workflows/test_ollama.yml
@@ -1,5 +1,10 @@
 name: test | ollama
 
+# Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
+# only narrow this further; nothing in this workflow writes to the repository.
+permissions:
+  contents: read
+
 on:
   workflow_call:
 

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -1,7 +1,7 @@
 name: Test Suites
 permissions:
   contents: read
-  packages: write
+  packages: read  # reusable test workflows pull the ghcr.io CI image
 
 on:
   push:
@@ -28,6 +28,9 @@ env:
 jobs:
   # ── Build pre-baked CI container ──────────────────────────────────────
   build-ci-env:
+    permissions:
+      contents: read
+      packages: write  # pushes the CI image
     name: Build CI Environment
     runs-on: ubuntu-latest
     if: >-

--- a/.github/workflows/vector_db_tests.yml
+++ b/.github/workflows/vector_db_tests.yml
@@ -1,5 +1,11 @@
 name: Reusable Vector DB Tests
 
+# Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
+# only narrow this further; nothing in this workflow writes to the repository.
+permissions:
+  contents: read
+  packages: read  # pull the ghcr.io service images
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/vector_db_tests.yml
+++ b/.github/workflows/vector_db_tests.yml
@@ -1,10 +1,12 @@
 name: Reusable Vector DB Tests
 
 # Least-privilege GITHUB_TOKEN (OSSF Scorecard: Token-Permissions). A caller can
-# only narrow this further; nothing in this workflow writes to the repository.
+# only narrow this further. packages: read is required: the jobs run inside the
+# private ghcr.io CI image (and pull ghcr.io service images), which the runner
+# fetches with this token before the first step. Nothing here writes.
 permissions:
   contents: read
-  packages: read  # pull the ghcr.io service images
+  packages: read
 
 on:
   workflow_call:


### PR DESCRIPTION
## Summary

Part of [SDK-566](https://linear.app/cognee/issue/SDK-566) (OpenSSF Scorecard). Fixes [SDK-567](https://linear.app/cognee/issue/SDK-567).

Scorecard's **Token-Permissions** check scores 0 today. Two causes:

- 11 reusable (`workflow_call`) workflows declare no `permissions:` block at all, so they run with whatever the caller grants.
- 6 workflows grant `write` scopes at the top level, where every job inherits them.

## What changed

- Every workflow now starts from `permissions: contents: read`.
- All 11 reusable test workflows get `contents: read` + `packages: read`, matching the other reusable workflows in the repo. `packages: read` is not optional: their jobs run inside the private ghcr.io CI image, which the runner pulls with the job token before the first step. The first revision of this PR set `contents: read` only and every containerised job failed at "Initialize containers" with a denied pull; commit `d230aaf` fixes that.
- Write scopes move to the one job that uses them:

| Workflow | Job | Scope |
|---|---|---|
| `test_suites.yml` | `build-ci-env` | `packages: write` (pushes the CI image); top level drops to `packages: read` so the reusable suites can still pull it |
| `spec_extras_sync.yml` | `sync-spec-extras` | `contents: write`, `pull-requests: write` |
| `router_docstring_sync.yml` | `sync-docstrings`, `describe-params` | `contents: write`, `pull-requests: write` |
| `telemetry-insights.yml` | `telemetry-insights` | `issues: write`, `pull-requests: read` |
| `mirror-images.yml` | `mirror` | `packages: write` |
| `community_greetings.yml` | `greeting` | `issues: write` |

`label-core-team.yml` is the one remaining top-level write and is rewritten in the Dangerous-Workflow PR (SDK-568).

## Behaviour

No job loses a scope it uses. A reusable workflow called from a job with no `permissions:` inherits the caller's top level, which for `test_suites` is now `contents: read` + `packages: read`; the only job that pushed packages was `build-ci-env`, which keeps `packages: write` explicitly.

## Test plan

- [x] All 54 workflow files parse; a script confirms every one has a top-level block and none grants `write` there (except `label-core-team.yml`, handled separately)
- [x] Structural check after the fix-up: every edited workflow still parses and keeps its `jobs` section
- [ ] Test Suites run green on this PR (the reusable workflows exercise the new read-only defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

