### PR TITLE
feat(ui): manage local memory access, promotion and teams (SDK-574)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ To open the local UI, run:
 cognee-cli -ui
 ```
 
+For a shared local server with agent permissions, team invitations and reviewed
+memory promotion, see the [local memory workspace guide](docs/local-memory-workspace.md).
+
 > **Note:** The MCP server launched by `cognee-cli -ui` runs inside a Docker container.
 > Docker Desktop, Colima, or any OCI-compatible runtime with a working `docker` CLI is
 > required. See [Docker & Colima Setup](docs/docker-colima-setup.md) for details.

--- a/cognee-frontend/AGENTS.md
+++ b/cognee-frontend/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/cognee-frontend/CLAUDE.md
+++ b/cognee-frontend/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/cognee-frontend/src/app/(app)/integrations/IntegrationsPage.tsx
+++ b/cognee-frontend/src/app/(app)/integrations/IntegrationsPage.tsx
@@ -5,8 +5,7 @@ import { TrackPageView } from "@/modules/analytics";
 import { AGENT_CARDS } from "@/modules/integrations/agentCards";
 import { AUTOMATION_CARDS } from "@/modules/integrations/automationCards";
 import SetupConnectorSection from "./partials/SetupConnectorSection";
-import DataSourceSection from "./partials/DataSourceSection";
-import MoreDataSourcesSection from "./partials/MoreDataSourcesSection";
+import LocalSources from "./partials/LocalSources";
 import { useAgentConnectionStatus } from "./partials/useAgentConnectionStatus";
 
 export default function IntegrationsPage(): ReactElement {
@@ -38,11 +37,10 @@ export default function IntegrationsPage(): ReactElement {
 
         <div style={{ height: 1, background: "rgba(255,255,255,0.08)" }} />
 
-        <DataSourceSection />
+        <LocalSources />
 
         <div style={{ height: 1, background: "rgba(255,255,255,0.08)" }} />
 
-        <MoreDataSourcesSection />
 
       </div>
     </div>

--- a/cognee-frontend/src/app/(app)/integrations/partials/LocalSources.tsx
+++ b/cognee-frontend/src/app/(app)/integrations/partials/LocalSources.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { request, describeError, type WorkspaceContext } from "@/modules/workspace/api";
+import Sources from "../../workspace/partials/Sources";
+
+export default function LocalSources() {
+  const [context, setContext] = useState<WorkspaceContext | null>(null);
+  const [error, setError] = useState("");
+  useEffect(() => {
+    let cancelled = false;
+    request<WorkspaceContext>("/v1/workspace/context")
+      .then((value) => { if (!cancelled) setContext(value); })
+      .catch((error) => { if (!cancelled) setError(describeError(error)); });
+    return () => { cancelled = true; };
+  }, []);
+  return <section><h2>Data sources on this server</h2>
+    <p>Connections belong to your account. Share their datasets through <Link href="/workspace">Manage memory</Link>.</p>
+    {error && <p role="alert">{error}</p>}{context && <Sources context={context} />}
+  </section>;
+}

--- a/cognee-frontend/src/app/(app)/workspace/WorkspacePage.tsx
+++ b/cognee-frontend/src/app/(app)/workspace/WorkspacePage.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { getLocalApiUrl } from "@/modules/users/getLocalApiUrl";
+import { request, describeError, type WorkspaceContext } from "@/modules/workspace/api";
+import Sources from "./partials/Sources";
+import Access from "./partials/Access";
+import Promote from "./partials/Promote";
+import Team from "./partials/Team";
+import Activity from "./partials/Activity";
+import styles from "./workspace.module.css";
+
+const TABS = ["Sources", "Agent access", "Promote memory", "Team", "Activity"] as const;
+
+export default function WorkspacePage() {
+  const [context, setContext] = useState<WorkspaceContext | null>(null);
+  const [tab, setTab] = useState<typeof TABS[number]>("Sources");
+  const [error, setError] = useState("");
+  const refresh = useCallback(async () => {
+    try { setContext(await request<WorkspaceContext>("/v1/workspace/context")); setError(""); }
+    catch (error) { setError(describeError(error)); }
+  }, []);
+  useEffect(() => { void refresh(); }, [refresh]);
+  return <div className={styles.page}>
+    <div className={styles.header}>
+      <div><h1>Manage memory</h1><p>Connect sources. Set agent access. Review what becomes shared memory.</p>
+        <div className={styles.muted}>{getLocalApiUrl()} · {context?.user.email ?? "Checking your account…"}</div></div>
+      <div className={styles.row}><Link className={styles.button} href="/sessions">Inspect sessions</Link>
+        <button className={styles.button} onClick={() => setTab("Activity")}>Live agent activity</button></div>
+    </div>
+    {error && <div role="alert" className={styles.error}>{error} <button className={styles.button} onClick={refresh}>Retry</button></div>}
+    <div className={styles.tabs} role="tablist" aria-label="Memory management">
+      {TABS.map((name) => <button key={name} role="tab" aria-selected={tab === name} onClick={() => setTab(name)}>{name}</button>)}
+    </div>
+    {context && <div role="tabpanel">
+      {tab === "Sources" && <Sources context={context} />}
+      {tab === "Agent access" && <Access context={context} refresh={refresh} />}
+      {tab === "Promote memory" && <Promote context={context} refresh={refresh} />}
+      {tab === "Team" && <Team context={context} refresh={refresh} />}
+      {tab === "Activity" && <Activity context={context} />}
+    </div>}
+  </div>;
+}

--- a/cognee-frontend/src/app/(app)/workspace/page.tsx
+++ b/cognee-frontend/src/app/(app)/workspace/page.tsx
@@ -1,0 +1,5 @@
+import WorkspacePage from "./WorkspacePage";
+
+export const metadata = { title: "Manage memory | Cognee" };
+
+export default function Page() { return <WorkspacePage />; }

--- a/cognee-frontend/src/app/(app)/workspace/partials/Access.tsx
+++ b/cognee-frontend/src/app/(app)/workspace/partials/Access.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { request, describeError, type Access as AccessState, type Permission, type WorkspaceContext } from "@/modules/workspace/api";
+import styles from "../workspace.module.css";
+
+const PERMISSIONS: Permission[] = ["read", "write", "share", "delete"];
+
+export default function Access({ context, refresh }: { context: WorkspaceContext; refresh: () => Promise<void> }) {
+  const [dataset, setDataset] = useState("");
+  const [access, setAccess] = useState<AccessState | null>(null);
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [plugin, setPlugin] = useState("codex");
+  const [credential, setCredential] = useState<{ agentId: string; apiKey: string } | null>(null);
+  const [identitiesChanged, setIdentitiesChanged] = useState(0);
+  useEffect(() => {
+    let cancelled = false;
+    setAccess(null); setError("");
+    if (dataset) request<AccessState>(`/v1/workspace/datasets/${dataset}/access`)
+      .then((value) => { if (!cancelled) setAccess(value); })
+      .catch((error) => { if (!cancelled) setError(describeError(error)); });
+    return () => { cancelled = true; };
+  }, [dataset, identitiesChanged]);
+  async function change(principalId: string, permission: Permission, allowed: boolean) {
+    setBusy(true); setError("");
+    try {
+      setAccess(await request<AccessState>(`/v1/workspace/datasets/${dataset}/access`, "PUT", { principal_id: principalId, permission, allowed }));
+      await refresh();
+    } catch (error) { setError(describeError(error)); }
+    finally { setBusy(false); }
+  }
+  return <div className={styles.stack}>
+    <div className={styles.card}><h2>Dataset permissions</h2>
+      <p>Read allows searching. Write allows saving and processing. Share allows granting access and promoting saved documents. Delete allows removing data. Inherited access comes from team or role grants.</p>
+      <label className={styles.field}>Dataset<select value={dataset} onChange={(e) => setDataset(e.target.value)} disabled={busy}>
+        <option value="">Choose a dataset you can share</option>
+        {context.datasets.filter((row) => row.permissions.includes("share")).map((row) => <option key={row.id} value={row.id}>{row.name} · {row.id.slice(0, 8)}</option>)}
+      </select></label>
+      {error && <div role="alert" className={styles.error}>{error}</div>}
+      {access && <div className={styles.scroll}><table className={styles.table}>
+        <thead><tr><th>Person, agent or group</th>{PERMISSIONS.map((p) => <th key={p}>Direct {p}</th>)}<th>Inherited</th></tr></thead>
+        <tbody>{access.principals.map((principal) => <tr key={principal.id}>
+          <td>{principal.name}<div className={styles.muted}>{principal.kind}{principal.owner && " · dataset owner"}</div></td>
+          {PERMISSIONS.map((permission) => <td key={permission}><input type="checkbox" aria-label={`${permission} for ${principal.name}`} checked={principal.direct.includes(permission)} disabled={busy || principal.owner}
+            onChange={(e) => change(principal.id, permission, e.target.checked)} /></td>)}
+          <td>{principal.inherited.join(", ") || "None"}</td>
+        </tr>)}</tbody>
+      </table><p>Removing a direct grant does not remove access inherited from a team or role. Change that group’s grant to remove inherited access. Saved permissions are reloaded after each change.</p></div>}
+    </div>
+    {!context.user.is_agent && <div className={styles.card}><h2>Set up a plugin identity</h2>
+      <p>Create a separate identity before granting agent access. Existing plugin identities are kept; this action never rotates their keys.</p>
+      <div className={styles.row}><label className={styles.field}>Plugin<select value={plugin} onChange={(e) => setPlugin(e.target.value)} disabled={busy}><option value="codex">Codex</option><option value="claude-code">Claude Code</option><option value="mcp">MCP</option></select></label>
+        <button className={styles.button} disabled={busy} onClick={async () => {
+          setBusy(true); setError(""); setCredential(null);
+          try { setCredential(await request(`/v1/integrations/plugins/${plugin}/provision?create_only=true`, "POST")); setIdentitiesChanged((value) => value + 1); await refresh(); }
+          catch (error) { setError(describeError(error)); } finally { setBusy(false); }
+        }}>Create identity</button>
+        <button className={styles.button} disabled={busy} onClick={async () => {
+          if (!window.confirm(`Revoke ${plugin}'s keys and disconnect it? Its saved memory will remain.`)) return;
+          setBusy(true); setError(""); setCredential(null);
+          try { await request(`/v1/integrations/plugins/${plugin}`, "DELETE"); setIdentitiesChanged((value) => value + 1); await refresh(); }
+          catch (error) { setError(describeError(error)); } finally { setBusy(false); }
+        }}>Disconnect plugin</button>
+      </div>
+      {credential && <div className={styles.stack}><p>Copy this key now. It will not be shown again. In the plugin’s Manage Access skill, choose reconnect and provide this key through its named environment variable.</p>
+        <label className={styles.field}>New agent key<input type="password" readOnly value={credential.apiKey} autoComplete="off" /></label>
+        <button className={styles.button} onClick={() => navigator.clipboard.writeText(credential.apiKey)}>Copy key</button>
+        <button className={styles.button} onClick={() => setCredential(null)}>Hide key</button>
+      </div>}
+    </div>}
+  </div>;
+}

