### PR TITLE
feat(memory): add permission-checked promotion (SDK-573)

### DIFF
--- a/cognee/__init__.py
+++ b/cognee/__init__.py
@@ -35,6 +35,7 @@ logger = setup_logging()
 # V1 API
 # ---------------------------------------------------------------------------
 from .api.v1.add import add
+from .api.v1.promote import promote, PromotionResult
 from .api.v1.delete import delete
 from .api.v1.cognify import cognify
 from .modules.memify import memify

--- a/cognee/api/v1/integrations/routers/get_integrations_router.py
+++ b/cognee/api/v1/integrations/routers/get_integrations_router.py
@@ -40,7 +40,7 @@ from typing import Optional
 from urllib.parse import quote
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse
 from fastapi_users.exceptions import UserAlreadyExists
 from sqlalchemy.exc import IntegrityError
@@ -367,7 +367,12 @@ def get_integrations_router():
 
     @integrations_router.post("/plugins/{plugin_key}/provision")
     async def provision_plugin(
-        plugin_key: str, user: User = Depends(get_authenticated_user)
+        plugin_key: str,
+        user: User = Depends(get_authenticated_user),
+        create_only: bool = Query(
+            False,
+            description="Create only; existing identities return 409 without key rotation.",
+        ),
     ) -> PluginProvisionDTO:
         """Provision (or re-key) a dedicated agent identity for a plugin.
 
@@ -376,6 +381,10 @@ def get_integrations_router():
         returns the same agent but rotates the key (old keys are revoked —
         re-provision *is* the rotation flow). The returned key is shown once
         and never retrievable again.
+
+        Automatic clients must use ``create_only=true``. Existing identities
+        (including concurrent first-create losers) then return 409 without
+        revoking keys. Omitting it preserves explicit legacy rotation behavior.
 
         ## Path Parameters
         - **plugin_key** (str): Key of a known plugin (see GET /api/v1/integrations/status).
@@ -403,6 +412,11 @@ def get_integrations_router():
                     raise HTTPException(
                         status_code=409,
                         detail=f"Plugin agent for {plugin_key!r} exists but could not be resolved.",
+                    )
+                if create_only:
+                    raise HTTPException(
+                        status_code=409,
+                        detail="Plugin identity exists; explicit reconnect is required.",
                     )
                 api_key = await _rotate_agent_api_key(agent_user, plugin_key)
 

--- a/cognee/api/v1/promote/__init__.py
+++ b/cognee/api/v1/promote/__init__.py
@@ -1,0 +1,3 @@
+from .promote import PromotionResult, promote
+
+__all__ = ["PromotionResult", "promote"]

--- a/cognee/api/v1/promote/promote.py
+++ b/cognee/api/v1/promote/promote.py
@@ -114,8 +114,9 @@ async def promote(
     share permissions, and target write permission; ancestry is not authority.
 
     Agents choose which persisted document to promote and why. Inspect the
-    selected document: a persisted session window can contain several entries. This operation never grants itself
-    permissions, impersonates the target owner, copies other memories, or runs
+    selected document: a persisted session window can contain several entries.
+    This operation never grants itself permissions, impersonates the target
+    owner, copies other memories, or runs
     an LLM. Session entries must first be persisted with improve(). The copied
     document is ingest-complete; call cognify(datasets=[target_dataset_id],
     user=user) explicitly to make it searchable in the destination graph.

--- a/cognee/api/v1/promote/promote.py
+++ b/cognee/api/v1/promote/promote.py
@@ -8,7 +8,6 @@ from typing import Literal
 from uuid import NAMESPACE_URL, UUID, uuid4, uuid5
 
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
 
 from cognee.base_config import get_base_config
 from cognee.infrastructure.databases.relational import get_relational_engine
@@ -80,18 +79,30 @@ async def _persist_copy(row, content, provenance, actor, target, target_id) -> b
             await session.commit()
         return True
     except Exception as error:
+        # A failed commit acknowledgement does not prove rollback. Re-read
+        # before deleting the object: the committed row might reference it.
         try:
-            await storage.remove(relative)
-        except Exception:  # noqa: BLE001 - cleanup must preserve the original persistence error
-            get_logger("promotion").exception("Could not clean an uncommitted promotion object")
-        if isinstance(error, IntegrityError):
             winner = await _get_data(target_id, target.id)
-            if (
-                winner is not None
-                and (winner.system_metadata or {}).get("promotion", {}).get("source_revision")
-                == provenance["source_revision"]
-            ):
-                return False
+        except Exception as lookup_error:
+            get_logger("promotion").warning(
+                "Promotion commit could not be verified; retaining its storage object"
+            )
+            raise error from lookup_error
+        referenced = winner is not None and location in (
+            winner.raw_data_location,
+            winner.original_data_location,
+        )
+        if not referenced:
+            try:
+                await storage.remove(relative)
+            except Exception:  # noqa: BLE001 - preserve the original persistence error
+                get_logger("promotion").exception("Could not clean an uncommitted promotion object")
+        if (
+            winner is not None
+            and (winner.system_metadata or {}).get("promotion", {}).get("source_revision")
+            == provenance["source_revision"]
+        ):
+            return referenced
         raise
 
 

--- a/cognee/api/v1/promote/promote.py
+++ b/cognee/api/v1/promote/promote.py
@@ -1,0 +1,203 @@
+"""Explicit, permission-checked promotion of one persisted memory snapshot."""
+
+import hashlib
+import io
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Literal
+from uuid import NAMESPACE_URL, UUID, uuid4, uuid5
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from cognee.base_config import get_base_config
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.infrastructure.files.storage import get_file_storage
+from cognee.infrastructure.files.utils.open_data_file import open_data_file
+from cognee.modules.data.methods.get_authorized_dataset import get_authorized_dataset
+from cognee.modules.data.models import Data
+from cognee.modules.users.methods import get_user
+from cognee.modules.users.models import User
+from cognee.modules.users.permissions.methods.get_principal import get_principal
+from cognee.modules.users.permissions.methods.get_principal_datasets import get_principal_datasets
+from cognee.shared.logging_utils import get_logger
+
+
+@dataclass(frozen=True)
+class PromotionResult:
+    source_data_id: UUID
+    target_data_id: UUID
+    source_dataset_id: UUID
+    target_dataset_id: UUID
+    level: str
+    status: Literal["planned", "copied", "already_promoted"]
+
+
+async def _get_data(data_id: UUID, dataset_id: UUID) -> Data | None:
+    async with get_relational_engine().get_async_session() as session:
+        return (
+            await session.execute(
+                select(Data).where(Data.id == data_id, Data.dataset_id == dataset_id)
+            )
+        ).scalar_one_or_none()
+
+
+async def _persist_copy(row, content, provenance, actor, target, target_id) -> bool:
+    """Insert only: a concurrent retry must never UPDATE an existing memory."""
+    storage = get_file_storage(get_base_config().data_root_directory)
+    extension = str(row.extension or "txt").lstrip(".")
+    if not extension.isalnum():
+        extension = "txt"
+    # Each attempt gets its own object. The DB primary key selects the winner;
+    # concurrent writers never overwrite each other's storage or user edits.
+    relative = f"{actor.id}/promotions/{target.id}/{uuid4().hex}.{extension}"
+    location = await storage.store(relative, io.BytesIO(content))
+    copied = Data(
+        id=target_id,
+        dataset_id=target.id,
+        owner_id=actor.id,
+        tenant_id=target.tenant_id,
+        name=row.name,
+        label=row.label,
+        extension=extension,
+        mime_type=row.mime_type,
+        original_extension=extension,
+        original_mime_type=row.mime_type,
+        loader_engine=row.loader_engine,
+        raw_data_location=location,
+        original_data_location=location,
+        content_hash=row.raw_content_hash,
+        raw_content_hash=row.raw_content_hash,
+        data_size=len(content),
+        token_count=-1,
+        external_metadata=row.external_metadata,
+        system_metadata={"promotion": provenance},
+        pipeline_status={},
+    )
+    try:
+        async with get_relational_engine().get_async_session() as session:
+            session.add(copied)
+            await session.commit()
+        return True
+    except Exception as error:
+        try:
+            await storage.remove(relative)
+        except Exception:  # noqa: BLE001 - cleanup must preserve the original persistence error
+            get_logger("promotion").exception("Could not clean an uncommitted promotion object")
+        if isinstance(error, IntegrityError):
+            winner = await _get_data(target_id, target.id)
+            if (
+                winner is not None
+                and (winner.system_metadata or {}).get("promotion", {}).get("source_revision")
+                == provenance["source_revision"]
+            ):
+                return False
+        raise
+
+
+async def promote(
+    data_id: UUID,
+    *,
+    source_dataset_id: UUID,
+    target_dataset_id: UUID,
+    level: Literal["user", "team"],
+    reason: str,
+    user: User,
+    dry_run: bool = False,
+    max_bytes: int = 64 * 1024 * 1024,
+) -> PromotionResult:
+    """Copy selected persisted memory upward, without changing source ACLs.
+
+    ``level='user'`` permits an agent-owned dataset -> its parent's dataset.
+    ``level='team'`` permits a human-owned dataset -> a dataset already shared
+    for reading with the current tenant. The caller needs source read AND
+    share permissions, and target write permission; ancestry is not authority.
+
+    Agents choose which persisted document to promote and why. Inspect the
+    selected document: a persisted session window can contain several entries. This operation never grants itself
+    permissions, impersonates the target owner, copies other memories, or runs
+    an LLM. Session entries must first be persisted with improve(). The copied
+    document is ingest-complete; call cognify(datasets=[target_dataset_id],
+    user=user) explicitly to make it searchable in the destination graph.
+
+    Retries of the same source revision and destination return the same data
+    ID without overwriting destination edits. Changed source content produces a
+    new snapshot. Source edits/deletion do not propagate to promoted copies.
+    ``dry_run`` performs authorization and relationship checks without writes.
+    """
+    if level not in ("user", "team") or not reason.strip() or max_bytes <= 0:
+        raise ValueError("A user/team level, nonempty reason and positive max_bytes are required")
+    data_id, source_dataset_id, target_dataset_id = map(
+        UUID, map(str, (data_id, source_dataset_id, target_dataset_id))
+    )
+    if source_dataset_id == target_dataset_id:
+        raise ValueError("Promotion requires different source and target datasets")
+    if user is None:
+        raise ValueError("Promotion requires an explicit authenticated user")
+    actor = await get_user(user.id)
+    source = await get_authorized_dataset(actor, source_dataset_id, "read")
+    shareable = await get_authorized_dataset(actor, source_dataset_id, "share")
+    target = await get_authorized_dataset(actor, target_dataset_id, "write")
+    if source is None or target is None or shareable is None:
+        raise ValueError("Source or target dataset is unavailable")
+    source_owner = await get_user(source.owner_id)
+    if level == "user":
+        if source_owner.parent_user_id != target.owner_id:
+            raise ValueError("User promotion must target the source agent's parent")
+    else:
+        if source_owner.parent_user_id is not None:
+            raise ValueError("Promote agent memory to its user before promoting to a team")
+        if not actor.tenant_id or target.tenant_id != actor.tenant_id:
+            raise ValueError("Team promotion must stay in the caller's current tenant")
+        tenant = await get_principal(actor.tenant_id)
+        team_datasets = await get_principal_datasets(tenant, "read")
+        if target.id not in {dataset.id for dataset in team_datasets}:
+            raise ValueError("Target is not shared for reading with this team")
+    row = await _get_data(data_id, source_dataset_id)
+    if row is None:
+        raise ValueError("Selected memory is unavailable in the source dataset")
+    stored_digest = row.raw_content_hash
+    if not stored_digest:
+        raise ValueError("Source memory lacks a content revision; re-ingest before promotion")
+    async with open_data_file(row.raw_data_location, "rb") as stream:
+        content = stream.read(max_bytes + 1)
+    if len(content) > max_bytes:
+        raise ValueError("Selected memory exceeds max_bytes")
+    if hashlib.md5(content).hexdigest() != stored_digest:
+        raise ValueError("Source changed during promotion; retry with the current revision")
+    revision = hashlib.sha256(content).hexdigest()
+    target_id = uuid5(
+        NAMESPACE_URL,
+        f"cognee:promotion:v1:{source_dataset_id}:{data_id}:{revision}:{target_dataset_id}",
+    )
+    base = {
+        "source_data_id": data_id,
+        "target_data_id": target_id,
+        "source_dataset_id": source_dataset_id,
+        "target_dataset_id": target_dataset_id,
+        "level": level,
+    }
+    existing = await _get_data(target_id, target_dataset_id)
+    if existing is not None:
+        provenance = (existing.system_metadata or {}).get("promotion", {})
+        if (
+            provenance.get("source_data_id") != str(data_id)
+            or provenance.get("source_revision") != revision
+        ):
+            raise ValueError("Destination ID conflicts with a different memory")
+        return PromotionResult(**base, status="already_promoted")
+    if dry_run:
+        return PromotionResult(**base, status="planned")
+    provenance = {
+        "source_data_id": str(data_id),
+        "source_dataset_id": str(source_dataset_id),
+        "source_revision": revision,
+        "target_dataset_id": str(target_dataset_id),
+        "promoted_by": str(actor.id),
+        "level": level,
+        "reason": reason.strip(),
+        "promoted_at": datetime.now(timezone.utc).isoformat(),
+        "previous": (row.system_metadata or {}).get("promotion"),
+    }
+    created = await _persist_copy(row, content, provenance, actor, target, target_id)
+    return PromotionResult(**base, status="copied" if created else "already_promoted")

--- a/cognee/api/v1/promote/promote.py
+++ b/cognee/api/v1/promote/promote.py
@@ -106,6 +106,30 @@ async def _persist_copy(row, content, provenance, actor, target, target_id) -> b
         raise
 
 
+async def get_promotion_source(actor, dataset_id, permission, level):
+    """Permit an explicit own-personal-to-team copy without changing tenant state."""
+    from cognee.modules.users.exceptions import PermissionDeniedError
+
+    if permission not in ("read", "share"):
+        raise ValueError("Promotion source access requires read or share")
+    try:
+        return await get_authorized_dataset(actor, dataset_id, permission)
+    except PermissionDeniedError:
+        # Normal dataset access remains tenant-scoped. Only this explicit copy
+        # operation may read a human actor's own personal dataset while that
+        # actor has selected the destination team. Each source grant is checked
+        # independently; another person's personal data is never eligible.
+        if level == "team" and actor.parent_user_id is None and actor.tenant_id:
+            for dataset in await get_principal_datasets(actor, permission):
+                if (
+                    dataset.id == dataset_id
+                    and dataset.owner_id == actor.id
+                    and dataset.tenant_id is None
+                ):
+                    return dataset
+        raise
+
+
 async def promote(
     data_id: UUID,
     *,
@@ -147,8 +171,8 @@ async def promote(
     if user is None:
         raise ValueError("Promotion requires an explicit authenticated user")
     actor = await get_user(user.id)
-    source = await get_authorized_dataset(actor, source_dataset_id, "read")
-    shareable = await get_authorized_dataset(actor, source_dataset_id, "share")
+    source = await get_promotion_source(actor, source_dataset_id, "read", level)
+    shareable = await get_promotion_source(actor, source_dataset_id, "share", level)
     target = await get_authorized_dataset(actor, target_dataset_id, "write")
     if source is None or target is None or shareable is None:
         raise ValueError("Source or target dataset is unavailable")

--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -193,6 +193,7 @@ async def _remember_entry(
     entry,
     *,
     dataset_name: str,
+    dataset_id: UUID | None = None,
     session_id: Optional[str],
     user,
     skill_improvement: Optional[dict[str, Any]] = None,
@@ -209,6 +210,7 @@ async def _remember_entry(
         payload = await client.remember_entry(
             entry,
             dataset_name=dataset_name,
+            **({"dataset_id": dataset_id} if dataset_id is not None else {}),
             session_id=session_id,
             skill_improvement=skill_improvement,
         )
@@ -234,6 +236,7 @@ async def _remember_entry(
     return await _dispatch_session_entry(
         entry,
         dataset_name=dataset_name,
+        dataset_id=dataset_id,
         session_id=session_id,
         user=user,
         skill_improvement=skill_improvement,
@@ -244,6 +247,7 @@ async def _dispatch_session_entry(
     entry: "MemoryEntry",
     *,
     dataset_name: str,
+    dataset_id: UUID | None = None,
     session_id: Optional[str],
     user,
     skill_improvement: Optional[dict[str, Any]] = None,
@@ -256,6 +260,8 @@ async def _dispatch_session_entry(
     can chain writes.
     """
     if isinstance(entry, SkillRunEntry):
