### PR TITLE
SDK-572 fix(mcp): remove unreachable list_data helper

### DIFF
--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -476,7 +476,7 @@ docker run \
 **API Mode behavior:**
 The MCP server intentionally exposes only the memory API: `remember`, `recall`, and `forget`.
 In API mode these tools call the Cognee API server endpoints directly. Operational helpers such as
-`cognify`, `search`, `list_data`, `delete`, `prune`, `improve`, and document retrieval helpers are
+`cognify`, `search`, `delete`, `prune`, `improve`, and document retrieval helpers are
 kept internal and are not exposed as MCP tools.
 
 ## 💻 Basic Usage

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -750,7 +750,7 @@ async def get_document(
     """
     Retrieve a complete source document and its chunks from the knowledge graph.
 
-    Use this after a CHUNKS search or list_data lookup when you need the full source
+    Use this after a CHUNKS search when you need the full source
     context around a result. If a chunk ID is provided instead of a document ID, the
     tool resolves the chunk's parent document and returns that document.
 
@@ -825,134 +825,6 @@ async def get_chunk_neighbors(
             error_msg = f"get_chunk_neighbors failed: {str(e)}"
             logger.error(error_msg)
             return [types.TextContent(type="text", text=f"Error: {error_msg}")]
-
-
-@log_usage(function_name="MCP list_data", log_type="mcp_tool")
-async def list_data(dataset_id: str = None) -> list:
-    """
-    List all datasets and their data items with IDs for deletion operations.
-
-    This function helps users identify data IDs and dataset IDs that can be used
-    with the delete tool. It provides a comprehensive view of available data.
-
-    Parameters
-    ----------
-    dataset_id : str, optional
-        If provided, only list data items from this specific dataset.
-        If None, lists all datasets and their data items.
-        Should be a valid UUID string.
-
-    Returns
-    -------
-    list
-        A list containing a single TextContent object with formatted information
-        about datasets and data items, including their IDs for deletion.
-
-    Notes
-    -----
-    - Use this tool to identify data_id and dataset_id values for the delete tool
-    - The output includes both dataset information and individual data items
-    - UUIDs are displayed in a format ready for use with other tools
-    """
-    from uuid import UUID
-
-    with redirect_stdout(sys.stderr):
-        try:
-            output_lines = []
-
-            if dataset_id:
-                # Detailed data listing for specific dataset is only available in direct mode
-                if cognee_client.use_api:
-                    return [
-                        types.TextContent(
-                            type="text",
-                            text="❌ Detailed data listing for specific datasets is not available in API mode.\nPlease use the API directly or use direct mode.",
-                        )
-                    ]
-
-                from cognee.modules.users.methods import get_default_user
-                from cognee.modules.data.methods import get_dataset, get_dataset_data
-
-                logger.info(f"Listing data for dataset: {dataset_id}")
-                dataset_uuid = UUID(dataset_id)
-                user = await get_default_user()
-
-                dataset = await get_dataset(user.id, dataset_uuid)
-
-                if not dataset:
-                    return [
-                        types.TextContent(type="text", text=f"❌ Dataset not found: {dataset_id}")
-                    ]
-
-                # Get data items in the dataset
-                data_items = await get_dataset_data(dataset.id)
-
-                output_lines.append(f"📁 Dataset: {dataset.name}")
-                output_lines.append(f"   ID: {dataset.id}")
-                output_lines.append(f"   Created: {dataset.created_at}")
-                output_lines.append(f"   Data items: {len(data_items)}")
-                output_lines.append("")
-
-                if data_items:
-                    for i, data_item in enumerate(data_items, 1):
-                        output_lines.append(f"   📄 Data item #{i}:")
-                        output_lines.append(f"      Data ID: {data_item.id}")
-                        output_lines.append(f"      Name: {data_item.name or 'Unnamed'}")
-                        output_lines.append(f"      Created: {data_item.created_at}")
-                        output_lines.append("")
-                else:
-                    output_lines.append("   (No data items in this dataset)")
-
-            else:
-                # List all datasets - works in both modes
-                logger.info("Listing all datasets")
-                datasets = await cognee_client.list_datasets()
-
-                if not datasets:
-                    return [
-                        types.TextContent(
-                            type="text",
-                            text="📂 No datasets found.\nUse the cognify tool to create your first dataset!",
-                        )
-                    ]
-
-                output_lines.append("📂 Available Datasets:")
-                output_lines.append("=" * 50)
-                output_lines.append("")
-
-                for i, dataset in enumerate(datasets, 1):
-                    # In API mode, dataset is a dict; in direct mode, it's formatted as dict
-                    if isinstance(dataset, dict):
-                        output_lines.append(f"{i}. 📁 {dataset.get('name', 'Unnamed')}")
-                        output_lines.append(f"   Dataset ID: {dataset.get('id')}")
-                        output_lines.append(f"   Created: {dataset.get('created_at', 'N/A')}")
-                    else:
-                        output_lines.append(f"{i}. 📁 {dataset.name}")
-                        output_lines.append(f"   Dataset ID: {dataset.id}")
-                        output_lines.append(f"   Created: {dataset.created_at}")
-                    output_lines.append("")
-
-                if not cognee_client.use_api:
-                    output_lines.append("💡 To see data items in a specific dataset, use:")
-                    output_lines.append('   list_data(dataset_id="your-dataset-id-here")')
-                    output_lines.append("")
-                output_lines.append("🗑️  To delete specific data, use:")
-                output_lines.append('   delete(data_id="data-id", dataset_id="dataset-id")')
-
-            result_text = "\n".join(output_lines)
-            logger.info("List data operation completed successfully")
-
-            return [types.TextContent(type="text", text=result_text)]
-
-        except ValueError as e:
-            error_msg = f"❌ Invalid UUID format: {str(e)}"
-            logger.error(error_msg)
-            return [types.TextContent(type="text", text=error_msg)]
-
-        except Exception as e:
-            error_msg = f"❌ Failed to list data: {str(e)}"
-            logger.error(f"List data error: {str(e)}")
-            return [types.TextContent(type="text", text=error_msg)]
 
 
 @log_usage(function_name="MCP delete_dataset", log_type="mcp_tool")


### PR DESCRIPTION
## Summary

Closes SDK-572.

`cognee-mcp/src/server.py` defined `list_data(dataset_id=None)` decorated with `@log_usage(function_name="MCP list_data", log_type="mcp_tool")` but never registered it with the tool registry, and nothing in the server called it. Since `fix(cognee-mcp): expose only memory tools` the operational helpers are intentionally internal, but this one was not used internally either, so it was dead code with two user-visible side effects:

- its own output told users to call `list_data(dataset_id="...")`, which the server answers with `Unknown tool: 'list_data'`
- the `get_document` docstring described a "list_data lookup" step that does not exist

Found by the MCP client journey (`cognee/tests/journeys/test_mcp_journey.py`, #4939), whose direct call to the tool returned `Unknown tool`.

### Change

- Delete `list_data` (128 lines) and its decorator.
- Drop the stale mention from the `get_document` docstring.
- Remove `list_data` from the README's list of internal helpers.

No tool surface change: `test_mcp_exposes_only_memory_tools` and the tool-search tests are unaffected.

### Worth a product call (not done here)

`save_interaction`, `search`, `get_document`, `get_chunk_neighbors`, `delete_dataset`, `prune` and `improve` are in the same state: usage-logged, unregistered, and with no internal call sites. `cognify` and `delete` are used by `remember` and `forget`. Deleting the rest, or re-exposing them as hidden searchable tools like `cognify_status`, is tracked in SDK-572's notes.

## Test plan

- [x] `pytest cognee-mcp/tests` → 80 passed
- [x] `ruff check` / `ruff format --check` clean
- [x] No remaining `list_data` references in `cognee-mcp` (`list_datasets` on the client is a different method and untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