--- a/cognee-frontend/src/app/(app)/workspace/partials/Activity.tsx
+++ b/cognee-frontend/src/app/(app)/workspace/partials/Activity.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { request, describeError, type WorkspaceContext } from "@/modules/workspace/api";
+import styles from "../workspace.module.css";
+
+interface Connection {
+  id: string; agent_session_name: string; type: string; status: string;
+  user_id: string; session_id: string | null; last_active_at: string | null;
+  datasets: { id?: string; name?: string; role: string }[];
+}
+interface Operation {
+  id: string; operation_name: string | null; pipeline_name: string | null;
+  outcome: string | null; status: string | null; background: boolean | null;
+  owner_email: string | null; owner_id: string | null; user_id: string | null; dataset_name: string | null;
+  session_id: string | null; created_at: string; error_class: string | null;
+}
+interface SessionDetail {
+  recent_qas?: { qa_id?: string; question?: string; answer?: string; time?: string }[];
+  recent_traces?: unknown[];
+}
+interface PromotedDocument {
+  data_id: string; name: string; dataset_name: string;
+  promotion: { reason: string; level: string; promoted_at: string; promoted_by: string };
+}
+export function operationStatus(row: Pick<Operation, "outcome" | "background" | "status">): string {
+  if (row.outcome === "failed" || row.status?.includes("ERRORED")) return "Failed";
+  if (row.background && row.outcome === "succeeded") return "Started in background";
+  if (row.outcome === "succeeded" || row.status?.includes("COMPLETED")) return "Completed";
+  return row.status ? "Running" : "Not recorded";
+}
+export function operationActor(row: Pick<Operation, "owner_email" | "owner_id" | "user_id">): string {
+  if (!row.user_id) return "Not recorded";
+  return row.owner_id === row.user_id ? row.owner_email ?? row.user_id : row.user_id;
+}
+
+export default function Activity({ context }: { context: WorkspaceContext }) {
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [operations, setOperations] = useState<Operation[]>([]);
+  const [promotions, setPromotions] = useState<PromotedDocument[]>([]);
+  const [dataset, setDataset] = useState("");
+  const [offset, setOffset] = useState(0);
+  const [live, setLive] = useState(true);
+  const [updated, setUpdated] = useState("");
+  const [error, setError] = useState("");
+  const [detail, setDetail] = useState<{ title: string; data: SessionDetail } | null>(null);
+  useEffect(() => {
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout>;
+    async function load() {
+      try {
+        const params = new URLSearchParams({ limit: "50", offset: String(offset) });
+        if (dataset) params.set("dataset_id", dataset);
+        const [agents, rows, copies] = await Promise.all([
+          request<{ agents: Connection[] }>("/v1/agents/connections?active_only=false&range=all&limit=100"),
+          request<Operation[]>(`/v1/activity/pipeline-runs?${params}`),
+          request<PromotedDocument[]>("/v1/workspace/promotions"),
+        ]);
+        if (stopped) return;
+        setConnections(agents.agents); setOperations(rows); setPromotions(copies);
+        setUpdated(new Date().toLocaleTimeString()); setError("");
+      } catch (error) { if (!stopped) setError(describeError(error)); }
+      finally { if (!stopped && live) timer = setTimeout(load, 10000); }
+    }
+    void load();
+    return () => { stopped = true; clearTimeout(timer); };
+  }, [dataset, offset, live]);
+  return <div className={styles.stack}>
+    <div className={styles.row}><label><input type="checkbox" checked={live} onChange={(e) => setLive(e.target.checked)} /> Refresh every 10 seconds</label><span className={styles.muted}>{updated ? `Last updated ${updated}` : "Loading activity…"}</span></div>
+    {error && <div role="alert" className={styles.error}>Activity refresh failed: {error}. Any displayed rows are from the last successful refresh.</div>}
+    <section className={styles.card}><h2>Agent connections</h2><p>Connections and declared dataset bindings reported to this server. Permissions are checked separately on every memory request.</p>
+      <div className={styles.scroll}><table className={styles.table}><thead><tr><th>Connection</th><th>Status</th><th>Datasets</th><th>Last active</th><th /></tr></thead><tbody>{connections.map((agent) => <tr key={agent.id}><td>{agent.agent_session_name}<div className={styles.muted}>{agent.type}</div></td><td>{agent.status}</td><td>{agent.datasets.map((row) => `${row.name ?? row.id} (${row.role})`).join(", ") || "None declared"}</td><td>{agent.last_active_at ? new Date(agent.last_active_at).toLocaleString() : "Unknown"}</td><td><button className={styles.button} onClick={async () => {
+        setError("");
+        try { const data = await request<SessionDetail>(`/v1/agents/connections/${agent.user_id}?${new URLSearchParams({ agent_session_name: agent.agent_session_name })}`); setDetail({ title: agent.agent_session_name, data }); }
+        catch (error) { setError(describeError(error)); }
+      }}>Inspect</button></td></tr>)}</tbody></table></div>
+      {!connections.length && updated && <p>No visible agent connections have been registered.</p>}
+    </section>
+    <section className={`${styles.card} ${styles.stack}`}><h2>Recent operations</h2>
+      <label className={styles.field}>Dataset filter<select value={dataset} onChange={(e) => { setDataset(e.target.value); setOffset(0); }}><option value="">My agents and datasets shared with me</option>{context.datasets.filter((row) => row.permissions.includes("read")).map((row) => <option key={row.id} value={row.id}>{row.name}</option>)}</select></label>
+      <div className={styles.scroll}><table className={styles.table}><thead><tr><th>When</th><th>Operation</th><th>Actor</th><th>Dataset</th><th>Result</th></tr></thead><tbody>{operations.map((row) => <tr key={row.id}><td>{new Date(row.created_at).toLocaleString()}</td><td>{row.operation_name ?? row.pipeline_name ?? "Operation"}</td><td>{operationActor(row)}</td><td>{row.dataset_name ?? "Not recorded or not readable"}</td><td>{operationStatus(row)}{row.error_class && <div className={styles.muted}>{row.error_class}</div>}</td></tr>)}</tbody></table></div>
+      <div className={styles.row}><button className={styles.button} disabled={offset === 0} onClick={() => setOffset(Math.max(0, offset - 50))}>Newer</button><button className={styles.button} disabled={operations.length < 50} onClick={() => setOffset(offset + 50)}>Older</button><Link className={styles.link} href="/sessions">Open session conversations and traces</Link></div>
+      <p>A pipeline can produce several progress rows. “Started in background” confirms that work began, not that it finished.</p>
+    </section>
+    <section className={styles.card}><h2>Recent promotions</h2><p>Copies in datasets you can read, including who promoted them and why.</p>
+      <div className={styles.scroll}><table className={styles.table}><thead><tr><th>Document</th><th>Destination</th><th>Promoted by</th><th>Reason</th></tr></thead><tbody>{promotions.map((row) => <tr key={row.data_id}><td>{row.name}</td><td>{row.dataset_name} · {row.promotion.level}</td><td>{row.promotion.promoted_by}</td><td>{row.promotion.reason}</td></tr>)}</tbody></table></div>
+    </section>
+    {detail && <section className={styles.card}><div className={styles.row}><h2>{detail.title}</h2><button className={styles.button} onClick={() => setDetail(null)}>Close details</button></div><p>Recorded session entries and tool traces visible to your account.</p>
+      {detail.data.recent_qas?.map((qa, index) => <article key={qa.qa_id ?? index} className={styles.card}><h3>{qa.question ?? "Saved conversation"}</h3><p className={styles.conversation}>{qa.answer}</p>{qa.time && <time className={styles.muted}>{new Date(qa.time).toLocaleString()}</time>}</article>)}
+      {!detail.data.recent_qas?.length && <p>No recent conversations are available for this connection.</p>}
+      <details><summary>Recorded tool traces ({detail.data.recent_traces?.length ?? 0})</summary><pre className={styles.preview}>{JSON.stringify(detail.data.recent_traces ?? [], null, 2)}</pre></details>
+      <details><summary>Connection details</summary><pre className={styles.preview}>{JSON.stringify(detail.data, null, 2)}</pre></details></section>}
+  </div>;
+}

