### PR TITLE
chore: Enforce and fix exception-handling rules (SDK-583)

### DIFF
--- a/.github/workflows/community_tests.yml
+++ b/.github/workflows/community_tests.yml
@@ -47,6 +47,15 @@ jobs:
       - name: Ruff check
         run: uv run ruff check .
 
+      # Exception-handling rules are enforced without escape hatch: `--ignore-noqa`
+      # makes a `# noqa` comment on these rules count as a finding, so a silent
+      # `except Exception` has to be fixed (log with traceback, re-raise, or narrow
+      # the type), not suppressed. Scope: BLE001 blind except, S110/S112 try-except
+      # pass/continue, G201 exc_info logging, TRY201 verbose raise, TRY002 vanilla
+      # Exception raise.
+      - name: Ruff exception-handling rules (strict, noqa ignored)
+        run: uv run ruff check . --select BLE001,S110,S112,G201,TRY201,TRY002 --ignore-noqa
+
       - name: Ruff format check
         run: uv run ruff format --check .
 

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -381,10 +381,10 @@ def start_api_server(host: str = "0.0.0.0", port: int = 8000):
 
         config = uvicorn.Config(app, host=host, port=port)
         uvicorn.Server(config).run(sockets=[sock])
-    except Exception as e:
-        logger.exception(f"Failed to start server: {e}")
+    except Exception:
+        logger.exception("Failed to start server")
         # Here you could add any cleanup code or error recovery code.
-        raise e
+        raise
 
 
 if __name__ == "__main__":

--- a/cognee/api/v1/forget/routers/get_forget_router.py
+++ b/cognee/api/v1/forget/routers/get_forget_router.py
@@ -116,9 +116,9 @@ def get_forget_router() -> APIRouter:
                     "error": "Invalid request parameters. Specify dataset or dataset_id, data_id+dataset, or everything=True."
                 },
             )
-        except Exception as error:
+        except Exception:
             logger = get_logger()
-            logger.error("Forget endpoint error: %s", error, exc_info=True)
+            logger.exception("Forget endpoint error")
             return JSONResponse(
                 status_code=500,
                 content={"error": "An error occurred during deletion."},

--- a/cognee/api/v1/health/health.py
+++ b/cognee/api/v1/health/health.py
@@ -69,7 +69,7 @@ class HealthChecker:
             )
         except Exception as e:
             response_time = int((time.time() - start_time) * 1000)
-            logger.error(f"Relational DB health check failed: {e!s}", exc_info=True)
+            logger.exception("Relational DB health check failed")
             return ComponentHealth(
                 status=HealthStatus.UNHEALTHY,
                 provider="unknown",
@@ -105,7 +105,7 @@ class HealthChecker:
             )
         except Exception as e:
             response_time = int((time.time() - start_time) * 1000)
-            logger.error(f"Vector DB health check failed: {e!s}", exc_info=True)
+            logger.exception("Vector DB health check failed")
             return ComponentHealth(
                 status=HealthStatus.UNHEALTHY,
                 provider="unknown",
@@ -137,7 +137,7 @@ class HealthChecker:
             )
         except Exception as e:
             response_time = int((time.time() - start_time) * 1000)
-            logger.error(f"Graph DB health check failed: {e!s}", exc_info=True)
+            logger.exception("Graph DB health check failed")
             return ComponentHealth(
                 status=HealthStatus.UNHEALTHY,
                 provider="unknown",
@@ -216,7 +216,7 @@ class HealthChecker:
             )
         except Exception as e:
             response_time = int((time.time() - start_time) * 1000)