+        if dataset_id is not None:
+            raise ValueError("Skill-run entries currently require dataset_name")
         from cognee.modules.tools.skill_runs import remember_skill_run_entry
 
         run, dataset = await remember_skill_run_entry(
@@ -324,37 +330,44 @@ async def _dispatch_session_entry(
     if not sm.is_available:
         raise RuntimeError("Session cache unavailable — set CACHING=true to enable session memory")
 
-    # Resolve the dataset UUID for this session so the session_records
-    # row carries dataset_id — otherwise downstream permission filtering
-    # (e.g. the dashboard listing) can't match the session via granted
-    # dataset reads. We backfill via ensure_and_touch_session, which
-    # upserts the row and only sets dataset_id when currently null.
-    try:
-        from uuid import UUID as _UUID
+    if dataset_id is not None:
+        from .session_dataset import bind_typed_session_dataset
 
-        from cognee.modules.data.methods.get_authorized_dataset import get_authorized_dataset
-        from cognee.modules.session_lifecycle.metrics import ensure_and_touch_session
-
-        resolved_dataset = None
+        dataset = await bind_typed_session_dataset(user, session_id, dataset_id)
+        dataset_name = dataset.name
+    else:
+        # Resolve the dataset UUID for this session so the session_records
+        # row carries dataset_id — otherwise downstream permission filtering
+        # (e.g. the dashboard listing) can't match the session via granted
+        # dataset reads. We backfill via ensure_and_touch_session, which
+        # upserts the row and only sets dataset_id when currently null.
         try:
-            ds = await get_authorized_dataset(user, dataset_name, "write")
-            if ds is not None:
-                resolved_dataset = ds.id
-        except Exception:
-            # Fall through with None — we still create the session row.
-            resolved_dataset = None
+            from uuid import UUID as _UUID
 
-        await ensure_and_touch_session(
-            session_id=session_id,
-            user_id=_UUID(user_id),
-            dataset_id=resolved_dataset,
-        )
-    except Exception as exc:
-        logger.debug("remember: pre-upsert session_record failed (%s)", exc)
+            from cognee.modules.data.methods.get_authorized_dataset import get_authorized_dataset
+            from cognee.modules.session_lifecycle.metrics import ensure_and_touch_session
+
+            resolved_dataset = None
+            try:
+                ds = await get_authorized_dataset(user, dataset_name, "write")
+                if ds is not None:
+                    resolved_dataset = ds.id
+            except Exception:
+                # Fall through with None — we still create the session row.
+                resolved_dataset = None
+
+            await ensure_and_touch_session(
+                session_id=session_id,
+                user_id=_UUID(user_id),
+                dataset_id=resolved_dataset,
+            )
+        except Exception as exc:
+            logger.debug("remember: pre-upsert session_record failed (%s)", exc)
 
     result = RememberResult(
         status="session_stored",
         dataset_name=dataset_name,
+        dataset_id=str(dataset_id) if dataset_id is not None else None,
         session_ids=[session_id],
     )
     result.elapsed_seconds = time.monotonic() - result._started_at
@@ -693,8 +706,9 @@ async def remember(
         dataset_name: Target dataset. Defaults to ``"main_dataset"``.
         dataset_id: UUID of an existing dataset to target directly. Takes
             precedence over ``dataset_name``. Not supported for
-            ``MemorySource`` imports or typed ``MemoryEntry`` payloads,
-            which are dataset-name based.
+            ``MemorySource`` imports or ``SkillRunEntry`` payloads. Typed
+            QA, trace and feedback entries support UUIDs and require a
+            writable dataset; a session cannot change its dataset binding.
         session_id: Optional session ID. When set, stores data in the
             session cache instead of the permanent graph.
         chunk_size: Max tokens per chunk. Auto-calculated when *None*.
@@ -817,13 +831,10 @@ async def remember(
     if isinstance(data, MEMORY_ENTRY_TYPES):
         if dry_run:
             raise ValueError("dry_run is supported for add+cognify remember inputs only.")
-        if dataset_id is not None:
-            raise ValueError(
-                "dataset_id is not supported for typed memory entries; use dataset_name."
-            )
         return await _remember_entry(
             data,
             dataset_name=dataset_name,
+            dataset_id=dataset_id,
             session_id=session_id,
             user=kwargs.get("user"),
             skill_improvement=kwargs.get("skill_improvement"),

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -638,7 +638,11 @@ def get_remember_router() -> APIRouter:
         )
         skill_improvement: Optional[dict] = None
 
-    @router.post("/entry", response_model=dict)
+    @router.post(
+        "/entry",
+        response_model=dict,
+        openapi_extra={"x-cognee-session-dataset-ids": True},
+    )
     @log_usage(function_name="POST /v1/remember/entry", log_type="api_endpoint")
     async def remember_entry(
         payload: RememberEntryRequest,

--- a/cognee/api/v1/remember/session_dataset.py
+++ b/cognee/api/v1/remember/session_dataset.py
@@ -1,0 +1,32 @@
+"""Authorize and atomically bind typed session writes to one dataset."""
+
+from uuid import UUID
+
+from sqlalchemy import select
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.data.methods.get_authorized_dataset import get_authorized_dataset
+from cognee.modules.session_lifecycle.metrics import ensure_and_touch_session
+from cognee.modules.session_lifecycle.models import SessionRecord
+
+
+async def bind_typed_session_dataset(user, session_id: str, dataset_id: UUID):
+    dataset = await get_authorized_dataset(user, UUID(str(dataset_id)), "write")
+    if dataset is None:
+        raise ValueError("Selected session dataset is unavailable")
+    # The upsert only fills an unset binding, so concurrent first writers to
+    # different datasets cannot reassign a session. Verify before cache writes.
+    await ensure_and_touch_session(session_id=session_id, user_id=user.id, dataset_id=dataset.id)
+    async with get_relational_engine().get_async_session() as session:
+        bound, status = (
+            await session.execute(
+                select(SessionRecord.dataset_id, SessionRecord.status).where(
+                    SessionRecord.session_id == session_id, SessionRecord.user_id == user.id
+                )
+            )
+        ).one()
+    if bound != dataset.id:
+        raise ValueError("Session belongs to another dataset; use a new session_id")
+    if status != "running":
+        raise ValueError("Session is already ended; use a new session_id")
+    return dataset

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -188,6 +188,7 @@ class CloudClient:
         dataset_name: str = "main_dataset",
         session_id: Optional[str] = None,
         skill_improvement: Optional[dict] = None,
+        dataset_id: UUID | None = None,
     ) -> dict:
         """POST /api/v1/remember/entry — store a typed MemoryEntry.
 
@@ -204,6 +205,9 @@ class CloudClient:
             "session_id": session_id,
             "skill_improvement": skill_improvement,
         }
+
+        if dataset_id is not None:
+            payload["dataset_id"] = str(dataset_id)
 
         async with session.post(
             f"{self.service_url}/api/v1/remember/entry",

--- a/cognee/modules/users/permissions/methods/authorized_get_principal_datasets.py
+++ b/cognee/modules/users/permissions/methods/authorized_get_principal_datasets.py
@@ -1,4 +1,3 @@
-from typing import List
 from uuid import UUID
 
 from cognee.modules.data.models import Dataset
@@ -15,10 +14,12 @@ from cognee.modules.users.permissions.methods.has_user_management_permission imp
     has_user_management_permission,
 )
 
+from .get_all_user_permission_datasets import get_all_user_permission_datasets
+
 
 async def authorized_get_principal_datasets(
     principal_id: UUID, permission_name: str, requester_id: UUID
-) -> List[Dataset]:
+) -> list[Dataset]:
     """
         Return the datasets a principal holds a permission on, if the requester
         is allowed to ask about that principal.
@@ -74,6 +75,11 @@ async def authorized_get_principal_datasets(
     else:
         raise PermissionDeniedError(message=f"Unsupported principal type: {principal.type}")
 
-    datasets = await get_principal_datasets(principal, permission_name)
+    if principal.type == "user" and principal.id == requester_id:
+        # The plugin dataset picker needs effective write access, including
+        # tenant and role grants, rather than direct ACL rows alone.
+        datasets = await get_all_user_permission_datasets(requester, permission_name)
+    else:
+        datasets = await get_principal_datasets(principal, permission_name)
 
     return [dataset for dataset in datasets if dataset.tenant_id == tenant_id]

--- a/cognee/tests/unit/modules/integrations/test_memory_promotion.py
+++ b/cognee/tests/unit/modules/integrations/test_memory_promotion.py
@@ -240,3 +240,132 @@ async def test_concurrent_promotion_inserts_once_and_never_overwrites_edits(tmp_
         assert len(objects) == 1
     finally:
         await engine.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_real_permissions_and_storage_agent_to_user_to_team(tmp_path, monkeypatch):
+    """Exercise public promotion with real ACL joins, SQLite and local files."""
+    from sqlalchemy import func, select
+
+    from cognee.base_config import get_base_config
+    from cognee.infrastructure.databases.relational import (
+        get_relational_config,
+        get_relational_engine,
+    )
+    from cognee.infrastructure.files.storage import get_file_storage
+    from cognee.modules.data.models import Data, Dataset
+    from cognee.modules.users.exceptions import PermissionDeniedError
+    from cognee.modules.users.models import ACL, Permission, Role, Tenant, User
+    from cognee.modules.users.permissions.methods.authorized_get_principal_datasets import (
+        authorized_get_principal_datasets,
+    )
+    from cognee.tasks.documents.classify_documents import classify_documents
+
+    monkeypatch.setattr(get_relational_config(), "db_path", str(tmp_path))
+    monkeypatch.setattr(get_relational_config(), "db_name", "promotion-real.db")
+    monkeypatch.setattr(get_relational_config(), "db_provider", "sqlite")
+    monkeypatch.setattr(get_base_config(), "data_root_directory", str(tmp_path / "files"))
+    engine = get_relational_engine()
+    await engine.create_database()
+    tenant = Tenant(id=uuid4(), name="test team")
+    parent = User(
+        id=uuid4(),
+        email="parent@example.test",
+        hashed_password="unused",
+        tenant_id=tenant.id,
+        tenants=[tenant],
+    )
+    agent = User(
+        id=uuid4(),
+        email="agent@example.test",
+        hashed_password="unused",
+        parent_user_id=parent.id,
+        tenant_id=tenant.id,
+        tenants=[tenant],
+    )
+    role = Role(id=uuid4(), name="publisher", tenant_id=tenant.id, users=[parent])
+    datasets = [
+        Dataset(id=uuid4(), name=name, owner_id=owner, tenant_id=tenant.id)
+        for name, owner in [("agent", agent.id), ("user", parent.id), ("team", parent.id)]
+    ]
+    source, personal, shared = datasets
+    permissions = {name: Permission(id=uuid4(), name=name) for name in ("read", "share", "write")}
+
+    def acl(principal, dataset, name):
+        return ACL(
+            principal_id=principal.id, dataset_id=dataset.id, permission_id=permissions[name].id
+        )
+
+    content = b"One verified lesson selected by the agent."
+    storage = get_file_storage(get_base_config().data_root_directory)
+    location = await storage.store("source.txt", BytesIO(content))
+    original = Data(
+        id=uuid4(),
+        dataset_id=source.id,
+        owner_id=agent.id,
+        tenant_id=tenant.id,
+        name="lesson",
+        extension="txt",
+        mime_type="text/plain",
+        loader_engine="text_loader",
+        raw_data_location=location,
+        original_data_location=location,
+        content_hash=hashlib.md5(content).hexdigest(),
+        raw_content_hash=hashlib.md5(content).hexdigest(),
+        pipeline_status={},
+        external_metadata={"reviewed": True},
+    )
+    try:
+        async with engine.get_async_session() as session:
+            session.add_all(
+                [tenant, parent, agent, role, *datasets, *permissions.values(), original]
+            )
+            await session.flush()
+            session.add_all(
+                [
+                    acl(agent, source, "read"),
+                    acl(agent, source, "share"),
+                    acl(parent, personal, "read"),
+                    acl(parent, personal, "share"),
+                    acl(role, shared, "write"),
+                    acl(tenant, shared, "read"),
+                ]
+            )
+            await session.commit()
+        kwargs = {
+            "source_dataset_id": source.id,
+            "target_dataset_id": personal.id,
+            "level": "user",
+            "reason": "Reusable lesson",
+            "user": agent,
+        }
+        with pytest.raises(PermissionDeniedError):
+            await m.promote(original.id, **kwargs)
+        async with engine.get_async_session() as session:
+            assert await session.scalar(select(func.count()).select_from(Data)) == 1
+            session.add(acl(agent, personal, "write"))
+            await session.commit()
+        first = await m.promote(original.id, **kwargs)
+        assert first.status == "copied"
+        assert (await m.promote(original.id, **kwargs)).status == "already_promoted"
+        effective = await authorized_get_principal_datasets(parent.id, "write", parent.id)
+        assert shared.id in {dataset.id for dataset in effective}
+        second = await m.promote(
+            first.target_data_id,
+            source_dataset_id=personal.id,
+            target_dataset_id=shared.id,
+            level="team",
+            reason="Team approved lesson",
+            user=parent,
+        )
+        assert second.status == "copied"
+        copied = await m._get_data(second.target_data_id, shared.id)
+        assert copied.system_metadata["promotion"]["previous"]["source_data_id"] == str(original.id)
+        async with m.open_data_file(copied.raw_data_location, "rb") as stream:
+            assert stream.read() == content
+        documents = await classify_documents([copied])
+        assert documents[0].id == second.target_data_id
+        async with engine.get_async_session() as session:
+            assert await session.scalar(select(func.count()).select_from(Data)) == 3
+    finally:
+        await engine.engine.dispose()

--- a/cognee/tests/unit/modules/integrations/test_memory_promotion.py
+++ b/cognee/tests/unit/modules/integrations/test_memory_promotion.py
@@ -243,9 +243,12 @@ async def test_concurrent_promotion_inserts_once_and_never_overwrites_edits(tmp_
 
 
 @pytest.mark.asyncio
-async def test_real_permissions_and_storage_agent_to_user_to_team(tmp_path, monkeypatch):
+@pytest.mark.parametrize("personal_workspace", [False, True])
+async def test_real_permissions_and_storage_agent_to_user_to_team(
+    tmp_path, monkeypatch, personal_workspace
+):
     """Exercise public promotion with real ACL joins, SQLite and local files."""
-    from sqlalchemy import func, select
+    from sqlalchemy import func, select, update
 
     from cognee.base_config import get_base_config
     from cognee.infrastructure.databases.relational import (
@@ -289,6 +292,8 @@ async def test_real_permissions_and_storage_agent_to_user_to_team(tmp_path, monk
         for name, owner in [("agent", agent.id), ("user", parent.id), ("team", parent.id)]
     ]
     source, personal, shared = datasets
+    if personal_workspace:
+        source.tenant_id = personal.tenant_id = parent.tenant_id = agent.tenant_id = None
     permissions = {name: Permission(id=uuid4(), name=name) for name in ("read", "share", "write")}
 
     def acl(principal, dataset, name):
@@ -303,7 +308,7 @@ async def test_real_permissions_and_storage_agent_to_user_to_team(tmp_path, monk
         id=uuid4(),
         dataset_id=source.id,
         owner_id=agent.id,
-        tenant_id=tenant.id,
+        tenant_id=source.tenant_id,
         name="lesson",
         extension="txt",
         mime_type="text/plain",
@@ -348,6 +353,12 @@ async def test_real_permissions_and_storage_agent_to_user_to_team(tmp_path, monk
         first = await m.promote(original.id, **kwargs)
         assert first.status == "copied"
         assert (await m.promote(original.id, **kwargs)).status == "already_promoted"
+        if personal_workspace:
+            async with engine.get_async_session() as session:
+                await session.execute(
+                    update(User).where(User.id == parent.id).values(tenant_id=tenant.id)
+                )
+                await session.commit()
         effective = await authorized_get_principal_datasets(parent.id, "write", parent.id)
         assert shared.id in {dataset.id for dataset in effective}
         second = await m.promote(
@@ -438,3 +449,26 @@ async def test_commit_ack_failure_never_removes_published_storage(
         assert objects[copied.raw_data_location] == b"lesson"
     finally:
         await engine.engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["own_personal", "foreign_personal", "other_team", "user_level"])
+async def test_personal_source_exception_is_limited_to_explicit_own_team_promotion(
+    state, monkeypatch, kind
+):
+    from cognee.modules.users.exceptions import PermissionDeniedError
+
+    state.actor.parent_user_id = None
+    state.actor.tenant_id = uuid4()
+    state.source.tenant_id = uuid4() if kind == "other_team" else None
+    state.source.owner_id = uuid4() if kind == "foreign_personal" else state.actor.id
+    monkeypatch.setattr(
+        m, "get_authorized_dataset", AsyncMock(side_effect=PermissionDeniedError("tenant scope"))
+    )
+    monkeypatch.setattr(m, "get_principal_datasets", AsyncMock(return_value=[state.source]))
+    args = (state.actor, state.source.id, "read", "user" if kind == "user_level" else "team")
+    if kind == "own_personal":
+        assert await m.get_promotion_source(*args) is state.source
+    else:
+        with pytest.raises(PermissionDeniedError):
+            await m.get_promotion_source(*args)

--- a/cognee/tests/unit/modules/integrations/test_memory_promotion.py
+++ b/cognee/tests/unit/modules/integrations/test_memory_promotion.py
@@ -1,0 +1,242 @@
+"""Promotion must enforce the sharing boundary before reading or copying data."""
+
+import hashlib
+import importlib
+from contextlib import asynccontextmanager
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+m = importlib.import_module("cognee.api.v1.promote.promote")
+
+
+@pytest.fixture
+def state(monkeypatch):
+    actor = SimpleNamespace(id=uuid4(), tenant_id=None, parent_user_id=uuid4())
+    parent = SimpleNamespace(id=actor.parent_user_id, tenant_id=None, parent_user_id=None)
+    source = SimpleNamespace(id=uuid4(), owner_id=actor.id, tenant_id=None)
+    target = SimpleNamespace(id=uuid4(), owner_id=parent.id, tenant_id=None)
+    content = b"A selected, reusable lesson."
+    row = SimpleNamespace(
+        id=uuid4(),
+        dataset_id=source.id,
+        raw_data_location="file:///memory.txt",
+        raw_content_hash=hashlib.md5(content).hexdigest(),
+        extension="txt",
+        label="lesson",
+        external_metadata={"tag": "verified"},
+        system_metadata={"private_routing": "do-not-copy"},
+    )
+    rows = {(row.id, source.id): row}
+
+    async def get_data(ident, dataset):
+        return rows.get((ident, dataset))
+
+    async def get_user(ident):
+        return actor if ident == actor.id else parent
+
+    async def authorize(user, dataset, permission):
+        return source if dataset == source.id else target
+
+    @asynccontextmanager
+    async def open_file(*args):
+        yield BytesIO(content)
+
+    async def ingest(source_row, content, provenance, actor, target, target_id):
+        rows[(target_id, target.id)] = SimpleNamespace(system_metadata={"promotion": provenance})
+        return True
+
+    monkeypatch.setattr(m, "_get_data", get_data)
+    monkeypatch.setattr(m, "get_user", get_user)
+    auth = AsyncMock(side_effect=authorize)
+    monkeypatch.setattr(m, "get_authorized_dataset", auth)
+    opened = []
+
+    def read(*args):
+        opened.append(args)
+        return open_file(*args)
+
+    monkeypatch.setattr(m, "open_data_file", read)
+    add = AsyncMock(side_effect=ingest)
+    monkeypatch.setattr(m, "_persist_copy", add)
+
+    async def run(**overrides):
+        args = {
+            "source_dataset_id": source.id,
+            "target_dataset_id": target.id,
+            "level": "user",
+            "reason": "Useful beyond this task",
+            "user": actor,
+        }
+        args.update(overrides)
+        return await m.promote(row.id, **args)
+
+    return SimpleNamespace(**locals())
+
+
+@pytest.mark.asyncio
+async def test_copy_has_provenance_and_retries_do_not_overwrite(state):
+    first = await state.run()
+    second = await state.run()
+    assert (first.status, second.status) == ("copied", "already_promoted")
+    assert first.target_data_id == second.target_data_id != state.row.id
+    state.add.assert_awaited_once()
+    source, content, provenance, actor, target, copied_id = state.add.await_args.args
+    assert source is state.row and target is state.target
+    assert copied_id == first.target_data_id
+    assert content == state.content
+    assert provenance["source_data_id"] == str(state.row.id)
+    assert provenance["promoted_by"] == str(state.actor.id)
+    assert actor is state.actor
+    assert [call.args[2] for call in state.auth.await_args_list[:3]] == ["read", "share", "write"]
+
+
+@pytest.mark.asyncio
+async def test_dry_run_reads_the_selected_snapshot_without_writes(state):
+    result = await state.run(dry_run=True)
+    assert result.status == "planned"
+    assert len(state.opened) == 1
+    state.add.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("permission", ["read", "share", "write"])
+async def test_denied_permission_precedes_storage_reads(state, permission):
+    original = state.auth.side_effect
+
+    async def reject(user, dataset, requested):
+        if permission == requested:
+            raise PermissionError("denied")
+        return await original(user, dataset, requested)
+
+    state.auth.side_effect = reject
+    with pytest.raises(PermissionError):
+        await state.run()
+    assert not state.opened
+    state.add.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_agent_cannot_skip_user_and_promote_to_team(state):
+    with pytest.raises(ValueError, match="before"):
+        await state.run(level="team")
+    state.add.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wrong_parent_rejected(state):
+    state.target.owner_id = uuid4()
+    with pytest.raises(ValueError, match="parent"):
+        await state.run()
+    state.add.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_changed_source_aborts_copy(state):
+    state.row.raw_content_hash = "stale"
+    with pytest.raises(ValueError, match="changed"):
+        await state.run()
+    state.add.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_bounded_copy_rejects_oversized_memory(state):
+    with pytest.raises(ValueError, match="max_bytes"):
+        await state.run(max_bytes=3)
+    state.add.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_ingestion_is_not_reported_as_success(state):
+    state.add.side_effect = RuntimeError("persist failed")
+    with pytest.raises(RuntimeError, match="persist"):
+        await state.run()
+
+
+@pytest.mark.asyncio
+async def test_team_promotion_requires_preexisting_team_read_access(state, monkeypatch):
+    state.actor.parent_user_id = None
+    state.actor.tenant_id = state.source.tenant_id = state.target.tenant_id = uuid4()
+    tenant = SimpleNamespace(id=state.actor.tenant_id)
+    monkeypatch.setattr(m, "get_principal", AsyncMock(return_value=tenant))
+    readable = AsyncMock(return_value=[])
+    monkeypatch.setattr(m, "get_principal_datasets", readable)
+    with pytest.raises(ValueError, match="not shared"):
+        await state.run(level="team")
+    state.add.assert_not_awaited()
+    readable.return_value = [state.target]
+    result = await state.run(level="team")
+    assert result.status == "copied"
+
+
+@pytest.mark.asyncio
+async def test_team_promotion_rejects_other_tenant(state):
+    state.actor.parent_user_id = None
+    state.actor.tenant_id, state.target.tenant_id = uuid4(), uuid4()
+    with pytest.raises(ValueError, match="current tenant"):
+        await state.run(level="team")
+    state.add.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_promotion_inserts_once_and_never_overwrites_edits(tmp_path, monkeypatch):
+    import asyncio
+
+    from sqlalchemy import select, update
+
+    from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter import (
+        SQLAlchemyAdapter,
+    )
+    from cognee.modules.data.models import Data
+
+    engine = SQLAlchemyAdapter(f"sqlite+aiosqlite:///{tmp_path / 'promotion.db'}")
+    await engine.create_database()
+    objects = {}
+
+    class Storage:
+        async def store(self, path, stream):
+            objects[path] = stream.getvalue()
+            await asyncio.sleep(0)
+            return path
+
+        async def remove(self, path):
+            objects.pop(path, None)
+
+    monkeypatch.setattr(m, "get_relational_engine", lambda: engine)
+    monkeypatch.setattr(m, "get_file_storage", lambda root: Storage())
+    actor = SimpleNamespace(id=uuid4())
+    target = SimpleNamespace(id=uuid4(), tenant_id=None)
+    target_id = uuid4()
+    content = b"lesson"
+    revision = hashlib.md5(content).hexdigest()
+    row = SimpleNamespace(
+        name="original",
+        label="lesson",
+        extension="txt",
+        mime_type="text/plain",
+        loader_engine="text_loader",
+        raw_content_hash=revision,
+        external_metadata={},
+    )
+    provenance = {"source_data_id": str(uuid4()), "source_revision": revision}
+    try:
+        results = await asyncio.gather(
+            *[m._persist_copy(row, content, provenance, actor, target, target_id) for _ in range(2)]
+        )
+        assert sorted(results) == [False, True]
+        assert len(objects) == 1
+        async with engine.get_async_session() as session:
+            await session.execute(
+                update(Data).where(Data.id == target_id).values(name="user-edited")
+            )
+            await session.commit()
+        assert await m._persist_copy(row, content, provenance, actor, target, target_id) is False
+        async with engine.get_async_session() as session:
+            rows = (await session.execute(select(Data))).scalars().all()
+            assert len(rows) == 1 and rows[0].name == "user-edited"
+        assert len(objects) == 1
+    finally:
+        await engine.engine.dispose()

--- a/cognee/tests/unit/modules/integrations/test_memory_promotion.py
+++ b/cognee/tests/unit/modules/integrations/test_memory_promotion.py
@@ -369,3 +369,72 @@ async def test_real_permissions_and_storage_agent_to_user_to_team(tmp_path, monk
             assert await session.scalar(select(func.count()).select_from(Data)) == 3
     finally:
         await engine.engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("can_verify", [True, False])
+async def test_commit_ack_failure_never_removes_published_storage(
+    tmp_path, monkeypatch, can_verify
+):
+    from sqlalchemy import select
+
+    from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter import (
+        SQLAlchemyAdapter,
+    )
+    from cognee.modules.data.models import Data
+
+    engine = SQLAlchemyAdapter(f"sqlite+aiosqlite:///{tmp_path / 'ack.db'}")
+    await engine.create_database()
+    objects = {}
+
+    class Storage:
+        async def store(self, path, stream):
+            objects[path] = stream.getvalue()
+            return path
+
+        async def remove(self, path):
+            objects.pop(path, None)
+
+    class InterruptedEngine:
+        calls = 0
+
+        @asynccontextmanager
+        async def get_async_session(self):
+            self.calls += 1
+            first = self.calls == 1
+            if not first and not can_verify:
+                raise ConnectionError("database unavailable")
+            async with engine.get_async_session() as session:
+                yield session
+            if first:
+                raise ConnectionError("commit acknowledgement lost")
+
+    monkeypatch.setattr(m, "get_relational_engine", lambda: interrupted_engine)
+    interrupted_engine = InterruptedEngine()
+    monkeypatch.setattr(m, "get_file_storage", lambda root: Storage())
+    actor = SimpleNamespace(id=uuid4())
+    target = SimpleNamespace(id=uuid4(), tenant_id=None)
+    target_id = uuid4()
+    row = SimpleNamespace(
+        name="lesson",
+        label=None,
+        extension="txt",
+        mime_type="text/plain",
+        loader_engine="text_loader",
+        raw_content_hash=hashlib.md5(b"lesson").hexdigest(),
+        external_metadata={},
+    )
+    provenance = {"source_revision": hashlib.sha256(b"lesson").hexdigest()}
+    try:
+        if can_verify:
+            assert (
+                await m._persist_copy(row, b"lesson", provenance, actor, target, target_id) is True
+            )
+        else:
+            with pytest.raises(ConnectionError, match="acknowledgement"):
+                await m._persist_copy(row, b"lesson", provenance, actor, target, target_id)
+        async with engine.get_async_session() as session:
+            copied = (await session.execute(select(Data))).scalar_one()
+        assert objects[copied.raw_data_location] == b"lesson"
+    finally:
+        await engine.engine.dispose()

--- a/cognee/tests/unit/modules/integrations/test_plugin_provisioning.py
+++ b/cognee/tests/unit/modules/integrations/test_plugin_provisioning.py
@@ -479,3 +479,30 @@ async def test_last_used_at_write_failure_never_breaks_auth():
 
     with patch(f"{USER_MANAGER_MODULE}.get_relational_engine", return_value=engine):
         assert await manager.get_by_token("raw-key") is user
+
+
+@pytest.mark.parametrize(
+    "conflict", [UserAlreadyExists(), IntegrityError("insert", {}, Exception())]
+)
+def test_create_only_never_rotates_an_existing_identity(client, conflict):
+    with (
+        patch.object(_router_module, "create_agent", AsyncMock(side_effect=conflict)),
+        patch.object(
+            _router_module, "_find_plugin_agent", AsyncMock(return_value=_fake_agent_user())
+        ),
+        patch.object(_router_module, "_rotate_agent_api_key", AsyncMock()) as rotate,
+        patch.object(_router_module, "register_agent_connection", AsyncMock()) as register,
+    ):
+        response = client.post(
+            "/api/v1/integrations/plugins/claude-code/provision?create_only=true"
+        )
+    assert response.status_code == 409
+    rotate.assert_not_awaited()
+    register.assert_not_awaited()
+
+
+def test_create_only_capability_is_discoverable(client):
+    operation = client.get("/openapi.json").json()["paths"][
+        "/api/v1/integrations/plugins/{plugin_key}/provision"
+    ]["post"]
+    assert any(p["name"] == "create_only" and p["in"] == "query" for p in operation["parameters"])

--- a/cognee/tests/unit/modules/integrations/test_typed_dataset_ids.py
+++ b/cognee/tests/unit/modules/integrations/test_typed_dataset_ids.py
@@ -1,0 +1,161 @@
+"""Typed UUID writes must honor permissions and immutable session bindings."""
+
+import asyncio
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+from cognee.api.v1.remember import remember
+from cognee.api.v1.remember.routers.get_remember_router import get_remember_router
+from cognee.infrastructure.databases.relational import get_relational_config, get_relational_engine
+from cognee.memory import QAEntry
+from cognee.modules.data.models import Dataset
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.methods import get_authenticated_user
+from cognee.modules.users.models import ACL, Permission, User
+
+
+@pytest_asyncio.fixture
+async def state(tmp_path, monkeypatch):
+    cfg = get_relational_config()
+    monkeypatch.setattr(cfg, "db_path", str(tmp_path))
+    monkeypatch.setattr(cfg, "db_name", "typed.db")
+    monkeypatch.setattr(cfg, "db_provider", "sqlite")
+    engine = get_relational_engine()
+    await engine.create_database()
+    user = User(id=uuid4(), email="writer@test.example", hashed_password="unused")
+    owned = Dataset(id=uuid4(), name="same-name", owner_id=user.id)
+    shared = Dataset(id=uuid4(), name="same-name", owner_id=uuid4())
+    write = Permission(id=uuid4(), name="write")
+    async with engine.get_async_session() as session:
+        session.add_all([user, owned, shared, write])
+        await session.flush()
+        session.add_all(
+            [
+                ACL(principal_id=user.id, dataset_id=ds.id, permission_id=write.id)
+                for ds in (owned, shared)
+            ]
+        )
+        await session.commit()
+    sm = SimpleNamespace(is_available=True, add_qa=AsyncMock(return_value="qa-id"))
+    monkeypatch.setattr(
+        importlib.import_module("cognee.infrastructure.session.get_session_manager"),
+        "get_session_manager",
+        lambda: sm,
+    )
+    monkeypatch.setattr(
+        importlib.import_module("cognee.modules.engine.operations.setup"), "setup", AsyncMock()
+    )
+    monkeypatch.setattr(
+        importlib.import_module("cognee.api.v1.serve.state"), "get_remote_client", lambda: None
+    )
+    try:
+        yield SimpleNamespace(**locals())
+    finally:
+        await engine.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_typed_uuid_targets_shared_dataset_with_same_name(state):
+    result = await remember(
+        QAEntry(question="q", answer="a"),
+        dataset_id=state.shared.id,
+        session_id="shared-session",
+        user=state.user,
+    )
+    assert result.dataset_id == str(state.shared.id)
+    assert result.dataset_name == state.shared.name
+    state.sm.add_qa.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_typed_uuid_permission_denial_precedes_cache_write(state):
+    with pytest.raises(PermissionDeniedError):
+        await remember(
+            QAEntry(question="q", answer="a"),
+            dataset_id=uuid4(),
+            session_id="denied-session",
+            user=state.user,
+        )
+    state.sm.add_qa.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_two_datasets_cannot_claim_same_session(state):
+    outcomes = await asyncio.gather(
+        *[
+            remember(
+                QAEntry(question="q", answer="a"),
+                dataset_id=dataset.id,
+                session_id="concurrent-session",
+                user=state.user,
+            )
+            for dataset in (state.owned, state.shared)
+        ],
+        return_exceptions=True,
+    )
+    assert sum(isinstance(result, ValueError) for result in outcomes) == 1
+    state.sm.add_qa.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_entry_really_accepts_advertised_uuid(state):
+    app = FastAPI()
+    app.include_router(get_remember_router(), prefix="/api/v1/remember")
+    app.dependency_overrides[get_authenticated_user] = lambda: state.user
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        spec = (await client.get("/openapi.json")).json()
+        assert (
+            spec["paths"]["/api/v1/remember/entry"]["post"]["x-cognee-session-dataset-ids"] is True
+        )
+        response = await client.post(
+            "/api/v1/remember/entry",
+            json={
+                "entry": {"type": "qa", "question": "q", "answer": "a"},
+                "dataset_id": str(state.shared.id),
+                "session_id": "http-session",
+            },
+        )
+    assert response.status_code == 200, response.text
+    assert response.json()["dataset_id"] == str(state.shared.id)
+    state.sm.add_qa.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_remote_client_preserves_dataset_uuid(monkeypatch):
+    from cognee.api.v1.serve.cloud_client import CloudClient
+
+    captured = {}
+
+    class Response:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def json(self):
+            return {"status": "session_stored"}
+
+    class Session:
+        def post(self, url, *, json):
+            captured.update(json)
+            return Response()
+
+    client = CloudClient("http://test", "test-key")
+    monkeypatch.setattr(client, "_get_session", AsyncMock(return_value=Session()))
+    ident = uuid4()
+    await client.remember_entry(
+        QAEntry(question="q", answer="a"), dataset_id=ident, session_id="remote-session"
+    )
+    assert captured["dataset_id"] == str(ident)

--- a/cognee/tests/unit/users/permissions/test_authorized_get_principal_datasets.py
+++ b/cognee/tests/unit/users/permissions/test_authorized_get_principal_datasets.py
@@ -56,6 +56,7 @@ def _patch(
     monkeypatch.setattr(_mod, "get_user", fake_get_user)
     monkeypatch.setattr(_mod, "get_principal", fake_get_principal)
     monkeypatch.setattr(_mod, "get_principal_datasets", fake_get_principal_datasets)
+    monkeypatch.setattr(_mod, "get_all_user_permission_datasets", fake_get_principal_datasets)
     monkeypatch.setattr(_mod, "get_user_role_names_in_tenant", fake_get_user_role_names_in_tenant)
     monkeypatch.setattr(_mod, "has_user_management_permission", fake_has_user_management_permission)
 

--- a/examples/python/memory/promote_memory.py
+++ b/examples/python/memory/promote_memory.py
@@ -1,0 +1,52 @@
+"""Promote a selected persisted memory using pre-authorized dataset IDs.
+
+Create the user/team datasets and grant read+share on the source and write on
+its destination before calling this example. The team destination must already
+be shared for reading with the tenant. No permissions are granted by promote().
+"""
+
+from uuid import UUID
+
+import cognee
+from cognee.modules.users.models import User
+
+
+async def agent_to_user_to_team(
+    memory_id: UUID,
+    agent_dataset: UUID,
+    user_dataset: UUID,
+    team_dataset: UUID,
+    agent: User,
+    owner: User,
+):
+    # The agent selects a useful persisted lesson. Pending session entries must
+    # first be persisted with improve(); promotion never copies the whole session.
+    plan = await cognee.promote(
+        memory_id,
+        source_dataset_id=agent_dataset,
+        target_dataset_id=user_dataset,
+        level="user",
+        reason="A verified lesson useful across this user's projects",
+        user=agent,
+        dry_run=True,
+    )
+    personal = await cognee.promote(
+        plan.source_data_id,
+        source_dataset_id=agent_dataset,
+        target_dataset_id=user_dataset,
+        level="user",
+        reason="A verified lesson useful across this user's projects",
+        user=agent,
+    )
+    # A separate selection/approval policy decides whether this personal lesson
+    # belongs in team memory. The owner's permissions gate this second step.
+    shared = await cognee.promote(
+        personal.target_data_id,
+        source_dataset_id=user_dataset,
+        target_dataset_id=team_dataset,
+        level="team",
+        reason="Reviewed team practice",
+        user=owner,
+    )
+    await cognee.cognify(datasets=[team_dataset], user=owner)
+    return shared


### PR DESCRIPTION
Agents can retain useful memory privately, but there is no explicit SDK operation to promote a selected memory into its user's or team's dataset with permission checks and provenance.

Adds `cognee.promote(data_id, source_dataset_id=..., target_dataset_id=..., level="user"|"team", reason=..., user=...)`. It copies one selected persisted document as an independent snapshot. User promotion requires the source agent's parent as destination owner; team promotion requires a human-owned source and an existing tenant-readable destination. Both require source read+share and destination write permission. Promotion never grants permissions or impersonates another user.

Snapshots use SHA-256 revision identities, carry source/actor/reason/previous-promotion provenance, and are inserted rather than updated. A database uniqueness constraint resolves concurrent attempts; retries preserve destination edits and clean losing storage objects. A lost commit acknowledgement is resolved by re-reading the database before cleanup. If the commit cannot be verified, retain the storage object and report the original error. Dry runs read and validate the selected snapshot without writing. An example demonstrates agent → user → team.

Three supporting SDK contracts address bugs found in topoteretes/cognee-integrations#363 and its access-management stack topoteretes/cognee-integrations#394:
- Plugin provisioning accepts `create_only=true`: existing identities and concurrent first-create losers return 409 without rotating keys. The capability is discoverable through OpenAPI. Legacy explicit rotation remains compatible.
- A user's own permission query returns effective permissions, including role and tenant grants, for correct shared-dataset selection.
- Typed QA/trace/feedback writes now accept dataset UUIDs, enforce write permission before saving, and atomically bind a session to one dataset. The HTTP route advertises a tested capability marker; the remote client preserves the UUID. This fixes a schema/runtime mismatch in 1.5.4. Skill-run entries still use dataset names.

Validation: 62 targeted tests passed across promotion, provisioning, permission queries and permission routes. Includes a real SQLite/local-storage agent-to-user-to-team flow with effective role grants, denied destination writes, real SQLite concurrent inserts, retry-after-edit, denied read/share/write, wrong parent/team, changed source revision, size limits, and failed persistence. Changed-code lint and formatting checked.

Scope: promotion operates on persisted documents (including persisted session windows). Inspect the selected document before promoting; it is not automatic semantic filtering. Call `cognify` explicitly to build the destination graph. No MCP/UI changes or automatic promotion policy are included.

Tracks [SDK-573](https://linear.app/cognee/issue/SDK-573/add-permission-checked-agent-to-user-to-team-memory-promotion).

CI baseline: the repository-wide Code Quality job reports existing lint violations. Comparison of every changed Python file against dev found no new lint diagnostic codes/messages; newly added files are clean. The full SDK CI suite is still being evaluated.
