### PR TITLE
fix(modules): fix stray f-prefix in DatasetTypeError message and stale docstring arg

### DIFF
--- a/cognee/modules/data/methods/get_dataset_ids.py
+++ b/cognee/modules/data/methods/get_dataset_ids.py
@@ -12,7 +12,6 @@ async def get_dataset_ids(datasets: Union[list[str], list[UUID]], user):
     If a user wants to write to a dataset he is not the owner of it must be provided through UUID.
     Args:
         datasets:
-        pipeline_name:
         user:
 
     Returns: a list of write access dataset_ids if they exist
@@ -34,7 +33,7 @@ async def get_dataset_ids(datasets: Union[list[str], list[UUID]], user):
             ]
         else:
             raise DatasetTypeError(
-                f"One or more of the provided dataset types is not handled: f{datasets}"
+                f"One or more of the provided dataset types is not handled: {datasets}"
             )
 
     return dataset_ids


### PR DESCRIPTION
Two small fixes in `cognee/modules/data/methods/get_dataset_ids.py`:

1. The `DatasetTypeError` message was `f"...not handled: f{datasets}"` — a literal `f` before the interpolation, so users saw `...not handled: f['foo']`. Removed the stray prefix (repo-wide `f{var}` grep shows this is the only instance).
2. The docstring documented a `pipeline_name` parameter that `get_dataset_ids(datasets, user)` does not take; removed.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.