--- a/cognee-frontend/src/app/(app)/workspace/partials/Promote.tsx
+++ b/cognee-frontend/src/app/(app)/workspace/partials/Promote.tsx
@@ -22,7 +22,7 @@ export default function Promote({ context, refresh }: { context: WorkspaceContex
   useEffect(() => {
     let cancelled = false;
     setDocuments([]); setDocument("");
-    if (source) request<Document[]>(`/v1/datasets/${source}/data`)
+    if (source) request<Document[]>(`/v1/promote/sources/${source}/data`)
       .then((rows) => { if (!cancelled) setDocuments(rows); })
       .catch((error) => { if (!cancelled) setError(describeError(error)); });
     return () => { cancelled = true; };
@@ -39,10 +39,10 @@ export default function Promote({ context, refresh }: { context: WorkspaceContex
     finally { setBusy(false); }
   }
   return <section className={`${styles.card} ${styles.stack}`}><h2>Review a document before sharing it more widely</h2>
-    <p>Agent → user copies a document into the agent owner’s dataset. User → team copies it into a dataset already shared with the team. Each copy requires source read and share access, plus destination write access. The original stays in place.</p>
+    <p>Agent → user copies a document into the agent owner’s dataset. User → team copies it into a dataset already shared with the team. Each copy requires source read and share access, plus destination write access. The original stays in place. With a team selected, your own personal documents are also available as promotion sources; normal team searches stay scoped to that team.</p>
     {error && <div role="alert" className={styles.error}>{error}</div>}
     <div className={styles.row}>
-      <label className={styles.field}>Source dataset<select disabled={busy} value={source} onChange={(e) => setSource(e.target.value)}><option value="">Select source</option>{context.datasets.filter((row) => row.permissions.includes("read") && row.permissions.includes("share")).map((row) => <option key={row.id} value={row.id}>{row.name} · {row.id.slice(0, 8)}</option>)}</select></label>
+      <label className={styles.field}>Source dataset<select disabled={busy} value={source} onChange={(e) => setSource(e.target.value)}><option value="">Select source</option>{(context.promotion_sources ?? context.datasets).filter((row) => row.permissions.includes("read") && row.permissions.includes("share")).map((row) => <option key={row.id} value={row.id}>{row.name} · {row.id.slice(0, 8)}</option>)}</select></label>
       <label className={styles.field}>Saved document<select disabled={busy} value={document} onChange={(e) => setDocument(e.target.value)}><option value="">Select document</option>{documents.map((row) => <option key={row.id} value={row.id}>{row.name}</option>)}</select></label>
     </div>
     <div className={styles.row}>

--- a/cognee-frontend/src/app/(app)/workspace/partials/Promote.tsx
+++ b/cognee-frontend/src/app/(app)/workspace/partials/Promote.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { request, describeError, previewDocument, type Promotion, type WorkspaceContext } from "@/modules/workspace/api";
+import styles from "../workspace.module.css";
+
+interface Document { id: string; name: string }
+export default function Promote({ context, refresh }: { context: WorkspaceContext; refresh: () => Promise<void> }) {
+  const [source, setSource] = useState("");
+  const [target, setTarget] = useState("");
+  const [document, setDocument] = useState("");
+  const [documents, setDocuments] = useState<Document[]>([]);
+  const [level, setLevel] = useState("user");
+  const [reason, setReason] = useState("");
+  const [preview, setPreview] = useState<Awaited<ReturnType<typeof previewDocument>> | null>(null);
+  const [plan, setPlan] = useState<Promotion | null>(null);
+  const [confirmed, setConfirmed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<Promotion | null>(null);
+  useEffect(() => { setPreview(null); setPlan(null); setConfirmed(false); setResult(null); }, [source, target, document, reason, level]);
+  useEffect(() => {
+    let cancelled = false;
+    setDocuments([]); setDocument("");
+    if (source) request<Document[]>(`/v1/datasets/${source}/data`)
+      .then((rows) => { if (!cancelled) setDocuments(rows); })
+      .catch((error) => { if (!cancelled) setError(describeError(error)); });
+    return () => { cancelled = true; };
+  }, [source]);
+  const body = { data_id: document, source_dataset_id: source, target_dataset_id: target, level, reason };
+  async function check() {
+    setBusy(true); setError(""); setPlan(null); setPreview(null); setConfirmed(false);
+    try {
+      const next = await request<Promotion>("/v1/promote", "POST", { ...body, dry_run: true });
+      const content = await previewDocument(source, document);
+      if (content.revision !== next.source_revision) throw new Error("The document changed during preview. Load it again.");
+      setPlan(next); setPreview(content);
+    } catch (error) { setError(describeError(error)); }
+    finally { setBusy(false); }
+  }
+  return <section className={`${styles.card} ${styles.stack}`}><h2>Review a document before sharing it more widely</h2>
+    <p>Agent → user copies a document into the agent owner’s dataset. User → team copies it into a dataset already shared with the team. Each copy requires source read and share access, plus destination write access. The original stays in place.</p>
+    {error && <div role="alert" className={styles.error}>{error}</div>}
+    <div className={styles.row}>
+      <label className={styles.field}>Source dataset<select disabled={busy} value={source} onChange={(e) => setSource(e.target.value)}><option value="">Select source</option>{context.datasets.filter((row) => row.permissions.includes("read") && row.permissions.includes("share")).map((row) => <option key={row.id} value={row.id}>{row.name} · {row.id.slice(0, 8)}</option>)}</select></label>
+      <label className={styles.field}>Saved document<select disabled={busy} value={document} onChange={(e) => setDocument(e.target.value)}><option value="">Select document</option>{documents.map((row) => <option key={row.id} value={row.id}>{row.name}</option>)}</select></label>
+    </div>
+    <div className={styles.row}>
+      <label className={styles.field}>Promotion<select disabled={busy} value={level} onChange={(e) => setLevel(e.target.value)}><option value="user">Agent → user</option><option value="team">User → team</option></select></label>
+      <label className={styles.field}>Destination dataset<select disabled={busy} value={target} onChange={(e) => setTarget(e.target.value)}><option value="">Select destination</option>{context.datasets.filter((row) => row.id !== source && row.permissions.includes("write")).map((row) => <option key={row.id} value={row.id}>{row.name} · {row.id.slice(0, 8)}</option>)}</select></label>
+    </div>
+    <label className={styles.field}>Why should this memory be shared?<textarea disabled={busy} value={reason} maxLength={2000} onChange={(e) => setReason(e.target.value)} /></label>
+    <button className={styles.button} disabled={busy || !source || !target || !document || !reason.trim()} onClick={check}>{busy ? "Checking…" : "Preview and check permissions"}</button>
+    {plan && preview && <div className={styles.stack}>
+      <div className={styles.muted}>{preview.size.toLocaleString()} bytes · {preview.truncated ? "Preview shows the first 16,000 bytes. The entire document will be copied." : "Complete document shown below."}</div>
+      <pre className={styles.preview}>{preview.text}</pre>
+      <label><input type="checkbox" checked={confirmed} onChange={(e) => setConfirmed(e.target.checked)} disabled={busy || !!result} /> I have reviewed the document and want to copy all of it to the selected destination.</label>
+      <button className={`${styles.button} ${styles.primary}`} disabled={!confirmed || busy || !!result} onClick={async () => {
+        setBusy(true); setError("");
+        try { setResult(await request<Promotion>("/v1/promote", "POST", { ...body, dry_run: false, expected_source_revision: plan.source_revision })); await refresh(); }
+        catch (error) { setError(describeError(error)); } finally { setBusy(false); }
+      }}>Confirm promotion</button>
+    </div>}
+    {result && <div role="status" className={styles.success}>{result.status === "copied" ? "Document copied." : "This document revision was already copied; no duplicate was created."} Open the destination in Brain and run Cognify to make the copy searchable in its knowledge graph.</div>}
+  </section>;
+}

--- a/cognee-frontend/src/app/(app)/workspace/partials/Sources.tsx
+++ b/cognee-frontend/src/app/(app)/workspace/partials/Sources.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { request, describeError, type WorkspaceContext } from "@/modules/workspace/api";
+import styles from "../workspace.module.css";
+
+interface Connection { connected: boolean; accountLabel?: string; providerAccountId?: string }
+interface Channel { id: string; name: string; allowed: boolean }
+
+function Source({ provider }: { provider: WorkspaceContext["providers"][number] }) {
+  const [connection, setConnection] = useState<Connection | null>(null);
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [channels, setChannels] = useState<Channel[] | null>(null);
+  const [restrict, setRestrict] = useState(false);
+  const name = provider.provider === "slack" ? "Slack" : "GitHub";
+  useEffect(() => {
+    let cancelled = false;
+    request<Connection>(`/v1/integrations/${provider.provider}/connection`)
+      .then((value) => { if (!cancelled) setConnection(value); })
+      .catch((error) => { if (!cancelled) setError(describeError(error)); });
+    return () => { cancelled = true; };
+  }, [provider.provider]);
+  async function run(action: () => Promise<void>) {
+    setBusy(true); setError("");
+    try { await action(); } catch (error) { setError(describeError(error)); }
+    finally { setBusy(false); }
+  }
+  return <section className={`${styles.card} ${styles.stack}`}>
+    <div className={styles.row}><h2>{name}</h2><span className={styles.badge}>{connection === null ? "Checking" : connection.connected ? "Connected" : "Not connected"}</span></div>
+    <p>{name === "Slack" ? "Save selected messages and notes with the existing Cognee Slack app. Channel settings below control where slash commands can run; they do not import channel history." : "Index code from the repositories selected in your GitHub App installation. Repository access stays limited by that installation."}</p>
+    {connection?.accountLabel && <strong>{connection.accountLabel}</strong>}
+    {error && <div role="alert" className={styles.error}>{error}</div>}
+    {!provider.configured && <details><summary>Server setup required</summary><p>Configure your own {name} app on this server. Required settings:</p><ul>{provider.missing_settings.map((key) => <li key={key}><code>{key}</code></li>)}</ul></details>}
+    <div className={styles.row}>
+      {!connection?.connected && <button className={`${styles.button} ${styles.primary}`} disabled={busy || !provider.configured || connection === null} onClick={() => run(async () => {
+        const value = await request<{ authorizeUrl: string }>(`/v1/integrations/${provider.provider}/authorize`, "POST");
+        const url = new URL(value.authorizeUrl);
+        if (url.protocol !== "https:" || !["slack.com", "github.com"].includes(url.hostname)) throw new Error("The server returned an unexpected authorization address");
+        window.location.assign(url.href);
+      })}>Connect {name}</button>}
+      {connection?.connected && <button className={styles.button} disabled={busy} onClick={() => {
+        if (window.confirm(`Disconnect ${name}? Existing Cognee memory will remain.`)) void run(async () => {
+          await request(`/v1/integrations/${provider.provider}/connection`, "DELETE");
+          setConnection({ connected: false }); setChannels(null);
+        });
+      }}>Disconnect</button>}
+      {connection?.connected && name === "GitHub" && <a className={styles.link} target="_blank" rel="noreferrer" href="https://github.com/settings/installations">Choose repositories on GitHub</a>}
+      {connection?.connected && name === "Slack" && <button className={styles.button} disabled={busy} onClick={() => run(async () => {
+        const value = await request<{ channels: Channel[] }>("/v1/slack/channels");
+        setChannels(value.channels); setRestrict(value.channels.some((channel) => channel.allowed));
+      })}>Manage command channels</button>}
+    </div>
+    {channels && <div className={styles.stack}>
+      <label><input type="checkbox" checked={restrict} onChange={(e) => setRestrict(e.target.checked)} /> Restrict slash commands to selected channels</label>
+      {restrict && channels.map((channel) => <label key={channel.id}><input type="checkbox" checked={channel.allowed} onChange={(e) => setChannels(channels.map((row) => row.id === channel.id ? { ...row, allowed: e.target.checked } : row))} /> #{channel.name}</label>)}
+      <button className={styles.button} disabled={busy || (restrict && !channels.some((row) => row.allowed))} onClick={() => run(async () => {
+        await request("/v1/slack/channels", "PUT", { channel_ids: restrict ? channels.filter((row) => row.allowed).map((row) => row.id) : [] });
+        setChannels(null);
+      })}>Save channel settings</button>
+    </div>}
+  </section>;
+}
+
+export default function Sources({ context }: { context: WorkspaceContext }) {
+  return <div className={styles.grid}>{context.providers.map((provider) => <Source key={provider.provider} provider={provider} />)}</div>;
+}

--- a/cognee-frontend/src/app/(app)/workspace/partials/Team.tsx
+++ b/cognee-frontend/src/app/(app)/workspace/partials/Team.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { request, describeError, type WorkspaceContext } from "@/modules/workspace/api";
+import styles from "../workspace.module.css";
+
+interface Invite { id: string; email: string; expires_at: string; accepted_at: string | null; revoked_at: string | null }
+interface Member { id: string; email: string; roles: { id: string; name: string }[] }
+
+export default function Team({ context, refresh }: { context: WorkspaceContext; refresh: () => Promise<void> }) {
+  const team = context.teams.find((row) => row.id === context.user.tenant_id);
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [token, setToken] = useState("");
+  const [issued, setIssued] = useState("");
+  const [invites, setInvites] = useState<Invite[]>([]);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState("");
+  async function reload() {
+    if (!team?.is_owner) return;
+    const [rows, people] = await Promise.all([
+      request<Invite[]>(`/v1/workspace/teams/${team.id}/invitations`),
+      request<Member[]>(`/v1/permissions/tenants/${team.id}/users`),
+    ]);
+    setInvites(rows); setMembers(people);
+  }
+  useEffect(() => { void reload().catch((error) => setError(describeError(error))); }, [team?.id, team?.is_owner]); // eslint-disable-line react-hooks/exhaustive-deps
+  async function run(action: () => Promise<void>) {
+    setBusy(true); setError(""); setNotice("");
+    try { await action(); await reload(); } catch (error) { setError(describeError(error)); }
+    finally { setBusy(false); }
+  }
+  return <div className={styles.stack}>
+    {error && <div role="alert" className={styles.error}>{error}</div>}
+    {notice && <div role="status" className={styles.success}>{notice}</div>}
+    <section className={styles.card}><h2>Your teams</h2><p>Each person signs in with their own account. Joining a team gives access to datasets shared with that team. It does not expose every member’s private data.</p>
+      <div className={styles.row}><label className={styles.field}>Active team<select value={context.user.tenant_id ?? ""} disabled={busy} onChange={(e) => run(async () => {
+        await request("/v1/permissions/tenants/select", "POST", { tenant_id: e.target.value || null }); window.location.reload();
+      })}><option value="">Personal</option>{context.teams.map((row) => <option key={row.id} value={row.id}>{row.name}</option>)}</select></label>
+        <label className={styles.field}>New team name<input value={name} onChange={(e) => setName(e.target.value)} maxLength={120} /></label>
+        <button className={styles.button} disabled={busy || !name.trim() || context.user.is_agent} onClick={() => run(async () => {
+          await request(`/v1/permissions/tenants?${new URLSearchParams({ tenant_name: name.trim() })}`, "POST"); window.location.reload();
+        })}>Create team</button>
+      </div>
+    </section>
+    {team?.is_owner && <section className={`${styles.card} ${styles.stack}`}><h2>Invite to {team.name}</h2>
+      <p>Create a code for one email address. Share it yourself. It expires after seven days and can be used once. The recipient must create an account or sign in on this same server with that email.</p>
+      <div className={styles.row}><label className={styles.field}>Recipient email<input type="email" value={email} onChange={(e) => setEmail(e.target.value)} /></label>
+        <button className={styles.button} disabled={busy || !email.includes("@")} onClick={() => run(async () => {
+          const result = await request<{ token: string }>(`/v1/workspace/teams/${team.id}/invitations`, "POST", { email }); setIssued(result.token); setEmail("");
+        })}>Create invitation</button></div>
+      {issued && <div className={styles.row}><span className={styles.muted}>Invitation created. Copy it now; it cannot be retrieved later.</span><button className={styles.button} onClick={() => navigator.clipboard.writeText(issued)}>Copy invitation code</button><button className={styles.button} onClick={() => setIssued("")}>Hide</button></div>}
+      <div className={styles.scroll}><table className={styles.table}><thead><tr><th>Email</th><th>Status</th><th>Expires</th><th /></tr></thead><tbody>{invites.map((invite) => <tr key={invite.id}><td>{invite.email}</td><td>{invite.accepted_at ? "Accepted" : invite.revoked_at ? "Revoked" : new Date(invite.expires_at) < new Date() ? "Expired" : "Pending"}</td><td>{new Date(invite.expires_at).toLocaleDateString()}</td><td>{!invite.accepted_at && !invite.revoked_at && <button className={styles.button} disabled={busy} onClick={() => run(async () => { await request(`/v1/workspace/teams/${team.id}/invitations/${invite.id}`, "DELETE"); })}>Revoke</button>}</td></tr>)}</tbody></table></div>
+      <h2>Members</h2><p>To let someone continue work, grant them Read and Write on the relevant dataset. Add Share if they should manage its access or promote its documents.</p>
+      <div className={styles.scroll}><table className={styles.table}><thead><tr><th>Account</th><th>Roles</th><th /></tr></thead><tbody>{members.map((member) => <tr key={member.id}><td>{member.email}</td><td>{member.roles.map((role) => role.name).join(", ") || "Member"}</td><td>{member.id !== context.user.id && <button className={styles.button} disabled={busy} onClick={() => {
+        if (window.confirm(`Remove ${member.email} from ${team.name}? Team access will be revoked.`)) void run(async () => { await request(`/v1/permissions/tenants/${team.id}/users/${member.id}`, "DELETE"); });
+      }}>Remove</button>}</td></tr>)}</tbody></table></div>
+    </section>}
+    {!context.user.is_agent && <section className={`${styles.card} ${styles.stack}`}><h2>Accept an invitation</h2><p>Signed in as {context.user.email}. Use the email address named in the invitation.</p>
+      <label className={styles.field}>Invitation code<input type="password" autoComplete="off" value={token} onChange={(e) => setToken(e.target.value)} /></label>
+      <button className={styles.button} disabled={busy || token.length < 32} onClick={() => run(async () => {
+        await request("/v1/workspace/invitations/accept", "POST", { token: token.trim() }); setToken(""); await refresh(); setNotice("Invitation accepted. Select the team above to open its memory.");
+      })}>Join team</button>
+    </section>}
+  </div>;
+}

--- a/cognee-frontend/src/app/(app)/workspace/partials/__tests__/Activity.test.tsx
+++ b/cognee-frontend/src/app/(app)/workspace/partials/__tests__/Activity.test.tsx
@@ -1,0 +1,13 @@
+import { operationActor, operationStatus } from "../Activity";
+
+describe("activity attribution and completion", () => {
+  it("does not attribute an agent operation to the dataset owner", () => {
+    expect(operationActor({ user_id: "agent", owner_id: "person", owner_email: "person@example.test" })).toBe("agent");
+    expect(operationActor({ user_id: null, owner_id: "person", owner_email: "person@example.test" })).toBe("Not recorded");
+  });
+  it("does not call a launched background operation completed", () => {
+    expect(operationStatus({ outcome: "succeeded", background: true, status: null })).toBe("Started in background");
+    expect(operationStatus({ outcome: "failed", background: true, status: null })).toBe("Failed");
+    expect(operationStatus({ outcome: null, background: false, status: "PIPELINE_RUN_COMPLETED" })).toBe("Completed");
+  });
+});

--- a/cognee-frontend/src/app/(app)/workspace/workspace.module.css
+++ b/cognee-frontend/src/app/(app)/workspace/workspace.module.css
@@ -1,0 +1,30 @@
+.page { max-width: 1180px; margin: 0 auto; padding: 32px; color: #edecea; }
+.header { display: flex; justify-content: space-between; gap: 20px; align-items: flex-start; margin-bottom: 28px; }
+.page h1 { margin: 0 0 8px; font-size: 26px; font-weight: 600; }
+.page h2 { margin: 0 0 10px; font-size: 18px; font-weight: 600; }
+.page p { color: #aaa9a7; line-height: 1.6; font-size: 14px; }
+.muted { color: #aaa9a7; font-size: 13px; overflow-wrap: anywhere; }
+.tabs { display: flex; gap: 6px; padding-bottom: 16px; border-bottom: 1px solid #ffffff20; margin-bottom: 24px; flex-wrap: wrap; }
+.tabs button, .button { border: 1px solid #ffffff25; background: #ffffff08; color: #edecea; border-radius: 8px; padding: 9px 14px; cursor: pointer; font: inherit; font-size: 13px; }
+.tabs button[aria-selected=true], .primary { background: #bc9bff; color: #201832; border-color: #bc9bff; }
+.button:disabled { opacity: .45; cursor: default; }
+.button:hover:not(:disabled) { border-color: #bc9bff; }
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(290px, 1fr)); gap: 18px; }
+.card { border: 1px solid #ffffff20; border-radius: 12px; padding: 22px; background: #171719; }
+.row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.stack { display: flex; flex-direction: column; gap: 16px; }
+.field { display: flex; flex-direction: column; gap: 7px; font-size: 13px; flex: 1; min-width: 180px; }
+.field input, .field select, .field textarea { width: 100%; background: #212121; border: 1px solid #ffffff30; border-radius: 7px; padding: 10px; color: #edecea; font: inherit; }
+.field textarea { min-height: 78px; }
+.error { border: 1px solid #f8717180; background: #f8717110; color: #fca5a5; border-radius: 8px; padding: 12px 16px; margin-bottom: 18px; }
+.success { color: #a7f3d0; }
+.table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.table th, .table td { text-align: left; border-bottom: 1px solid #ffffff15; padding: 12px 10px; vertical-align: top; }
+.table th { color: #aaa9a7; font-weight: 500; }
+.scroll { overflow-x: auto; }
+.preview { white-space: pre-wrap; overflow-wrap: anywhere; max-height: 300px; overflow-y: auto; background: #111; border-radius: 8px; padding: 16px; font-size: 12px; }
+.link { color: #bc9bff; text-decoration: underline; }
+.badge { display: inline-block; font-size: 12px; padding: 4px 8px; border-radius: 5px; background: #ffffff0d; }
+@media (max-width: 640px) { .page { padding: 20px 14px; } .header { flex-direction: column; } }
+
+.conversation { white-space: pre-wrap; }

--- a/cognee-frontend/src/app/(auth)/local-login/partials/LocalSignInForm.tsx
+++ b/cognee-frontend/src/app/(auth)/local-login/partials/LocalSignInForm.tsx
@@ -5,13 +5,11 @@ import { Flex, Text, Title, TextInput, PasswordInput, Button } from "@mantine/co
 import AuthCard from "@/ui/elements/Auth/AuthCard";
 import { getLocalApiUrl } from "@/modules/users/getLocalApiUrl";
 
-const DEFAULT_EMAIL = "default_user@example.com";
-const DEFAULT_PASSWORD = "default_password";
-
 export default function LocalSignInForm() {
   const localApiUrl = getLocalApiUrl();
-  const [email, setEmail] = useState(DEFAULT_EMAIL);
-  const [password, setPassword] = useState(DEFAULT_PASSWORD);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [register, setRegister] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -21,6 +19,17 @@ export default function LocalSignInForm() {
     setIsLoading(true);
 
     try {
+      if (register) {
+        const created = await global.fetch(`${localApiUrl}/api/v1/auth/register`, {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email, password }), credentials: "include",
+        });
+        if (!created.ok) {
+          const data = await created.json().catch(() => null);
+          setError(typeof data?.detail === "string" ? data.detail : "Could not create your account.");
+          return;
+        }
+      }
       const formData = new URLSearchParams();
       formData.append("username", email);
       formData.append("password", password);
@@ -70,10 +79,10 @@ export default function LocalSignInForm() {
           className="!text-[2.5rem] !font-light !leading-[1.1] !tracking-[-0.04em] !text-[#EDECEA]"
           style={{ fontFamily: '"TWKLausanne", sans-serif' }}
         >
-          Local instance
+          Your Cognee server
         </Title>
         <Text size="sm" className="!text-[#EDECEA]/85 !font-light !text-center">
-          Sign in to your local Cognee backend
+          {register ? "Create your own account to accept a team invitation" : "Sign in with your own account"}
         </Text>
       </Flex>
 
@@ -110,7 +119,7 @@ export default function LocalSignInForm() {
           value={password}
           onChange={(e) => setPassword(e.currentTarget.value)}
           required
-          autoComplete="current-password"
+          autoComplete={register ? "new-password" : "current-password"}
           size="md"
           radius="md"
           classNames={{
@@ -122,7 +131,7 @@ export default function LocalSignInForm() {
         />
 
         <Text size="xs" className="!text-[#EDECEA]/60 !font-light" mt={-4}>
-          Default credentials are pre-filled for local development
+          Team access uses your own account and dataset permissions.
         </Text>
 
         <Button
@@ -135,8 +144,11 @@ export default function LocalSignInForm() {
           className="!bg-[#BC9BFF] !text-[#1e1e1c] hover:!bg-[#A87CFF] !transition-colors !border-none"
         >
           <Text size="sm" fw={500}>
-            Sign in
+            {register ? "Create account and sign in" : "Sign in"}
           </Text>
+        </Button>
+        <Button variant="subtle" disabled={isLoading} onClick={() => { setRegister(!register); setError(null); }}>
+          {register ? "Already have an account? Sign in" : "Create an account"}
         </Button>
       </form>
     </AuthCard>

--- a/cognee-frontend/src/modules/instances/localFetch.ts
+++ b/cognee-frontend/src/modules/instances/localFetch.ts
@@ -1,7 +1,9 @@
 import handleServerErrors from "@/utils/handleServerErrors";
 import { getLocalApiUrl } from "@/modules/users/getLocalApiUrl";
 
-let apiKey: string | null = process.env.NEXT_PUBLIC_COGWIT_API_KEY || null;
+// Keys may be supplied by the signed-in user at runtime. Never bake a server
+// owner's key into the public JavaScript bundle served to every teammate.
+let apiKey: string | null = null;
 
 export default async function localFetch(url: URL | RequestInfo, options: RequestInit = {}): Promise<Response> {
   const authHeaders: Record<string, string> = {};

--- a/cognee-frontend/src/modules/tenant/LocalProvider.tsx
+++ b/cognee-frontend/src/modules/tenant/LocalProvider.tsx
@@ -6,23 +6,17 @@ import { TenantContext, localInstance } from "./TenantContext";
 import { tokens } from "@/ui/theme/tokens";
 import { getLocalApiUrl } from "@/modules/users/getLocalApiUrl";
 import { UserContext, type AvailableTenant } from "@/modules/users/UserContext";
+import { request, type WorkspaceContext } from "@/modules/workspace/api";
 
-// Single-user local mode: the only user is always the owner of the only
-// workspace. `useTenant()` derives isOwner by looking the active tenant up in
-// UserContext's availableTenants, and the cloud UserProvider that would fill
-// that list is not mounted here — so without this, isOwner is permanently
-// false and every owner-gated surface (the Connect buttons on the Data
-// Sources cards, for one) renders inert.
-const LOCAL_TENANT_ID = "local";
-const LOCAL_AVAILABLE_TENANTS: AvailableTenant[] = [
-  { id: LOCAL_TENANT_ID, name: LOCAL_TENANT_ID, isOwner: true, ownerHasSubscription: false },
-];
+// Local servers can have several users and teams. Ownership must come from
+// the authenticated SDK account, just as it does for a hosted workspace.
 
 export function LocalProvider({ children }: { children: React.ReactNode }) {
   const localApiUrl = getLocalApiUrl();
   const [tenant, setTenant] = useState<Tenant | null>(null);
   const [isInitializing, setIsInitializing] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [workspace, setWorkspace] = useState<WorkspaceContext | null>(null);
 
   // Memoized: consumers key effects off availableTenants, so a fresh array on
   // every render would re-fire them on unrelated re-renders.
@@ -34,13 +28,15 @@ export function LocalProvider({ children }: { children: React.ReactNode }) {
       markWelcomeSeen: async () => {},
       markOnboardingComplete: async () => {},
       dismissFeatureAnnouncement: async () => {},
-      availableTenants: LOCAL_AVAILABLE_TENANTS,
+      availableTenants: (workspace?.teams ?? []).map((team): AvailableTenant => ({
+        id: team.id, name: team.name, isOwner: team.is_owner, ownerHasSubscription: false,
+      })),
       isLoadingTenants: false,
       isTenantsError: false,
       refetchTenants: () => {},
       setAvailableTenantsOptimistic: () => {},
     }),
-    [],
+    [workspace],
   );
 
   useEffect(() => {
@@ -72,7 +68,11 @@ export function LocalProvider({ children }: { children: React.ReactNode }) {
         if (cancelled) return;
 
         // Authenticated — set up the local instance
-        setTenant({ tenant_id: LOCAL_TENANT_ID, tenant_name: LOCAL_TENANT_ID });
+        const current = await request<WorkspaceContext>("/v1/workspace/context");
+        if (cancelled) return;
+        setWorkspace(current);
+        const selected = current.teams.find((team) => team.id === current.user.tenant_id);
+        setTenant({ tenant_id: selected?.id ?? "", tenant_name: selected?.name ?? "Personal" });
       } catch (err) {
         if (cancelled) return;
 
@@ -95,7 +95,7 @@ export function LocalProvider({ children }: { children: React.ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [localApiUrl]);
 
   if (error && !isInitializing) {
     return (
@@ -120,10 +120,15 @@ export function LocalProvider({ children }: { children: React.ReactNode }) {
         podUnreachable: false,
         error,
         statusMessage: null,
-        switchTenant: () => {},
+        switchTenant: async (tenantId) => {
+          try {
+            await request("/v1/permissions/tenants/select", "POST", { tenant_id: tenantId || null });
+            window.location.reload();
+          } catch (error) { setError(error instanceof Error ? error.message : "Could not switch team"); }
+        },
         planType: null,
         hasAccess: true,
-        requestCreateWorkspace: () => {},
+        requestCreateWorkspace: () => { window.location.href = "/workspace"; },
         nameModalOpen: false,
         releaseLoader: () => {},
       }}>

--- a/cognee-frontend/src/modules/tenant/__tests__/LocalProvider.isOwner.test.tsx
+++ b/cognee-frontend/src/modules/tenant/__tests__/LocalProvider.isOwner.test.tsx
@@ -3,18 +3,7 @@ import { LocalProvider } from "../LocalProvider";
 import { useTenant } from "../TenantContext";
 import { useUser } from "@/modules/users/UserContext";
 
-// Regression guard for a sync revert that shipped twice.
-//
-// `useTenant()` derives isOwner by looking the active tenant up in
-// UserContext's availableTenants. In cloud mode UserProvider fills that list;
-// in local mode nothing does, so LocalProvider has to supply it. When the SaaS
-// sync dropped that (it deleted LocalProvider's `isOwner: true`), isOwner went
-// permanently false and every owner-gated control rendered inert — most
-// visibly the Connect buttons on the Data Sources cards, which
-// DataSourceCard's `ctaFor` returns null for when !isOwner.
-//
-// The failure was invisible: it type-checks, it builds, and the only frontend
-// CI job renders /local-login, which reads none of this.
+// Local ownership follows the authenticated server account, including invited members.
 
 function Probe() {
   const { isOwner, tenant } = useTenant();
@@ -39,9 +28,11 @@ describe("LocalProvider ownership", () => {
     fetchMock.resetMocks();
   });
 
-  it("treats the single local user as owner of the local workspace", async () => {
-    // The /api/v1/users/me probe LocalProvider runs before it sets the tenant.
-    fetchMock.mockResponseOnce(JSON.stringify({ id: "local" }));
+  it.each([true, false])("uses the server ownership flag %s", async (isOwner) => {
+    fetchMock.mockResponses(
+      JSON.stringify({ id: "person" }),
+      JSON.stringify({ user: { id: "person", tenant_id: "team" }, teams: [{ id: "team", name: "Engineering", is_owner: isOwner }] }),
+    );
 
     render(
       <LocalProvider>
@@ -50,13 +41,16 @@ describe("LocalProvider ownership", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId("tenant-id")).toHaveTextContent("local");
+      expect(screen.getByTestId("tenant-id")).toHaveTextContent("team");
     });
-    expect(screen.getByTestId("is-owner")).toHaveTextContent("true");
+    expect(screen.getByTestId("is-owner")).toHaveTextContent(String(isOwner));
   });
 
   it("exposes the local workspace as an owned tenant, so owner-gated lists are not empty", async () => {
-    fetchMock.mockResponseOnce(JSON.stringify({ id: "local" }));
+    fetchMock.mockResponses(
+      JSON.stringify({ id: "person" }),
+      JSON.stringify({ user: { id: "person", tenant_id: "team" }, teams: [{ id: "team", name: "Engineering", is_owner: true }] }),
+    );
 
     render(
       <LocalProvider>

--- a/cognee-frontend/src/modules/workspace/api.ts
+++ b/cognee-frontend/src/modules/workspace/api.ts
@@ -1,0 +1,56 @@
+import localFetch from "@/modules/instances/localFetch";
+
+export type Permission = "read" | "write" | "share" | "delete";
+export interface Dataset { id: string; name: string; owner_id: string; permissions: Permission[] }
+export interface Team { id: string; name: string; is_owner: boolean }
+export interface WorkspaceContext {
+  user: { id: string; email: string; tenant_id: string | null; is_agent: boolean };
+  teams: Team[];
+  datasets: Dataset[];
+  providers: { provider: string; configured: boolean; missing_settings: string[] }[];
+}
+export interface Principal {
+  id: string; name: string; kind: string; owner: boolean;
+  direct: Permission[]; inherited: Permission[]; effective: Permission[];
+}
+export interface Access { dataset_id: string; principals: Principal[] }
+export interface Promotion {
+  status: "planned" | "copied" | "already_promoted";
+  source_revision: string; target_data_id: string; target_dataset_id: string;
+}
+
+export async function request<T>(path: string, method = "GET", body?: unknown): Promise<T> {
+  const response = await localFetch(path, {
+    method,
+    ...(body === undefined ? {} : { body: JSON.stringify(body), headers: { "Content-Type": "application/json" } }),
+  });
+  return response.json() as Promise<T>;
+}
+
+export function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : "The request failed. Refresh and try again.";
+}
+
+export async function previewDocument(datasetId: string, documentId: string) {
+  const response = await localFetch(`/v1/datasets/${datasetId}/data/${documentId}/raw`);
+  const limit = 64 * 1024 * 1024;
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error("The server returned no document content");
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      size += chunk.value.byteLength;
+      if (size > limit) throw new Error("The document is too large to preview and promote (64 MiB limit)");
+      chunks.push(chunk.value);
+    }
+  } finally { await reader.cancel(); }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const revision = Array.from(new Uint8Array(digest), (v) => v.toString(16).padStart(2, "0")).join("");
+  return { revision, text: new TextDecoder().decode(bytes.slice(0, 16000)), size, truncated: size > 16000 };
+}

--- a/cognee-frontend/src/modules/workspace/api.ts
+++ b/cognee-frontend/src/modules/workspace/api.ts
@@ -7,6 +7,7 @@ export interface WorkspaceContext {
   user: { id: string; email: string; tenant_id: string | null; is_agent: boolean };
   teams: Team[];
   datasets: Dataset[];
+  promotion_sources?: Dataset[];
   providers: { provider: string; configured: boolean; missing_settings: string[] }[];
 }
 export interface Principal {
@@ -32,7 +33,7 @@ export function describeError(error: unknown): string {
 }
 
 export async function previewDocument(datasetId: string, documentId: string) {
-  const response = await localFetch(`/v1/datasets/${datasetId}/data/${documentId}/raw`);
+  const response = await localFetch(`/v1/promote/sources/${datasetId}/data/${documentId}/raw`);
   const limit = 64 * 1024 * 1024;
   const reader = response.body?.getReader();
   if (!reader) throw new Error("The server returned no document content");

--- a/cognee-frontend/src/ui/layout/Navbar/CustomAppShellNavbar.tsx
+++ b/cognee-frontend/src/ui/layout/Navbar/CustomAppShellNavbar.tsx
@@ -133,6 +133,7 @@ const NAV_SECTIONS: NavSection[] = [
     label: "CONNECT",
     items: [
       { text: "Integrations", link: "/integrations", icon: IntegrationsIcon },
+      { text: "Manage memory", link: "/workspace", icon: DatabaseIcon },
       { text: "API Keys", link: "/api-keys", icon: KeyIcon },
     ],
   },

--- a/cognee/alembic/versions/e7a1c9d2f4b6_add_team_invitations.py
+++ b/cognee/alembic/versions/e7a1c9d2f4b6_add_team_invitations.py
@@ -1,0 +1,34 @@
+"""Add expiring team invitations.
+
+Revision ID: e7a1c9d2f4b6
+Revises: a7c2e9f4b8d1
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e7a1c9d2f4b6"
+down_revision = "a7c2e9f4b8d1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "team_invitations",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "tenant_id", sa.UUID(), sa.ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        ),
+        sa.Column("created_by", sa.UUID(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("token_hash", sa.String(64), unique=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True)),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("accepted_at", sa.DateTime(timezone=True)),
+        sa.Column("revoked_at", sa.DateTime(timezone=True)),
+    )
+
+
+def downgrade():
+    op.drop_table("team_invitations")

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -57,6 +57,8 @@ from cognee.api.v1.activity.routers import get_activity_router
 from cognee.api.v1.sessions import get_sessions_router
 from cognee.api.v1.slack.routers import get_slack_channels_router, get_slack_router
 from cognee.api.v1.integrations.routers import get_integrations_router
+from cognee.api.v1.promote.routers import get_promote_router
+from cognee.api.v1.users.routers.get_workspace_router import get_workspace_router
 
 # Registers the GitHub and Linear integrations with the integrations registry
 # as import side effects. Slack registers via its router imports above; GitHub
@@ -351,6 +353,8 @@ app.include_router(get_forget_router(), prefix="/api/v1/forget", tags=["forget"]
 app.include_router(get_slack_router(), prefix="/api/v1/slack", tags=["slack"])
 app.include_router(get_slack_channels_router(), prefix="/api/v1/slack", tags=["slack"])
 app.include_router(get_integrations_router(), prefix="/api/v1/integrations", tags=["integrations"])
+app.include_router(get_promote_router(), prefix="/api/v1/promote", tags=["memory promotion"])
+app.include_router(get_workspace_router(), prefix="/api/v1/workspace", tags=["workspace"])
 
 
 @app.get("/")

--- a/cognee/api/v1/promote/promote.py
+++ b/cognee/api/v1/promote/promote.py
@@ -30,6 +30,7 @@ class PromotionResult:
     target_dataset_id: UUID
     level: str
     status: Literal["planned", "copied", "already_promoted"]
+    source_revision: str
 
 
 async def _get_data(data_id: UUID, dataset_id: UUID) -> Data | None:
@@ -116,6 +117,7 @@ async def promote(
     user: User,
     dry_run: bool = False,
     max_bytes: int = 64 * 1024 * 1024,
+    expected_source_revision: str | None = None,
 ) -> PromotionResult:
     """Copy selected persisted memory upward, without changing source ACLs.
 
@@ -178,6 +180,8 @@ async def promote(
     if hashlib.md5(content).hexdigest() != stored_digest:
         raise ValueError("Source changed during promotion; retry with the current revision")
     revision = hashlib.sha256(content).hexdigest()
+    if expected_source_revision is not None and revision != expected_source_revision:
+        raise ValueError("Source memory changed after preview; review it again before promoting")
     target_id = uuid5(
         NAMESPACE_URL,
         f"cognee:promotion:v1:{source_dataset_id}:{data_id}:{revision}:{target_dataset_id}",
@@ -188,6 +192,7 @@ async def promote(
         "source_dataset_id": source_dataset_id,
         "target_dataset_id": target_dataset_id,
         "level": level,
+        "source_revision": revision,
     }
     existing = await _get_data(target_id, target_dataset_id)
     if existing is not None:

--- a/cognee/api/v1/promote/routers.py
+++ b/cognee/api/v1/promote/routers.py
@@ -1,0 +1,39 @@
+"""Authenticated HTTP access to the SDK's promotion operation."""
+
+from dataclasses import asdict
+from typing import Annotated, Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from cognee.api.v1.promote import promote
+from cognee.modules.users.methods import get_authenticated_user
+from cognee.modules.users.models import User
+
+CurrentUser = Annotated[User, Depends(get_authenticated_user)]
+
+
+class PromoteRequest(BaseModel):
+    data_id: UUID
+    source_dataset_id: UUID
+    target_dataset_id: UUID
+    level: Literal["user", "team"]
+    reason: str = Field(min_length=1, max_length=2000)
+    dry_run: bool = True
+    expected_source_revision: str | None = Field(default=None, pattern="^[a-f0-9]{64}$")
+
+
+def get_promote_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.post("")
+    async def promote_document(payload: PromoteRequest, user: CurrentUser):
+        if not payload.dry_run and payload.expected_source_revision is None:
+            raise HTTPException(400, "Preview the document before confirming promotion")
+        try:
+            return asdict(await promote(user=user, **payload.model_dump()))
+        except ValueError as error:
+            raise HTTPException(400, str(error)) from error
+
+    return router

--- a/cognee/api/v1/promote/routers.py
+++ b/cognee/api/v1/promote/routers.py
@@ -4,10 +4,14 @@ from dataclasses import asdict
 from typing import Annotated, Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, Field
+from sqlalchemy import select
 
 from cognee.api.v1.promote import promote
+from cognee.api.v1.promote.promote import _get_data, get_promotion_source, open_data_file
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.data.models import Data
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.modules.users.models import User
 
@@ -26,6 +30,33 @@ class PromoteRequest(BaseModel):
 
 def get_promote_router() -> APIRouter:
     router = APIRouter()
+
+    async def authorize_source(user, dataset_id):
+        await get_promotion_source(user, dataset_id, "read", "team")
+        await get_promotion_source(user, dataset_id, "share", "team")
+
+    @router.get("/sources/{dataset_id}/data")
+    async def source_documents(dataset_id: UUID, user: CurrentUser):
+        await authorize_source(user, dataset_id)
+        async with get_relational_engine().get_async_session() as session:
+            rows = (
+                await session.execute(
+                    select(Data.id, Data.name).where(Data.dataset_id == dataset_id)
+                )
+            ).all()
+        return [{"id": row.id, "name": row.name} for row in rows]
+
+    @router.get("/sources/{dataset_id}/data/{data_id}/raw")
+    async def source_document(dataset_id: UUID, data_id: UUID, user: CurrentUser):
+        await authorize_source(user, dataset_id)
+        row = await _get_data(data_id, dataset_id)
+        if row is None:
+            raise HTTPException(404, "Document not found in this source dataset")
+        async with open_data_file(row.raw_data_location, "rb") as stream:
+            content = stream.read(64 * 1024 * 1024 + 1)
+        if len(content) > 64 * 1024 * 1024:
+            raise HTTPException(413, "Document exceeds the 64 MiB promotion limit")
+        return Response(content, media_type="text/plain")
 
     @router.post("")
     async def promote_document(payload: PromoteRequest, user: CurrentUser):

--- a/cognee/api/v1/users/routers/get_workspace_router.py
+++ b/cognee/api/v1/users/routers/get_workspace_router.py
@@ -1,0 +1,245 @@
+"""Local and self-hosted workspace controls backed by SDK authorization."""
+
+from datetime import datetime, timezone
+from typing import Annotated, Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, EmailStr, Field
+from sqlalchemy import select, update
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.data.models import Data, Dataset
+from cognee.modules.integrations.crypto import encrypt_credentials
+from cognee.modules.integrations.github.github_settings import github_settings
+from cognee.modules.integrations.slack.slack_settings import slack_settings
+from cognee.modules.users.methods import get_authenticated_user
+from cognee.modules.users.models import Tenant, User, UserTenant
+from cognee.modules.users.models.team_invitation import TeamInvitation
+from cognee.modules.users.permissions.methods import get_all_user_permission_datasets
+from cognee.modules.users.permissions.workspace_access import dataset_access, set_direct_access
+from cognee.modules.users.tenants.invitations import accept_invitation, create_invitation
+
+CurrentUser = Annotated[User, Depends(get_authenticated_user)]
+
+
+class InviteRequest(BaseModel):
+    email: EmailStr
+
+
+class AcceptRequest(BaseModel):
+    token: str = Field(min_length=32, max_length=128)
+
+
+class AccessRequest(BaseModel):
+    principal_id: UUID
+    permission: Literal["read", "write", "share", "delete"]
+    allowed: bool
+
+
+def _invite_json(row: TeamInvitation) -> dict:
+    result = {
+        name: getattr(row, name)
+        for name in (
+            "id",
+            "email",
+            "tenant_id",
+            "created_at",
+            "expires_at",
+            "accepted_at",
+            "revoked_at",
+        )
+    }
+    for name, value in result.items():
+        if isinstance(value, datetime) and value.tzinfo is None:
+            result[name] = value.replace(tzinfo=timezone.utc)
+    return result
+
+
+def get_workspace_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/context")
+    async def context(user: CurrentUser):
+        async with get_relational_engine().get_async_session() as session:
+            teams = (
+                (
+                    await session.execute(
+                        select(Tenant)
+                        .join(UserTenant, Tenant.id == UserTenant.tenant_id)
+                        .where(UserTenant.user_id == user.id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        permissions: dict[str, list[str]] = {}
+        datasets = {}
+        for permission in ("read", "write", "share", "delete"):
+            for dataset in await get_all_user_permission_datasets(user, permission):
+                key = str(dataset.id)
+                permissions.setdefault(key, []).append(permission)
+                datasets[key] = {"id": key, "name": dataset.name, "owner_id": str(dataset.owner_id)}
+        providers = []
+        try:
+            encrypt_credentials({})
+            credentials_ready = True
+        except (RuntimeError, ValueError, TypeError, AttributeError):
+            credentials_ready = False
+        for provider, settings, fields in (
+            (
+                "slack",
+                slack_settings,
+                (
+                    "client_id",
+                    "client_secret",
+                    "signing_secret",
+                    "redirect_uri",
+                    "frontend_base_url",
+                ),
+            ),
+            (
+                "github",
+                github_settings,
+                (
+                    "client_id",
+                    "client_secret",
+                    "app_id",
+                    "app_slug",
+                    "app_private_key",
+                    "webhook_secret",
+                    "frontend_base_url",
+                ),
+            ),
+        ):
+            missing = [
+                f"{provider.upper()}_{field.upper()}"
+                for field in fields
+                if not getattr(settings, field)
+            ]
+            if not credentials_ready:
+                missing.append("INTEGRATION_CREDENTIALS_KEY (valid encryption key required)")
+            providers.append(
+                {"provider": provider, "configured": not missing, "missing_settings": missing}
+            )
+        return {
+            "user": {
+                "id": user.id,
+                "email": user.email,
+                "tenant_id": user.tenant_id,
+                "is_agent": user.parent_user_id is not None,
+            },
+            "teams": [
+                {"id": team.id, "name": team.name, "is_owner": team.owner_id == user.id}
+                for team in teams
+            ],
+            "datasets": [
+                {**dataset, "permissions": permissions[key]} for key, dataset in datasets.items()
+            ],
+            "providers": providers,
+        }
+
+    @router.get("/datasets/{dataset_id}/access")
+    async def access(dataset_id: UUID, user: CurrentUser):
+        try:
+            return await dataset_access(user, dataset_id)
+        except PermissionError as error:
+            raise HTTPException(403, str(error)) from error
+
+    @router.get("/promotions")
+    async def promotions(user: CurrentUser, offset: int = Query(0, ge=0)):
+        readable = await get_all_user_permission_datasets(user, "read")
+        async with get_relational_engine().get_async_session() as session:
+            rows = (
+                await session.execute(
+                    select(Data, Dataset.name)
+                    .join(Dataset, Data.dataset_id == Dataset.id)
+                    .where(
+                        Data.dataset_id.in_([dataset.id for dataset in readable]),
+                        Data.system_metadata["promotion"]["source_data_id"]
+                        .as_string()
+                        .is_not(None),
+                    )
+                    .order_by(Data.created_at.desc(), Data.id.desc())
+                    .limit(50)
+                    .offset(offset)
+                )
+            ).all()
+        return [
+            {
+                "data_id": row.id,
+                "name": row.name,
+                "dataset_id": row.dataset_id,
+                "dataset_name": dataset_name,
+                "promotion": row.system_metadata["promotion"],
+            }
+            for row, dataset_name in rows
+        ]
+
+    @router.put("/datasets/{dataset_id}/access")
+    async def save_access(dataset_id: UUID, payload: AccessRequest, user: CurrentUser):
+        try:
+            await set_direct_access(
+                user, dataset_id, payload.principal_id, payload.permission, payload.allowed
+            )
+            return await dataset_access(user, dataset_id)
+        except PermissionError as error:
+            raise HTTPException(403, str(error)) from error
+        except ValueError as error:
+            raise HTTPException(400, str(error)) from error
+
+    @router.get("/teams/{tenant_id}/invitations")
+    async def invitations(tenant_id: UUID, user: CurrentUser):
+        async with get_relational_engine().get_async_session() as session:
+            tenant = await session.get(Tenant, tenant_id)
+            if tenant is None or tenant.owner_id != user.id or user.parent_user_id:
+                raise HTTPException(403, "Only the team owner can inspect invitations")
+            rows = (
+                (
+                    await session.execute(
+                        select(TeamInvitation)
+                        .where(TeamInvitation.tenant_id == tenant_id)
+                        .order_by(TeamInvitation.created_at.desc())
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            return [_invite_json(row) for row in rows]
+
+    @router.post("/teams/{tenant_id}/invitations")
+    async def invite(tenant_id: UUID, payload: InviteRequest, user: CurrentUser):
+        try:
+            invitation, token = await create_invitation(user, tenant_id, str(payload.email))
+            return {**_invite_json(invitation), "token": token}
+        except PermissionError as error:
+            raise HTTPException(403, str(error)) from error
+
+    @router.delete("/teams/{tenant_id}/invitations/{invitation_id}")
+    async def revoke(tenant_id: UUID, invitation_id: UUID, user: CurrentUser):
+        async with get_relational_engine().get_async_session() as session:
+            tenant = await session.get(Tenant, tenant_id)
+            if tenant is None or tenant.owner_id != user.id or user.parent_user_id:
+                raise HTTPException(403, "Only the team owner can revoke invitations")
+            await session.execute(
+                update(TeamInvitation)
+                .where(
+                    TeamInvitation.id == invitation_id,
+                    TeamInvitation.tenant_id == tenant_id,
+                    TeamInvitation.accepted_at.is_(None),
+                )
+                .values(revoked_at=datetime.now(timezone.utc))
+            )
+            await session.commit()
+            return {"revoked": True}
+
+    @router.post("/invitations/accept")
+    async def accept(payload: AcceptRequest, user: CurrentUser):
+        try:
+            return {"tenant_id": await accept_invitation(user, payload.token)}
+        except PermissionError as error:
+            raise HTTPException(403, str(error)) from error
+        except ValueError as error:
+            raise HTTPException(400, str(error)) from error
+
+    return router

--- a/cognee/api/v1/users/routers/get_workspace_router.py
+++ b/cognee/api/v1/users/routers/get_workspace_router.py
@@ -16,7 +16,10 @@ from cognee.modules.integrations.slack.slack_settings import slack_settings
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.modules.users.models import Tenant, User, UserTenant
 from cognee.modules.users.models.team_invitation import TeamInvitation
-from cognee.modules.users.permissions.methods import get_all_user_permission_datasets
+from cognee.modules.users.permissions.methods import (
+    get_all_user_permission_datasets,
+    get_principal_datasets,
+)
 from cognee.modules.users.permissions.workspace_access import dataset_access, set_direct_access
 from cognee.modules.users.tenants.invitations import accept_invitation, create_invitation
 
@@ -80,6 +83,22 @@ def get_workspace_router() -> APIRouter:
                 key = str(dataset.id)
                 permissions.setdefault(key, []).append(permission)
                 datasets[key] = {"id": key, "name": dataset.name, "owner_id": str(dataset.owner_id)}
+        promotion_sources = dict(datasets)
+        if user.parent_user_id is None and user.tenant_id:
+            personal_readable = {
+                dataset.id: dataset
+                for dataset in await get_principal_datasets(user, "read")
+                if dataset.owner_id == user.id and dataset.tenant_id is None
+            }
+            for dataset in await get_principal_datasets(user, "share"):
+                if dataset.id in personal_readable:
+                    key = str(dataset.id)
+                    promotion_sources[key] = {
+                        "id": key,
+                        "name": dataset.name + " (Personal)",
+                        "owner_id": str(dataset.owner_id),
+                    }
+                    permissions[key] = ["read", "share"]
         providers = []
         try:
             encrypt_credentials({})
@@ -135,6 +154,10 @@ def get_workspace_router() -> APIRouter:
             ],
             "datasets": [
                 {**dataset, "permissions": permissions[key]} for key, dataset in datasets.items()
+            ],
+            "promotion_sources": [
+                {**dataset, "permissions": permissions[key]}
+                for key, dataset in promotion_sources.items()
             ],
             "providers": providers,
         }

--- a/cognee/modules/users/models/team_invitation.py
+++ b/cognee/modules/users/models/team_invitation.py
@@ -1,0 +1,22 @@
+"""Single-use, email-bound invitations; only token hashes are stored."""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy import UUID, Column, DateTime, ForeignKey, String
+
+from cognee.infrastructure.databases.relational import Base
+
+
+class TeamInvitation(Base):
+    __tablename__ = "team_invitations"
+
+    id = Column(UUID, primary_key=True, default=uuid4)
+    tenant_id = Column(UUID, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False)
+    created_by = Column(UUID, ForeignKey("users.id"), nullable=False)
+    email = Column(String, nullable=False)
+    token_hash = Column(String(64), unique=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    accepted_at = Column(DateTime(timezone=True), nullable=True)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)

--- a/cognee/modules/users/permissions/workspace_access.py
+++ b/cognee/modules/users/permissions/workspace_access.py
@@ -1,0 +1,137 @@
+"""Read back persisted grants and distinguish them from inherited access."""
+
+from uuid import UUID
+
+from sqlalchemy import delete, select
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.data.methods.get_authorized_dataset import get_authorized_dataset
+from cognee.modules.users.models import ACL, Permission, Role, Tenant, User, UserRole, UserTenant
+from cognee.modules.users.permissions.methods.give_permission_on_dataset import (
+    give_permission_on_dataset,
+)
+
+PERMISSIONS = {"read", "write", "share", "delete"}
+
+
+async def dataset_access(user: User, dataset_id: UUID) -> dict:
+    dataset = await get_authorized_dataset(user, dataset_id, "share")
+    if dataset is None or dataset.tenant_id != user.tenant_id:
+        raise PermissionError("You cannot manage access to this dataset")
+    async with get_relational_engine().get_async_session() as session:
+        tenant = await session.get(Tenant, dataset.tenant_id) if dataset.tenant_id else None
+        # Only the team owner may enumerate the whole membership directory.
+        # Other sharers may manage their own agents and existing grantees.
+        grants = (
+            await session.execute(
+                select(ACL.principal_id, Permission.name)
+                .join(Permission, Permission.id == ACL.permission_id)
+                .where(ACL.dataset_id == dataset_id)
+            )
+        ).all()
+        direct: dict[UUID, set[str]] = {}
+        for principal_id, name in grants:
+            direct.setdefault(principal_id, set()).add(name)
+        team_members = set(
+            (
+                await session.execute(
+                    select(UserTenant.user_id).where(UserTenant.tenant_id == dataset.tenant_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        # Plugin creation sets the active tenant but does not enroll the agent
+        # as a team member. Those agents still need explicit dataset grants.
+        members = select(User).where(
+            User.id.in_(team_members)
+            | ((User.parent_user_id == user.id) & (User.tenant_id == dataset.tenant_id))
+        )
+        if tenant is None or tenant.owner_id != user.id:
+            members = members.where(
+                (User.id == user.id) | (User.parent_user_id == user.id) | User.id.in_(direct)
+            )
+        users = list((await session.execute(members)).scalars().all())
+        if not any(member.id == user.id for member in users):
+            users.append(user)
+        roles = list(
+            (await session.execute(select(Role).where(Role.tenant_id == dataset.tenant_id)))
+            .scalars()
+            .all()
+        )
+        memberships = (
+            await session.execute(
+                select(UserRole.user_id, UserRole.role_id).where(
+                    UserRole.user_id.in_([member.id for member in users]),
+                    UserRole.role_id.in_([role.id for role in roles]),
+                )
+            )
+        ).all()
+        rows = []
+        for member in users:
+            inherited = (
+                set(direct.get(dataset.tenant_id, set())) if member.id in team_members else set()
+            )
+            for member_id, role_id in memberships:
+                if member_id == member.id and member.id in team_members:
+                    inherited.update(direct.get(role_id, set()))
+            own = direct.get(member.id, set())
+            rows.append(
+                {
+                    "id": member.id,
+                    "name": member.email,
+                    "kind": "agent" if member.parent_user_id else "person",
+                    "direct": sorted(own),
+                    "inherited": sorted(inherited),
+                    "effective": sorted(own | inherited),
+                    "owner": member.id == dataset.owner_id,
+                }
+            )
+        for principal, kind in [(role, "role") for role in roles] + (
+            [(tenant, "team")] if tenant else []
+        ):
+            own = sorted(direct.get(principal.id, set()))
+            rows.append(
+                {
+                    "id": principal.id,
+                    "name": principal.name,
+                    "kind": kind,
+                    "direct": own,
+                    "inherited": [],
+                    "effective": own,
+                    "owner": False,
+                }
+            )
+        return {"dataset_id": dataset.id, "principals": rows}
+
+
+async def set_direct_access(
+    user: User, dataset_id: UUID, principal_id: UUID, permission: str, allowed: bool
+):
+    if permission not in PERMISSIONS:
+        raise ValueError("Unknown dataset permission")
+    listing = await dataset_access(user, dataset_id)
+    principal = next((row for row in listing["principals"] if row["id"] == principal_id), None)
+    if principal is None:
+        raise PermissionError("Principal is not available in this team")
+    if principal["owner"]:
+        raise ValueError("The dataset owner's permissions cannot be changed here")
+    # Mutate only the selected permission. A stale tab must not overwrite a
+    # concurrent change to any of this principal's other permissions.
+    async with get_relational_engine().get_async_session() as session:
+        if allowed:
+            from cognee.modules.users.models.Principal import Principal
+
+            target = await session.get(Principal, principal_id)
+            await give_permission_on_dataset(target, dataset_id, permission)
+        else:
+            await session.execute(
+                delete(ACL).where(
+                    ACL.dataset_id == dataset_id,
+                    ACL.principal_id == principal_id,
+                    ACL.permission_id.in_(
+                        select(Permission.id).where(Permission.name == permission)
+                    ),
+                )
+            )
+            await session.commit()

--- a/cognee/modules/users/tenants/invitations.py
+++ b/cognee/modules/users/tenants/invitations.py
@@ -1,0 +1,75 @@
+"""Explicit invitation creation and acceptance without sending email."""
+
+import hashlib
+import secrets
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+from sqlalchemy import select, update
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.users.models import Tenant, User, UserTenant
+from cognee.modules.users.models.team_invitation import TeamInvitation
+
+
+def _human(user: User) -> None:
+    if user.parent_user_id is not None or not user.is_active:
+        raise PermissionError("Sign in as a person to manage team invitations")
+
+
+async def create_invitation(user: User, tenant_id: UUID, email: str) -> tuple[TeamInvitation, str]:
+    _human(user)
+    token = secrets.token_urlsafe(32)
+    async with get_relational_engine().get_async_session() as session:
+        tenant = await session.get(Tenant, tenant_id)
+        if tenant is None or tenant.owner_id != user.id:
+            raise PermissionError("Only the team owner can invite members")
+        invitation = TeamInvitation(
+            tenant_id=tenant_id,
+            created_by=user.id,
+            email=email.strip().casefold(),
+            token_hash=hashlib.sha256(token.encode()).hexdigest(),
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        session.add(invitation)
+        await session.commit()
+        await session.refresh(invitation)
+        return invitation, token
+
+
+async def accept_invitation(user: User, token: str) -> UUID:
+    _human(user)
+    now = datetime.now(timezone.utc)
+    async with get_relational_engine().get_async_session() as session:
+        invitation = (
+            await session.execute(
+                select(TeamInvitation).where(
+                    TeamInvitation.token_hash == hashlib.sha256(token.encode()).hexdigest(),
+                    TeamInvitation.email == user.email.strip().casefold(),
+                    TeamInvitation.expires_at > now,
+                    TeamInvitation.accepted_at.is_(None),
+                    TeamInvitation.revoked_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+        if invitation is None:
+            raise ValueError("Invitation is invalid, expired, or belongs to another email")
+        tenant = await session.get(Tenant, invitation.tenant_id)
+        if tenant is None or tenant.owner_id != invitation.created_by:
+            raise ValueError("The invitation's owner can no longer invite members")
+        claimed = await session.execute(
+            update(TeamInvitation)
+            .where(
+                TeamInvitation.id == invitation.id,
+                TeamInvitation.accepted_at.is_(None),
+                TeamInvitation.revoked_at.is_(None),
+            )
+            .values(accepted_at=now)
+        )
+        if claimed.rowcount != 1:
+            raise ValueError("Invitation was already used or revoked")
+        membership = await session.get(UserTenant, (user.id, tenant.id))
+        if membership is None:
+            session.add(UserTenant(user_id=user.id, tenant_id=tenant.id))
+        await session.commit()
+        return tenant.id

--- a/cognee/tests/unit/modules/integrations/test_memory_promotion.py
+++ b/cognee/tests/unit/modules/integrations/test_memory_promotion.py
@@ -103,6 +103,17 @@ async def test_dry_run_reads_the_selected_snapshot_without_writes(state):
 
 
 @pytest.mark.asyncio
+async def test_promotion_rejects_document_changed_since_preview(state):
+    preview = await state.run(dry_run=True)
+    assert preview.source_revision == hashlib.sha256(state.content).hexdigest()
+    with pytest.raises(ValueError, match="after preview"):
+        await state.run(expected_source_revision="0" * 64)
+    state.add.assert_not_awaited()
+    result = await state.run(expected_source_revision=preview.source_revision)
+    assert result.status == "copied"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("permission", ["read", "share", "write"])
 async def test_denied_permission_precedes_storage_reads(state, permission):
     original = state.auth.side_effect
@@ -438,3 +449,48 @@ async def test_commit_ack_failure_never_removes_published_storage(
         assert objects[copied.raw_data_location] == b"lesson"
     finally:
         await engine.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_http_requires_preview_revision_and_rechecks_permissions(state):
+    import httpx
+    from fastapi import FastAPI
+
+    from cognee.api.v1.promote.routers import get_promote_router
+    from cognee.modules.users.methods import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(get_promote_router(), prefix="/promote")
+    app.dependency_overrides[get_authenticated_user] = lambda: state.actor
+    payload = {
+        "data_id": str(state.row.id),
+        "source_dataset_id": str(state.source.id),
+        "target_dataset_id": str(state.target.id),
+        "level": "user",
+        "reason": "Reviewed lesson",
+    }
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        preview = await client.post("/promote", json=payload)
+        assert preview.status_code == 200
+        assert preview.json()["status"] == "planned"
+        state.add.assert_not_awaited()
+        missing = await client.post("/promote", json={**payload, "dry_run": False})
+        assert missing.status_code == 400
+        changed = await client.post(
+            "/promote", json={**payload, "dry_run": False, "expected_source_revision": "0" * 64}
+        )
+        assert changed.status_code == 400
+        state.add.assert_not_awaited()
+        copied = await client.post(
+            "/promote",
+            json={
+                **payload,
+                "dry_run": False,
+                "expected_source_revision": preview.json()["source_revision"],
+            },
+        )
+        assert copied.status_code == 200
+        assert copied.json()["status"] == "copied"
+        assert len(state.auth.await_args_list) == 9  # preview, stale revision, confirmed copy

--- a/cognee/tests/unit/users/test_workspace_management.py
+++ b/cognee/tests/unit/users/test_workspace_management.py
@@ -212,3 +212,63 @@ async def test_toggling_one_permission_preserves_other_changes(state):
     listing = await dataset_access(state.owner, state.dataset.id)
     member = next(row for row in listing["principals"] if row["id"] == state.member.id)
     assert member["effective"] == ["write"]
+
+
+@pytest.mark.asyncio
+async def test_personal_promotion_sources_do_not_expand_normal_team_visibility(state, tmp_path):
+    from fastapi.responses import JSONResponse
+
+    from cognee.api.v1.promote.routers import get_promote_router
+    from cognee.modules.data.models import Data
+
+    personal = Dataset(
+        id=uuid4(), name="My personal notes", owner_id=state.owner.id, tenant_id=None
+    )
+    foreign = Dataset(
+        id=uuid4(), name="Someone else's notes", owner_id=state.stranger.id, tenant_id=None
+    )
+    path = tmp_path / "lesson.txt"
+    path.write_text("Reviewed personal lesson")
+    document = Data(
+        id=uuid4(),
+        dataset_id=personal.id,
+        owner_id=state.owner.id,
+        name="Lesson",
+        raw_data_location=path.as_uri(),
+    )
+    async with state.engine.get_async_session() as session:
+        session.add_all([personal, foreign, document])
+        await session.flush()
+        for dataset in (personal, foreign):
+            for permission in state.permissions:
+                if permission.name in ("read", "share"):
+                    session.add(
+                        ACL(
+                            principal_id=state.owner.id,
+                            dataset_id=dataset.id,
+                            permission_id=permission.id,
+                        )
+                    )
+        await session.commit()
+    app = FastAPI()
+    app.include_router(get_workspace_router(), prefix="/workspace")
+    app.include_router(get_promote_router(), prefix="/promote")
+    app.dependency_overrides[get_authenticated_user] = lambda: state.owner
+    app.add_exception_handler(
+        PermissionDeniedError,
+        lambda request, error: JSONResponse(status_code=403, content={"detail": "Denied"}),
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        context = (await client.get("/workspace/context")).json()
+        assert str(personal.id) not in {row["id"] for row in context["datasets"]}
+        sources = {row["id"] for row in context["promotion_sources"]}
+        assert str(personal.id) in sources and str(foreign.id) not in sources
+        listed = await client.get(f"/promote/sources/{personal.id}/data")
+        assert listed.status_code == 200
+        assert listed.json() == [{"id": str(document.id), "name": "Lesson"}]
+        raw = await client.get(f"/promote/sources/{personal.id}/data/{document.id}/raw")
+        assert raw.status_code == 200 and raw.text == path.read_text()
+        denied = await client.get(f"/promote/sources/{foreign.id}/data")
+        assert denied.status_code == 403

--- a/cognee/tests/unit/users/test_workspace_management.py
+++ b/cognee/tests/unit/users/test_workspace_management.py
@@ -1,0 +1,214 @@
+"""Real SQLite checks for local workspace permissions and invitation boundaries."""
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from sqlalchemy import delete, select, update
+
+from cognee.api.v1.users.routers.get_workspace_router import get_workspace_router
+from cognee.infrastructure.databases.relational import get_relational_config, get_relational_engine
+from cognee.modules.data.models import Dataset
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.methods import get_authenticated_user, get_user
+from cognee.modules.users.models import ACL, Permission, Role, Tenant, User, UserRole, UserTenant
+from cognee.modules.users.models.team_invitation import TeamInvitation
+from cognee.modules.users.permissions.workspace_access import dataset_access, set_direct_access
+from cognee.modules.users.tenants.invitations import accept_invitation, create_invitation
+
+
+@pytest_asyncio.fixture
+async def state(tmp_path, monkeypatch):
+    cfg = get_relational_config()
+    monkeypatch.setattr(cfg, "db_path", str(tmp_path))
+    monkeypatch.setattr(cfg, "db_name", "workspace.db")
+    monkeypatch.setattr(cfg, "db_provider", "sqlite")
+    engine = get_relational_engine()
+    await engine.create_database()
+    owner_id, member_id, agent_id, stranger_id, team_id = [uuid4() for _ in range(5)]
+    owner = User(id=owner_id, email="owner@example.test", hashed_password="unused", is_active=True)
+    member = User(
+        id=member_id, email="member@example.test", hashed_password="unused", is_active=True
+    )
+    stranger = User(
+        id=stranger_id, email="stranger@example.test", hashed_password="unused", is_active=True
+    )
+    agent = User(
+        id=agent_id,
+        email="agent@cognee.agent",
+        hashed_password="unused",
+        is_active=True,
+        parent_user_id=owner_id,
+    )
+    team = Tenant(id=team_id, name="Engineering", owner_id=owner_id)
+    role = Role(id=uuid4(), name="Reviewers", tenant_id=team_id)
+    dataset = Dataset(id=uuid4(), name="Shared lessons", owner_id=owner_id, tenant_id=team_id)
+    permissions = [
+        Permission(id=uuid4(), name=name) for name in ("read", "write", "share", "delete")
+    ]
+    async with engine.get_async_session() as session:
+        session.add_all([owner, member, stranger])
+        await session.flush()
+        session.add_all([team, agent])
+        await session.flush()
+        for person in (owner, member, agent):
+            person.tenant_id = team_id
+            session.add(UserTenant(user_id=person.id, tenant_id=team_id))
+        session.add_all([role, dataset, *permissions])
+        await session.flush()
+        session.add(UserRole(user_id=agent_id, role_id=role.id))
+        session.add_all(
+            [
+                ACL(principal_id=owner_id, permission_id=p.id, dataset_id=dataset.id)
+                for p in permissions
+            ]
+        )
+        session.add(
+            ACL(principal_id=role.id, permission_id=permissions[0].id, dataset_id=dataset.id)
+        )
+        await session.commit()
+    owner, member, stranger, agent = [
+        await get_user(ident) for ident in (owner_id, member_id, stranger_id, agent_id)
+    ]
+    try:
+        yield SimpleNamespace(**locals())
+    finally:
+        await engine.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_access_reloads_direct_and_inherited_permissions(state):
+    await set_direct_access(state.owner, state.dataset.id, state.agent.id, "write", True)
+    await set_direct_access(state.owner, state.dataset.id, state.agent.id, "write", False)
+    result = await dataset_access(state.owner, state.dataset.id)
+    agent = next(row for row in result["principals"] if row["id"] == state.agent.id)
+    assert agent["direct"] == []
+    assert agent["inherited"] == agent["effective"] == ["read"]
+    assert state.stranger.id not in [row["id"] for row in result["principals"]]
+
+
+@pytest.mark.asyncio
+async def test_access_cannot_change_owner_or_grant_foreign_principal(state):
+    with pytest.raises(ValueError, match="owner"):
+        await set_direct_access(state.owner, state.dataset.id, state.owner.id, "read", False)
+    with pytest.raises(PermissionError, match="Principal"):
+        await set_direct_access(state.owner, state.dataset.id, state.stranger.id, "read", True)
+    with pytest.raises(PermissionDeniedError):
+        await set_direct_access(state.member, state.dataset.id, state.agent.id, "read", True)
+
+
+@pytest.mark.asyncio
+async def test_invitation_is_email_bound_and_one_use(state):
+    invitation, token = await create_invitation(
+        state.owner, state.team.id, state.stranger.email.upper()
+    )
+    async with state.engine.get_async_session() as session:
+        saved = await session.get(TeamInvitation, invitation.id)
+        assert saved.token_hash == hashlib.sha256(token.encode()).hexdigest()
+        assert token not in saved.token_hash
+    with pytest.raises(ValueError, match="another email"):
+        await accept_invitation(state.member, token)
+    assert await accept_invitation(state.stranger, token) == state.team.id
+    with pytest.raises(ValueError):
+        await accept_invitation(state.stranger, token)
+    async with state.engine.get_async_session() as session:
+        assert await session.get(UserTenant, (state.stranger.id, state.team.id)) is not None
+        grants = (
+            (await session.execute(select(ACL).where(ACL.principal_id == state.stranger.id)))
+            .scalars()
+            .all()
+        )
+        assert grants == []  # joining never grants another person's private datasets
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("condition", ["expired", "revoked", "owner_changed"])
+async def test_invalidated_invitation_cannot_join(state, condition):
+    invitation, token = await create_invitation(state.owner, state.team.id, state.stranger.email)
+    async with state.engine.get_async_session() as session:
+        if condition == "owner_changed":
+            await session.execute(
+                update(Tenant).where(Tenant.id == state.team.id).values(owner_id=state.member.id)
+            )
+        else:
+            value = (
+                {"expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)}
+                if condition == "expired"
+                else {"revoked_at": datetime.now(timezone.utc)}
+            )
+            await session.execute(
+                update(TeamInvitation).where(TeamInvitation.id == invitation.id).values(**value)
+            )
+        await session.commit()
+    with pytest.raises(ValueError):
+        await accept_invitation(state.stranger, token)
+
+
+@pytest.mark.asyncio
+async def test_invitation_requires_human_team_owner(state):
+    for person in (state.member, state.stranger, state.agent):
+        with pytest.raises(PermissionError):
+            await create_invitation(person, state.team.id, "invite@example.test")
+
+
+@pytest.mark.asyncio
+async def test_workspace_http_uses_real_account_and_persisted_grants(state, monkeypatch):
+    monkeypatch.setenv("INTEGRATION_CREDENTIALS_KEYS", "[]")
+    app = FastAPI()
+    app.include_router(get_workspace_router(), prefix="/api/v1/workspace")
+    app.dependency_overrides[get_authenticated_user] = lambda: state.owner
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/api/v1/workspace/context")
+        assert response.status_code == 200
+        assert response.json()["user"]["id"] == str(state.owner.id)
+        assert response.json()["teams"][0]["is_owner"] is True
+        assert all(not provider["configured"] for provider in response.json()["providers"])
+        response = await client.put(
+            f"/api/v1/workspace/datasets/{state.dataset.id}/access",
+            json={"principal_id": str(state.member.id), "permission": "write", "allowed": True},
+        )
+        assert response.status_code == 200
+        member = next(
+            row for row in response.json()["principals"] if row["id"] == str(state.member.id)
+        )
+        assert member["effective"] == ["write"]
+        response = await client.post(
+            f"/api/v1/workspace/teams/{state.team.id}/invitations", json={"email": "not-an-email"}
+        )
+        assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_plugin_agent_without_team_membership_has_only_direct_access(state):
+    async with state.engine.get_async_session() as session:
+        await session.execute(delete(UserTenant).where(UserTenant.user_id == state.agent.id))
+        session.add(
+            ACL(
+                principal_id=state.team.id,
+                permission_id=state.permissions[0].id,
+                dataset_id=state.dataset.id,
+            )
+        )
+        await session.commit()
+    await set_direct_access(state.owner, state.dataset.id, state.agent.id, "write", True)
+    listing = await dataset_access(state.owner, state.dataset.id)
+    agent = next(row for row in listing["principals"] if row["id"] == state.agent.id)
+    assert agent["effective"] == ["write"]
+    assert agent["inherited"] == []
+
+
+@pytest.mark.asyncio
+async def test_toggling_one_permission_preserves_other_changes(state):
+    await set_direct_access(state.owner, state.dataset.id, state.member.id, "read", True)
+    await set_direct_access(state.owner, state.dataset.id, state.member.id, "write", True)
+    await set_direct_access(state.owner, state.dataset.id, state.member.id, "read", False)
+    listing = await dataset_access(state.owner, state.dataset.id)
+    member = next(row for row in listing["principals"] if row["id"] == state.member.id)
+    assert member["effective"] == ["write"]

--- a/docs/local-memory-workspace.md
+++ b/docs/local-memory-workspace.md
@@ -1,0 +1,135 @@
+# Local memory workspace
+
+The SDK and UI on this branch can serve several plugins and people from one
+Cognee backend. Each request still uses a particular account and dataset.
+Point every client at the same backend URL; sharing a server does not grant
+access to every dataset.
+
+## Run the matching SDK and UI
+
+Use this checkout for both services. A published UI image or `cognee-cli -ui`
+may contain a different UI revision. Back up existing storage before running
+an unreleased SDK against it. Never start two backend processes on the same
+embedded database directory.
+
+```sh
+uv sync --dev --locked
+# Export your existing storage, authentication and model configuration first.
+# Keep REQUIRE_AUTHENTICATION=true and ENABLE_BACKEND_ACCESS_CONTROL=true.
+uv run uvicorn cognee.api.client:app --host 127.0.0.1 --port 8011
+```
+
+In another terminal:
+
+```sh
+cd cognee-frontend
+npm ci
+npm run build
+COGNEE_BACKEND_URL=http://localhost:8011 npm start -- --hostname 127.0.0.1 --port 3000
+```
+
+Allow the UI origin in the API's `CORS_ALLOWED_ORIGINS`. Set
+`SYSTEM_ROOT_DIRECTORY`, `DATA_ROOT_DIRECTORY`, and `CACHE_ROOT_DIRECTORY` to
+persistent locations outside the Python environment. Leave `CACHING` enabled.
+For a continuously running central server, leave `COGNEE_AGENT_MODE=false`.
+The Codex and Claude plugins connect to a healthy existing server without
+starting another one. A separately managed server needs its own restart policy.
+
+Open `/workspace` and sign in with your own account. Existing plugin memory
+belongs to the account that originally saved it. Creating another UI account
+does not transfer that memory. Never put an owner API key in a `NEXT_PUBLIC_`
+environment variable or share the owner's login with teammates.
+
+For access from another machine, use a reachable HTTPS backend URL and UI URL,
+configure CORS and authentication cookies for that deployment, and protect the
+server with your chosen private network or reverse proxy. A browser on another
+machine cannot use the server's `localhost` address. Deployment and external
+network exposure are separate from the local setup.
+
+## Configure the existing Slack and GitHub integrations
+
+The Sources tab uses the SDK's existing integration endpoints. No Cognee Cloud
+account is required. It displays missing setting names without exposing values.
+Configure your own provider apps on the **backend**, then restart it:
+
+- Slack: `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_SIGNING_SECRET`,
+  `SLACK_REDIRECT_URI`, `SLACK_FRONTEND_BASE_URL`.
+- GitHub App: `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `GITHUB_APP_ID`,
+  `GITHUB_APP_SLUG`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET`,
+  `GITHUB_FRONTEND_BASE_URL`.
+- Token encryption: `INTEGRATION_CREDENTIALS_KEYS` (JSON object of key IDs to
+  base64-encoded 32-byte keys) and `INTEGRATION_CREDENTIALS_ACTIVE_KEY_ID`.
+  The existing single-key `INTEGRATION_CREDENTIALS_KEY` remains supported.
+  Preserve encryption keys in backups so existing provider tokens remain usable.
+
+Both frontend base URLs point to the UI origin. OAuth callback URLs are
+`<backend>/api/v1/integrations/slack/callback` and
+`<backend>/api/v1/integrations/github/callback`. Generic provider event URLs are
+`<backend>/api/v1/integrations/<provider>/events`. Slack also uses its existing
+command/interaction routes; configure the app against the SDK's Slack router.
+Providers must be able to reach webhook endpoints: a purely loopback server
+cannot receive their events. Configure a reachable HTTPS endpoint when needed.
+
+Select repositories in your GitHub App installation. The existing connector
+indexes repository code; it does not promise an issues/PR discussion archive.
+The Slack app saves selected messages and notes. Its channel allowlist controls
+where slash commands run; it is not a channel-history importer. Empty channel
+selection means unrestricted commands in the existing SDK, so the UI requires
+at least one channel when restriction is enabled.
+
+Connections belong to the authenticated SDK account. Dataset permissions
+control access to ingested memory separately from provider installation access.
+
+## Agent permissions and team access
+
+The Agent access tab shows direct and inherited dataset permissions. Change
+Read, Write, Share or Delete for a person, agent, role or team. Each toggle
+changes only that permission and reloads the saved grants. Revoking direct
+Read cannot remove Read inherited from a team or role.
+
+Plugin identities are created with `create_only=true`, so an existing identity
+returns a conflict rather than rotating its key. Copy a newly created key once
+and use the plugin's Manage Access reconnect workflow. Existing sessions need
+a fresh host session to use a changed identity. Dataset access alone does not
+change the plugin's selected write dataset or graph-read selection; use the
+plugin's explicit dataset/read-selection workflow for those bindings.
+
+The Team tab creates invitations for a specific email address. Copy the code
+and deliver it yourself. The recipient creates an account on this same server,
+accepts the code, then selects the team. Codes expire after seven days, are
+stored hashed, can be revoked, and are accepted once. No email is sent. Only the
+team owner creates invitations. Joining makes existing team grants effective;
+it does not grant private datasets. Grant Read and Write to let a colleague
+continue work; grant Share if they should also manage access. This is shared
+access to memory, not a transfer of the original account or provider tokens.
+
+## Review and promote memory
+
+1. Choose the source dataset and a persisted document in Promote memory.
+2. Choose Agent → user or User → team, a destination and a reason.
+3. Preview the saved document. The API checks source Read and Share, destination
+   Write, and the agent-parent or team relationship.
+4. Confirm the copy. The revision must match the preview; a changed source must
+   be reviewed again. The original remains, and the destination copy records
+   its source, actor, reason and previous promotion.
+5. Open the destination in Brain and run Cognify when you want its graph built.
+
+Promotion copies the whole persisted document, including a whole persisted
+session window if selected. It does not automatically extract only a useful
+sentence. The preview displays up to 16,000 bytes and explicitly marks longer
+content. The operation accepts at most 64 MiB and does not change permissions or
+call an LLM. Repeated promotion of the same source revision preserves destination
+edits. SDK agents can propose or invoke this workflow under their own grants;
+there is no automatic promotion policy installed by this UI.
+
+## Inspect activity
+
+The Activity tab refreshes every ten seconds and shows registered connections,
+declared dataset bindings, recent operations, visible promotion copies, and
+available conversations and traces. Background launch success is displayed as
+“Started in background”; completion requires a completion record. Actor IDs
+refer to the account that executed the operation, not the dataset owner.
+
+This is an inspection view over existing SDK records, not an immutable audit
+log or a remote terminal for controlling an agent. It shows the latest 100
+connections, pages of 50 operation rows, and the latest 50 visible promotions.

--- a/docs/local-memory-workspace.md
+++ b/docs/local-memory-workspace.md
@@ -106,6 +106,10 @@ access to memory, not a transfer of the original account or provider tokens.
 ## Review and promote memory
 
 1. Choose the source dataset and a persisted document in Promote memory.
+   With a team selected, your own personal-workspace datasets are also shown as
+   sources when you have direct Read and Share. This explicit promotion path
+   does not make personal memory available to normal team searches. Other
+   people's personal datasets and transfers between unrelated teams are excluded.
 2. Choose Agent → user or User → team, a destination and a reason.
 3. Preview the saved document. The API checks source Read and Share, destination
    Write, and the agent-parent or team relationship.


### PR DESCRIPTION
The local UI currently treats every account as an owner and exposes Cloud placeholders for source connections and activity. This prevents a shared local server from managing real agent permissions, reviewed memory promotion, or invited teammates.

Adds `/workspace` with the existing SDK Slack/GitHub connections, persisted dataset grants, safe plugin identity creation/disconnection, document promotion preview/confirmation, email-bound invitation codes, and agent/operation/promotion inspection. The local provider now loads the authenticated user's actual teams and ownership; registration supports separate teammate accounts. Owner API keys are no longer embedded through a public frontend environment variable.

Stacked on #4942 (`feat/memory-promotion-20260905`). Its SDK promotion and identity contracts are required. This PR adds the HTTP promotion route, a source-revision confirmation check, workspace endpoints, and one invitation-table migration. Promotion copies the entire selected persisted document and requires a separate explicit Cognify operation to build the destination graph. It does not grant access or install an automatic promotion policy.

Permission toggles change only the selected grant, preserving other concurrent changes. The UI distinguishes direct access from team/role inheritance, including plugin agents that have an active tenant without team membership. Invitations are hashed, single-use, email-bound, expire after seven days, and require an explicit human owner action; delivery is manual. Joined accounts see only datasets covered by their effective permissions. Activity distinguishes background launch from completion and the acting user from the dataset owner.

Validation:
- 64 targeted Python tests covering promotion, provisioning, permissions, workspace access and invitations; the final workspace-only recheck also passed.
- 484 frontend tests; relevant ownership/activity tests rerun after the final presentation change.
- TypeScript, changed-code ESLint, new Python-file Ruff checks, and production `npm run build` passed.
- Browser: two independent accounts; account creation, invitation creation/acceptance, team selection, agent grant/revoke, agent→user→team promotion, promotion visibility isolation, session inspection, and desktop/mobile review. No browser errors in the checked flows.
- Migration applied to a copy of an existing SQLite database; integrity check passed and all pre-existing user/dataset/document/ACL row counts were preserved.

Limitations: provider OAuth/webhooks need the operator's own Slack/GitHub apps and reachable endpoints; no real provider connection was changed during validation. Existing Slack support saves selected messages/notes and scopes commands, not bulk channel history. GitHub indexes selected repository code, not issues/PR discussions. Activity is an inspection view, not an immutable audit log or remote agent terminal. Deployment instructions are in `docs/local-memory-workspace.md`.

Related: topoteretes/cognee-integrations#363 and topoteretes/cognee-integrations#394; promotion work tracked by SDK-573.

Tracks [SDK-574](https://linear.app/cognee/issue/SDK-574/manage-local-agent-memory-permissions-and-team-sharing-in-the-ui).
