### PR TITLE
CLO-476 test(journeys): extras install smoke + MCP client journey (stacked on #4938)

### DIFF
--- a/.github/workflows/journey_tests.yml
+++ b/.github/workflows/journey_tests.yml
@@ -140,7 +140,7 @@ jobs:
       fail-fast: false
       matrix:
         extras:
-          - "neo4j,neptune,postgres-binary,turso,redis,tracing,aws"
+          - "neo4j,neptune,postgres,postgres-binary,turso,redis,tracing,aws"
           - "anthropic,azure,groq,mistral,ollama,posthog,debug,notebook"
           - "fastembed,huggingface,codegraph,rapidocr"
           - "docs,langchain,llama-index,graphiti"

--- a/.github/workflows/journey_tests.yml
+++ b/.github/workflows/journey_tests.yml
@@ -81,9 +81,10 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
-      - name: Memory correctness, sessions, lifecycle, idempotency, HTTP API
+      - name: Memory correctness, sessions, lifecycle, idempotency, HTTP API, extras resolution
         run: |
           uv run pytest cognee/tests/journeys -m "journey and not quickstart" \
+            --ignore=cognee/tests/journeys/test_mcp_journey.py \
             -v --timeout=4800 -p no:cacheprovider -W ignore
 
   quickstart:
@@ -107,3 +108,59 @@ jobs:
         run: |
           uv run pytest cognee/tests/journeys/test_quickstart.py -m quickstart \
             -v --timeout=1500 -p no:cacheprovider -W ignore
+
+  mcp:
+    name: MCP as a client uses it (${{ inputs.mode }} LLM, stdio + HTTP)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Spawn cognee-mcp over stdio and HTTP, remember and recall through the tools
+        run: |
+          uv run --with "fastmcp>=3.4.0,<4.0.0" --with "mcp>=1.24.0,<2.0.0" \
+            pytest cognee/tests/journeys/test_mcp_journey.py \
+            -v --timeout=1500 -p no:cacheprovider -W ignore
+
+  extras-install:
+    name: Install smoke — cognee[${{ matrix.extras }}]
+    # Provider-independent, so only the mock-mode caller (the PR gate) runs it.
+    if: ${{ inputs.mode == 'mock' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        extras:
+          - "neo4j,neptune,postgres-binary,turso,redis,tracing,aws"
+          - "anthropic,azure,groq,mistral,ollama,posthog,debug,notebook"
+          - "fastembed,huggingface,codegraph,rapidocr"
+          - "docs,langchain,llama-index,graphiti"
+          - "docling,docling-full"
+          - "dlt,gmail,scraping,evals,deepeval,baml,dev"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Build the wheel, install each extra into an empty venv, import what it enables
+        env:
+          COGNEE_JOURNEY_EXTRAS: '1'
+          COGNEE_EXTRAS: ${{ matrix.extras }}
+        run: |
+          uv run pytest cognee/tests/journeys/test_extras_install_smoke.py -k installs_and_imports \
+            -v --timeout=2400 -p no:cacheprovider -W ignore

--- a/cognee/tests/journeys/README.md
+++ b/cognee/tests/journeys/README.md
@@ -13,6 +13,8 @@ something" is never a pass here.
 | `test_data_lifecycle.py` | remember, update, forget one item, forget dataset, forget everything, remember again; snapshot all three stores after each step | Stale vectors or graph nodes after update/delete, deletion leaving zombies |
 | `test_idempotency_and_recovery.py` | Same content twice, explicit cognify re-run, injected LLM outage, retry | Duplicate ingestion, half-written graphs, dishonest pipeline status |
 | `test_http_api_journey.py` | Register, login, add, cognify (blocking + background polling), search, remember/recall, isolation between users, delete; route-table snapshot | Wire-shape drift, auth holes, 500s on bad input, polling contract |
+| `test_mcp_journey.py` | Spawn `cognee-mcp` over stdio like Claude Code does: list tools, session remember on a fresh system, recall, permanent remember, graph recall, status; then read the same state over HTTP | stdout pollution breaking the protocol, first-session dataset creation (SDK-192), tool surface drift, transport-specific bugs |
+| `test_extras_install_smoke.py` | Resolve every extra alone and all together on Python 3.10 to 3.14 (always on); build the wheel and install each extra into an empty venv, then import `cognee`, every module the extra's requirements ship, and the cognee modules it enables (opt-in) | Extras that conflict (the docling-full vs codegraph case), extras that install but do not import, adapters broken by a dependency bump |
 
 ## Modes
 
@@ -46,6 +48,12 @@ COGNEE_JOURNEY_MODE=llm pytest cognee/tests/journeys -m "journey and not quickst
 
 # accept an intentional route-table change
 COGNEE_UPDATE_API_SNAPSHOT=1 pytest cognee/tests/journeys/test_http_api_journey.py
+
+# MCP journey (needs the mcp client and fastmcp in the interpreter)
+uv run --with fastmcp --with mcp pytest cognee/tests/journeys/test_mcp_journey.py
+
+# extras install smoke (slow; pick a subset with COGNEE_EXTRAS)
+COGNEE_JOURNEY_EXTRAS=1 COGNEE_EXTRAS=neo4j,redis pytest cognee/tests/journeys/test_extras_install_smoke.py
 ```
 
 ## Golden corpus

--- a/cognee/tests/journeys/extras_probe.py
+++ b/cognee/tests/journeys/extras_probe.py
@@ -1,0 +1,110 @@
+"""Import probe run inside a fresh virtualenv that has ``cognee[<extra>]`` installed.
+
+Prints one JSON object on the last line of stdout::
+
+    {"extra": "neo4j", "ok": true, "imported": [...], "failed": {...}, ...}
+
+Three things are checked, in order:
+
+1. ``import cognee`` still works with the extra installed (a version clash
+   introduced by the extra shows up here first).
+2. Every top-level module shipped by the extra's *direct* requirements imports.
+   The dist -> module mapping comes from ``importlib.metadata`` in the venv, so
+   no hand-maintained table can drift from ``pyproject.toml``.
+3. The cognee modules the extra is meant to enable import (curated list passed
+   in by the test), e.g. the Neo4j adapter for ``neo4j``.
+
+Standalone on purpose: no imports from the test package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import re
+import sys
+import traceback
+
+# Top-level names some dists expose that are not meant to be imported directly.
+_JUNK_TOP_LEVELS = {"tests", "test", "docs", "examples", "example", "scripts", "benchmarks", "bin"}
+
+
+def _normalize(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _dist_name(requirement: str) -> str:
+    """'unstructured[csv, pdf]>=0.18 ; python_version < "3.13"' -> 'unstructured'."""
+    head = requirement.split(";", 1)[0].strip()
+    match = re.match(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)", head)
+    return match.group(1) if match else head
+
+
+def _top_levels_for(dist_names: list[str]) -> dict[str, list[str]]:
+    from importlib.metadata import packages_distributions
+
+    wanted = {_normalize(d) for d in dist_names}
+    by_dist: dict[str, set[str]] = {}
+    for module_name, dists in packages_distributions().items():
+        if module_name.startswith("_") or module_name in _JUNK_TOP_LEVELS or "." in module_name:
+            continue
+        for dist in dists:
+            if _normalize(dist) in wanted:
+                by_dist.setdefault(_normalize(dist), set()).add(module_name)
+    return {dist: sorted(mods) for dist, mods in by_dist.items()}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--extra", required=True)
+    parser.add_argument("--requirements", default="[]", help="JSON list of requirement strings")
+    parser.add_argument("--cognee-modules", default="[]", help="JSON list of cognee module paths")
+    args = parser.parse_args()
+
+    requirements = json.loads(args.requirements)
+    cognee_modules = json.loads(args.cognee_modules)
+    report: dict = {
+        "extra": args.extra,
+        "python": sys.version.split()[0],
+        "imported": [],
+        "failed": {},
+        "missing_dists": [],
+    }
+
+    def try_import(name: str, bucket: str) -> None:
+        try:
+            importlib.import_module(name)
+            report["imported"].append(name)
+        except BaseException as error:  # noqa: BLE001 - report everything, even SystemExit
+            report["failed"][name] = {
+                "bucket": bucket,
+                "error": f"{type(error).__name__}: {error}",
+                "traceback": traceback.format_exc()[-2000:],
+            }
+
+    # 1. cognee itself must still import.
+    try_import("cognee", "base")
+
+    # 2. every top-level module of the extra's direct requirements.
+    dist_names = [_dist_name(r) for r in requirements]
+    top_levels = _top_levels_for(dist_names)
+    for dist in dist_names:
+        key = _normalize(dist)
+        if key not in top_levels:
+            report["missing_dists"].append(dist)
+            continue
+        for module_name in top_levels[key]:
+            try_import(module_name, f"dependency:{dist}")
+
+    # 3. cognee modules that the extra enables.
+    for module_name in cognee_modules:
+        try_import(module_name, "cognee")
+
+    report["ok"] = not report["failed"] and not report["missing_dists"]
+    print(json.dumps(report, default=str))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cognee/tests/journeys/test_extras_install_smoke.py
+++ b/cognee/tests/journeys/test_extras_install_smoke.py
@@ -1,0 +1,283 @@
+"""Journey 15: every install extra resolves, installs, and imports.
+
+Two tiers:
+
+* **Resolution** (always on, seconds): ``uv pip compile`` proves each extra
+  alone and all extras together have a consistent solution for every supported
+  Python version. If the full set fails, the pairs are bisected so the failure
+  names the two extras that conflict, e.g. ``docling-full`` vs ``codegraph``.
+
+* **Install smoke** (opt-in, ``COGNEE_JOURNEY_EXTRAS=1``): build the wheel once,
+  then for each extra create an empty venv, install ``cognee[extra]`` from the
+  wheel, and run ``extras_probe.py`` inside it: ``import cognee`` still works,
+  every top-level module of the extra's direct requirements imports, and the
+  cognee modules the extra enables import. Select a subset with
+  ``COGNEE_EXTRAS=neo4j,redis``; ``COGNEE_EXTRAS_SKIP`` defaults to extras that
+  compile from source (``llama-cpp``).
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    tomllib = None  # type: ignore[assignment]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HERE = Path(__file__).resolve().parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+SUPPORTED_PYTHONS = ("3.10", "3.11", "3.12", "3.13", "3.14")
+
+# Extras that compile native code from source (needs a toolchain, ~10 min).
+DEFAULT_SKIP = {"llama-cpp"}
+
+# The cognee modules an extra is meant to unlock. Import failure here means the
+# extra installs but the feature it advertises does not load.
+COGNEE_MODULES_BY_EXTRA: dict[str, list[str]] = {
+    "neo4j": ["cognee.infrastructure.databases.graph.neo4j_driver.adapter"],
+    "neptune": ["cognee.infrastructure.databases.graph.neptune_driver.adapter"],
+    "postgres": ["cognee.infrastructure.databases.vector.pgvector.PGVectorAdapter"],
+    "postgres-binary": ["cognee.infrastructure.databases.vector.pgvector.PGVectorAdapter"],
+    "turso": ["cognee.infrastructure.databases.relational.sqlalchemy.TursoAdapter"],
+    "fastembed": ["cognee.infrastructure.databases.vector.embeddings.FastembedEmbeddingEngine"],
+    "mistral": [
+        "cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mistral.adapter"
+    ],
+    "anthropic": [
+        "cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.anthropic.adapter"
+    ],
+    "azure": [
+        "cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.azure_openai.adapter"
+    ],
+    "llama-cpp": [
+        "cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llama_cpp.adapter"
+    ],
+    "huggingface": ["cognee.infrastructure.llm.tokenizer.HuggingFace.adapter"],
+    "ollama": ["cognee.infrastructure.llm.tokenizer.HuggingFace.adapter"],
+    "codegraph": ["cognee.infrastructure.llm.tokenizer.HuggingFace.adapter"],
+    "docling": ["cognee.infrastructure.loaders.external.docling_loader"],
+    "docling-full": ["cognee.infrastructure.loaders.external.docling_loader"],
+    "docs": ["cognee.infrastructure.loaders.external.unstructured_loader"],
+    "dlt": ["cognee.tasks.ingestion.create_dlt_source"],
+    "gmail": ["cognee.tasks.ingestion.create_dlt_source"],
+    "aws": ["cognee.infrastructure.files.storage.S3FileStorage"],
+    "redis": ["cognee.infrastructure.databases.cache.redis.RedisAdapter"],
+    "tracing": ["cognee.modules.observability.metrics"],
+    "graphiti": ["cognee.tasks.temporal_awareness.build_graph_with_temporal_awareness"],
+    "llama-index": ["cognee.tasks.ingestion.transform_data"],
+    "scraping": ["cognee.tasks.web_scraper.default_url_crawler"],
+    "deepeval": ["cognee.eval_framework.evaluation.deep_eval_adapter"],
+    "rapidocr": ["cognee.infrastructure.loaders.core.image_loader"],
+    "evals": ["cognee.eval_framework.metrics_dashboard"],
+}
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _extras() -> dict[str, list[str]]:
+    if tomllib is None:
+        pytest.skip("tomllib unavailable (Python 3.10 without tomli)")
+    with PYPROJECT.open("rb") as handle:
+        return dict(tomllib.load(handle)["project"]["optional-dependencies"])
+
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, **kwargs)
+
+
+def _resolve(extras: list[str], python_version: str, out: Path) -> subprocess.CompletedProcess:
+    cmd = [
+        "uv",
+        "pip",
+        "compile",
+        str(PYPROJECT),
+        "--quiet",
+        "--python-version",
+        python_version,
+        "-o",
+        str(out),
+    ]
+    for extra in extras:
+        cmd += ["--extra", extra]
+    return _run(cmd, cwd=REPO_ROOT)
+
+
+def _venv_bin(venv: Path, name: str) -> Path:
+    if platform.system() == "Windows":
+        return venv / "Scripts" / f"{name}.exe"
+    return venv / "bin" / name
+
+
+def _selected_extras() -> list[str]:
+    all_extras = [e for e in _extras() if e != "api" or _extras()["api"]]  # 'api' is empty
+    wanted = os.getenv("COGNEE_EXTRAS", "all").strip()
+    skip = {
+        s.strip()
+        for s in os.getenv("COGNEE_EXTRAS_SKIP", ",".join(DEFAULT_SKIP)).split(",")
+        if s.strip()
+    }
+    chosen = (
+        all_extras if wanted in ("", "all") else [e.strip() for e in wanted.split(",") if e.strip()]
+    )
+    unknown = sorted(set(chosen) - set(all_extras))
+    assert not unknown, f"COGNEE_EXTRAS names unknown extras: {unknown}"
+    return [e for e in chosen if e not in skip]
+
+
+# ---------------------------------------------------------------------------
+# tier 1: resolution (always on)
+# ---------------------------------------------------------------------------
+
+pytestmark = [
+    pytest.mark.journey,
+    pytest.mark.skipif(
+        shutil.which("uv") is None, reason="uv is required to resolve and install extras"
+    ),
+]
+
+
+@pytest.mark.parametrize("python_version", SUPPORTED_PYTHONS)
+def test_all_extras_resolve_together(tmp_path, python_version):
+    """One consistent solution for every extra at once means no pair conflicts."""
+    extras = sorted(_extras())
+    result = _resolve(extras, python_version, tmp_path / "all.txt")
+    if result.returncode == 0:
+        return
+
+    # Name the culprits: which pairs cannot coexist on this Python?
+    conflicting = []
+    for a, b in itertools.combinations(extras, 2):
+        pair = _resolve([a, b], python_version, tmp_path / f"{a}-{b}.txt")
+        if pair.returncode != 0:
+            conflicting.append(f"{a} + {b}")
+    alone = [
+        e for e in extras if _resolve([e], python_version, tmp_path / f"{e}.txt").returncode != 0
+    ]
+    pytest.fail(
+        f"cognee extras do not resolve together on Python {python_version}.\n"
+        + (f"  extras that fail alone: {alone}\n" if alone else "")
+        + (f"  conflicting pairs: {conflicting}\n" if conflicting else "")
+        + "uv output:\n"
+        + result.stderr[-3000:]
+    )
+
+
+def test_each_extra_resolves_alone(tmp_path):
+    """Per-extra check on the running interpreter's version with a readable failure."""
+    version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    failures = {}
+    for extra in sorted(_extras()):
+        result = _resolve([extra], version, tmp_path / f"{extra}.txt")
+        if result.returncode != 0:
+            failures[extra] = result.stderr[-1500:]
+    assert not failures, (
+        "extras that do not resolve on Python " + version + ":\n" + json.dumps(failures, indent=2)
+    )
+
+
+# ---------------------------------------------------------------------------
+# tier 2: install + import smoke (opt-in)
+# ---------------------------------------------------------------------------
+
+_INSTALL_SMOKE = pytest.mark.skipif(
+    os.getenv("COGNEE_JOURNEY_EXTRAS") != "1",
+    reason="set COGNEE_JOURNEY_EXTRAS=1 to build the wheel and install every extra in its own venv",
+)
+
+
+@pytest.fixture(scope="module")
+def wheel(tmp_path_factory) -> Path:
+    dist = tmp_path_factory.mktemp("extras-dist")
+    build = _run(["uv", "build", "--wheel", "--out-dir", str(dist)], cwd=REPO_ROOT)
+    assert build.returncode == 0, f"uv build failed:\n{build.stdout}\n{build.stderr}"
+    wheels = sorted(dist.glob("cognee-*.whl"))
+    assert wheels, f"no wheel produced in {dist}"
+    return wheels[-1]
+
+
+def _extra_ids() -> list[str]:
+    # Evaluated at collection so the parametrize ids are the extra names.
+    try:
+        return _selected_extras()
+    except Exception:
+        return []
+
+
+@_INSTALL_SMOKE
+@pytest.mark.parametrize("extra", _extra_ids())
+def test_extra_installs_and_imports(extra, wheel, tmp_path_factory):
+    requirements = _extras()[extra]
+    work = tmp_path_factory.mktemp(f"extra-{extra}")
+    venv = work / "venv"
+
+    create = _run(["uv", "venv", str(venv), "--python", sys.executable])
+    assert create.returncode == 0, f"uv venv failed:\n{create.stderr[-2000:]}"
+    python = _venv_bin(venv, "python")
+
+    spec = (
+        f"cognee[{extra}] @ {wheel.resolve().as_uri()}"
+        if requirements
+        else f"cognee @ {wheel.resolve().as_uri()}"
+    )
+    install = _run(["uv", "pip", "install", "--python", str(python), spec])
+    assert install.returncode == 0, (
+        f"`pip install cognee[{extra}]` fails for a user:\n{install.stderr[-4000:]}"
+    )
+
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith(("LLM_", "EMBEDDING_", "COGNEE_"))
+        and k not in ("PYTHONPATH", "VIRTUAL_ENV")
+    }
+    env.update(
+        {
+            "DATA_ROOT_DIRECTORY": str(work / "data"),
+            "SYSTEM_ROOT_DIRECTORY": str(work / "system"),
+            "TELEMETRY_DISABLED": "1",
+            "LLM_API_KEY": "smoke-key",
+            "COGNEE_SKIP_PREFLIGHT": "1",
+        }
+    )
+    probe = _run(
+        [
+            str(python),
+            str(HERE / "extras_probe.py"),
+            "--extra",
+            extra,
+            "--requirements",
+            json.dumps(requirements),
+            "--cognee-modules",
+            json.dumps(COGNEE_MODULES_BY_EXTRA.get(extra, [])),
+        ],
+        env=env,
+        cwd=work,
+    )
+    lines = [line for line in probe.stdout.strip().splitlines() if line.startswith("{")]
+    assert lines, (
+        f"probe printed no report for [{extra}]:\n{probe.stdout[-2000:]}\n{probe.stderr[-3000:]}"
+    )
+    report = json.loads(lines[-1])
+
+    assert report["ok"], (
+        f"cognee[{extra}] installs but does not import cleanly.\n"
+        f"  failed imports: {json.dumps({k: v['error'] for k, v in report['failed'].items()}, indent=2)}\n"
+        f"  requirements with no installed distribution: {report['missing_dists']}\n"
+        f"  stderr tail:\n{probe.stderr[-2000:]}"
+    )
+    assert "cognee" in report["imported"]

--- a/cognee/tests/journeys/test_mcp_journey.py
+++ b/cognee/tests/journeys/test_mcp_journey.py
@@ -1,0 +1,336 @@
+"""Journey 9: the MCP server the way an agent client uses it.
+
+Spawns ``cognee-mcp`` over stdio exactly like Claude Code or Codex would, lists
+the tools, remembers into a fresh system inside a session (the first-session
+dataset-creation regression, SDK-192), recalls it back, remembers permanently,
+recalls from the graph, and checks the status tool. Then starts the same server
+over HTTP and recalls the session fact again, proving state persisted across
+transports. A stray print to stdout in stdio mode would corrupt the protocol and
+fail the handshake, so a green run also proves stdout carries only frames.
+
+Requires the ``mcp`` client and ``fastmcp`` in the running interpreter
+(``uv run --with fastmcp --with mcp pytest ...``); skips otherwise.
+
+In mock mode the server subprocess gets the deterministic AI stand-ins through a
+``sitecustomize.py`` on ``PYTHONPATH`` so no network or key is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from cognee.tests.journeys import _support
+
+mcp = pytest.importorskip("mcp", reason="mcp client library not installed")
+pytest.importorskip("fastmcp", reason="fastmcp (server runtime) not installed")
+
+from mcp import ClientSession, StdioServerParameters  # noqa: E402
+from mcp.client.stdio import stdio_client  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HERE = Path(__file__).resolve().parent
+SERVER = REPO_ROOT / "cognee-mcp" / "src" / "server.py"
+
+DATASET = "mcp_journey"
+SESSION_FACT = (
+    "The Ashcombe signal box was staffed by Wilhelmina Prost until the line closed in 1994."
+)
+PERMANENT_FACT = (
+    "Title: Ashcombe Ropeworks\n\nThe Ashcombe Ropeworks was founded by Cassius Delacroix-Nwosu and "
+    "still twists hemp by hand."
+)
+
+pytestmark = [
+    pytest.mark.journey,
+    pytest.mark.skipif(not SERVER.exists(), reason="cognee-mcp not in tree"),
+]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _text(result) -> str:
+    parts = []
+    for item in getattr(result, "content", []) or []:
+        text = getattr(item, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+    return "\n".join(parts)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _server_env(work: Path) -> dict:
+    """Environment for the server subprocess: isolated roots, mocks in mock mode."""
+    env = {k: v for k, v in os.environ.items() if k not in ("PYTHONPATH", "VIRTUAL_ENV")}
+    env.update(
+        {
+            "DATA_ROOT_DIRECTORY": str(work / "data"),
+            "SYSTEM_ROOT_DIRECTORY": str(work / "system"),
+            "TELEMETRY_DISABLED": "1",
+            "ENV": "dev",
+        }
+    )
+    pythonpath = [str(REPO_ROOT)]
+    if _support.IS_MOCK:
+        shim = work / "shim"
+        shim.mkdir(exist_ok=True)
+        (shim / "mock_ai.py").write_bytes((HERE / "mock_ai.py").read_bytes())
+        (shim / "sitecustomize.py").write_text(
+            "import os, sys\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import mock_ai\n"
+            "mock_ai.install_all()\n"
+        )
+        pythonpath.insert(0, str(shim))
+        env.update(
+            {
+                "LLM_API_KEY": "mock-key",
+                "LLM_PROVIDER": "openai",
+                "LLM_MODEL": "openai/gpt-5-mini",
+                "EMBEDDING_PROVIDER": "openai",
+                "EMBEDDING_MODEL": "openai/text-embedding-3-small",
+                "EMBEDDING_DIMENSIONS": "256",
+                "EMBEDDING_API_KEY": "mock-key",
+                "COGNEE_SKIP_PREFLIGHT": "1",
+                "COGNEE_SKIP_CONNECTION_TEST": "true",
+            }
+        )
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath)
+    return env
+
+
+def _dataset_names(env: dict) -> list[str]:
+    """Dataset names as a fresh process on the same roots sees them."""
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import asyncio, json, cognee\n"
+            "async def main():\n"
+            "    rows = await cognee.datasets.list_datasets()\n"
+            "    print('DATASETS=' + json.dumps([d.name for d in rows]))\n"
+            "asyncio.run(main())",
+        ],
+        env=env,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    for line in probe.stdout.splitlines():
+        if line.startswith("DATASETS="):
+            import json
+
+            return json.loads(line[len("DATASETS=") :])
+    raise AssertionError(f"dataset probe failed:\n{probe.stdout[-1000:]}\n{probe.stderr[-2000:]}")
+
+
+@pytest.fixture
+def work(tmp_path) -> Path:
+    return Path(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# stdio: the Claude Code / Codex path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stdio_client_journey(work):
+    env = _server_env(work)
+    stderr_path = work / "server.stderr"
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=[str(SERVER), "--transport", "stdio"],
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+    session_id = f"mcp-journey-{uuid.uuid4().hex[:8]}"
+
+    with stderr_path.open("w") as errlog:
+        async with stdio_client(params, errlog=errlog) as (read, write):
+            async with ClientSession(read, write) as session:
+                await asyncio.wait_for(session.initialize(), timeout=120)
+
+                # --- the memory API is advertised -----------------------------------
+                tools = {tool.name for tool in (await session.list_tools()).tools}
+                for required in ("remember", "recall", "forget"):
+                    assert required in tools, (
+                        f"tool {required!r} not advertised; got {sorted(tools)}"
+                    )
+
+                # --- first ever remember on a fresh system, inside a session ----------
+                remembered = await session.call_tool(
+                    "remember",
+                    arguments={
+                        "data": SESSION_FACT,
+                        "session_id": session_id,
+                        "dataset_name": DATASET,
+                    },
+                )
+                assert not remembered.isError, _text(remembered)
+                assert "session" in _text(remembered).lower(), _text(remembered)
+
+                recalled = await session.call_tool(
+                    "recall",
+                    arguments={
+                        "query": "Who staffed the Ashcombe signal box?",
+                        "session_id": session_id,
+                    },
+                )
+                assert not recalled.isError, _text(recalled)
+                assert "prost" in _text(recalled).lower(), (
+                    f"session recall over MCP did not return the fact: {_text(recalled)[:400]}"
+                )
+
+                # The session remember created its dataset up front (SDK-192):
+                # visible to any other process on the same roots before any build.
+                assert DATASET in _dataset_names(env), (
+                    "session remember did not create its dataset before the background bridge"
+                )
+
+                # --- permanent memory: remember runs the build, recall reads the graph --
+                permanent = await session.call_tool(
+                    "remember", arguments={"data": PERMANENT_FACT, "dataset_name": DATASET}
+                )
+                assert not permanent.isError, _text(permanent)
+
+                from_graph = await session.call_tool(
+                    "recall",
+                    arguments={"query": "Who founded the Ashcombe Ropeworks?", "datasets": DATASET},
+                )
+                assert not from_graph.isError, _text(from_graph)
+                assert "delacroix" in _text(from_graph).lower(), (
+                    f"graph recall over MCP did not return the fact: {_text(from_graph)[:400]}"
+                )
+
+                # --- status tool answers, forget validates its arguments ---------------
+                status = await session.call_tool("cognify_status", arguments={})
+                assert not status.isError, _text(status)
+                assert _text(status).strip(), "cognify_status returned no text"
+
+                bad_forget = await session.call_tool("forget", arguments={})
+                assert "dataset" in _text(bad_forget).lower() or bad_forget.isError, (
+                    "forget with no target neither errored nor explained itself"
+                )
+
+    stderr = stderr_path.read_text(errors="ignore")
+    assert "Traceback" not in stderr, f"server logged a traceback:\n{stderr[-3000:]}"
+
+
+# ---------------------------------------------------------------------------
+# HTTP: the hosted / shared path, reading state written over stdio
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_http_client_reads_state_written_over_stdio(work):
+    try:
+        from mcp.client.streamable_http import streamable_http_client as _http_client
+    except ImportError:
+        try:
+            from mcp.client.streamable_http import streamablehttp_client as _http_client
+        except ImportError:  # pragma: no cover - old mcp
+            pytest.skip("mcp client lacks streamable HTTP support")
+
+    env = _server_env(work)
+    session_id = f"mcp-journey-{uuid.uuid4().hex[:8]}"
+
+    # Write over stdio first.
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=[str(SERVER), "--transport", "stdio"],
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+    with (work / "stdio.stderr").open("w") as errlog:
+        async with stdio_client(params, errlog=errlog) as (read, write):
+            async with ClientSession(read, write) as session:
+                await asyncio.wait_for(session.initialize(), timeout=120)
+                remembered = await session.call_tool(
+                    "remember",
+                    arguments={
+                        "data": SESSION_FACT,
+                        "session_id": session_id,
+                        "dataset_name": DATASET,
+                    },
+                )
+                assert not remembered.isError, _text(remembered)
+
+    # Then read over HTTP from a separate server process on the same roots.
+    port = _free_port()
+    with (work / "http.log").open("w") as log:
+        proc = subprocess.Popen(
+            [
+                str(sys.executable),
+                str(SERVER),
+                "--transport",
+                "http",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+            ],
+            env=env,
+            cwd=str(REPO_ROOT),
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            import httpx
+
+            deadline = time.monotonic() + 120
+            healthy = False
+            while time.monotonic() < deadline and proc.poll() is None:
+                try:
+                    if httpx.get(f"http://127.0.0.1:{port}/health", timeout=3).status_code == 200:
+                        healthy = True
+                        break
+                except Exception:
+                    pass
+                await asyncio.sleep(1)
+            assert healthy, (
+                f"MCP HTTP server did not become healthy:\n{(work / 'http.log').read_text()[-3000:]}"
+            )
+
+            async with _http_client(f"http://127.0.0.1:{port}/mcp") as (read, write, *_):
+                async with ClientSession(read, write) as session:
+                    await asyncio.wait_for(session.initialize(), timeout=60)
+                    tools = {tool.name for tool in (await session.list_tools()).tools}
+                    assert {"remember", "recall"} <= tools, sorted(tools)
+                    recalled = await session.call_tool(
+                        "recall",
+                        arguments={
+                            "query": "Who staffed the Ashcombe signal box?",
+                            "session_id": session_id,
+                        },
+                    )
+                    assert not recalled.isError, _text(recalled)
+                    assert "prost" in _text(recalled).lower(), (
+                        f"fact written over stdio was not readable over HTTP: {_text(recalled)[:400]}"
+                    )
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+    log_text = (work / "http.log").read_text(errors="ignore")
+    assert "Traceback" not in log_text, f"HTTP server logged a traceback:\n{log_text[-3000:]}"


### PR DESCRIPTION
## Summary

Two more product journeys, stacked on #4938 (which is stacked on #4932). Base is the nightly branch because the new CI jobs use its `mode` input.

### Journey 15: extras install smoke (`test_extras_install_smoke.py`)

**Resolution tier, always on.** `uv pip compile` proves every extra alone, and all extras together, resolve on Python 3.10 through 3.14. If the full set ever fails, the test bisects pairs and names the two extras that conflict. This is the check that would have caught docling-full vs codegraph at PR time. It takes seconds.

**Install tier, opt-in.** Build the wheel once, then for each extra: empty venv, `pip install cognee[extra]` from the wheel, run `extras_probe.py` inside it. The probe imports `cognee`, every top-level module shipped by the extra's direct requirements (mapping read from `importlib.metadata` in the venv, so there is no hand-maintained table to drift), and the cognee modules the extra is meant to enable (Neo4j adapter for `neo4j`, PGVector adapter for `postgres`, and so on).

CI runs it as six matrix shards covering every extra except `llama-cpp`, which compiles from source.

### Journey 9: MCP as a client uses it (`test_mcp_journey.py`)

Spawns `cognee-mcp/src/server.py --transport stdio` exactly as Claude Code does, then:

- tool surface advertises `remember`, `recall`, `forget`
- a **session** remember on a fresh system creates its dataset before the background bridge (the SDK-192 regression), verified from a separate process on the same roots
- session recall returns the fact; permanent remember runs the build; graph recall returns the second fact
- `cognify_status` answers; `forget` without a target explains itself
- server stderr contains no traceback

A stray print to stdout in stdio mode would corrupt the protocol and fail the handshake, so a green run also proves the channel is clean. A second test starts the server over HTTP on the same roots and recalls the fact written over stdio.

Mock mode injects the deterministic AI stand-ins into the server subprocess through a `sitecustomize.py` on `PYTHONPATH`. No network, no key.

### CI

- `mcp` job: `uv run --with fastmcp --with mcp pytest …`, runs in both modes
- `extras-install` matrix: mock mode only, since it is provider-independent
- the main journeys job now also runs the extras resolution tier

### Local results

| Check | Result |
|---|---|
| Extras resolve alone + together, Python 3.10–3.14 | 6 passed in 8s |
| Install smoke: neo4j, redis, tracing, anthropic, postgres-binary, docling | 6 passed in 2m05s |
| MCP stdio journey + HTTP journey (mock) | 2 passed in 40s |

## Test plan

- [x] Resolution tier and a six-extra install sample locally (above)
- [x] MCP stdio + HTTP journeys locally with the cognee-mcp venv (fastmcp 3.4.6)
- [x] Workflow YAML parses; matrix covers every extra exactly once (checked by script)
- [ ] Full extras matrix and `postgres` (source build) on the ubuntu runner: first CI run of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
