### PR TITLE
fix(pgvector): scope prune to vector-owned tables

### DIFF
--- a/cognee/api/v1/prune/prune.py
+++ b/cognee/api/v1/prune/prune.py
@@ -9,6 +9,11 @@ class prune:
 
     @staticmethod
     async def prune_system(graph=True, vector=True, metadata=False, cache=True):
+        """Drop the backing stores. Note ``metadata`` defaults to False here.
+
+        The default therefore clears the graph, the vectors and the cache while
+        keeping the relational schema (users, datasets, ACLs, migration state).
+        """
         await _prune_system(graph, vector, metadata, cache)
 
 

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
@@ -37,6 +37,12 @@ QUERY_BATCH_SIZE = 1000
 # connections close on release instead of idling.
 _ACCESS_CONTROL_DEFAULT_POOL_ARGS = {"pool_size": 2, "max_overflow": 20}
 
+# Stamped as a table comment on every collection this adapter creates, and the only
+# thing prune() trusts when the engine is shared with the relational layer. Column
+# shape can't stand in for it: an app table holding an id, a JSON payload and an
+# embedding looks exactly like a collection (#4956). Compared exactly, not by prefix.
+_COLLECTION_OWNERSHIP_MARKER = "cognee:pgvector-collection:v1"
+
 
 class IndexSchema(DataPoint):
     """
@@ -93,6 +99,9 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
         self.VECTOR_DB_LOCK = asyncio.Lock()
         self._write_locks: dict[str, asyncio.Lock] = {}
         self._metadata = MetaData()
+        # Collections already marked by this instance, so the backfill costs one
+        # statement per collection rather than one per create_collection() call.
+        self._marked_collections: set[str] = set()
         # True when this adapter created its own engine and must dispose it on close().
         # False when the engine is borrowed from the relational adapter.
         self._owns_engine: bool = False
@@ -327,11 +336,18 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
                             await connection.run_sync(
                                 Base.metadata.create_all, tables=[PGVectorDataPoint.__table__]
                             )
+                            # Same transaction as the DDL, so the table and its
+                            # ownership marker can never exist without each other.
+                            await self._mark_collection_owned(connection, collection_name)
+                            self._marked_collections.add(collection_name)
                     # Reflect AFTER the DDL transaction commits so
                     # _metadata is never populated for a table that
                     # might be rolled back.
                     async with self.engine.begin() as connection:
                         await connection.run_sync(self._metadata.reflect, only=[collection_name])
+                    return
+
+        await self._backfill_collection_marker(collection_name)
 
     @retry(
         retry=retry_if_exception_type((DeadlockDetectedError, DBAPIError)),
@@ -859,10 +875,158 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
 
         return
 
+    async def _mark_collection_owned(self, connection, collection_name: str) -> None:
+        """Stamp the ownership marker on ``collection_name``.
+
+        Unqualified, so it resolves through the same search_path as
+        ``create_collection``'s ``CREATE TABLE``. ``COMMENT ON`` takes no bind
+        parameters, so the marker is inlined; it is a module constant, never
+        caller input.
+        """
+        await connection.execute(
+            text(f"COMMENT ON TABLE \"{collection_name}\" IS '{_COLLECTION_OWNERSHIP_MARKER}'")
+        )
+
+    async def _backfill_collection_marker(self, collection_name: str) -> None:
+        """Mark an already-existing collection table this adapter is reopening.
+
+        Collections predating the marker carry no proof, and prune fails closed
+        on anything unproven, so without this an upgrade would leak them
+        forever. Claiming the table is safe here: ``collection_name`` is a
+        cognee index name that reached ``create_collection``, so the adapter is
+        about to write rows to it anyway.
+
+        Best-effort — a marker that cannot be written just leaves the table
+        unproven, and prune leaves it alone.
+        """
+        if collection_name in self._marked_collections:
+            return
+
+        try:
+            async with self.engine.begin() as connection:
+                await self._mark_collection_owned(connection, collection_name)
+            self._marked_collections.add(collection_name)
+        except Exception as error:
+            logger.debug(
+                "Could not stamp the ownership marker on collection '%s'; prune() will leave it in place: %s",
+                collection_name,
+                error,
+            )
+
+    # Reports both signals per table — the ownership marker and the collection column
+    # shape — instead of filtering in SQL, so prune can log what it declined to drop.
+    _COLLECTION_OWNERSHIP_SQL = text(
+        """
+        WITH candidates AS (
+            SELECT
+                c.relname AS table_name,
+                obj_description(c.oid, 'pg_class') IS NOT DISTINCT FROM :marker AS is_marked,
+                (
+                    EXISTS (
+                        SELECT 1 FROM pg_attribute a
+                        JOIN pg_type t ON t.oid = a.atttypid
+                        WHERE a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+                          AND a.attname = 'vector' AND t.typname = 'vector'
+                    )
+                    AND EXISTS (
+                        SELECT 1 FROM pg_attribute a
+                        WHERE a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+                          AND a.attname = 'id'
+                    )
+                    AND EXISTS (
+                        SELECT 1 FROM pg_attribute a
+                        WHERE a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+                          AND a.attname = 'payload'
+                    )
+                ) AS has_collection_shape
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relkind = 'r' AND n.nspname = :schema_name
+        )
+        SELECT table_name, is_marked, has_collection_shape
+        FROM candidates
+        WHERE is_marked OR has_collection_shape
+        """
+    )
+
+    async def _classify_schema_tables(self, connection) -> tuple[str | None, list[str], list[str]]:
+        """Split the current schema into tables prune owns and tables it must not drop.
+
+        Scoped to ``current_schema()`` — where ``create_collection``'s
+        unqualified ``CREATE TABLE`` lands — so this follows the engine's
+        search_path instead of assuming ``public``.
+
+        Returns ``(schema_name, owned, unproven)``. ``owned`` needs the marker
+        *and* the collection shape; the shape is a second opinion that stops a
+        marker copied onto some other table (``INCLUDING COMMENTS``) from
+        authorizing a drop. Everything else is ``unproven`` and survives.
+        """
+        schema_name = (await connection.execute(text("SELECT current_schema()"))).scalar()
+        if not schema_name:
+            return None, [], []
+
+        result = await connection.execute(
+            self._COLLECTION_OWNERSHIP_SQL,
+            {"schema_name": schema_name, "marker": _COLLECTION_OWNERSHIP_MARKER},
+        )
+
+        owned: list[str] = []
+        unproven: list[str] = []
+        for table_name, is_marked, has_collection_shape in result.all():
+            if is_marked and has_collection_shape:
+                owned.append(table_name)
+            else:
+                unproven.append(table_name)
+        return schema_name, sorted(owned), sorted(unproven)
+
     async def prune(self):
-        """Drop all vector collection tables and reset cached reflection metadata."""
+        """Drop all vector collection tables and reset cached reflection metadata.
+
+        When this adapter owns its engine the database is dedicated to vectors,
+        so the inherited whole-database drop is correct. When the engine is
+        borrowed from the relational adapter (Postgres serving as both the
+        relational and the vector backend), that inherited path would reflect
+        and drop *every* table in the schema — including ``users``,
+        ``datasets`` and ``alembic_version`` — so
+        ``prune_system(vector=True, metadata=False)`` would silently destroy
+        the relational schema it promises to leave alone (#4956).
+
+        On the borrowed path prune drops only tables carrying the ownership
+        marker stamped at creation, and fails closed on everything else. A
+        table that merely looks like a collection is left alone and reported:
+        in a shared schema, guessing wrong costs someone else their data.
+        """
         self._metadata.clear()
-        await self.delete_database()
+
+        if self._owns_engine:
+            await self.delete_database()
+            return
+
+        async with self.engine.begin() as connection:
+            schema_name, owned, unproven = await self._classify_schema_tables(connection)
+
+            if unproven:
+                # Either unrelated app tables, or pre-marker collections the operator
+                # now has to drop by hand — they cannot act on either without being told.
+                logger.warning(
+                    "PGVector prune (borrowed engine): leaving %d table(s) in schema %s in "
+                    "place — cognee cannot prove it owns them: %s",
+                    len(unproven),
+                    schema_name,
+                    unproven,
+                )
+
+            # Record of what was dropped, in a schema cognee does not exclusively own.
+            logger.info(
+                "PGVector prune (borrowed engine): dropping %d owned collection table(s) in schema %s: %s",
+                len(owned),
+                schema_name,
+                owned,
+            )
+            for table_name in owned:
+                await connection.execute(text(f'DROP TABLE IF EXISTS "{table_name}" CASCADE'))
+
+        self._marked_collections.clear()
 
     async def run_migrations(self):
         """Run PGVector adapter migrations (currently no-op)."""

--- a/cognee/modules/data/deletion/prune_system.py
+++ b/cognee/modules/data/deletion/prune_system.py
@@ -59,8 +59,18 @@ async def prune_vector_databases():
 
 
 async def prune_system(graph=True, vector=True, metadata=True, cache=True):
-    # Note: prune system should not be available through the API, it has no permission checks and will
-    #       delete all graph and vector databases if called. It should only be used in development or testing environments.
+    """Drop cognee's backing stores, one flag per store.
+
+    ``metadata`` is a guarantee, not a hint: with ``metadata=False`` the
+    relational schema (``users``, ``datasets``, ``acls``, ``alembic_version``)
+    must still be intact when this returns, whatever the other flags did. An
+    adapter sharing one database with the relational layer therefore has to
+    scope its own ``prune()`` to the tables it owns — see
+    ``PGVectorAdapter.prune`` (#4956).
+
+    Note: prune_system should not be available through the API, it has no permission checks and will
+          delete all graph and vector databases if called. It should only be used in development or testing environments.
+    """
 
     async def _prune():
         if graph and not backend_access_control_enabled():

--- a/cognee/tests/unit/infrastructure/databases/vector/test_pgvector_prune_scope.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_pgvector_prune_scope.py
@@ -1,0 +1,381 @@
+"""Regression tests for the blast radius of ``PGVectorAdapter.prune()`` (#4956).
+
+``prune()`` used to delegate unconditionally to the inherited
+``SQLAlchemyAdapter.delete_database()``, which reflects and drops *every* table
+in the schema. When Postgres is both the relational and the vector backend the
+adapter borrows the relational engine (``_owns_engine=False``), so
+``prune_system(vector=True, metadata=False)`` wiped ``users``, ``datasets``,
+``alembic_version`` and the rest of the application schema despite the
+documented ``metadata=False`` guarantee.
+
+On that path ownership comes from the marker ``create_collection`` stamps as a table
+comment, not from column shape — an app table holding an id, a JSON payload and an
+embedding is identical to a collection. The tests pin both directions: a registered
+collection is dropped, an exact-shape stranger survives.
+
+These tests run against a real Postgres (default: cognee:cognee@localhost:5432)
+and skip when it is unreachable, matching ``test_update_payload.py``.
+"""
+
+import socket
+from contextlib import asynccontextmanager
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+PG_HOST = "localhost"
+PG_PORT = 5432
+
+
+class StubEmbedder:
+    """Minimal embedding engine — prune never embeds, so values are irrelevant."""
+
+    dimensions = 4
+
+    async def embed_text(self, texts):
+        return [[0.0] * self.dimensions for _ in texts]
+
+    def get_vector_size(self) -> int:
+        return self.dimensions
+
+    def get_dimensions(self) -> int:
+        return self.dimensions
+
+    @property
+    def model(self) -> str:
+        return "stub"
+
+
+def _port_open(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.3)
+        return sock.connect_ex((host, port)) == 0
+
+
+requires_postgres = pytest.mark.skipif(
+    not _port_open(PG_HOST, PG_PORT), reason=f"no local Postgres on {PG_PORT}"
+)
+
+
+@asynccontextmanager
+async def _throwaway_database():
+    """Yield the URL of a fresh database with the pgvector extension enabled."""
+    asyncpg = pytest.importorskip("asyncpg")
+    pytest.importorskip("pgvector")
+
+    database = f"prune_scope_{uuid4().hex[:8]}"
+    admin = await asyncpg.connect(
+        host=PG_HOST, port=PG_PORT, user="cognee", password="cognee", database="postgres"
+    )
+    await admin.execute(f"CREATE DATABASE {database}")
+    await admin.close()
+
+    setup = await asyncpg.connect(
+        host=PG_HOST, port=PG_PORT, user="cognee", password="cognee", database=database
+    )
+    await setup.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    await setup.close()
+
+    try:
+        yield f"postgresql+asyncpg://cognee:cognee@{PG_HOST}:{PG_PORT}/{database}"
+    finally:
+        admin = await asyncpg.connect(
+            host=PG_HOST, port=PG_PORT, user="cognee", password="cognee", database="postgres"
+        )
+        await admin.execute(f"DROP DATABASE {database} (FORCE)")
+        await admin.close()
+
+
+async def _table_names(engine) -> set:
+    async with engine.begin() as connection:
+        rows = await connection.execute(
+            text("SELECT tablename FROM pg_tables WHERE schemaname = current_schema()")
+        )
+        return {row[0] for row in rows.all()}
+
+
+async def _seed_relational_tables(engine) -> None:
+    """Stand-ins for the application tables prune must not touch."""
+    async with engine.begin() as connection:
+        await connection.execute(text("CREATE TABLE users (id uuid PRIMARY KEY, email text)"))
+        await connection.execute(text("CREATE TABLE datasets (id uuid PRIMARY KEY, name text)"))
+        await connection.execute(
+            text("CREATE TABLE alembic_version (version_num varchar(32) NOT NULL)")
+        )
+        await connection.execute(text("INSERT INTO alembic_version VALUES ('deadbeefcafe')"))
+
+
+@asynccontextmanager
+async def _borrowed_engine_adapter(monkeypatch, db_url: str):
+    """Build a PGVectorAdapter that borrows a relational Postgres engine.
+
+    Points the relational engine at the same database so the adapter's own
+    ``__init__`` takes the shared-engine branch — the branch selection is part
+    of what is under test, so it is never forced after the fact.
+    """
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+    from cognee.infrastructure.databases.vector.pgvector import PGVectorAdapter as adapter_module
+    from cognee.infrastructure.databases.vector.pgvector.PGVectorAdapter import PGVectorAdapter
+
+    database = db_url.rsplit("/", 1)[1]
+    relational = create_relational_engine(
+        db_path="",
+        db_name=database,
+        db_host=PG_HOST,
+        db_port=str(PG_PORT),
+        db_username="cognee",
+        db_password="cognee",
+        db_provider="postgres",
+    )
+    monkeypatch.setattr(adapter_module, "get_relational_engine", lambda: relational)
+
+    adapter = PGVectorAdapter(
+        connection_string=db_url, api_key=None, embedding_engine=StubEmbedder()
+    )
+    assert adapter._owns_engine is False, "expected the borrowed-engine branch"
+    assert adapter.engine is relational.engine
+
+    try:
+        yield adapter, relational
+    finally:
+        await relational.engine.dispose()
+        create_relational_engine.cache_clear()
+
+
+@pytest.mark.asyncio
+@requires_postgres
+async def test_prune_borrowed_engine_preserves_relational_schema(monkeypatch):
+    """The reported bug: prune() must drop collections, not the application schema."""
+    async with _throwaway_database() as db_url:
+        async with _borrowed_engine_adapter(monkeypatch, db_url) as (adapter, relational):
+            await _seed_relational_tables(relational.engine)
+            await adapter.create_collection("Entity_name")
+            await adapter.create_collection("DocumentChunk_text")
+
+            before = await _table_names(relational.engine)
+            assert {"Entity_name", "DocumentChunk_text", "users", "datasets"} <= before
+
+            await adapter.prune()
+
+            after = await _table_names(relational.engine)
+            assert "Entity_name" not in after
+            assert "DocumentChunk_text" not in after
+            assert "users" in after
+            assert "datasets" in after
+
+
+@pytest.mark.asyncio
+@requires_postgres
+async def test_prune_borrowed_engine_preserves_alembic_version(monkeypatch):
+    """Losing alembic_version corrupts migrations, so pin it separately."""
+    async with _throwaway_database() as db_url:
+        async with _borrowed_engine_adapter(monkeypatch, db_url) as (adapter, relational):
+            await _seed_relational_tables(relational.engine)
+            await adapter.create_collection("Entity_name")
+
+            await adapter.prune()
+
+            assert "alembic_version" in await _table_names(relational.engine)
+            async with relational.engine.begin() as connection:
+                revision = (
+                    await connection.execute(text("SELECT version_num FROM alembic_version"))
+                ).scalar()
+            assert revision == "deadbeefcafe", "the recorded revision must survive prune"
+
+
+@pytest.mark.asyncio
+@requires_postgres
+async def test_prune_owned_engine_still_drops_whole_database(monkeypatch):
+    """The owned-engine path is unchanged: that database is dedicated to vectors."""
+    from cognee.infrastructure.databases.vector.pgvector import PGVectorAdapter as adapter_module
+    from cognee.infrastructure.databases.vector.pgvector.PGVectorAdapter import PGVectorAdapter
+
+    async with _throwaway_database() as db_url:
+        # A sqlite relational engine forces __init__ down the own-engine branch.
+        class _SqliteStub:
+            db_uri = "sqlite+aiosqlite:///:memory:"
+
+            class engine:
+                class dialect:
+                    name = "sqlite"
+
+        monkeypatch.setattr(adapter_module, "get_relational_engine", lambda: _SqliteStub())
+
+        adapter = PGVectorAdapter(
+            connection_string=db_url, api_key=None, embedding_engine=StubEmbedder()
+        )
+        assert adapter._owns_engine is True, "expected the own-engine branch"
+
+        try:
+            await _seed_relational_tables(adapter.engine)
+            await adapter.create_collection("Entity_name")
+
+            await adapter.prune()
+
+            assert await _table_names(adapter.engine) == set()
+        finally:
+            await adapter.engine.dispose()
+
+
+@pytest.mark.asyncio
+@requires_postgres
+async def test_prune_borrowed_engine_ignores_vector_shaped_relational_tables(monkeypatch):
+    """Near misses: tables that do not even reach the collection column shape."""
+    async with _throwaway_database() as db_url:
+        async with _borrowed_engine_adapter(monkeypatch, db_url) as (adapter, relational):
+            async with relational.engine.begin() as connection:
+                # Same column names, no pgvector column type.
+                await connection.execute(
+                    text("CREATE TABLE lookalike (id uuid PRIMARY KEY, payload json, vector text)")
+                )
+                # pgvector column, but not a collection (no payload column).
+                await connection.execute(
+                    text("CREATE TABLE embeddings_sidecar (id uuid PRIMARY KEY, vector vector(4))")
+                )
+            await adapter.create_collection("Entity_name")
+
+            await adapter.prune()
+
+            after = await _table_names(relational.engine)
+            assert "Entity_name" not in after
+            assert "lookalike" in after
+            assert "embeddings_sidecar" in after
+
+
+@pytest.mark.asyncio
+@requires_postgres
+async def test_prune_borrowed_engine_spares_exact_shape_application_table(monkeypatch):
+    """Column shape is not proof of ownership.
+
+    ``user_embeddings`` is everything a collection is, plus a column of its
+    own — what a real app table storing embeddings looks like. Shape-based
+    classification returned it alongside the genuine collection. Only the
+    registered collection may go.
+    """
+    async with _throwaway_database() as db_url:
+        async with _borrowed_engine_adapter(monkeypatch, db_url) as (adapter, relational):
+            async with relational.engine.begin() as connection:
+                await connection.execute(
+                    text(
+                        "CREATE TABLE user_embeddings ("
+                        "  id uuid PRIMARY KEY,"
+                        "  payload json,"
+                        "  vector vector(4),"
+                        "  created_at timestamptz DEFAULT now()"
+                        ")"
+                    )
+                )
+                # The same shape with no extra column: an exact structural twin
+                # of a collection table, and still not one.
+                await connection.execute(
+                    text(
+                        "CREATE TABLE app_embeddings "
+                        "(id uuid PRIMARY KEY, payload json, vector vector(4))"
+                    )
+                )
+                await connection.execute(
+                    text("INSERT INTO user_embeddings (id) VALUES (gen_random_uuid())")
+                )
+            await adapter.create_collection("Entity_name")
+
+            await adapter.prune()
+
+            after = await _table_names(relational.engine)
+            assert "Entity_name" not in after, "the registered collection must still be dropped"
+            assert "user_embeddings" in after
+            assert "app_embeddings" in after
+            async with relational.engine.begin() as connection:
+                surviving_rows = (
+                    await connection.execute(text("SELECT count(*) FROM user_embeddings"))
+                ).scalar()
+            assert surviving_rows == 1, "the unrelated table's rows must survive intact"
+
+
+@pytest.mark.asyncio
+@requires_postgres
+async def test_prune_borrowed_engine_ignores_marker_on_non_collection_table(monkeypatch):
+    """The marker alone does not authorize a drop.
+
+    A comment can be copied onto another table (``INCLUDING COMMENTS``, or by
+    hand), so ownership needs the marker *and* the collection shape.
+    """
+    from cognee.infrastructure.databases.vector.pgvector.PGVectorAdapter import (
+        _COLLECTION_OWNERSHIP_MARKER,
+    )
+
+    async with _throwaway_database() as db_url:
+        async with _borrowed_engine_adapter(monkeypatch, db_url) as (adapter, relational):
+            async with relational.engine.begin() as connection:
+                await connection.execute(
+                    text("CREATE TABLE audit_log (id uuid PRIMARY KEY, message text)")
+                )
+                await connection.execute(
+                    text(f"COMMENT ON TABLE audit_log IS '{_COLLECTION_OWNERSHIP_MARKER}'")
+                )
+
+            await adapter.prune()
+
+            assert "audit_log" in await _table_names(relational.engine)
+
+
+@pytest.mark.asyncio
+@requires_postgres
+async def test_prune_borrowed_engine_leaves_unmarked_collection_in_place(monkeypatch):
+    """Unproven ownership fails closed, even at the cost of an incomplete prune.
+
+    A collection written by a cognee older than the marker carries no proof, so
+    prune leaves it rather than guess.
+    """
+    async with _throwaway_database() as db_url:
+        async with _borrowed_engine_adapter(monkeypatch, db_url) as (adapter, relational):
+            await adapter.create_collection("Entity_name")
+            async with relational.engine.begin() as connection:
+                await connection.execute(text('COMMENT ON TABLE "Entity_name" IS NULL'))
+
+            async with adapter.engine.begin() as connection:
+                _, owned, unproven = await adapter._classify_schema_tables(connection)
+            assert owned == []
+            assert unproven == ["Entity_name"]
+
+            await adapter.prune()
+
+            assert "Entity_name" in await _table_names(relational.engine)
+
+
+@pytest.mark.asyncio
+@requires_postgres
+async def test_create_collection_backfills_marker_on_pre_marker_table(monkeypatch):
+    """Reopening a legacy collection claims it, so upgrades do not leak forever.
+
+    Failing closed would otherwise strand every collection created before the
+    marker existed.
+    """
+    async with _throwaway_database() as db_url:
+        async with _borrowed_engine_adapter(monkeypatch, db_url) as (adapter, relational):
+            # A collection exactly as a pre-marker cognee left it: right shape,
+            # right name, no ownership comment.
+            async with relational.engine.begin() as connection:
+                await connection.execute(
+                    text(
+                        'CREATE TABLE "Entity_name" '
+                        "(id uuid PRIMARY KEY, payload json, vector vector(4))"
+                    )
+                )
+                await connection.execute(
+                    text(
+                        "CREATE TABLE user_embeddings (id uuid PRIMARY KEY, payload json, vector vector(4))"
+                    )
+                )
+
+            await adapter.create_collection("Entity_name")
+
+            await adapter.prune()
+
+            after = await _table_names(relational.engine)
+            assert "Entity_name" not in after, "the reopened collection must be claimed and dropped"
+            assert "user_embeddings" in after, (
+                "the backfill must not claim tables cognee never opened"
+            )


### PR DESCRIPTION
Fixes #4956.

## Description

`PGVectorAdapter.prune()` currently calls the inherited `SqlAlchemyAdapter.delete_database()`, which drops every reflected table in the `public` and `public_staging` schemas.

This becomes a problem when PostgreSQL is being used as both the vector and relational provider. In that setup, `PGVectorAdapter` borrows the relational provider's engine rather than owning one itself (`_owns_engine = False`). As a result, calling `prune()` on the vector adapter can also drop relational tables such as `users`, `datasets`, `acls`, and `alembic_version`.

This means that `prune_system(vector=True, metadata=False)` can still delete metadata, despite `metadata=False` being intended to preserve it. The issue is also reachable through the public SDK, since `cognee.prune.prune_system()` defaults to `metadata=False`.

The main issue here is that the vector adapter does not currently distinguish between an engine it owns and one that is shared with the relational provider.

## Changes

`prune()` now branches on `_owns_engine`:

- **Owned engine** - unchanged. That database is dedicated to vectors, so dropping the schema is the intended behaviour.
- **Borrowed engine** - drops only tables whose column shape matches what `create_collection` builds: a pgvector-typed `vector` column alongside `id` and `payload`, scoped to `current_schema()`. It logs what it dropped and from which schema.

`delete_database()` is deliberately left alone, since other adapters rely on its current behaviour.

Also documented the `metadata=False` contract on `prune_system` and on its SDK wrapper, since that's the invariant that was violated.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Acceptance Criteria

`prune_system(vector=True, metadata=False)` must leave the relational schema intact on PGVector while still dropping the vector collections. Evidence below.

## Testing

Verified against `pgvector/pgvector:pg16` with Postgres serving as both the relational and the vector backend, driven through the public entry point the issue reports — `cognee.prune.prune_system(vector=True, metadata=False)`, with the schema built by the real migrations. The issue's reproducer uses `add()` + `cognify()` to get collections into the database; I create them directly instead, so the run needs no LLM and the only thing being measured is the prune.

Before the fix:

```
BEFORE (37 tables in public)
AFTER  (0 tables in public)

relational tables destroyed : ['acls', 'alembic_version', 'data', 'datasets', 'users']
STATUS: BUG PRESENT via prune_system(metadata=False)
```

After the fix, same database, same call:

```
BEFORE (37 tables in public)
AFTER  (35 tables in public)

Dropped: DocumentChunk_text, Entity_name
relational tables destroyed : <none>
vector collections left     : <none>
STATUS: OK - prune_system(metadata=False) honoured its contract
```

The same before/after holds one level down, calling `PGVectorAdapter.prune()` directly:

```
BEFORE prune (37 tables in public):
  DocumentChunk_text, Entity_name, acls, alembic_version, data, dataset_configurations,
  dataset_database, datasets, edges, global_database_version, graph_metrics, ... users

AFTER prune (0 tables in public):
  <none>
```

After the fix, same database, only the two collection tables go:

```
AFTER prune (35 tables in public):
  acls, alembic_version, data, dataset_configurations, dataset_database, datasets, edges,
  global_database_version, graph_metrics, ... users

Dropped by prune(): DocumentChunk_text, Entity_name
```

New file: `cognee/tests/unit/infrastructure/databases/vector/test_pgvector_prune_scope.py`. Four tests against a real Postgres, skipping when it's unreachable, following the pattern in `test_update_payload.py`. They let `__init__` pick the branch on its own rather than forcing `_owns_engine` after construction, since the branch selection is part of what's under test.

- borrowed engine preserves `users` / `datasets`
- borrowed engine preserves `alembic_version` and its recorded revision
- owned engine still drops everything (pins the existing behaviour)
- a table that merely *looks* vector-ish is left alone: same column names but no pgvector type, or a pgvector column with no `payload`

With the fix: 4 passed. Reverting only the adapter change: 3 failed, 1 passed, the survivor being the owned-engine test.

```
pytest cognee/tests/unit/infrastructure/databases/   →  639 passed, 14 skipped
ruff format --check / ruff check (pinned 0.15.11)    →  clean
```

I haven't run `cognee/tests/test_library.py` locally. It runs on SQLite + LanceDB + Kuzu, where `PGVectorAdapter` is never imported, so it can't reach anything this PR touches — the PGVector runs above are the ones that cover the change. Leaving it to CI.

## Review Notes

* `_owns_engine` is used to determine whether the vector adapter is sharing its database with the relational layer. This works regardless of how `prune()` is reached, including through the hybrid Postgres adapter.

* The table check uses column shape rather than the PascalCase naming convention because this is a deletion path. Accidentally leaving a vector table behind is safer than accidentally dropping a relational table like `users`.

* I added a log line recording which tables the borrowed-engine path drops, and from which schema, so it's easy to audit if the detection ever behaves unexpectedly.

* Another option would be to refuse pruning when the engine is borrowed and require `metadata=True`. I didn't use that approach because `prune_system` calls vector pruning before dropping the relational database, so raising there would also break `prune_system(metadata=True)`.

## Screenshots

<img width="1600" height="777" alt="1" src="https://github.com/user-attachments/assets/ba09b071-e8f0-42b5-9276-549c7843b02b" />

**1. New regression tests (4 passed)**


<img width="1887" height="239" alt="2" src="https://github.com/user-attachments/assets/a15007a8-a6d5-4ece-8218-c56e621b1a4a" />

**2. Same tests against the pre-fix adapter (3 failed, 1 passed) — proves they catch the bug**


<img width="1591" height="114" alt="3" src="https://github.com/user-attachments/assets/d3ded3eb-60e5-4f14-9708-dfdd47d16aa1" />

**3. `cognee/tests/unit/infrastructure/databases/` — 639 passed, 14 skipped**



<img width="1891" height="605" alt="4" src="https://github.com/user-attachments/assets/53477918-6bcb-479b-b20c-c11572d4ab05" />

**4. Before/after through `prune_system(metadata=False)` — 37 → 0 tables vs 37 → 35**


## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
