### PR TITLE
ci: Stop checking out under pull_request_target (SDK-568)

### DIFF
--- a/.github/workflows/label-core-team.yml
+++ b/.github/workflows/label-core-team.yml
@@ -4,49 +4,50 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review, edited]
 
+# pull_request_target runs in the context of the base branch with a token that
+# can write to the repository, so nothing from the pull request may be checked
+# out or executed here. The core-team list is read from the base ref through the
+# API, and the PR author reaches the shell through an environment variable
+# rather than expression interpolation (OSSF Scorecard: Dangerous-Workflow).
 permissions:
   contents: read
-  issues: write
 
 jobs:
   label-core-team:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write         # PR labels are issue labels
+      pull-requests: write
     steps:
-      - name: Check out base repository
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ github.repository }}
-          ref: ${{ github.event.pull_request.base.ref }}
-
       - name: Determine if PR author is a core team member
         id: check_core
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.base_ref }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          AUTHOR="${{ github.event.pull_request.user.login }}"
-          LIST_FILE=".github/core-team.txt"
+          # Read .github/core-team.txt from the base branch without a checkout.
+          LIST="$(gh api -H "Accept: application/vnd.github.raw+json" \
+            "repos/${REPO}/contents/.github/core-team.txt?ref=${BASE_REF}" 2>/dev/null)" || LIST=""
 
-          if [ ! -f "$LIST_FILE" ]; then
+          if [ -z "$LIST" ]; then
             echo "core=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Normalize author to lowercase and strip leading '@'
-          AUTHOR_NORM="$(echo "$AUTHOR" | tr '[:upper:]' '[:lower:]' | sed 's/^@//')"
+          # Normalize author to lowercase and strip a leading '@'.
+          AUTHOR_NORM="$(printf '%s' "$AUTHOR" | tr '[:upper:]' '[:lower:]' | sed 's/^@//')"
 
-          # Compare against normalized list values (ignore comments/blank lines)
-          if awk -v author="$AUTHOR_NORM" '
-            BEGIN { found=0 }
-            {
-              line=$0
-              sub(/^[ \t]+|[ \t]+$/, "", line)
-              if (line ~ /^#/ || line == "") next
-              sub(/^@/, "", line)
-              line=tolower(line)
-              if (line == author) { found=1; exit }
-            }
-            END { exit(found ? 0 : 1) }
-          ' "$LIST_FILE"; then
+          # Compare against normalized list entries; comments and blank lines are ignored.
+          if printf '%s\n' "$LIST" \
+               | grep -vE '^[[:space:]]*(#|$)' \
+               | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/^@//' \
+               | tr '[:upper:]' '[:lower:]' \
+               | grep -qxF "$AUTHOR_NORM"; then
             echo "core=true" >> "$GITHUB_OUTPUT"
           else
             echo "core=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Part of [SDK-566](https://linear.app/cognee/issue/SDK-566) (OpenSSF Scorecard). Fixes [SDK-568](https://linear.app/cognee/issue/SDK-568).

Scorecard's **Dangerous-Workflow** check scores 0, and `label-core-team.yml` is the only file that trips it. It runs on `pull_request_target`, which carries a write-capable token, and then:

1. checks out with `ref: ${{ github.event.pull_request.base.ref }}` — the base ref is safe in practice, but any `github.event.pull_request` ref under `pull_request_target` matches the untrusted-checkout pattern;
2. interpolates `${{ github.event.pull_request.user.login }}` directly into a `run:` block — the script-injection pattern.

## What changed

- No checkout at all. `.github/core-team.txt` is read from the base branch through `gh api` with the raw content header.
- The author, repository, and base ref reach the shell through `env:`, never through expression interpolation inside `run:`.
- The matching logic is unchanged in behaviour (case-insensitive, leading `@` stripped, comments and blank lines ignored) and now mirrors the core-team gate already used by `claude-review` in `test_suites.yml`.
- `permissions` at the top level drops to `contents: read`; the job gets `issues: write` and `pull-requests: write` for the label call.

## Test plan

- [x] YAML parses
- [x] Shell matching logic run locally against the real `core-team.txt`: a listed login matches with and without `@` and in mixed case, an unlisted one does not
- [ ] Label lands on the next core-team PR opened after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
