### PR TITLE
CLO-476 ci(nightly): run product journeys against the real LLM nightly (stacked on #4932)

### DIFF
--- a/.github/workflows/journey_tests.yml
+++ b/.github/workflows/journey_tests.yml
@@ -1,9 +1,10 @@
 name: Reusable Product Journey Tests
 
-# High-level product contract tests (cognee/tests/journeys). The mock tier needs
-# no secrets, so it runs for fork PRs too and gives them a real signal.
-# Real-LLM runs of the same journeys are wired separately (nightly) via
-# COGNEE_JOURNEY_MODE=llm.
+# High-level product contract tests (cognee/tests/journeys).
+#
+# mode: mock (default) needs no secrets, so it runs for fork PRs too and gives
+# them a real signal. mode: llm runs the same journeys against the real
+# providers from secrets; nightly_tests.yml calls it that way.
 
 on:
   workflow_call:
@@ -16,28 +17,58 @@ on:
         required: false
         type: string
         default: ''
+      mode:
+        description: "'mock' (deterministic, no secrets) or 'llm' (real providers)."
+        required: false
+        type: string
+        default: 'mock'
+    secrets:
+      # Only read when mode == 'llm'. Callers pass `secrets: inherit`.
+      LLM_PROVIDER:
+        required: false
+      LLM_MODEL:
+        required: false
+      LLM_ENDPOINT:
+        required: false
+      LLM_API_KEY:
+        required: false
+      LLM_API_VERSION:
+        required: false
+      EMBEDDING_PROVIDER:
+        required: false
+      EMBEDDING_MODEL:
+        required: false
+      EMBEDDING_ENDPOINT:
+        required: false
+      EMBEDDING_API_KEY:
+        required: false
 
 env:
   RUNTIME__LOG_LEVEL: ERROR
   ENV: 'dev'
   TELEMETRY_DISABLED: '1'
-  COGNEE_JOURNEY_MODE: mock
-  # Mock mode never calls a provider; config validation still wants these present.
-  LLM_PROVIDER: openai
-  LLM_MODEL: openai/gpt-5-mini
-  LLM_API_KEY: mock-key
-  EMBEDDING_PROVIDER: openai
-  EMBEDDING_MODEL: openai/text-embedding-3-small
-  EMBEDDING_DIMENSIONS: '256'
-  EMBEDDING_API_KEY: mock-key
-  COGNEE_SKIP_PREFLIGHT: '1'
+  COGNEE_JOURNEY_MODE: ${{ inputs.mode }}
+  # llm: provider settings from secrets. mock: never called, but config
+  # validation still wants the variables present.
+  LLM_PROVIDER: ${{ inputs.mode == 'llm' && secrets.LLM_PROVIDER || 'openai' }}
+  LLM_MODEL: ${{ inputs.mode == 'llm' && secrets.LLM_MODEL || 'openai/gpt-5-mini' }}
+  LLM_ENDPOINT: ${{ inputs.mode == 'llm' && secrets.LLM_ENDPOINT || '' }}
+  LLM_API_KEY: ${{ inputs.mode == 'llm' && secrets.LLM_API_KEY || 'mock-key' }}
+  LLM_API_VERSION: ${{ inputs.mode == 'llm' && secrets.LLM_API_VERSION || '' }}
+  EMBEDDING_PROVIDER: ${{ inputs.mode == 'llm' && secrets.EMBEDDING_PROVIDER || 'openai' }}
+  EMBEDDING_MODEL: ${{ inputs.mode == 'llm' && secrets.EMBEDDING_MODEL || 'openai/text-embedding-3-small' }}
+  EMBEDDING_ENDPOINT: ${{ inputs.mode == 'llm' && secrets.EMBEDDING_ENDPOINT || '' }}
+  EMBEDDING_API_KEY: ${{ inputs.mode == 'llm' && secrets.EMBEDDING_API_KEY || 'mock-key' }}
+  EMBEDDING_DIMENSIONS: ${{ inputs.mode == 'llm' && '300' || '256' }}
+  COGNEE_SKIP_PREFLIGHT: ${{ inputs.mode == 'mock' && '1' || '' }}
   COGNEE_SKIP_CONNECTION_TEST: 'true'
 
 jobs:
-  journeys-mock:
-    name: Product Journeys (mock LLM)
+  journeys:
+    name: Product Journeys (${{ inputs.mode }} LLM)
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    # llm mode makes a few hundred provider calls; observed ~30 min locally.
+    timeout-minutes: ${{ inputs.mode == 'llm' && 90 || 30 }}
     container: ${{ inputs.ci-image != '' && fromJSON(format('{{"image":"{0}","credentials":{{"username":"{1}","password":"{2}"}}}}', inputs.ci-image, github.actor, github.token)) || null }}
     steps:
       - name: Check out repository
@@ -53,10 +84,10 @@ jobs:
       - name: Memory correctness, sessions, lifecycle, idempotency, HTTP API
         run: |
           uv run pytest cognee/tests/journeys -m "journey and not quickstart" \
-            -v --timeout=1500 -p no:cacheprovider -W ignore
+            -v --timeout=4800 -p no:cacheprovider -W ignore
 
-  quickstart-mock:
-    name: Quickstart in a fresh venv (wheel install)
+  quickstart:
+    name: Quickstart in a fresh venv (${{ inputs.mode }} LLM, wheel install)
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -40,6 +40,16 @@ env:
   ENV: 'dev'
 
 jobs:
+  # ══ Product journeys against the real providers ═══════════════════════════
+  # The PR gate runs these in mock mode; nightly is where the hit-rate and
+  # answer-leak thresholds are measured against the model we actually ship with.
+  journeys-llm:
+    name: Product Journeys (real LLM)
+    uses: ./.github/workflows/journey_tests.yml
+    with:
+      mode: llm
+    secrets: inherit
+
   # ══ Performance: each caller runs BOTH file_based and postgres backends ════
   perf-small-llm:
     name: Performance — 50 Small Documents (real LLM)
@@ -208,6 +218,7 @@ jobs:
   notify:
     name: Test Completion Status
     needs: [
+      journeys-llm,
       perf-small-llm,
       perf-small-mock,
       perf-wap-llm,
@@ -238,7 +249,8 @@ jobs:
           # and inline interpolation would splice it into this shell script.
           CADENCE: ${{ inputs.cadence }}
         run: |
-          if [[ "${{ needs.perf-small-llm.result }}" == "success" &&
+          if [[ "${{ needs.journeys-llm.result }}" == "success" &&
+                "${{ needs.perf-small-llm.result }}" == "success" &&
                 "${{ needs.perf-small-mock.result }}" == "success" &&
                 "${{ needs.perf-wap-llm.result }}" == "success" &&
                 "${{ needs.perf-wap-mock.result }}" == "success" &&


### PR DESCRIPTION
## Summary

Stacked on #4932 (base is that branch; GitHub retargets to `dev` when it merges).

`journey_tests.yml` gains a `mode` input:

- `mock` (default): what the PR gate in `test_suites.yml` already calls. Deterministic, no secrets, fork-safe. Unchanged behaviour.
- `llm`: provider settings come from repo secrets (`secrets: inherit`), `COGNEE_JOURNEY_MODE=llm`, preflight enabled, longer timeouts. Runs the same ten journeys plus the fresh-venv quickstart against the model we ship with.

`nightly_tests.yml` calls it with `mode: llm` as `journeys-llm` and includes it in the `notify` gate, alongside the perf arms.

### Why nightly and not per PR

The llm run makes a few hundred provider calls and took ~30 minutes locally. It also measures thresholds (golden-corpus hit rate, answer leaks from unrelated documents) that move with the model, not with the PR. Nightly is where that signal belongs; the PR gate keeps the deterministic tier.

### Local real-LLM results (gpt-5-mini, default stack)

| Path | Answered |
|---|---|
| `search(CHUNKS)` | 30/30 |
| `search(RAG_COMPLETION)` | 30/30 |
| `search(GRAPH_COMPLETION)` | 30/30 |
| `search(SUMMARIES)` | 30/30 |

Session, lifecycle, idempotency/recovery and HTTP API journeys: passed. Quickstart in a fresh venv with the real key: passed in 89s.

The first llm run failed only on the leak check, which was over-broad (it scanned raw top-k chunk payloads and matched digits inside dataset UUIDs). That is fixed in #4932's second commit: leak checks now apply to completion answers only and match whole tokens.

## Test plan

- [x] Both workflow files parse
- [x] `COGNEE_JOURNEY_MODE=llm` journeys run locally (see above)
- [ ] Trigger `Nightly Tests` via `workflow_dispatch` on this branch once #4932 is in, to confirm secrets resolve in the reusable call

🤖 Generated with [Claude Code](https://claude.com/claude-code)
