### PR TITLE
fix(tasks): compare primary key column by value, not identity

### DIFF
--- a/cognee/tasks/ingestion/migrate_relational_database.py
+++ b/cognee/tasks/ingestion/migrate_relational_database.py
@@ -230,7 +230,7 @@ async def complete_database_ingestion(schema, migrate_column_data):
 
                     for key, value in row_properties.items():
                         # Skip mapping primary key information to itself and mapping of foreign key information (as it will be mapped bellow)
-                        if key is primary_key_col or key in foreign_keys:
+                        if key == primary_key_col or key in foreign_keys:
                             continue
 
                         # Create column value node


### PR DESCRIPTION
In `cognee/tasks/ingestion/migrate_relational_database.py` (migrate_column_data path), the skip check used identity comparison:

```python
if key is primary_key_col or key in foreign_keys:
```

`primary_key_col` comes from `details["primary_key"]`, which the schema builder sets from a separate reflection call (`get_pk_constraint` in `SqlAlchemyAdapter`), while the `key` strings iterate `column["name"]` objects from `get_columns`. On the SQLite path the same object happens to be reused so identity holds; on Postgres/MySQL it fails, so the primary-key column is not skipped and a spurious `ColumnValue` node plus a row→its-own-PK edge is created.

Changed `is` → `==` (value comparison), matching the stated intent in the comment above it. `cognee/tests/test_relational_db_migration.py` covers sqlite and postgres but does not assert on PK-column nodes, which is why this survived.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.