### PR TITLE
docs(examples): index company_brain_demo.py in the demos table

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ They double as the smoke-test corpus the team uses to verify behaviour across th
 |---|---|---|
 | [`guides/`](guides/) | One feature per script: concise, self-contained how-tos | 31 |
 | [`advanced_guides/`](advanced_guides/) | Deeper takes on topics a guide already covers | 8 |
-| [`demos/`](demos/) | Multiple features stitched into use cases, grouped by topic | 25 |
+| [`demos/`](demos/) | Multiple features stitched into use cases, grouped by topic | 26 |
 
 One line each: **guides teach a feature, advanced guides deepen a feature, demos combine
 features.** See [Contributing](#-contributing-a-new-example) for the precise category rules.
@@ -106,7 +106,13 @@ Each script names the simpler guide it builds on and states what it adds.
 
 ## 🎯 `demos/` — features combined into use cases
 
-Every demo lives in a topic folder.
+Every demo lives in a topic folder — with one root-level exception, the showcase
+linked from the root README.
+
+### Root level — the root-README showcase
+| Script | Demonstrates |
+|---|---|
+| [`company_brain_demo.py`](demos/company_brain_demo.py) | Text, code (Enola extraction), and session lessons distilled into one queryable company brain; supports `--recall-only` |
 
 ### [`comprehensive_example/`](demos/comprehensive_example/) — everything at once
 | Script | Demonstrates |


### PR DESCRIPTION
## What

Adds the missing demos index entry for `examples/demos/company_brain_demo.py` in `examples/README.md` and bumps the demos count from 25 to 26.

## Why

#4950 added `company_brain_demo.py` at the `demos/` root and linked it from the root README (["Build a small Company Brain from text, code, and session lessons"](/topoteretes/cognee/blob/main/README.md)), but the script never got a row in the demos index — `grep company examples/README.md` returns nothing on `main`, and the folder table still counted 25 demos. Per this README's own Contributing rule (*"add a row to the matching table in this README"*), the entry was due.

## How

- New root-level subsection with a single-row table entry, placed ahead of the topic folders since it is the showcase linked from the root README.
- The intro line now notes the one root-level exception instead of claiming every demo lives in a topic folder.
- The script itself is not moved — it stays at the `demos/` root as introduced by #4950 so the root README link keeps working. Moving it into a topic folder (e.g. a future `distillation/`) is left to maintainers' preference.

The entry text follows the demo docstring: text, code (Enola extraction), and session lessons distilled into one queryable company brain, with a `--recall-only` mode.