### PR TITLE
fix(ui): tolerate occupied optional MCP port

### DIFF
--- a/cognee/api/v1/ui/ui.py
+++ b/cognee/api/v1/ui/ui.py
@@ -478,16 +478,13 @@ def start_ui(
     """
     logger.info("Starting cognee UI...")
 
-    ports_to_check = [(port, "Frontend UI")]
+    required_ports = [(port, "Frontend UI")]
 
     if start_backend:
-        ports_to_check.append((backend_port, "Backend API"))
-
-    if start_mcp:
-        ports_to_check.append((mcp_port, "MCP Server"))
+        required_ports.append((backend_port, "Backend API"))
 
     logger.info("Checking port availability...")
-    all_ports_available, unavailable_services = _check_required_ports(ports_to_check)
+    all_ports_available, unavailable_services = _check_required_ports(required_ports)
 
     if not all_ports_available:
         error_msg = f"Cannot start cognee UI: The following services have ports already in use: {', '.join(unavailable_services)}"
@@ -495,7 +492,18 @@ def start_ui(
         logger.error("Please stop the conflicting services or change the port configuration.")
         return None
 
-    logger.info("✓ All required ports are available")
+    if start_mcp:
+        mcp_port_available, unavailable_mcp_services = _check_required_ports(
+            [(mcp_port, "MCP Server")]
+        )
+        if not mcp_port_available:
+            logger.warning(
+                "The optional MCP server port is already in use: "
+                f"{', '.join(unavailable_mcp_services)}. Skipping MCP server startup."
+            )
+            start_mcp = False
+
+    logger.info("✓ All required UI ports are available")
     backend_process = None
 
     if start_mcp:

--- a/cognee/tests/unit/api/v1/ui/test_docker_preflight.py
+++ b/cognee/tests/unit/api/v1/ui/test_docker_preflight.py
@@ -97,6 +97,58 @@ class TestStartUiDockerIntegration:
 
     @patch("cognee.api.v1.ui.ui.prompt_user_for_download", return_value=False)
     @patch("cognee.api.v1.ui.ui.find_frontend_path", return_value=None)
+    @patch("cognee.api.v1.ui.ui._check_docker_available")
+    @patch(
+        "cognee.api.v1.ui.ui._check_required_ports",
+        side_effect=[(True, []), (False, ["MCP Server (port 8001)"])],
+    )
+    def test_skips_mcp_when_its_optional_port_is_occupied(
+        self, mock_ports, mock_docker, mock_frontend, mock_prompt
+    ):
+        """An MCP port conflict must not prevent the UI from continuing startup."""
+        from cognee.api.v1.ui.ui import start_ui
+
+        start_ui(
+            pid_callback=lambda p: None,
+            start_mcp=True,
+            start_backend=False,
+        )
+
+        assert mock_ports.call_args_list == [
+            call([(3000, "Frontend UI")]),
+            call([(8001, "MCP Server")]),
+        ]
+        mock_docker.assert_not_called()
+        mock_frontend.assert_called_once()
+        mock_prompt.assert_called_once()
+
+    @patch("cognee.api.v1.ui.ui.prompt_user_for_download")
+    @patch("cognee.api.v1.ui.ui.find_frontend_path")
+    @patch("cognee.api.v1.ui.ui._check_docker_available")
+    @patch(
+        "cognee.api.v1.ui.ui._check_required_ports",
+        return_value=(False, ["Frontend UI (port 3000)"]),
+    )
+    def test_still_aborts_when_a_required_ui_port_is_occupied(
+        self, mock_ports, mock_docker, mock_frontend, mock_prompt
+    ):
+        """Frontend and backend port conflicts remain fatal startup errors."""
+        from cognee.api.v1.ui.ui import start_ui
+
+        result = start_ui(
+            pid_callback=lambda p: None,
+            start_mcp=True,
+            start_backend=False,
+        )
+
+        assert result is None
+        mock_ports.assert_called_once_with([(3000, "Frontend UI")])
+        mock_docker.assert_not_called()
+        mock_frontend.assert_not_called()
+        mock_prompt.assert_not_called()
+
+    @patch("cognee.api.v1.ui.ui.prompt_user_for_download", return_value=False)
+    @patch("cognee.api.v1.ui.ui.find_frontend_path", return_value=None)
     @patch("cognee.api.v1.ui.ui._check_docker_available", return_value=(False, "no docker"))
     @patch("cognee.api.v1.ui.ui._check_required_ports", return_value=(True, []))
     def test_skips_mcp_docker_pull_when_docker_unavailable(


### PR DESCRIPTION
## Description

Fixes #4959.

UI/backend ports remain required, but the MCP port is now checked separately. If the optional MCP port is occupied, startup logs a warning, disables MCP for that launch, and continues with the frontend/backend. This matches the existing graceful fallback when Docker is unavailable.

## Acceptance Criteria

- An occupied optional MCP port does not abort UI startup.
- Docker preflight/pull is not attempted after the MCP port is found occupied.
- An occupied frontend or backend port still aborts startup.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

No visual layout changed. Targeted local verification:

```text
cognee/tests/unit/api/v1/ui/test_docker_preflight.py
10 passed, 14 warnings in 1.04s
```

`uv run ruff format --check` passed for both changed files. A full-file `ruff check` still reports 36 pre-existing findings in these files; none point to the changed lines.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
