### PR TITLE
fix(memify): decode Neo4j JSON-string metadata when rebuilding canonicals

### DIFF
--- a/cognee/tasks/memify/consolidate_entities.py
+++ b/cognee/tasks/memify/consolidate_entities.py
@@ -411,6 +411,16 @@ def _build_canonical_entity(
     props.pop("is_a", None)
     props["name"] = canonical["name"]
     props["id"] = canonical["id"]
+    # Graph stores that cannot hold nested maps (Neo4j) persist dict-valued
+    # properties as JSON strings; get_graph_data() returns them verbatim, and
+    # Entity.from_dict then rejects `metadata` with a dict_type error — which
+    # silently skipped this rebuild for every canonical. Decode before validating.
+    metadata = props.get("metadata")
+    if isinstance(metadata, str):
+        try:
+            props["metadata"] = json.loads(metadata)
+        except ValueError:
+            props.pop("metadata", None)
 
     unioned = _union_descriptions([canonical] + duplicates)
     if unioned is not None:

--- a/cognee/tests/unit/memify_pipelines/test_consolidate_entities_pipeline.py
+++ b/cognee/tests/unit/memify_pipelines/test_consolidate_entities_pipeline.py
@@ -338,6 +338,42 @@ async def test_merge_without_clusters_is_noop():
 # --------------------------------------------------------------------------- #
 # belongs_to_set union + canonical id preservation
 # --------------------------------------------------------------------------- #
+def test_build_canonical_entity_decodes_json_string_metadata():
+    from cognee.tasks.memify.consolidate_entities import _build_canonical_entity
+
+    canonical_id = str(uuid4())
+    canonical = {
+        "id": canonical_id,
+        "name": "patse-ops",
+        "type": "project",
+        "description": "ops tooling",
+        "belongs_to_set": ["homelab"],
+        "props": {
+            "id": canonical_id,
+            "name": "patse-ops",
+            "description": "ops tooling",
+            "belongs_to_set": ["homelab"],
+            # Neo4j cannot store nested maps: dict-valued properties come back as JSON text.
+            "metadata": '{"index_fields": ["name"], "identity_fields": ["name"]}',
+        },
+    }
+    duplicate = {
+        "id": str(uuid4()),
+        "name": "patse ops",
+        "type": "project",
+        "description": "the same ops tooling",
+        "belongs_to_set": ["ipse-patse"],
+        "props": {},
+    }
+
+    entity = _build_canonical_entity(canonical, duplicate and [duplicate])
+
+    assert entity is not None
+    assert str(entity.id) == canonical_id
+    assert entity.metadata == {"index_fields": ["name"], "identity_fields": ["name"]}
+    assert set(entity.belongs_to_set) == {"homelab", "ipse-patse"}
+
+
 def test_union_belongs_to_set_handles_mixed_shapes_and_dedups():
     members = [
         {"belongs_to_set": ["a", "b"]},


### PR DESCRIPTION
## Description
`_build_canonical_entity()` in `consolidate_entities` hands the canonical node's raw graph properties to `Entity.from_dict`. Neo4j cannot store nested maps, so dict-valued properties such as `metadata` are persisted as JSON strings and `get_graph_data()` returns them verbatim. Pydantic then rejects the string (`dict_type`) and the rebuild is skipped for every canonical: after a merge the surviving node never receives the unioned description or the members' `belongs_to_set` tags, while the duplicates and their edges are still removed. Observed on a 16.8k-entity Neo4j graph: 231 of 231 canonical rebuilds skipped.

This decodes a string `metadata` before validation; a value that is not valid JSON is dropped rather than failing the rebuild. Stores that return real dicts are unaffected.

## Acceptance Criteria
- A canonical whose `metadata` comes back as a JSON string is rebuilt with the merged description and tags.
- Dict-valued `metadata` behaves exactly as before.
- The new test fails on `dev` (`dict_type` validation error skips the rebuild) and passes with the fix.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
```
$ .venv/Scripts/python.exe -m pytest cognee/tests/unit/memify_pipelines/test_consolidate_entities_pipeline.py -q
24 passed, 12 warnings in 0.58s        (dev + test only: 1 failed, 23 passed)
$ uvx ruff check / ruff format --check  cognee/tasks/memify/consolidate_entities.py cognee/tests/unit/memify_pipelines/test_consolidate_entities_pipeline.py
All checks passed! / 2 files already formatted
```
(Windows 11, Python 3.12, `uv sync` on `dev` @ 6c02245.)

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