-            logger.error(f"LLM provider health check failed: {e!s}", exc_info=True)
+            logger.exception("LLM provider health check failed")
             return ComponentHealth(
                 status=HealthStatus.DEGRADED,
                 provider="unknown",

--- a/cognee/api/v1/improve/routers/get_improve_router.py
+++ b/cognee/api/v1/improve/routers/get_improve_router.py
@@ -102,8 +102,8 @@ def get_improve_router() -> APIRouter:
             # Cognee errors carry their own status code and actionable message;
             # the global handler in cognee/api/client.py returns them.
             raise
-        except Exception as error:
-            logger.error("Improve endpoint error: %s", error, exc_info=True)
+        except Exception:
+            logger.exception("Improve endpoint error")
             return JSONResponse(
                 status_code=409,
                 content={"error": "An error occurred during graph improvement."},

--- a/cognee/api/v1/proposals/routers/get_proposals_router.py
+++ b/cognee/api/v1/proposals/routers/get_proposals_router.py
@@ -126,8 +126,8 @@ def get_proposals_router() -> APIRouter:
             return JSONResponse(
                 status_code=403, content={"error": "Not authorized for this dataset"}
             )
-        except Exception as exc:
-            logger.error("get proposal failed: %s", exc, exc_info=True)
+        except Exception:
+            logger.exception("get proposal failed")
             return JSONResponse(status_code=409, content={"error": "Failed to fetch proposal"})
 
     return router

--- a/cognee/api/v1/recall/recall_stream.py
+++ b/cognee/api/v1/recall/recall_stream.py
@@ -195,7 +195,7 @@ class RecallStream:
             except (asyncio.CancelledError, GeneratorExit):
                 raise
             except Exception as error:  # noqa: BLE001 - the client already has a 200
-                logger.error("Streaming recall failed: %s", error, exc_info=True)
+                logger.exception("Streaming recall failed")
                 if not self._errored:
                     # Only if the engine has not already reported it: a second
                     # `error` frame would arrive after a client that treats the
@@ -209,7 +209,7 @@ class RecallStream:
                 # unvalidated, which is exactly the shape jsonable_encoder can
                 # fail on. Letting that propagate would truncate the response
                 # with no terminal event at all; the JSON path degrades to a 409.
-                logger.error("Could not encode the streamed recall payload", exc_info=True)
+                logger.exception("Could not encode the streamed recall payload")
                 if not self._errored:
                     yield encode_sse("error", _error_payload(error))
                 return

--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -184,9 +184,9 @@ def get_recall_router() -> APIRouter:
         try:
             history = await get_history(user.id, limit=0)
             return history
-        except Exception as error:
+        except Exception:
             logger = get_logger()
-            logger.error("Recall history error: %s", error, exc_info=True)
+            logger.exception("Recall history error")
             return JSONResponse(
                 status_code=500,
                 content={"error": "An error occurred while fetching recall history."},
@@ -340,9 +340,9 @@ def get_recall_router() -> APIRouter:
                     f"{sorted(_VALID_SCOPES)}."
                 },
             )
-        except Exception as error:
+        except Exception:
             logger = get_logger()
-            logger.error("Recall endpoint error: %s", error, exc_info=True)
+            logger.exception("Recall endpoint error")
             return JSONResponse(
                 status_code=409,
                 content={"error": "An error occurred during recall."},

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -91,16 +91,16 @@ async def _import_cogx_archives(
         # and actionable message; the global handler in cognee/api/client.py
         # returns them.
         raise
-    except (ValueError, tarfile.TarError) as error:
+    except (ValueError, tarfile.TarError):
         # Log the detail server-side; the response stays generic so exception
         # text / stack frames are not exposed to the caller (CodeQL py/stack-trace-exposure).
-        logger.error("COGX archive import validation error: %s", error, exc_info=True)
+        logger.exception("COGX archive import validation error")
         return JSONResponse(
             status_code=400,
             content={"error": "Invalid COGX archive."},
         )
-    except Exception as error:
-        logger.error("COGX archive import error: %s", error, exc_info=True)
+    except Exception:
+        logger.exception("COGX archive import error")
         return JSONResponse(
             status_code=409,
             content={"error": "An error occurred during COGX archive import."},
@@ -599,13 +599,13 @@ def get_remember_router() -> APIRouter:
             # the global handler in cognee/api/client.py returns them.
             raise
         except ValueError as error:
-            logger.error("Remember endpoint validation error: %s", error, exc_info=True)
+            logger.exception("Remember endpoint validation error")
             return JSONResponse(
                 status_code=409,
                 content={"error": f"Invalid request data for remember operation: {error}"},
             )
         except Exception as error:
-            logger.error("Remember endpoint error: %s", error, exc_info=True)
+            logger.exception("Remember endpoint error")
             return JSONResponse(
                 status_code=409,
                 content={"error": f"An error occurred during remember: {error}"},
@@ -705,8 +705,8 @@ def get_remember_router() -> APIRouter:
             # Cognee errors carry their own status code and actionable message;
             # the global handler in cognee/api/client.py returns them.
             raise
-        except Exception as error:
-            logger.error("Remember entry endpoint error: %s", error, exc_info=True)
+        except Exception:
+            logger.exception("Remember entry endpoint error")
             return JSONResponse(
                 status_code=409,
                 content={"error": "An error occurred during remember."},

--- a/cognee/api/v1/responses/routers/get_responses_router.py
+++ b/cognee/api/v1/responses/routers/get_responses_router.py
@@ -146,7 +146,7 @@ def get_responses_router() -> APIRouter:
                     function_result = await dispatch_function(tool_call)
                     output_status = "success"
                 except Exception as e:
-                    logger.exception(f"Error executing function {function_name}: {e}")
+                    logger.exception(f"Error executing function {function_name}")
                     function_result = f"Error executing {function_name}: {e!s}"
                     output_status = "error"
 

--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -131,8 +131,8 @@ def get_sessions_router() -> APIRouter:
                     "has_more": page.has_more,
                 }
             )
-        except Exception as exc:
-            logger.error("list_sessions failed: %s", exc, exc_info=True)
+        except Exception:
+            logger.exception("list_sessions failed")
             return JSONResponse(status_code=500, content={"error": "list failed"})
 
     @router.get("/stats")
@@ -369,8 +369,8 @@ def get_sessions_router() -> APIRouter:
             # message; the global handler in cognee/api/client.py returns
             # them to the caller.
             raise
-        except Exception as exc:
-            logger.error("list_sessions_with_agent_info failed: %s", exc, exc_info=True)
+        except Exception:
+            logger.exception("list_sessions_with_agent_info failed")
             return JSONResponse(status_code=500, content={"error": "list failed"})
 
     @router.get("/cost-by-user-agent")
@@ -406,8 +406,8 @@ def get_sessions_router() -> APIRouter:
             # message; the global handler in cognee/api/client.py returns
             # them to the caller.
             raise
-        except Exception as exc:
-            logger.error("cost_by_user_agent failed: %s", exc, exc_info=True)
+        except Exception:
+            logger.exception("cost_by_user_agent failed")
             return JSONResponse(status_code=500, content={"error": "aggregation failed"})
 
     @router.get("/{session_id}")

--- a/cognee/api/v1/skills/routers/get_skills_router.py
+++ b/cognee/api/v1/skills/routers/get_skills_router.py
@@ -135,8 +135,8 @@ def get_skills_router() -> APIRouter:
                 **({"dataset_id": payload.dataset_id} if payload.dataset_id else {}),
             )
             return jsonable_encoder(result.to_dict())
-        except Exception as exc:
-            logger.error("ingest skill failed: %s", exc, exc_info=True)
+        except Exception:
+            logger.exception("ingest skill failed")
             return JSONResponse(status_code=409, content={"error": "Failed to ingest skill"})
 
     @router.get(
@@ -194,8 +194,8 @@ def get_skills_router() -> APIRouter:
             return JSONResponse(
                 status_code=403, content={"error": "Not authorized for this dataset"}
             )
-        except Exception as exc:
-            logger.error("list skills failed: %s", exc, exc_info=True)
+        except Exception:
+            logger.exception("list skills failed")
             return JSONResponse(status_code=409, content={"error": "Failed to list skills"})
 
     @router.get(
@@ -232,8 +232,8 @@ def get_skills_router() -> APIRouter:
             return JSONResponse(
                 status_code=403, content={"error": "Not authorized for this dataset"}
             )
-        except Exception as exc:
-            logger.error("get skill failed: %s", exc, exc_info=True)
+        except Exception:
+            logger.exception("get skill failed")
             return JSONResponse(status_code=409, content={"error": "Failed to fetch skill"})
 
     @router.delete(
@@ -270,8 +270,8 @@ def get_skills_router() -> APIRouter:
             return JSONResponse(
                 status_code=403, content={"error": "Not authorized for this dataset"}
             )
-        except Exception as exc:
-            logger.error("delete skill failed: %s", exc, exc_info=True)
+        except Exception:
+            logger.exception("delete skill failed")
             return JSONResponse(status_code=409, content={"error": "Failed to delete skill"})
 
     return router

--- a/cognee/api/v1/validate/routers/get_validate_router.py
+++ b/cognee/api/v1/validate/routers/get_validate_router.py
@@ -42,8 +42,8 @@ def get_validate_router() -> APIRouter:
             report = await validate(dataset=dataset, user=user)
             status_code = 503 if report.status == ValidationStatus.UNHEALTHY else 200
             return JSONResponse(status_code=status_code, content=report.model_dump(mode="json"))
-        except Exception as error:
-            logger.error("validate() failed: %s", error, exc_info=True)
+        except Exception:
+            logger.exception("validate() failed")
             return JSONResponse(
                 status_code=500,
                 content={"status": "error", "reason": "validation failed; see server logs."},

--- a/cognee/api/v1/visualize/routers/get_schema_router.py
+++ b/cognee/api/v1/visualize/routers/get_schema_router.py
@@ -125,8 +125,8 @@ def get_schema_router() -> APIRouter:
                 status_code=403,
                 content={"error": "Not authorized to read this dataset"},
             )
-        except Exception as exc:
-            logger.error("schema inventory failed: %s", exc, exc_info=True)
+        except Exception:
+            logger.exception("schema inventory failed")
             return JSONResponse(
                 status_code=409,
                 content={"error": "Failed to build schema inventory"},
@@ -180,8 +180,8 @@ def get_schema_router() -> APIRouter:
                 scope_user_ids=scope_user_ids,
             )
             return HTMLResponse(html)
-        except Exception as exc:
-            logger.error("schema provenance failed: %s", exc, exc_info=True)
+        except Exception:
+            logger.exception("schema provenance failed")
             return JSONResponse(
                 status_code=409,
                 content={"error": "Failed to build memory provenance"},
@@ -239,8 +239,8 @@ def get_schema_router() -> APIRouter:
                 scope_user_ids=scope_user_ids,
             )
             return JSONResponse(status_code=200, content=payload)
-        except Exception as exc:
-            logger.error("schema provenance json failed: %s", exc, exc_info=True)
+        except Exception:
+            logger.exception("schema provenance json failed")
             return JSONResponse(
                 status_code=409,
                 content={"error": "Failed to build memory provenance"},

--- a/cognee/cli/_cognee.py
+++ b/cognee/cli/_cognee.py
@@ -389,7 +389,7 @@ def main() -> int:
             fmt.error(f"Error starting UI: {ex!s}")
             signal_handler(signal.SIGTERM, None)
             if debug.is_debug_enabled():
-                raise ex
+                raise
             return 1
 
     # When --api-url is set, delegate to the API server instead of running
@@ -404,7 +404,7 @@ def main() -> int:
         except Exception as ex:
             fmt.error(str(ex))
             if debug.is_debug_enabled():
-                raise ex
+                raise
             return 1
         return 0
 

--- a/cognee/eval_framework/corpus_builder/task_getters/get_cascade_graph_tasks.py
+++ b/cognee/eval_framework/corpus_builder/task_getters/get_cascade_graph_tasks.py
@@ -44,7 +44,7 @@ async def get_cascade_graph_tasks(
             ),
             Task(add_data_points, task_config={"batch_size": 10}),
         ]
-    except Exception as error:
+    except Exception:
         send_telemetry("cognee.cognify DEFAULT TASKS CREATION ERRORED", user)
-        raise error
+        raise
     return default_tasks

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -348,7 +348,7 @@ class DatasetQueue:
                 if reaped:
                     logger.debug("Idle reaper closed %d subprocess engine(s)", reaped)
             except Exception:
-                logger.error("Idle reaper sweep failed", exc_info=True)
+                logger.exception("Idle reaper sweep failed")
 
     def _evict_subprocess_engines(self) -> None:
         """Evict this context's subprocess-mode engines from their caches.

--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -569,7 +569,7 @@ class LadybugAdapter(GraphDBInterface):
             logger.debug("Ladybug database initialized successfully")
         except Exception as e:
             logger.error(f"Failed to initialize Ladybug database: {e}")
-            raise e
+            raise
 
     async def push_to_s3(self) -> None:
         if os.getenv("STORAGE_BACKEND", "").lower() == "s3" and hasattr(self, "temp_graph_file"):
@@ -3962,8 +3962,8 @@ class LadybugAdapter(GraphDBInterface):
 
                 triplets.append(triplet)
 
-            except Exception as e:
-                logger.error(f"Error processing triplet at index {idx}: {e}", exc_info=True)
+            except Exception:
+                logger.exception(f"Error processing triplet at index {idx}")
                 continue
 
         return triplets

--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -275,8 +275,8 @@ class Neo4jAdapter(GraphDBInterface):
             except Neo4jError as error:
                 otel_span.set_status(StatusCode.ERROR, str(error))
                 otel_span.record_exception(error)
-                logger.error("Neo4j query error: %s", error, exc_info=True)
-                raise error
+                logger.exception("Neo4j query error")
+                raise
 
     async def has_node(self, node_id: str) -> bool:
         """
@@ -1117,9 +1117,9 @@ class Neo4jAdapter(GraphDBInterface):
                 for result in results
                 if result["edge_exists"]
             ]
-        except Neo4jError as error:
-            logger.error("Neo4j query error: %s", error, exc_info=True)
-            raise error
+        except Neo4jError:
+            logger.exception("Neo4j query error")
+            raise
 
     async def add_edge(
         self,
@@ -1274,9 +1274,9 @@ class Neo4jAdapter(GraphDBInterface):
             ):
                 results = await self.query(query, {"edges": edges, **provenance_params})
             return results
-        except Neo4jError as error:
-            logger.error("Neo4j query error: %s", error, exc_info=True)
-            raise error
+        except Neo4jError:
+            logger.exception("Neo4j query error")
+            raise
 
     async def get_edges(self, node_id: str):
         """
@@ -1470,7 +1470,7 @@ class Neo4jAdapter(GraphDBInterface):
             return [_strip_provenance(row["properties"]) for row in result] if result else []
         except Exception as exc:
             logger.error(f"Failed to get neighbors for node {node_id}: {exc}")
-            raise exc
+            raise
 
     async def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
         """

--- a/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
+++ b/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
@@ -327,7 +327,7 @@ class SQLAlchemyAdapter:
 
         except Exception as e:
             logger.error(f"Insert failed: {e!s}")
-            raise e  # Re-raise for error handling upstream
+            raise  # Re-raise for error handling upstream
 
     async def get_schema_list(self) -> List[str]:
         """
@@ -661,7 +661,7 @@ class SQLAlchemyAdapter:
                 logger.debug("Database tables dropped successfully.")
             except Exception as e:
                 logger.error(f"Error dropping database tables: {e}")
-                raise e
+                raise
 
     async def create_database(self, script_location: Optional[str] = None):
         """
@@ -771,7 +771,7 @@ class SQLAlchemyAdapter:
 
         except Exception as e:
             logger.error(f"Error deleting database: {e}")
-            raise e
+            raise
 
         logger.info("Database deleted successfully.")
 

--- a/cognee/infrastructure/databases/utils/closing_lru_cache.py
+++ b/cognee/infrastructure/databases/utils/closing_lru_cache.py
@@ -580,13 +580,12 @@ class ClosingLRUCache:
             # a result, never an exception (see _start_close). Getting here
             # means that invariant broke — surface it loudly, but still
             # proceed: a creator must not fail over close bookkeeping.
-            logger.error(
+            logger.exception(
                 "BUG: unexpected error while waiting for pending close of cache key %s — "
                 "registry futures must only ever resolve with None (see _start_close), so "
                 "the closing-registry contract was violated and must be root-caused "
                 "(the operation itself continues safely)",
                 _key_id(key),
-                exc_info=True,
             )
 
     def _track_close(self, key, value) -> None:
@@ -663,13 +662,12 @@ class ClosingLRUCache:
             # a result, never an exception (see _start_close). Getting here
             # means that invariant broke — surface it loudly, but let the
             # caller proceed: failing it over close bookkeeping is worse.
-            logger.error(
+            logger.exception(
                 "BUG: unexpected error while waiting for pending close of cache key %s — "
                 "registry futures must only ever resolve with None (see _start_close), so "
                 "the closing-registry contract was violated and must be root-caused "
                 "(the operation itself continues safely)",
                 _key_id(key),
-                exc_info=True,
             )
 
     def _wrap_cached_value(self, entry):

--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -313,7 +313,7 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
                 return [pooled.tolist()]
 
             logger.error("Embedding input exceeds the model's max length: %s", str(error))
-            raise error
+            raise
 
         except asyncio.TimeoutError as e:
             # Per-attempt timeout – likely an unreachable endpoint

--- a/cognee/infrastructure/llm/streaming/token_sink.py
+++ b/cognee/infrastructure/llm/streaming/token_sink.py
@@ -371,7 +371,7 @@ async def answer_scope(
         # The consumer has already been handed a 200 and part of an answer, so
         # the failure has to reach it as an event. The detail stays server-side:
         # provider errors embed the rendered prompt and connection details.
-        logger.error("Answer streaming failed: %s", error, exc_info=True)
+        logger.exception("Answer streaming failed")
         if sink.owns(producer):
             sink.fail(
                 f"{type(error).__name__} during answer generation",

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
@@ -237,9 +237,9 @@ class AzureOpenAIAdapter(OpenAIAdapter):
             ContentFilterFinishReasonError,
             ContentPolicyViolationError,
             InstructorRetryException,
-        ) as e:
+        ):
             if not (self.fallback_model and self.fallback_api_key):
-                raise e
+                raise
             # Fall back to litellm for fallback model
             try:
                 fallback_aclient = instructor.from_litellm(litellm.acompletion)
@@ -270,7 +270,7 @@ class AzureOpenAIAdapter(OpenAIAdapter):
                     isinstance(error, InstructorRetryException)
                     and "content management policy" not in str(error).lower()
                 ):
-                    raise error
+                    raise
                 else:
                     raise ContentPolicyFilterError(
                         f"The provided input contains content that is not aligned with our content policy: {text_input}"

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/bedrock/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/bedrock/adapter.py
@@ -143,7 +143,7 @@ class BedrockAdapter(LLMInterface):
                 isinstance(error, InstructorRetryException)
                 and "content management policy" not in str(error).lower()
             ):
-                raise error
+                raise
 
             raise ContentPolicyFilterError(
                 f"The provided input contains content that is not aligned with our content policy: {text_input}"

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/gemini/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/gemini/adapter.py
@@ -160,7 +160,7 @@ class GeminiAdapter(GenericAPIAdapter):
                 isinstance(error, InstructorRetryException)
                 and "content management policy" not in str(error).lower()
             ):
-                raise error
+                raise
 
             if not (self.fallback_model and self.fallback_api_key and self.fallback_endpoint):
                 raise ContentPolicyFilterError(
@@ -196,7 +196,7 @@ class GeminiAdapter(GenericAPIAdapter):
                     isinstance(error, InstructorRetryException)
                     and "content management policy" not in str(error).lower()
                 ):
-                    raise error
+                    raise
                 else:
                     raise ContentPolicyFilterError(
                         f"The provided input contains content that is not aligned with our content policy: {text_input}"

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -278,7 +278,7 @@ class GenericAPIAdapter(LLMInterface):
                 isinstance(error, InstructorRetryException)
                 and "content management policy" not in str(error).lower()
             ):
-                raise error
+                raise
 
             if not (self.fallback_model and self.fallback_api_key and self.fallback_endpoint):
                 raise ContentPolicyFilterError(
@@ -319,7 +319,7 @@ class GenericAPIAdapter(LLMInterface):
                     isinstance(error, InstructorRetryException)
                     and "content management policy" not in str(error).lower()
                 ):
-                    raise error
+                    raise
                 else:
                     raise ContentPolicyFilterError(
                         f"The provided input contains content that is not aligned with our content policy: {text_input}"

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
@@ -179,9 +179,9 @@ class OpenAIAdapter(GenericAPIAdapter):
             ContentFilterFinishReasonError,
             ContentPolicyViolationError,
             InstructorRetryException,
-        ) as e:
+        ):
             if not (self.fallback_model and self.fallback_api_key):
-                raise e
+                raise
             try:
                 async with llm_rate_limiter_context_manager():
                     return await self.aclient.chat.completions.create(
@@ -211,7 +211,7 @@ class OpenAIAdapter(GenericAPIAdapter):
                     isinstance(error, InstructorRetryException)
                     and "content management policy" not in str(error).lower()
                 ):
-                    raise error
+                    raise
                 else:
                     raise ContentPolicyFilterError(
                         f"The provided input contains content that is not aligned with our content policy: {text_input}"

--- a/cognee/infrastructure/llm/utils.py
+++ b/cognee/infrastructure/llm/utils.py
@@ -112,17 +112,17 @@ async def test_llm_connection() -> None:
         )
         logger.error(msg)
         raise TimeoutError(msg)
-    except litellm.exceptions.AuthenticationError as e:
+    except litellm.exceptions.AuthenticationError:
         msg = (
             "LLM authentication failed. Check your LLM_API_KEY configuration. "
             "Set COGNEE_SKIP_CONNECTION_TEST=true to bypass this check."
         )
         logger.error(msg)
-        raise e
+        raise
     except Exception as e:
         logger.error(e)
         logger.error("Connection to LLM could not be established.")
-        raise e
+        raise
 
 
 async def test_embedding_connection() -> int:
@@ -160,7 +160,7 @@ async def test_embedding_connection() -> int:
     except Exception as e:
         logger.error(e)
         logger.error("Connection to Embedding handler could not be established.")
-        raise e
+        raise
 
 
 async def determine_embedding_dimensions(detected_dimensions: int) -> None:

--- a/cognee/modules/chunking/TextChunker.py
+++ b/cognee/modules/chunking/TextChunker.py
@@ -83,7 +83,7 @@ class TextChunker(Chunker):
                             )
                         except Exception as e:
                             logger.error(e)
-                            raise e
+                            raise
                         paragraph_chunks = [chunk_data]
                         self.chunk_size = chunk_data["chunk_size"]
 
@@ -111,4 +111,4 @@ class TextChunker(Chunker):
                 )
             except Exception as e:
                 logger.error(e)
-                raise e
+                raise

--- a/cognee/modules/chunking/text_chunker_with_overlap.py
+++ b/cognee/modules/chunking/text_chunker_with_overlap.py
@@ -88,7 +88,7 @@ class TextChunkerWithOverlap(Chunker):
             )
         except Exception as e:
             logger.error(e)
-            raise e
+            raise
 
     def _create_chunk_from_accumulation(self):
         """Create a DocumentChunk from current accumulated chunk_data."""

--- a/cognee/modules/cognify/recovery.py
+++ b/cognee/modules/cognify/recovery.py
@@ -105,10 +105,8 @@ async def recover_stale_cognify_runs_on_startup() -> None:
                 pipeline_run.pipeline_run_id,
                 pipeline_run.dataset_id,
             )
-        except Exception as error:
-            logger.error(
-                "Startup recovery failed for cognify run %s: %s",
+        except Exception:
+            logger.exception(
+                "Startup recovery failed for cognify run %s",
                 pipeline_run.pipeline_run_id,
-                error,
-                exc_info=True,
             )

--- a/cognee/modules/graph/cognee_graph/CogneeGraph.py
+++ b/cognee/modules/graph/cognee_graph/CogneeGraph.py
@@ -277,7 +277,7 @@ class CogneeGraph(CogneeAbstractGraph):
         except EntityNotFoundError:
             raise
         except Exception:
-            logger.error("Error during graph projection", exc_info=True)
+            logger.exception("Error during graph projection")
             raise
 
     async def project_neighborhood_from_db(
@@ -332,7 +332,7 @@ class CogneeGraph(CogneeAbstractGraph):
             )
 
         except Exception:
-            logger.error("Error during neighborhood projection", exc_info=True)
+            logger.exception("Error during neighborhood projection")
             raise
 
     async def map_vector_distances_to_graph_nodes(

--- a/cognee/modules/ingestion/data_types/S3BinaryData.py
+++ b/cognee/modules/ingestion/data_types/S3BinaryData.py
@@ -66,14 +66,13 @@ class S3BinaryData(IngestionData):
             async with file_storage.open(file_path, "rb") as file:
                 self.metadata = await get_file_metadata(file)
         except (OSError, ValueError, ClientError, NoCredentialsError) as error:
-            logger.error(
+            logger.exception(
                 "S3 metadata fetch failed",
                 extra={
                     "s3_path": self.s3_path,
                     "file_path": file_path,
                     "error": str(error),
                 },
-                exc_info=True,
             )
             raise
 

--- a/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
+++ b/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
@@ -128,7 +128,7 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
 
             self.build_lookup()
         except Exception as e:
-            logger.error("Failed to load ontology", exc_info=True)
+            logger.exception("Failed to load ontology")
             raise OntologyInitializationError(f"Failed to load ontology: {e}") from e
 
     def _uri_to_key(self, uri: URIRef) -> str:

--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -172,11 +172,10 @@ async def run_tasks(
                             total_items=total_items,
                             current_stage=progress_state["current_stage"],
                         )
-                    except Exception as progress_error:
+                    except Exception:
                         # Progress reporting must never fail the pipeline run.
-                        logger.error(
-                            f"Failed to log pipeline run progress: {progress_error}",
-                            exc_info=True,
+                        logger.exception(
+                            "Failed to log pipeline run progress",
                         )
 
                 async def _run_item(data_item, item_tasks):
@@ -310,8 +309,8 @@ async def run_tasks(
                             data_ingestion_info=locals().get("results"),
                             error=error,
                         )
-                    except Exception as rollback_error:
-                        logger.error("Rollback errored: %s", rollback_error, exc_info=True)
+                    except Exception:
+                        logger.exception("Rollback errored")
 
                 # Per-item failures arrive wrapped in a generic
                 # PipelineRunFailedError; record and surface the ROOT cause so
@@ -347,4 +346,4 @@ async def run_tasks(
 
                 # In case of error during incremental loading of data just let the user know the pipeline Errored, don't raise error
                 if not isinstance(error, PipelineRunFailedError):
-                    raise error
+                    raise

--- a/cognee/modules/pipelines/operations/run_tasks_base.py
+++ b/cognee/modules/pipelines/operations/run_tasks_base.py
@@ -246,9 +246,8 @@ async def handle_task(
             span.set_status(StatusCode.ERROR, str(error))
             span.record_exception(error)
 
-            logger.error(
-                f"{task_type} task errored: `{task_name}`\n{error!s}\n",
-                exc_info=True,
+            logger.exception(
+                f"{task_type} task errored: `{task_name}`\n",
             )
             send_telemetry(
                 f"{task_type} Task Errored",
@@ -259,7 +258,7 @@ async def handle_task(
                     "tenant_id": str(user.tenant_id) if user.tenant_id else "Single User Tenant",
                 },
             )
-            raise error
+            raise
 
 
 async def run_tasks_base(

--- a/cognee/modules/pipelines/operations/run_tasks_data_item.py
+++ b/cognee/modules/pipelines/operations/run_tasks_data_item.py
@@ -277,7 +277,7 @@ async def run_tasks_data_item_incremental(
         }
 
         if os.getenv("RAISE_INCREMENTAL_LOADING_ERRORS", "true").lower() == "true":
-            raise error
+            raise
 
 
 async def run_tasks_data_item_regular(
@@ -401,11 +401,9 @@ async def run_tasks_data_item(
         # edge evidence also fails; rollback still has graph-native run refs.
         try:
             await flush_context_provenance(ctx)
-        except Exception as provenance_error:
-            logger.error(
-                "Failed to persist provenance for an errored data item: %s",
-                provenance_error,
-                exc_info=True,
+        except Exception:
+            logger.exception(
+                "Failed to persist provenance for an errored data item",
             )
         raise
 

--- a/cognee/modules/pipelines/operations/run_tasks_with_telemetry.py
+++ b/cognee/modules/pipelines/operations/run_tasks_with_telemetry.py
@@ -48,12 +48,10 @@ async def run_tasks_with_telemetry(
             }
             | config,
         )
-    except Exception as error:
-        logger.error(
-            "Pipeline run errored: `%s`\n%s\n",
+    except Exception:
+        logger.exception(
+            "Pipeline run errored: `%s`\n",
             pipeline_name,
-            str(error),
-            exc_info=True,
         )
         send_telemetry(
             "Pipeline Run Errored",
@@ -66,4 +64,4 @@ async def run_tasks_with_telemetry(
             | config,
         )
 
-        raise error
+        raise

--- a/cognee/modules/provenance/manager.py
+++ b/cognee/modules/provenance/manager.py
@@ -212,8 +212,8 @@ class ProvenanceManager:
             )
         except (ValueError, TypeError):
             raise
-        except Exception as error:
-            logger.error("Failed to track entity %r: %s", entity_id, error, exc_info=True)
+        except Exception:
+            logger.exception("Failed to track entity %r", entity_id)
             return None
 
     def _relationship_write(
@@ -275,10 +275,8 @@ class ProvenanceManager:
             )
         except (ValueError, TypeError):
             raise
-        except Exception as error:
-            logger.error(
-                "Failed to track relationship %r: %s", relationship_id, error, exc_info=True
-            )
+        except Exception:
+            logger.exception("Failed to track relationship %r", relationship_id)
             return None
 
     def _chunk_write(
@@ -362,8 +360,8 @@ class ProvenanceManager:
             )
         except (ValueError, TypeError):
             raise
-        except Exception as error:
-            logger.error("Failed to track chunk %r: %s", chunk_id, error, exc_info=True)
+        except Exception:
+            logger.exception("Failed to track chunk %r", chunk_id)
             return None
 
     def batch(self) -> "ProvenanceBatch":
@@ -692,12 +690,10 @@ class ProvenanceBatch:
             return []
         try:
             return await storage.append_chained_many(write_fns)
-        except Exception as error:
-            logger.error(
-                "Failed to commit provenance batch of %d entries: %s",
+        except Exception:
+            logger.exception(
+                "Failed to commit provenance batch of %d entries",
                 len(write_fns),
-                error,
-                exc_info=True,
             )
             return None
 

--- a/cognee/modules/retrieval/utils/brute_force_triplet_search.py
+++ b/cognee/modules/retrieval/utils/brute_force_triplet_search.py
@@ -372,4 +372,4 @@ async def brute_force_triplet_search(
                 query_batch if query_list_length else [query],
                 error,
             )
-            raise error
+            raise

--- a/cognee/modules/retrieval/utils/description_to_codepart_search.py
+++ b/cognee/modules/retrieval/utils/description_to_codepart_search.py
@@ -52,7 +52,7 @@ async def code_description_to_code_part(
         vector_engine = await get_vector_engine_async()
         graph_engine = await get_graph_engine()
     except Exception as init_error:
-        logger.error("Failed to initialize engines: %s", init_error, exc_info=True)
+        logger.exception("Failed to initialize engines")
         raise RuntimeError("System initialization error. Please try again later.") from init_error
 
     send_telemetry("code_description_to_code_part_search EXECUTION STARTED", user)
@@ -131,12 +131,10 @@ async def code_description_to_code_part(
         return code_pieces_to_return, context_from_documents
 
     except Exception as exec_error:
-        logger.error(
-            "Error during code description to code part search for user: %s, query: '%s'. Error: %s",
+        logger.exception(
+            "Error during code description to code part search for user: %s, query: '%s'. Error",
             user.id,
             query,
-            exec_error,
-            exc_info=True,
         )
         send_telemetry("code_description_to_code_part_search EXECUTION FAILED", user)
         raise RuntimeError("An error occurred while processing your request.") from exec_error
@@ -153,6 +151,6 @@ if __name__ == "__main__":
             logger.debug("Retrieved Code Parts:", results)
         except Exception as e:
             logger.error(f"An error occurred: {e}")
-            raise e
+            raise
 
     asyncio.run(main())

--- a/cognee/modules/sync/methods/update_sync_operation.py
+++ b/cognee/modules/sync/methods/update_sync_operation.py
@@ -194,16 +194,12 @@ async def update_sync_operation(
                 logger.debug(f"Successfully updated sync operation {run_id}")
                 return sync_operation
 
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"Database error updating sync operation {run_id}: {e!s}", exc_info=True
-                )
+            except SQLAlchemyError:
+                logger.exception(f"Database error updating sync operation {run_id}")
                 await session.rollback()
                 raise
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error updating sync operation {run_id}: {e!s}", exc_info=True
-                )
+            except Exception:
+                logger.exception(f"Unexpected error updating sync operation {run_id}")
                 await session.rollback()
                 raise
 

--- a/cognee/modules/tools/execute_tool.py
+++ b/cognee/modules/tools/execute_tool.py
@@ -84,5 +84,5 @@ async def execute_tool(
     except (ToolPermissionError, ToolScopeError):
         raise
     except Exception as exc:
-        logger.error("Tool %s raised during execution", tool_name, exc_info=True)
+        logger.exception("Tool %s raised during execution", tool_name)
         raise ToolInvocationError(f"{tool_name} failed: {exc}") from exc

--- a/cognee/modules/users/authentication/methods/authenticate_user.py
+++ b/cognee/modules/users/authentication/methods/authenticate_user.py
@@ -19,6 +19,6 @@ async def authenticate_user(email: str, password: str):
                     if user is None or not user.is_active:
                         return None
                     return user
-    except UserNotExists as error:
+    except UserNotExists:
         print(f"User {email} doesn't exist")
-        raise error
+        raise

--- a/cognee/modules/users/methods/create_user.py
+++ b/cognee/modules/users/methods/create_user.py
@@ -43,6 +43,6 @@ async def create_user(
                     _ = await user.awaitable_attrs.roles
 
                     return user
-    except UserAlreadyExists as error:
+    except UserAlreadyExists:
         print("A user with this email already exists")
-        raise error
+        raise

--- a/cognee/modules/users/methods/delete_user.py
+++ b/cognee/modules/users/methods/delete_user.py
@@ -15,6 +15,6 @@ async def delete_user(email: str):
                 async with get_user_manager_context(user_db) as user_manager:
                     user = await user_manager.get_by_email(email)
                     await user_manager.delete(user)
-    except UserNotExists as error:
+    except UserNotExists:
         print(f"User {email} doesn't exist")
-        raise error
+        raise

--- a/cognee/shared/usage_logger.py
+++ b/cognee/shared/usage_logger.py
@@ -230,8 +230,8 @@ async def _log_usage_async(
             ttl=config.usage_logging_ttl,
         )
         logger.info(f"Successfully logged usage for {function_name} (user_id={user_id})")
-    except Exception as e:
-        logger.error(f"Failed to log usage for {function_name}: {e!s}", exc_info=True)
+    except Exception:
+        logger.exception(f"Failed to log usage for {function_name}")
 
 
 def _is_streaming_response(result: Any) -> bool:
@@ -283,10 +283,9 @@ def _wrap_streaming_result(result: Any, emit, function_name: str):
             # for the same reason — CancelledError is not an Exception.
             try:
                 await asyncio.shield(asyncio.ensure_future(emit(None, success, error)))
-            except BaseException as log_error:  # noqa: BLE001
-                logger.error(
-                    f"Failed to log usage for {function_name}: {log_error!s}",
-                    exc_info=True,
+            except BaseException:  # noqa: BLE001
+                logger.exception(
+                    f"Failed to log usage for {function_name}",
                 )
 
     result.body_iterator = _logged()
@@ -407,10 +406,9 @@ def log_usage(function_name: str | None = None, log_type: str = "function"):
                 if not deferred_to_stream:
                     try:
                         await _emit(result, success, error)
-                    except Exception as e:
-                        logger.error(
-                            f"Failed to log usage for {resolved_function_name}: {e!s}",
-                            exc_info=True,
+                    except Exception:
+                        logger.exception(
+                            f"Failed to log usage for {resolved_function_name}",
                         )
 
         return async_wrapper

--- a/cognee/tasks/memify/get_triplet_datapoints.py
+++ b/cognee/tasks/memify/get_triplet_datapoints.py
@@ -283,10 +283,9 @@ async def get_triplet_datapoints(
                 )
                 break
 
-        except Exception as e:
-            logger.error(
-                f"Error retrieving triplet batch {batch_number} at offset {offset}: {e}",
-                exc_info=True,
+        except Exception:
+            logger.exception(
+                f"Error retrieving triplet batch {batch_number} at offset {offset}",
             )
             raise
 


### PR DESCRIPTION
## Description
Container PR for the exception-handling rules that ruff 0.16 enables by default ([SDK-583](https://linear.app/cognee/issue/SDK-583/fix-red-code-quality-ci-after-the-ruff-0160-bump)): **BLE001** blind except, **S110** / **S112** try-except-pass/continue, **G201** exc_info logging, **TRY201** verbose raise, **TRY002** vanilla `Exception` raise, plus **TRY401** (redundant exception in a `logger.exception` message), which G201 fixes produce.

Goal: no silent exception swallowing anywhere in the tree, enforced without an escape hatch.

### Enforcement (commit 2)
A new Code Quality step runs ruff on the six rules with `--ignore-noqa`, so `# noqa: BLE001` and friends no longer bypass the check. The step stays red until the sweep below is complete; that is the definition of done for this PR. Once green, anyone adding a silent `except Exception` fails CI and has to fix it: log with the traceback, re-raise, or narrow the type.

Note: BLE001 already exempts handlers that re-raise, call `logger.exception`, or log with `exc_info=True`. The rule does not forbid catching `Exception`; it forbids doing so silently.

### Batch 1, mechanical (commit 1)
- **G201** (58): `logger.error(..., exc_info=True)` → `logger.exception(...)`.
- **TRY401** (51): the handled exception dropped from the message; `.exception()` records it with the traceback. `"Foo failed: %s", error` → `"Foo failed"`. Other placeholders/arguments kept.
- **TRY201** (37): `raise error` inside the handler → bare `raise` (keeps the original traceback).
- Follow-up: 45 `except X as error:` clauses lose the now-unused name.

No handler changes what it catches or whether it swallows.

### Remaining sweep, current dev numbers (with `--ignore-noqa`)
| Rule | Count | Fix per site |
|---|---|---|
| BLE001 | 593 | Add `logger.exception(...)` where the error is dropped or logged without traceback; re-raise; or narrow to the real exception type |
| S110 | 111 | `except ...: pass` → log at the right level, or narrow, or comment why silence is intended and re-raise elsewhere |
| S112 | 6 | Same as S110 for `continue` |
| TRY002 | 22 | `raise Exception(...)` → a `CogneeApiError` subclass or the matching built-in |

By area (all six rules on dev): infrastructure 190, tests 168, modules 151, api 120, cognee_db_workers 46, shared 38, tasks 35, cognee-mcp 21, cli 18, eval_framework 13, tools 13, evals 18. Roughly 20% of the findings are in tests; a per-file ignore for `cognee/tests/` is a reasonable scope decision if the team prefers to keep the strict check on library code only.

### Numbers
- Six rules with `--ignore-noqa`: 843 on dev → 748 after batch 1.
- Whole-tree `ruff check .`: 8997 → 8900. No new findings of any rule on the touched files.
- `ruff format --check .` passes; pre-commit ruff 0.15.11 check and format pass on every touched file.
- Full unit suite passes locally (see the PR checks for CI).

## Type of Change
- [x] Code refactoring
- [x] Other (please specify): CI enforcement
