### PR TITLE
SDK-575 fix(update): Preserve node sets on incremental chunks

### DIFF
--- a/cognee/api/v1/update/incremental.py
+++ b/cognee/api/v1/update/incremental.py
@@ -336,6 +336,8 @@ def _rehydrate_chunk(document: Document, node: dict, chunk_index: int) -> Docume
         chunk_index=chunk_index,
         cut_type=str(node.get("cut_type", "paragraph_end")),
         is_part_of=document,
+        belongs_to_set=document.belongs_to_set,
+        source_node_set=document.source_node_set,
         contains=[],
         importance_weight=node.get("importance_weight", document.importance_weight),
         document_id=str(document.id),
@@ -896,6 +898,11 @@ async def _write_and_publish(
     batch_size = cognify_config.chunks_per_batch or DEFAULT_CHUNKS_PER_BATCH
     for start in range(0, len(plan.fresh), batch_size):
         batch = plan.fresh[start : start + batch_size]
+        # Match extract_chunks_from_documents: policies plan content, while
+        # the writer carries document membership into graph and vector storage.
+        for chunk in batch:
+            chunk.belongs_to_set = document.belongs_to_set
+            chunk.source_node_set = document.source_node_set
         summaries = await extract_graph_and_summarize(
             batch,
             graph_model=graph_model,

--- a/cognee/tests/unit/api/test_incremental_node_sets.py
+++ b/cognee/tests/unit/api/test_incremental_node_sets.py
@@ -1,0 +1,98 @@
+"""Incremental writes must remain searchable by the document's node sets."""
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.chunking.chunk_policy import ChunkPlan
+from cognee.modules.chunking.models import DocumentChunk
+from cognee.modules.data.processing.document_types.TextDocument import TextDocument
+from cognee.tasks.documents.classify_documents import update_node_set
+
+incremental = importlib.import_module("cognee.api.v1.update.incremental")
+
+
+def _document(tagged=True):
+    document = TextDocument(
+        id=uuid4(),
+        title="brief.md",
+        name="brief",
+        raw_data_location="/tmp/brief.md",
+        mime_type="text/markdown",
+        external_metadata='{"node_set":["workflow:meeting-actions","kind:brief"]}'
+        if tagged
+        else "{}",
+    )
+    update_node_set(document)
+    return document
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tagged", [True, False])
+async def test_fresh_chunks_reach_extraction_with_document_membership(monkeypatch, tagged):
+    document = _document(tagged)
+    fresh = [
+        DocumentChunk(
+            id=uuid4(),
+            text=f"Changed action {i}",
+            chunk_size=3,
+            chunk_index=i,
+            cut_type="paragraph_end",
+            is_part_of=document,
+        )
+        for i in range(2)
+    ]
+    observed = []
+
+    async def extract(batch, **kwargs):
+        observed.extend(batch)
+        for chunk in batch:
+            assert chunk.belongs_to_set == document.belongs_to_set
+            assert chunk.source_node_set == document.source_node_set
+        return []
+
+    config = SimpleNamespace(
+        chunks_per_batch=1, triplet_embedding=False, contradiction_detection=False
+    )
+    publish = AsyncMock()
+    monkeypatch.setattr(incremental, "get_cognify_config", lambda: config)
+    monkeypatch.setattr(incremental, "_resolve_extraction_config", lambda: None)
+    monkeypatch.setattr(incremental, "extract_graph_and_summarize", extract)
+    monkeypatch.setattr(incremental, "add_data_points", AsyncMock())
+    monkeypatch.setattr(incremental, "publish_updated_data", publish)
+    result = await incremental._write_and_publish(
+        {
+            "staged": object(),
+            "document": document,
+            "stored_chunks": [],
+            "plan": ChunkPlan(fresh=fresh),
+        },
+        document.id,
+        SimpleNamespace(id=uuid4()),
+        SimpleNamespace(id=uuid4()),
+        None,
+        object,
+        None,
+        uuid4(),
+    )
+    assert observed == fresh
+    assert result["added_chunks"] == 2
+    publish.assert_awaited_once()
+
+
+@pytest.mark.parametrize("tagged", [True, False])
+def test_repositioned_chunks_keep_document_membership(tagged):
+    document = _document(tagged)
+    chunk_id = uuid4()
+    chunk = incremental._rehydrate_chunk(
+        document,
+        {"id": str(chunk_id), "text": "existing action", "chunk_size": 2},
+        7,
+    )
+    assert chunk.belongs_to_set == document.belongs_to_set
+    assert chunk.source_node_set == document.source_node_set
+    assert chunk.id == chunk_id
+    assert chunk.chunk_index == 7

--- a/cognee/tests/unit/api/test_incremental_refusals.py
+++ b/cognee/tests/unit/api/test_incremental_refusals.py
@@ -638,7 +638,7 @@ async def test_fresh_chunks_are_extracted_in_bounded_batches(monkeypatch):
     fresh = [SimpleNamespace(id=uuid4(), chunk_size=1) for _ in range(7)]
     bundle = {
         "staged": SimpleNamespace(),
-        "document": SimpleNamespace(id=uuid4()),
+        "document": SimpleNamespace(id=uuid4(), belongs_to_set=None, source_node_set=None),
         "stored_chunks": [],
         "plan": ChunkPlan(fresh=fresh, regions=1),
         "data_item": SimpleNamespace(id=uuid4()),


### PR DESCRIPTION
Linear: [SDK-575](https://linear.app/cognee/issue/SDK-575/preserve-node-set-membership-on-incremental-document-chunks)

## Description

After a tagged document is updated incrementally, node-set-filtered chunk search can return no results even though the document and its metadata still exist. Fresh replacement chunks bypass the normal chunk-extraction task that copies membership, and rehydrated chunks also lose that membership when their position changes.

Copy the document's `belongs_to_set` and `source_node_set` into fresh chunks before extraction and into rehydrated chunks. This keeps graph/vector storage aligned with the document while preserving IDs, batching, and update permission checks. No API, MCP, or UI contract changes.

Prepared with Codex following a reproduced failure in a local source-ingestion workflow. The change prevents future updates from dropping tags; it does not automatically repair previously affected chunks.

## Acceptance Criteria

- [x] Tagged and untagged fresh chunks retain the document's membership before extraction.
- [x] Repositioned chunks retain membership and their original identity.
- [x] Live HTTP validation: an incremental document update keeps its ID and metadata; `CHUNKS` search filtered by its workflow node set returns the updated document for the owner and authorized agent.
- [x] An unchanged workflow replay skips model calls and duplicate writes; unrelated dataset reads remain denied.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Validation

The new regression cases fail on the original implementation and pass with this fix. Focused tests ran against this checkout using the installed SDK dependencies and an isolated pytest runner:

```text
test_incremental_node_sets.py
test_incremental_rehydrate.py
test_incremental_refusals.py
test_update_config_routing.py
test_chunk_policy.py
54 passed, 3 skipped
```

Ruff 0.15.11 check/format and `git diff --check` pass for the changed files. Local HTTP checks used Ladybug/LanceDB; other backends were not exercised locally. Private source data and local connector configuration are excluded from this PR.

## Pre-submission Checklist

- [x] Tested the affected update and retrieval behavior locally.
- [x] Kept the change limited to the bug and its regression tests.
- [x] Followed repository style and formatting.
- [x] Added tests demonstrating the bug.
- [x] Searched existing open PRs for this fix.
- [x] Signed the commit and included a DCO sign-off.

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

