### PR TITLE
fix(embeddings): recover from OpenAI's 2048-input cap in embed_text

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -45,11 +45,14 @@ logger = get_logger("LiteLLMEmbeddingEngine")
 # the per-prediction instance cap ("2048 instance(s) is allowed per prediction")
 # and the per-model batch cap ("a batchSize value of 1234 but the supported
 # range is from 1 (inclusive) to 251 (exclusive)" -- "too many instances").
+# OpenAI caps the number of inputs per embeddings request ("'$.input' is
+# invalid ... array length must be 2048 or less").
 _EMBED_LENGTH_ERROR_RE = re.compile(
     r"maximum\s+input\s+length"
     r"|instance\(s\)\s+is\s+allowed\s+per\s+prediction"
     r"|too\s+many\s+instances"
-    r"|batchsize\s+value\s+of",
+    r"|batchsize\s+value\s+of"
+    r"|array\s+length\s+must\s+be",
     re.IGNORECASE,
 )
 

--- a/cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py
+++ b/cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py
@@ -225,6 +225,40 @@ async def test_litellm_embedding_splits_batch_on_vertex_instance_limit_error():
 
 
 @pytest.mark.asyncio
+async def test_litellm_embedding_splits_batch_on_openai_array_length_error():
+    import litellm
+
+    with patch(
+        "cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine."
+        "LiteLLMEmbeddingEngine.get_tokenizer",
+        return_value=Mock(),
+    ):
+        from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine import (
+            LiteLLMEmbeddingEngine,
+        )
+
+        engine = LiteLLMEmbeddingEngine(model="test-model", dimensions=2)
+
+    array_length_error = litellm.exceptions.BadRequestError(
+        message="'$.input' is invalid. Please check the API reference: "
+        "https://platform.openai.com/docs/api-reference. array length must be 2048 or less",
+        model="test-model",
+        llm_provider="openai",
+    )
+
+    async def fake_aembedding(**kwargs):
+        if len(kwargs["input"]) > 2:
+            raise array_length_error
+        return Mock(data=[{"embedding": [1.0, 1.0]} for _ in kwargs["input"]])
+
+    with patch("litellm.aembedding", AsyncMock(side_effect=fake_aembedding)) as embed_mock:
+        result = await engine.embed_text(["a", "b", "c", "d"])
+
+    assert result == [[1.0, 1.0]] * 4
+    assert embed_mock.await_count > 1
+
+
+@pytest.mark.asyncio
 async def test_litellm_embedding_splits_batch_on_vertex_model_batch_limit_error():
     import litellm
 


### PR DESCRIPTION
## Description
OpenAI rejects an embeddings request with more than 2048 inputs with a 400 whose message reads `'$.input' is invalid ... array length must be 2048 or less`. `embed_text` already splits and retries oversized batches for the Vertex phrasings and for `maximum input length`, but this message is not matched, so any caller that embeds a whole collection in one call fails outright above 2048 items. `consolidate_entities` does exactly that (it embeds every Entity name), so the dedup pipeline cannot run on a graph with more than 2048 entities against OpenAI.

This adds the OpenAI phrasing to the existing fallback pattern, so the batch is halved and retried like the other providers' cap errors. No behaviour change below the cap.

## Acceptance Criteria
- A 400 carrying `array length must be 2048 or less` triggers the split-and-retry path instead of propagating.
- The other matched phrasings behave as before.
- The new test fails on `dev` and passes with the fix.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
```
$ .venv/Scripts/python.exe -m pytest cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py -q
7 passed, 2 skipped        (dev + test only: 1 failed, 6 passed, 2 skipped)
$ uvx ruff check / ruff format --check  cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py
All checks passed! / 2 files already formatted
```
(Windows 11, Python 3.12, `uv sync` on `dev` @ 6c02245.)

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
