### PR TITLE
fix(frontend): detect active agent connections

### DIFF
--- a/cognee-frontend/src/app/(app)/dashboard/hooks/__tests__/useConnectedIntegrations.test.tsx
+++ b/cognee-frontend/src/app/(app)/dashboard/hooks/__tests__/useConnectedIntegrations.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import type { SessionRow } from "@/modules/sessions/getSessions";
+
+const mockUseCogniInstance = jest.fn();
+const mockGetConnectedIntegrations = jest.fn();
+const mockPersistConnectedIntegrations = jest.fn();
+
+jest.mock("@/modules/tenant/TenantProvider", () => ({
+  useCogniInstance: () => mockUseCogniInstance(),
+}));
+
+jest.mock("@/utils/browserStorage", () => ({
+  getConnectedIntegrations: (...args: unknown[]) => mockGetConnectedIntegrations(...args),
+  setConnectedIntegrations: (...args: unknown[]) => mockPersistConnectedIntegrations(...args),
+}));
+
+import { useConnectedIntegrations } from "../useConnectedIntegrations";
+
+const mockFetch = jest.fn();
+
+function session(sessionId: string): SessionRow {
+  return {
+    session_id: sessionId,
+    user_id: "user-1",
+    dataset_id: null,
+    status: "running",
+    effective_status: "running",
+    started_at: null,
+    last_activity_at: null,
+    ended_at: null,
+    tokens_in: 0,
+    tokens_out: 0,
+    cost_usd: 0,
+    error_count: 0,
+    last_model: null,
+  };
+}
+
+beforeEach(() => {
+  mockUseCogniInstance.mockReturnValue({ cogniInstance: { fetch: mockFetch } });
+  mockGetConnectedIntegrations.mockReturnValue({});
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ agents: [] }),
+  });
+});
+
+describe("useConnectedIntegrations", () => {
+  it("marks Codex connected from an active connection before a session exists", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ agents: [{ session_id: "codex_live-session" }] }),
+    });
+
+    const { result } = renderHook(() => useConnectedIntegrations([], "tenant-1"));
+
+    await waitFor(() => expect(result.current.codex).toBe(true));
+    expect(mockFetch).toHaveBeenCalledWith("/v1/agents/connections?active_only=true");
+    expect(mockPersistConnectedIntegrations).toHaveBeenCalledWith("tenant-1", { codex: true });
+  });
+
+  it("keeps detecting integrations from sessions when the connection endpoint fails", async () => {
+    mockFetch.mockRejectedValue(new Error("endpoint unavailable"));
+
+    const { result } = renderHook(() =>
+      useConnectedIntegrations([session("cc_existing-session")], "tenant-1"),
+    );
+
+    await waitFor(() => expect(result.current["claude-code"]).toBe(true));
+  });
+});

--- a/cognee-frontend/src/app/(app)/dashboard/hooks/useConnectedIntegrations.ts
+++ b/cognee-frontend/src/app/(app)/dashboard/hooks/useConnectedIntegrations.ts
@@ -2,10 +2,21 @@
 
 import { useState, useEffect } from "react";
 import type { SessionRow } from "@/modules/sessions/getSessions";
+import { useCogniInstance } from "@/modules/tenant/TenantProvider";
 import {
   getConnectedIntegrations,
   setConnectedIntegrations as persistConnectedIntegrations,
 } from "@/utils/browserStorage";
+
+const CONNECTION_REFRESH_INTERVAL_MS = 15_000;
+
+interface AgentConnection {
+  session_id?: string | null;
+}
+
+interface AgentConnectionsResponse {
+  agents?: AgentConnection[];
+}
 
 // Per-integration session_id prefix. Detection is coarse on purpose — any session
 // whose id starts with the prefix counts as connected. Keep these in sync with
