### PR TITLE
ci: Attach distributions and provenance to releases (SDK-570)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
     # built artifacts also get a SLSA build-provenance attestation hosted by
     # GitHub. See docs/supply_chain_provenance.md for the one-time PyPI setup.
     permissions:
-      contents: read
+      contents: write       # Attach the distributions and provenance to the release
       id-token: write       # OIDC: Trusted Publishing + signing attestations
       attestations: write   # Persist the SLSA build provenance attestation
     runs-on: ubuntu-latest
@@ -132,6 +132,7 @@ jobs:
         run: uv build
 
       - name: Attest build provenance for distributions
+        id: attest
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2.4.0
         with:
           subject-path: "dist/*"
@@ -142,6 +143,30 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2 (twine 7.0.0: accepts Metadata-Version 2.5)
         with:
           packages-dir: dist/
+
+      - name: Attach distributions and provenance to the GitHub release
+        # The release page carried no assets, so the provenance that PyPI and
+        # the GitHub attestation store already hold was invisible there (OSSF
+        # Scorecard: Signed-Releases). Upload the wheel and sdist together with
+        # the SLSA build-provenance attestation in two shapes: the Sigstore
+        # bundle (certificate + signature + statement; verify with
+        # `gh attestation verify <dist> --bundle <file> --owner topoteretes`)
+        # and the bare DSSE envelope it wraps, in the .intoto.jsonl form the
+        # SLSA ecosystem expects. Runs after publish so a PyPI failure leaves
+        # the release page without artifacts that never shipped.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-github.outputs.tag }}
+          VERSION: ${{ needs.release-github.outputs.version }}
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          cp "${BUNDLE}" "dist/cognee-${VERSION}.sigstore.json"
+          jq -c '.dsseEnvelope' "${BUNDLE}" > "dist/cognee-${VERSION}.intoto.jsonl"
+          gh release upload "${TAG}" \
+            dist/*.whl dist/*.tar.gz \
+            "dist/cognee-${VERSION}.sigstore.json" \
+            "dist/cognee-${VERSION}.intoto.jsonl" \
+            --repo "${GITHUB_REPOSITORY}" --clobber
 
   release-docker-image:
     needs: release-github


### PR DESCRIPTION
## Summary

Part of [SDK-566](https://linear.app/cognee/issue/SDK-566) (OpenSSF Scorecard). Fixes [SDK-570](https://linear.app/cognee/issue/SDK-570).

Scorecard's **Signed-Releases** check reports -1 (inconclusive). It only looks at the assets attached to the last five GitHub releases, and ours have none: `release.yml` creates the release with notes only. The provenance exists, it just lives on PyPI (PEP 740 attestations via Trusted Publishing) and in GitHub's attestation store (SLSA build provenance from `actions/attest-build-provenance`), where the check cannot see it.

## What changed

In the `release-pypi-package` job, after the PyPI publish succeeds:

- upload `dist/*.whl` and `dist/*.tar.gz` to the release for the tag the first job created;
- upload the attestation the job already produces, in two shapes:
  - `cognee-<version>.sigstore.json`: the Sigstore bundle (certificate, signature, and in-toto statement). Verifiable with `gh attestation verify dist/cognee-<version>-py3-none-any.whl --bundle cognee-<version>.sigstore.json --owner topoteretes`.
  - `cognee-<version>.intoto.jsonl`: the DSSE envelope extracted from that bundle, the shape the SLSA ecosystem and Scorecard's provenance probe expect.
- `contents: write` on that job so `gh release upload` can attach files. The job keeps `id-token` and `attestations` write as before.

Scorecard recognises `.sigstore.json` as a signature and `.intoto.jsonl` as provenance, so the check should move from -1 to 10 once a release has run with this change.

## Behaviour

The upload step runs after publish on purpose: a PyPI failure leaves the release page without artifacts that never shipped. `--clobber` makes a re-run idempotent. Dev canaries create no GitHub release and are unaffected.

## Test plan

- [x] YAML parses; `jq` is on the ubuntu-latest image
- [ ] Next release from `dev` or `main` shows four assets on its release page and the Scorecard check updates on the following scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