@@ -17,22 +28,66 @@ export const INTEGRATION_SESSION_PREFIX: Record<string, string> = {
 };
 
 /**
- * Derives and persists per-integration "Connected" state from the session_id
- * prefixes. Sticky per tenant via localStorage so a card stays "Connected" after
- * its session ages out of the polled window.
+ * Derives and persists per-integration "Connected" state from session and active
+ * connection ids. Sticky per tenant via localStorage so a card stays "Connected"
+ * after its session or connection ages out of the polled window.
  */
 export function useConnectedIntegrations(
   sessions: SessionRow[],
   tenantId: string | null,
 ): Record<string, boolean> {
+  const { cogniInstance } = useCogniInstance();
+  const [activeSessionIds, setActiveSessionIds] = useState<string[]>([]);
   const [connectedIntegrations, setConnectedIntegrations] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    if (!cogniInstance || !tenantId) {
+      setActiveSessionIds([]);
+      return;
+    }
+
+    let cancelled = false;
+    const instance = cogniInstance;
+
+    async function loadActiveConnections() {
+      try {
+        const response = await instance.fetch("/v1/agents/connections?active_only=true");
+        if (!response.ok) return;
+
+        const payload = (await response.json()) as AgentConnectionsResponse;
+        if (!cancelled) {
+          setActiveSessionIds(
+            (payload.agents ?? [])
+              .map((connection) => connection.session_id)
+              .filter((sessionId): sessionId is string => Boolean(sessionId)),
+          );
+        }
+      } catch {
+        // Connection status is supplementary. Session-derived and persisted
+        // state still provide a useful fallback when this endpoint is absent.
+      }
+    }
+
+    void loadActiveConnections();
+    const interval = window.setInterval(loadActiveConnections, CONNECTION_REFRESH_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [cogniInstance, tenantId]);
 
   useEffect(() => {
     if (!tenantId) return;
     const persisted = getConnectedIntegrations(tenantId);
     const next = { ...persisted };
     for (const [key, prefix] of Object.entries(INTEGRATION_SESSION_PREFIX)) {
-      if (sessions.some((s) => s.session_id.startsWith(prefix))) next[key] = true;
+      if (
+        sessions.some((session) => session.session_id.startsWith(prefix)) ||
+        activeSessionIds.some((sessionId) => sessionId.startsWith(prefix))
+      ) {
+        next[key] = true;
+      }
     }
     if (JSON.stringify(next) !== JSON.stringify(persisted)) {
       persistConnectedIntegrations(tenantId, next);
@@ -40,7 +95,7 @@ export function useConnectedIntegrations(
     setConnectedIntegrations((prev) =>
       JSON.stringify(prev) !== JSON.stringify(next) ? next : prev,
     );
-  }, [sessions, tenantId]);
+  }, [activeSessionIds, sessions, tenantId]);
 
   return connectedIntegrations;
 }

--- a/cognee-frontend/src/app/(app)/integrations/partials/useAgentConnectionStatus.ts
+++ b/cognee-frontend/src/app/(app)/integrations/partials/useAgentConnectionStatus.ts
@@ -14,10 +14,9 @@ const UNCONNECTED: Record<string, boolean> = Object.fromEntries(
 );
 
 /**
- * One-shot (not polled) session lookup for the Agents card badges — this page
- * just needs "did this agent ever check in", not the dashboard's live feed.
- * Delegates the actual session_id → integration matching to the existing
- * useConnectedIntegrations hook so both pages agree on what "Connected" means.
+ * One-shot session lookup for the Agents card badges. Delegates matching and
+ * active-connection polling to the existing useConnectedIntegrations hook so
+ * this page and the dashboard agree on what "Connected" means.
  * That hook only ever reports `true` (sticky, never flips back to false), so
  * we seed every known key at `false` first and let real detections override it —
  * otherwise cards that were never connected would render no badge at all.


### PR DESCRIPTION
## Description

Fixes #4957.

Integration badges now combine the existing session-prefix detection with active agent connections returned by `/v1/agents/connections?active_only=true`. This covers the period after an agent registers but before it creates its first Q&A/session record.

The connection lookup is tenant-scoped, refreshes every 15 seconds, and degrades to the existing session/local-storage behavior if the endpoint is unavailable.

## Acceptance Criteria

- A registered active `codex_*` connection marks Codex as connected before any session row exists.
- Existing session-based detection still works if the connections endpoint fails.
- Dashboard and Integrations pages continue to share the same status logic.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

No visual layout changed. Local verification:

```text
Test Suites: 50 passed, 50 total
Tests:       483 passed, 483 total
Snapshots:   0 total
```

Additional checks:

```text
npx eslint <changed files>  # passed
npx tsc --noEmit            # passed
```

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
