### PR TITLE
chore: Resolve the exception-handling rules across the tree (SDK-583)

### DIFF
--- a/.github/scripts/motherduck_nightly_etl.py
+++ b/.github/scripts/motherduck_nightly_etl.py
@@ -43,6 +43,9 @@ import os
 import sys
 
 import duckdb
+import logging
+
+logger = logging.getLogger(__name__)
 
 MD_TARGET = os.environ.get("MD_TARGET", "ci_analytics.nightly")
 CATALOG, SCHEMA = MD_TARGET.split(".", 1)
@@ -195,7 +198,7 @@ def main() -> int:
         params.insert(3, f"SESSION_TOKEN '{os.environ['AWS_SESSION_TOKEN']}'")
     try:
         con.execute(f"CREATE OR REPLACE SECRET cognee_ci_s3 IN MOTHERDUCK ({', '.join(params)});")
-    except Exception as exc:  # never echo the statement -- it holds the key
+    except duckdb.Error as exc:  # never echo the statement or chain -- both hold the key
         raise RuntimeError(f"failed to register S3 secret: {type(exc).__name__}") from None
     print(f"registered S3 secret for s3://{BUCKET} ({REGION})")
 
@@ -235,6 +238,7 @@ def main() -> int:
             con.execute(f"CREATE OR REPLACE VIEW {TGT}.{name} AS {sql.format(t=TGT)};")
             print(f"view {name}: created")
         except Exception as exc:
+            logger.debug("Ignoring exception in main", exc_info=True)
             failures += 1
             print(f"WARN view {name} failed ({type(exc).__name__}): {str(exc).splitlines()[0]}")
 

--- a/.github/scripts/motherduck_nightly_etl.py
+++ b/.github/scripts/motherduck_nightly_etl.py
@@ -39,11 +39,11 @@ Env:
                            otherwise make them last-writer-wins.
 """
 
+import logging
 import os
 import sys
 
 import duckdb
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/.github/workflows/community_tests.yml
+++ b/.github/workflows/community_tests.yml
@@ -54,6 +54,9 @@ jobs:
       # pass/continue, G201 exc_info logging, TRY201 verbose raise, TRY002 vanilla
       # Exception raise.
       - name: Ruff exception-handling rules (strict, noqa ignored)
+        # Runs even when the general check above fails: this gate must report on
+        # its own while the wider lint backlog is still being worked down.
+        if: ${{ !cancelled() }}
         run: uv run ruff check . --select BLE001,S110,S112,G201,TRY201,TRY002 --ignore-noqa
 
       - name: Ruff format check

--- a/cognee-mcp/src/codingagents/coding_rule_associations.py
+++ b/cognee-mcp/src/codingagents/coding_rule_associations.py
@@ -85,7 +85,7 @@ async def get_origin_edges(data: str, rules: list[Rule]) -> list[Any]:
                         )
                     )
             except Exception as e:
-                logger.info(f"Warning: Skipping invalid rule due to error: {e}")
+                logger.info(f"Warning: Skipping invalid rule due to error: {e}", exc_info=True)
     else:
         logger.info("No valid origin_id or rules provided.")
 

--- a/cognee-mcp/src/retrieval_utils.py
+++ b/cognee-mcp/src/retrieval_utils.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Literal
 import logging
+from typing import Any, Literal
 
 logger = logging.getLogger(__name__)
 

--- a/cognee-mcp/src/retrieval_utils.py
+++ b/cognee-mcp/src/retrieval_utils.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import json
 from typing import Any, Literal
+import logging
+
+logger = logging.getLogger(__name__)
 
 DOCUMENT_TYPES = {
     "Document",
@@ -246,6 +249,7 @@ async def _document_from_subgraph(
     try:
         subgraph = await get_document_subgraph(document_id)
     except Exception:
+        logger.debug("Ignoring exception in _document_from_subgraph", exc_info=True)
         return None, []
 
     if not subgraph:

--- a/cognee-mcp/src/retrieval_utils.py
+++ b/cognee-mcp/src/retrieval_utils.py
@@ -249,7 +249,7 @@ async def _document_from_subgraph(
     try:
         subgraph = await get_document_subgraph(document_id)
     except Exception:
-        logger.debug("Ignoring exception in _document_from_subgraph", exc_info=True)
+        logger.debug("Falling back after error in _document_from_subgraph", exc_info=True)
         return None, []
 
     if not subgraph:

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1013,7 +1013,7 @@ async def delete_dataset(dataset_name: str) -> list:
                 )
             ]
         except Exception as e:
-            logger.debug("Ignoring exception in delete_dataset", exc_info=True)
+            logger.debug("Falling back after error in delete_dataset", exc_info=True)
             return [types.TextContent(type="text", text=f"Error deleting dataset: {e!s}")]
 
 
@@ -1213,7 +1213,7 @@ async def remember(
         try:
             decoded = base64.b64decode(content_base64, validate=True)
         except Exception as e:
-            logger.debug("Ignoring exception in remember", exc_info=True)
+            logger.debug("Falling back after error in remember", exc_info=True)
             return [types.TextContent(type="text", text=f"Error: invalid base64 content ({e}).")]
         if len(decoded) > _MAX_UPLOAD_BYTES:
             return [

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -452,7 +452,7 @@ async def cognify(
         except Exception as e:
             dataset = kwargs.get("dataset_name", "main_dataset")
             _record_task_error(dataset, str(e))
-            logger.error(f"Background cognify task failed for dataset '{dataset}': {e}")
+            logger.exception(f"Background cognify task failed for dataset '{dataset}'")
 
     _track_background(
         cognify_task_wrapper(
@@ -538,7 +538,7 @@ async def save_interaction(data: str) -> list:
             await save_user_agent_interaction(**kwargs)
         except Exception as e:
             _record_task_error("main_dataset", str(e))
-            logger.error(f"Background save_interaction task failed: {e}")
+            logger.exception("Background save_interaction task failed")
 
     _track_background(save_task_wrapper(data=data))
 
@@ -738,7 +738,7 @@ async def search(
         )
     except Exception as e:
         error_msg = f"Search failed: {e!s}"
-        logger.error(error_msg)
+        logger.exception(error_msg)
         return [types.TextContent(type="text", text=f"Error: {error_msg}")]
     return [types.TextContent(type="text", text=search_results)]
 
@@ -781,7 +781,7 @@ async def get_document(
             ]
         except Exception as e:
             error_msg = f"get_document failed: {e!s}"
-            logger.error(error_msg)
+            logger.exception(error_msg)
             return [types.TextContent(type="text", text=f"Error: {error_msg}")]
 
 
@@ -825,7 +825,7 @@ async def get_chunk_neighbors(
             ]
         except Exception as e:
             error_msg = f"get_chunk_neighbors failed: {e!s}"
-            logger.error(error_msg)
+            logger.exception(error_msg)
             return [types.TextContent(type="text", text=f"Error: {error_msg}")]
 
 
@@ -953,7 +953,7 @@ async def list_data(dataset_id: str | None = None) -> list:
 
         except Exception as e:
             error_msg = f"❌ Failed to list data: {e!s}"
-            logger.error(f"List data error: {e!s}")
+            logger.exception("List data error")
             return [types.TextContent(type="text", text=error_msg)]
 
 
@@ -1013,6 +1013,7 @@ async def delete_dataset(dataset_name: str) -> list:
                 )
             ]
         except Exception as e:
+            logger.debug("Ignoring exception in delete_dataset", exc_info=True)
             return [types.TextContent(type="text", text=f"Error deleting dataset: {e!s}")]
 
 
@@ -1091,7 +1092,7 @@ async def delete(data_id: str, dataset_id: str, mode: str = "soft") -> list:
         except Exception as e:
             # Handle all other errors (DocumentNotFoundError, DatasetNotFoundError, etc.)
             error_msg = f"❌ Delete operation failed: {e!s}"
-            logger.error(f"Delete operation error: {e!s}")
+            logger.exception("Delete operation error")
             return [types.TextContent(type="text", text=error_msg)]
 
 
@@ -1127,7 +1128,7 @@ async def prune():
             return [types.TextContent(type="text", text=error_msg)]
         except Exception as e:
             error_msg = f"❌ Prune operation failed: {e!s}"
-            logger.error(error_msg)
+            logger.exception(error_msg)
             return [types.TextContent(type="text", text=error_msg)]
 
 
@@ -1212,6 +1213,7 @@ async def remember(
         try:
             decoded = base64.b64decode(content_base64, validate=True)
         except Exception as e:
+            logger.debug("Ignoring exception in remember", exc_info=True)
             return [types.TextContent(type="text", text=f"Error: invalid base64 content ({e}).")]
         if len(decoded) > _MAX_UPLOAD_BYTES:
             return [
@@ -1237,7 +1239,7 @@ async def remember(
                 await cognee_client.remember(**kwargs)
             except Exception as e:
                 _record_task_error(dataset_name, str(e))
-                logger.error(f"Background remember task failed for dataset '{dataset_name}': {e}")
+                logger.exception(f"Background remember task failed for dataset '{dataset_name}'")
 
         _track_background(
             remember_task_wrapper(
@@ -1285,7 +1287,7 @@ async def remember(
             return [types.TextContent(type="text", text=text)]
         except Exception as e:
             error_msg = f"Remember failed: {e!s}"
-            logger.error(error_msg)
+            logger.exception(error_msg)
             return [types.TextContent(type="text", text=f"Error: {error_msg}")]
 
 
@@ -1346,7 +1348,7 @@ async def recall(
             ]
         except Exception as e:
             error_msg = f"Recall failed: {e!s}"
-            logger.error(error_msg)
+            logger.exception(error_msg)
             return [types.TextContent(type="text", text=f"Error: {error_msg}")]
 
 
@@ -1423,7 +1425,7 @@ async def forget(
             return [types.TextContent(type="text", text=text)]
         except Exception as e:
             error_msg = f"Forget failed: {e!s}"
-            logger.error(error_msg)
+            logger.exception(error_msg)
             return [types.TextContent(type="text", text=f"Error: {error_msg}")]
 
 
@@ -1470,7 +1472,7 @@ async def improve(
             return [types.TextContent(type="text", text=text)]
         except Exception as e:
             error_msg = f"Improve failed: {e!s}"
-            logger.error(error_msg)
+            logger.exception(error_msg)
             return [types.TextContent(type="text", text=f"Error: {error_msg}")]
 
 
@@ -1577,7 +1579,7 @@ async def cognify_status(
                 for ts, err in sorted(dataset_errors, reverse=True):
                     error_lines.append(f"  [{ts}] {err}")
                 error_msg += "\n".join(error_lines)
-            logger.error(error_msg)
+            logger.exception(error_msg)
             return [types.TextContent(type="text", text=error_msg)]
 
 

--- a/cognee-mcp/src/test_client.py
+++ b/cognee-mcp/src/test_client.py
@@ -8,6 +8,9 @@ from uuid import uuid4
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
+import logging
+
+logger = logging.getLogger(__name__)
 
 try:
     from .server import registry
@@ -77,6 +80,9 @@ class CogneeTestClient:
             }
             print(f"PASS tool discovery: {', '.join(sorted(available_tools))}")
         except Exception as e:
+            logger.debug(
+                "Ignoring exception in CogneeTestClient.test_tool_discovery", exc_info=True
+            )
             self.test_results["tool_discovery"] = {
                 "status": "FAIL",
                 "error": str(e),
@@ -110,6 +116,10 @@ class CogneeTestClient:
             }
             print("PASS hidden tool reachability")
         except Exception as e:
+            logger.debug(
+                "Ignoring exception in CogneeTestClient.test_hidden_tool_is_still_callable",
+                exc_info=True,
+            )
             self.test_results["hidden_tool"] = {
                 "status": "FAIL",
                 "error": str(e),
@@ -155,6 +165,7 @@ class CogneeTestClient:
             }
             print("PASS memory tools")
         except Exception as e:
+            logger.debug("Ignoring exception in CogneeTestClient.test_memory_tools", exc_info=True)
             self.test_results["memory_tools"] = {
                 "status": "FAIL",
                 "error": str(e),

--- a/cognee-mcp/src/test_client.py
+++ b/cognee-mcp/src/test_client.py
@@ -2,13 +2,13 @@
 """Smoke-test the public Cognee MCP memory tools."""
 
 import asyncio
+import logging
 import os
 from contextlib import asynccontextmanager
 from uuid import uuid4
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/alembic/versions/d6e8f0a2b4c6_backfill_dataset_scoped_data_drop_dataset_data.py
+++ b/cognee/alembic/versions/d6e8f0a2b4c6_backfill_dataset_scoped_data_drop_dataset_data.py
@@ -326,5 +326,5 @@ def downgrade() -> None:
         try:
             op.drop_index("ix_data_legacy_id", table_name="data")
         except Exception:
-            pass
+            logger.debug("Ignoring exception in downgrade", exc_info=True)
         op.drop_column("data", "legacy_id")

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -90,6 +90,7 @@ async def lifespan(app: FastAPI):
     try:
         await run_migrations()
     except Exception:
+        logger.debug("Ignoring exception in lifespan", exc_info=True)
         db_engine = get_relational_engine()
         await db_engine.create_database()
 

--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -278,7 +278,8 @@ def get_activity_router() -> APIRouter:
             ]
         except Exception:
             logger.debug(
-                "Ignoring exception in get_activity_router.get_tenant_users", exc_info=True
+                "Falling back to [] after error in get_activity_router.get_tenant_users",
+                exc_info=True,
             )
             return []
 

--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -277,6 +277,9 @@ def get_activity_router() -> APIRouter:
                 for u in users
             ]
         except Exception:
+            logger.debug(
+                "Ignoring exception in get_activity_router.get_tenant_users", exc_info=True
+            )
             return []
 
     @router.get("/agents")
@@ -447,6 +450,9 @@ def get_activity_router() -> APIRouter:
             nodes = graph.get("nodes", []) if isinstance(graph, dict) else []
             edges = graph.get("edges", []) if isinstance(graph, dict) else []
         except Exception:
+            logger.debug(
+                "Ignoring exception in get_activity_router.export_dataset_markdown", exc_info=True
+            )
             nodes, edges = [], []
 
         # Build markdown

--- a/cognee/api/v1/datasets/datasets.py
+++ b/cognee/api/v1/datasets/datasets.py
@@ -72,7 +72,9 @@ async def _invalidate_sessions_for_dataset_nonfatal(dataset_id: UUID) -> None:
 
         await invalidate_sessions_for_dataset(dataset_id)
     except Exception as error:
-        logger.warning("Session invalidation after dataset delete failed (non-fatal): %s", error)
+        logger.warning(
+            "Session invalidation after dataset delete failed (non-fatal): %s", error, exc_info=True
+        )
 
 
 async def _invalidate_sessions_for_deleted_data_nonfatal(
@@ -95,7 +97,9 @@ async def _invalidate_sessions_for_deleted_data_nonfatal(
             user_id=user_id,
         )
     except Exception as error:
-        logger.warning("Session invalidation after data delete failed (non-fatal): %s", error)
+        logger.warning(
+            "Session invalidation after data delete failed (non-fatal): %s", error, exc_info=True
+        )
 
 
 class datasets:

--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -512,8 +512,8 @@ def get_datasets_router() -> APIRouter:
             )
 
             return datasets_statuses
-        except Exception as error:
-            logger.error("Error retrieving dataset statuses: %s", error)
+        except Exception:
+            logger.exception("Error retrieving dataset statuses")
             return JSONResponse(
                 status_code=409,
                 content={"error": "Unable to retrieve dataset statuses."},
@@ -582,8 +582,8 @@ def get_datasets_router() -> APIRouter:
             )
 
             return datasets_progress
-        except Exception as error:
-            logger.error("Error retrieving dataset progress: %s", error)
+        except Exception:
+            logger.exception("Error retrieving dataset progress")
             return JSONResponse(
                 status_code=409,
                 content={"error": "Unable to retrieve dataset progress."},
@@ -649,7 +649,7 @@ def get_datasets_router() -> APIRouter:
                 return []
 
             counts = await get_datasets_graph_counts(authorized_datasets)
-        except Exception as error:
+        except Exception:
             # Same posture as GET /statuses above and the sibling
             # GET /visualize/brains-summary: a poll that fails transiently is a
             # 409 with a generic message, not an unhandled 500 carrying
@@ -658,7 +658,7 @@ def get_datasets_router() -> APIRouter:
             # over an already-validated shape, so a bug there still surfaces
             # as a real 500 instead of being misreported as this endpoint's
             # documented transient-failure case.
-            logger.error("Error retrieving dataset graph summary: %s", error)
+            logger.exception("Error retrieving dataset graph summary")
             return JSONResponse(
                 status_code=409,
                 content={"error": "Unable to retrieve dataset graph summary."},

--- a/cognee/api/v1/delete/routers/get_delete_router.py
+++ b/cognee/api/v1/delete/routers/get_delete_router.py
@@ -64,8 +64,8 @@ def get_delete_router() -> APIRouter:
             )
             return result
 
-        except Exception as error:
-            logger.error("Error during deletion by data_id: %s", error)
+        except Exception:
+            logger.exception("Error during deletion by data_id")
             return JSONResponse(status_code=409, content={"error": "Unable to delete data."})
 
     return router

--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -215,7 +215,7 @@ async def _forget_everything(user: Any) -> dict:
             if cache_engine is not None:
                 await cache_engine.prune()
     except Exception as e:
-        logger.warning("forget: session cache cleanup failed (non-fatal): %s", e)
+        logger.warning("forget: session cache cleanup failed (non-fatal): %s", e, exc_info=True)
 
     logger.info("forget: deleted all data for user=%s (%d datasets)", user.id, count)
     return {"datasets_removed": count, "status": "success"}
@@ -324,6 +324,7 @@ async def _forget_dataset_memory(dataset_ref: str | UUID, user: Any) -> dict:
                 "forget: session invalidation failed for dataset %s (non-fatal): %s",
                 dataset_id,
                 error,
+                exc_info=True,
             )
 
         # 1c. The edges are gone, so the evidence rows describing them are stale;
@@ -430,6 +431,7 @@ async def _forget_data_memory(data_id: UUID, dataset_ref: str | UUID, user: Any)
                 data_id,
                 dataset_id,
                 error,
+                exc_info=True,
             )
 
         # 1c. Drop this item's edge evidence with its edges (non-fatal).

--- a/cognee/api/v1/health/health.py
+++ b/cognee/api/v1/health/health.py
@@ -187,7 +187,9 @@ class HealthChecker:
                 details="Storage accessible",
             )
         except Exception as e:
-            logger.debug("Ignoring exception in HealthChecker.check_file_storage", exc_info=True)
+            logger.debug(
+                "Falling back after error in HealthChecker.check_file_storage", exc_info=True
+            )
             response_time = int((time.time() - start_time) * 1000)
             return ComponentHealth(
                 status=HealthStatus.UNHEALTHY,
@@ -242,7 +244,7 @@ class HealthChecker:
             )
         except Exception as e:
             logger.debug(
-                "Ignoring exception in HealthChecker.check_embedding_service", exc_info=True
+                "Falling back after error in HealthChecker.check_embedding_service", exc_info=True
             )
             response_time = int((time.time() - start_time) * 1000)
             return ComponentHealth(

--- a/cognee/api/v1/health/health.py
+++ b/cognee/api/v1/health/health.py
@@ -187,6 +187,7 @@ class HealthChecker:
                 details="Storage accessible",
             )
         except Exception as e:
+            logger.debug("Ignoring exception in HealthChecker.check_file_storage", exc_info=True)
             response_time = int((time.time() - start_time) * 1000)
             return ComponentHealth(
                 status=HealthStatus.UNHEALTHY,
@@ -240,6 +241,9 @@ class HealthChecker:
                 details="Embedding generation working",
             )
         except Exception as e:
+            logger.debug(
+                "Ignoring exception in HealthChecker.check_embedding_service", exc_info=True
+            )
             response_time = int((time.time() - start_time) * 1000)
             return ComponentHealth(
                 status=HealthStatus.DEGRADED,

--- a/cognee/api/v1/improve/improve.py
+++ b/cognee/api/v1/improve/improve.py
@@ -260,7 +260,9 @@ async def improve(
                             stages_run.append("build_truth_subspace")
                         except Exception as e:
                             logger.warning(
-                                "improve: truth subspace build failed (non-fatal): %s", e
+                                "improve: truth subspace build failed (non-fatal): %s",
+                                e,
+                                exc_info=True,
                             )
 
                 # Stage 3: default enrichment (triplet embeddings)
@@ -331,7 +333,9 @@ async def _build_global_context_index(
         logger.info("improve: global context index updated")
         return True
     except Exception as e:
-        logger.warning("improve: global context index update failed (non-fatal): %s", e)
+        logger.warning(
+            "improve: global context index update failed (non-fatal): %s", e, exc_info=True
+        )
         return False
 
 
@@ -368,7 +372,7 @@ async def _bridge_sessions(
         )
         logger.info("improve: feedback weights applied from %d session(s)", len(session_ids))
     except Exception as e:
-        logger.warning("improve: feedback weights failed (non-fatal): %s", e)
+        logger.warning("improve: feedback weights failed (non-fatal): %s", e, exc_info=True)
 
     # Stage 2: persist session Q&A into permanent graph
     from cognee.memify_pipelines.persist_sessions_in_knowledge_graph import (
@@ -421,6 +425,7 @@ async def _extract_agent_context(
                 "improve: agent-context extraction failed for '%s' (non-fatal): %s",
                 session_id,
                 e,
+                exc_info=True,
             )
     return touched
 
@@ -463,6 +468,7 @@ async def _distill_sessions(
                 "improve: session distillation failed for '%s' (non-fatal): %s",
                 session_id,
                 e,
+                exc_info=True,
             )
     return distilled
 
@@ -507,7 +513,7 @@ async def _update_user_preferences(
         )
         return result
     except Exception as e:
-        logger.warning("improve: user preference update failed (non-fatal): %s", e)
+        logger.warning("improve: user preference update failed (non-fatal): %s", e, exc_info=True)
         return None
 
 
@@ -547,4 +553,4 @@ async def _persist_session_traces(
             len(session_ids),
         )
     except Exception as e:
-        logger.warning("improve: trace persistence failed (non-fatal): %s", e)
+        logger.warning("improve: trace persistence failed (non-fatal): %s", e, exc_info=True)

--- a/cognee/api/v1/llm/routers/get_llm_router.py
+++ b/cognee/api/v1/llm/routers/get_llm_router.py
@@ -78,7 +78,7 @@ def _count_tokens(text: str, model: str) -> int | None:
     try:
         return litellm.token_counter(model=model, text=text)
     except Exception:
-        logger.debug("Ignoring exception in _count_tokens", exc_info=True)
+        logger.debug("Falling back to None after error in _count_tokens", exc_info=True)
         return None
 
 
@@ -143,7 +143,7 @@ def _model_aware_sample_text(
 
         return sample
     except Exception:
-        logger.debug("Ignoring exception in _model_aware_sample_text", exc_info=True)
+        logger.debug("Falling back after error in _model_aware_sample_text", exc_info=True)
         return _sample_text(text)
 
 

--- a/cognee/api/v1/llm/routers/get_llm_router.py
+++ b/cognee/api/v1/llm/routers/get_llm_router.py
@@ -78,6 +78,7 @@ def _count_tokens(text: str, model: str) -> int | None:
     try:
         return litellm.token_counter(model=model, text=text)
     except Exception:
+        logger.debug("Ignoring exception in _count_tokens", exc_info=True)
         return None
 
 
@@ -142,6 +143,7 @@ def _model_aware_sample_text(
 
         return sample
     except Exception:
+        logger.debug("Ignoring exception in _model_aware_sample_text", exc_info=True)
         return _sample_text(text)
 
 
@@ -258,8 +260,8 @@ def get_llm_router() -> APIRouter:
             return JSONResponse(
                 status_code=400, content={"error": "Invalid custom prompt request."}
             )
-        except Exception as error:
-            logger.error("LLM custom prompt generation request failed: %s", error)
+        except Exception:
+            logger.exception("LLM custom prompt generation request failed")
             return JSONResponse(
                 status_code=500,
                 content={"error": "LLM custom prompt generation failed."},
@@ -391,8 +393,8 @@ def get_llm_router() -> APIRouter:
                     "detail": "The configured LLM token budget is exhausted.",
                 },
             )
-        except Exception as error:
-            logger.error("LLM schema inference failed: %s", error)
+        except Exception:
+            logger.exception("LLM schema inference failed")
             return JSONResponse(status_code=500, content={"error": "LLM schema inference failed."})
 
     return router

--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -153,7 +153,7 @@ async def _resolve_session_cache_user_id(session_id: str, caller_user_id: str | 
         owner = getattr(chosen, "user_id", None)
         return str(owner) if owner is not None else caller_user_id
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _resolve_session_cache_user_id", exc_info=True)
     return caller_user_id
 
 
@@ -265,11 +265,13 @@ async def _search_trace(
         try:
             parts.append(json.dumps(mp, ensure_ascii=False))
         except Exception:
+            logger.debug("Ignoring exception in _search_trace", exc_info=True)
             parts.append(str(mp))
         mrv = entry.method_return_value
         try:
             parts.append(json.dumps(mrv, ensure_ascii=False))
         except Exception:
+            logger.debug("Ignoring exception in _search_trace", exc_info=True)
             parts.append(str(mrv))
 
         entry_words = _tokenize(" ".join(parts))
@@ -672,7 +674,9 @@ async def recall(
                     recall_config = get_recall_config()
                 except Exception as error:
                     logger.warning(
-                        "Recall warm-up config failed to load; skipping guard: %s", error
+                        "Recall warm-up config failed to load; skipping guard: %s",
+                        error,
+                        exc_info=True,
                     )
                 guard_active = (
                     recall_config is not None
@@ -706,6 +710,7 @@ async def recall(
                         logger.warning(
                             "Recall warm-up pre-probe authorization failed; skipping guard: %s",
                             error,
+                            exc_info=True,
                         )
                         guard_active = False
 
@@ -957,7 +962,7 @@ async def recall(
                         top_k=gate_top_k,
                     )
                 except Exception as error:
-                    logger.warning("Skill gate lookup failed (non-fatal): %s", error)
+                    logger.warning("Skill gate lookup failed (non-fatal): %s", error, exc_info=True)
                     return []
 
                 entries: list[RecallResponse] = []

--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -342,6 +342,7 @@ async def _dispatch_session_entry(
                 resolved_dataset = ds.id
         except Exception:
             # Fall through with None — we still create the session row.
+            logger.debug("Ignoring exception in _dispatch_session_entry", exc_info=True)
             resolved_dataset = None
 
         await ensure_and_touch_session(
@@ -350,7 +351,7 @@ async def _dispatch_session_entry(
             dataset_id=resolved_dataset,
         )
     except Exception as exc:
-        logger.debug("remember: pre-upsert session_record failed (%s)", exc)
+        logger.debug("remember: pre-upsert session_record failed (%s)", exc, exc_info=True)
 
     result = RememberResult(
         status="session_stored",
@@ -1372,7 +1373,9 @@ async def _remember_inner(
                             )
                         logger.info("remember: session '%s' bridged to permanent graph", session_id)
                     except Exception as exc:
-                        logger.warning("remember: session improve failed (non-fatal): %s", exc)
+                        logger.warning(
+                            "remember: session improve failed (non-fatal): %s", exc, exc_info=True
+                        )
 
                 result._task = asyncio.create_task(_session_improve())
                 _BACKGROUND_REMEMBER_TASKS.add(result._task)

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -534,7 +534,7 @@ def get_remember_router() -> APIRouter:
                         "Expected the same dict format as the cognify endpoint, "
                         "including a top-level 'title' key."
                     ),
-                )
+                ) from parse_err
 
         try:
             config_to_use = None

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -17,6 +17,10 @@ from cognee.modules.users.models import User
 from cognee.shared.usage_logger import log_usage
 from cognee.shared.utils import send_telemetry
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 
 # Note: Datasets sent by name will only map to datasets owned by the request sender
 #       To search for datasets not owned by the request sender dataset UUID is needed
@@ -177,6 +181,9 @@ def get_search_router() -> APIRouter:
 
             return history
         except Exception as error:
+            logger.debug(
+                "Ignoring exception in get_search_router.get_search_history", exc_info=True
+            )
             return JSONResponse(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 content=ErrorResponse(
@@ -295,6 +302,7 @@ def get_search_router() -> APIRouter:
             # returns them to the caller.
             raise
         except Exception as error:
+            logger.debug("Ignoring exception in get_search_router.search", exc_info=True)
             return JSONResponse(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 content=ErrorResponse(

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -14,10 +14,9 @@ from cognee.modules.search.operations import get_history
 from cognee.modules.search.types import ContextFormat, SearchResult, SearchType
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.modules.users.models import User
+from cognee.shared.logging_utils import get_logger
 from cognee.shared.usage_logger import log_usage
 from cognee.shared.utils import send_telemetry
-
-from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()
 

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -180,9 +180,7 @@ def get_search_router() -> APIRouter:
 
             return history
         except Exception as error:
-            logger.debug(
-                "Ignoring exception in get_search_router.get_search_history", exc_info=True
-            )
+            logger.exception("get_search_router.get_search_history failed, returning HTTP 500")
             return JSONResponse(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 content=ErrorResponse(
@@ -301,7 +299,7 @@ def get_search_router() -> APIRouter:
             # returns them to the caller.
             raise
         except Exception as error:
-            logger.debug("Ignoring exception in get_search_router.search", exc_info=True)
+            logger.exception("get_search_router.search failed, returning HTTP 500")
             return JSONResponse(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 content=ErrorResponse(

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -68,6 +68,7 @@ class CloudClient:
             async with session.get(f"{self.service_url}/health") as resp:
                 return resp.status == 200
         except Exception:
+            logger.debug("Ignoring exception in CloudClient._health_check", exc_info=True)
             return False
 
     async def _auth_check(self) -> int | None:
@@ -82,6 +83,7 @@ class CloudClient:
             async with session.get(f"{self.service_url}/api/v1/datasets") as resp:
                 return resp.status
         except Exception:
+            logger.debug("Ignoring exception in CloudClient._auth_check", exc_info=True)
             return None
 
     # ----- V2 Operations -----

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -68,7 +68,9 @@ class CloudClient:
             async with session.get(f"{self.service_url}/health") as resp:
                 return resp.status == 200
         except Exception:
-            logger.debug("Ignoring exception in CloudClient._health_check", exc_info=True)
+            logger.debug(
+                "Falling back to False after error in CloudClient._health_check", exc_info=True
+            )
             return False
 
     async def _auth_check(self) -> int | None:
@@ -83,7 +85,9 @@ class CloudClient:
             async with session.get(f"{self.service_url}/api/v1/datasets") as resp:
                 return resp.status
         except Exception:
-            logger.debug("Ignoring exception in CloudClient._auth_check", exc_info=True)
+            logger.debug(
+                "Falling back to None after error in CloudClient._auth_check", exc_info=True
+            )
             return None
 
     # ----- V2 Operations -----

--- a/cognee/api/v1/serve/credentials.py
+++ b/cognee/api/v1/serve/credentials.py
@@ -42,7 +42,7 @@ def load_credentials() -> CloudCredentials | None:
             **{k: v for k, v in data.items() if k in CloudCredentials.__dataclass_fields__}
         )
     except Exception as e:
-        logger.debug("Failed to load cloud credentials: %s", e)
+        logger.debug("Failed to load cloud credentials: %s", e, exc_info=True)
         return None
 
 

--- a/cognee/api/v1/serve/device_auth.py
+++ b/cognee/api/v1/serve/device_auth.py
@@ -184,5 +184,7 @@ def extract_email_from_id_token(id_token: str) -> str | None:
         payload = json.loads(base64.urlsafe_b64decode(payload_b64))
         return payload.get("email")
     except Exception:
-        logger.debug("Ignoring exception in extract_email_from_id_token", exc_info=True)
+        logger.debug(
+            "Falling back to None after error in extract_email_from_id_token", exc_info=True
+        )
         return None

--- a/cognee/api/v1/serve/device_auth.py
+++ b/cognee/api/v1/serve/device_auth.py
@@ -184,4 +184,5 @@ def extract_email_from_id_token(id_token: str) -> str | None:
         payload = json.loads(base64.urlsafe_b64decode(payload_b64))
         return payload.get("email")
     except Exception:
+        logger.debug("Ignoring exception in extract_email_from_id_token", exc_info=True)
         return None

--- a/cognee/api/v1/serve/serve.py
+++ b/cognee/api/v1/serve/serve.py
@@ -182,7 +182,7 @@ async def _serve_cloud(
                 print(f"  Connected to Cognee Cloud at {creds.service_url}")
                 return client
         except Exception as e:
-            logger.warning("Immediate health check failed: %s", e)
+            logger.warning("Immediate health check failed: %s", e, exc_info=True)
         await client.close()
 
         if not is_token_expired(creds):
@@ -215,7 +215,7 @@ async def _serve_cloud(
                     return client
                 await client.close()
             except Exception as e:
-                logger.warning("Token refresh failed, re-authenticating: %s", e)
+                logger.warning("Token refresh failed, re-authenticating: %s", e, exc_info=True)
 
     # Step 2: Device Code Flow — only possible with an Auth0 device client ID.
     # Fail loudly here rather than mid-flow: a bare serve() with nothing saved

--- a/cognee/api/v1/serve/state.py
+++ b/cognee/api/v1/serve/state.py
@@ -35,7 +35,7 @@ def _note_local_execution() -> None:
 
         creds = load_credentials()
     except Exception:
-        logger.debug("Ignoring exception in _note_local_execution", exc_info=True)
+        logger.debug("Giving up after error in _note_local_execution", exc_info=True)
         return
     if creds and creds.service_url and creds.api_key:
         logger.warning(

--- a/cognee/api/v1/serve/state.py
+++ b/cognee/api/v1/serve/state.py
@@ -35,6 +35,7 @@ def _note_local_execution() -> None:
 
         creds = load_credentials()
     except Exception:
+        logger.debug("Ignoring exception in _note_local_execution", exc_info=True)
         return
     if creds and creds.service_url and creds.api_key:
         logger.warning(

--- a/cognee/api/v1/session/session.py
+++ b/cognee/api/v1/session/session.py
@@ -102,7 +102,7 @@ async def get_session(
             try:
                 result.append(SessionQAEntry.model_validate(entry))
             except Exception as e:
-                logger.warning("get_session: skip invalid entry: %s", e)
+                logger.warning("get_session: skip invalid entry: %s", e, exc_info=True)
         elif isinstance(entry, SessionQAEntry):
             result.append(entry)
         else:

--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -460,7 +460,9 @@ def get_sessions_router() -> APIRouter:
                     user_id=owner_user_id, session_id=session_id
                 )
             except Exception:
-                pass
+                logger.debug(
+                    "Ignoring exception in get_sessions_router.get_session_detail", exc_info=True
+                )
 
         record = row.to_dict()
         # Label = first QA's question, else first trace's origin_function

--- a/cognee/api/v1/skills/list_skills.py
+++ b/cognee/api/v1/skills/list_skills.py
@@ -128,7 +128,7 @@ async def _delete_skill_in_context(skill_id: str, dataset: UUID) -> bool:
         vector_engine = await get_vector_engine_async()
         await vector_engine.delete_data_points("Skill_search_text", [str(skill.id)])
     except Exception as exc:
-        logger.warning("Skill vector cleanup skipped (non-fatal): %s", exc)
+        logger.warning("Skill vector cleanup skipped (non-fatal): %s", exc, exc_info=True)
     return True
 
 

--- a/cognee/api/v1/sync/routers/get_sync_router.py
+++ b/cognee/api/v1/sync/routers/get_sync_router.py
@@ -152,8 +152,8 @@ def get_sync_router() -> APIRouter:
         except ConnectionError as e:
             logger.error("Cloud service unavailable during sync: %s", e)
             return JSONResponse(status_code=409, content={"error": "Cloud service unavailable."})
-        except Exception as e:
-            logger.error(f"Cloud sync operation failed: {e!s}")
+        except Exception:
+            logger.exception("Cloud sync operation failed")
             return JSONResponse(status_code=409, content={"error": "Cloud sync operation failed."})
 
     @router.get("/status")
@@ -235,8 +235,8 @@ def get_sync_router() -> APIRouter:
 
             return response
 
-        except Exception as e:
-            logger.error(f"Failed to get sync status overview: {e!s}")
+        except Exception:
+            logger.exception("Failed to get sync status overview")
             return JSONResponse(
                 status_code=500, content={"error": "Failed to get sync status overview"}
             )

--- a/cognee/api/v1/sync/sync.py
+++ b/cognee/api/v1/sync/sync.py
@@ -49,7 +49,10 @@ async def _safe_update_progress(run_id: str, stage: str, **kwargs):
         logger.info(f"Sync {run_id}: Progress updated during {stage}")
     except Exception as e:
         # Log error but don't fail the sync - progress updates are nice-to-have
-        logger.warning(f"Sync {run_id}: Non-critical progress update failed during {stage}: {e!s}")
+        logger.warning(
+            f"Sync {run_id}: Non-critical progress update failed during {stage}: {e!s}",
+            exc_info=True,
+        )
         # Continue without raising - sync operation is more important than progress tracking
 
 
@@ -149,8 +152,8 @@ async def sync(
             user_id=user.id,
         )
         logger.info(f"Created sync operation record for {run_id}")
-    except Exception as e:
-        logger.error(f"Failed to create sync operation record: {e!s}")
+    except Exception:
+        logger.exception("Failed to create sync operation record")
         # Continue without database tracking if record creation fails
 
     # Start the sync operation in the background
@@ -194,10 +197,10 @@ async def _perform_background_sync(run_id: str, datasets: list[Dataset], user: U
                     dataset_sync_hashes,
                 ) = await _sync_to_cognee_cloud(datasets, user, run_id)
                 break
-            except Exception as e:
+            except Exception:
                 retry_count += 1
-                logger.error(
-                    f"Background sync {run_id}: Failed after {retry_count} retries with error: {e!s}"
+                logger.exception(
+                    f"Background sync {run_id}: Failed after {retry_count} retries with error"
                 )
                 await update_sync_operation(run_id, retry_count=retry_count)
                 await asyncio.sleep(2**retry_count)
@@ -229,7 +232,7 @@ async def _perform_background_sync(run_id: str, datasets: list[Dataset], user: U
         end_time = datetime.now(timezone.utc)
         duration = (end_time - start_time).total_seconds()
 
-        logger.error(f"Background sync {run_id}: Failed after {duration}s with error: {e!s}")
+        logger.exception(f"Background sync {run_id}: Failed after {duration}s with error")
 
         # Mark sync as failed with error message
         await mark_sync_failed(run_id, str(e))
@@ -313,9 +316,9 @@ async def _sync_to_cognee_cloud(
                     f"↑{dataset_result.records_uploaded} files ({dataset_result.bytes_uploaded} bytes), "
                     f"↓{dataset_result.records_downloaded} files ({dataset_result.bytes_downloaded} bytes)"
                 )
-            except Exception as e:
+            except Exception:
                 completed_datasets += 1
-                logger.error(f"Dataset file sync failed: {e!s}")
+                logger.exception("Dataset file sync failed")
                 # Update progress even for failed datasets
                 file_sync_progress = int((completed_datasets / len(datasets)) * 80)
                 await _safe_update_progress(
@@ -338,7 +341,7 @@ async def _sync_to_cognee_cloud(
                 )
                 logger.info("Cognify processing triggered successfully for all datasets")
             except Exception as e:
-                logger.warning(f"Failed to trigger cognify processing: {e!s}")
+                logger.warning(f"Failed to trigger cognify processing: {e!s}", exc_info=True)
                 # Don't fail the entire sync if cognify fails
         else:
             logger.info(
@@ -354,7 +357,7 @@ async def _sync_to_cognee_cloud(
                 await cognify()
                 logger.info("Local cognify processing completed successfully for all datasets")
             except Exception as e:
-                logger.warning(f"Failed to run local cognify processing: {e!s}")
+                logger.warning(f"Failed to run local cognify processing: {e!s}", exc_info=True)
                 # Don't fail the entire sync if local cognify fails
         else:
             logger.info(
@@ -374,7 +377,7 @@ async def _sync_to_cognee_cloud(
                 records_uploaded=total_records_uploaded,
             )
         except Exception as e:
-            logger.warning(f"Failed to update final sync progress: {e!s}")
+            logger.warning(f"Failed to update final sync progress: {e!s}", exc_info=True)
 
         logger.info(
             f"Multi-dataset sync completed: {len(datasets)} datasets processed, downloaded {total_records_downloaded} records/{total_bytes_downloaded} bytes, uploaded {total_records_uploaded} records/{total_bytes_uploaded} bytes"
@@ -389,7 +392,7 @@ async def _sync_to_cognee_cloud(
         )
 
     except Exception as e:
-        logger.error(f"Sync failed: {e!s}")
+        logger.exception("Sync failed")
         raise ConnectionError(f"Cloud sync failed: {e!s}")
 
 
@@ -535,7 +538,7 @@ async def _extract_local_files_with_hashes(
 
             except Exception as e:
                 skipped_count += 1
-                logger.warning(f"Failed to process file {data_entry.name}: {e!s}")
+                logger.warning(f"Failed to process file {data_entry.name}: {e!s}", exc_info=True)
                 # Continue with other entries even if one fails
                 continue
 
@@ -558,6 +561,7 @@ async def _get_file_size(file_path: str) -> int:
 
         return await file_storage.get_size(file_name)
     except Exception:
+        logger.debug("Ignoring exception in _get_file_size", exc_info=True)
         return 0
 
 
@@ -623,7 +627,7 @@ async def _check_hashes_diff(
                     )
 
     except Exception as e:
-        logger.error(f"Error checking missing hashes: {e!s}")
+        logger.exception("Error checking missing hashes")
         raise ConnectionError(f"Failed to check missing hashes: {e!s}")
 
 
@@ -689,8 +693,8 @@ async def _download_missing_files(
                         )
                         continue
 
-            except Exception as e:
-                logger.error(f"Error downloading file {file_hash}: {e!s}")
+            except Exception:
+                logger.exception(f"Error downloading file {file_hash}")
                 continue
 
     logger.info(
@@ -813,7 +817,7 @@ async def _upload_missing_files(
                         )
 
             except Exception as e:
-                logger.error(f"Error uploading file {file_info.name}: {e!s}")
+                logger.exception(f"Error uploading file {file_info.name}")
                 raise ConnectionError(f"Upload failed for {file_info.name}: {e!s}")
 
     logger.info(f"All {uploaded_count} files uploaded successfully: {total_bytes_uploaded} bytes")
@@ -853,8 +857,8 @@ async def _prune_cloud_dataset(
                     )
                     # Don't raise error for prune failures - sync partially succeeded
 
-    except Exception as e:
-        logger.error(f"Error pruning cloud dataset: {e!s}")
+    except Exception:
+        logger.exception("Error pruning cloud dataset")
         # Don't raise error for prune failures - sync partially succeeded
 
 
@@ -902,5 +906,5 @@ async def _trigger_remote_cognify(
                     # TODO: consider adding retries
 
     except Exception as e:
-        logger.warning(f"Error triggering cognify processing: {e!s}")
+        logger.warning(f"Error triggering cognify processing: {e!s}", exc_info=True)
         # TODO: consider adding retries

--- a/cognee/api/v1/sync/sync.py
+++ b/cognee/api/v1/sync/sync.py
@@ -561,7 +561,7 @@ async def _get_file_size(file_path: str) -> int:
 
         return await file_storage.get_size(file_name)
     except Exception:
-        logger.debug("Ignoring exception in _get_file_size", exc_info=True)
+        logger.debug("Falling back to 0 after error in _get_file_size", exc_info=True)
         return 0
 
 

--- a/cognee/api/v1/ui/node_setup.py
+++ b/cognee/api/v1/ui/node_setup.py
@@ -357,5 +357,5 @@ def check_node_npm() -> tuple[bool, str]:  # (is_available, error_message)
 
         return False, "Node.js/npm not found. Please install Node.js from https://nodejs.org/"
     except Exception as e:
-        logger.debug("Ignoring exception in check_node_npm", exc_info=True)
+        logger.debug("Falling back after error in check_node_npm", exc_info=True)
         return False, f"Error checking Node.js/npm: {e!s}"

--- a/cognee/api/v1/ui/node_setup.py
+++ b/cognee/api/v1/ui/node_setup.py
@@ -69,7 +69,7 @@ def check_nvm_installed() -> bool:
 
         return result.returncode == 0
     except Exception as e:
-        logger.debug(f"Exception checking nvm: {e!s}")
+        logger.debug(f"Exception checking nvm: {e!s}", exc_info=True)
         return False
 
 
@@ -128,13 +128,13 @@ def install_nvm() -> bool:
             try:
                 os.unlink(install_script_path)
             except Exception:
-                pass
+                logger.debug("Ignoring exception in install_nvm", exc_info=True)
 
     except requests.exceptions.RequestException as e:
         logger.error(f"Failed to download nvm installer: {e!s}")
         return False
-    except Exception as e:
-        logger.error(f"Failed to install nvm: {e!s}")
+    except Exception:
+        logger.exception("Failed to install nvm")
         return False
 
 
@@ -202,8 +202,8 @@ def install_node_with_nvm() -> bool:
     except subprocess.TimeoutExpired:
         logger.error("Timeout installing Node.js (this can take several minutes)")
         return False
-    except Exception as e:
-        logger.error(f"Error installing Node.js: {e!s}")
+    except Exception:
+        logger.exception("Error installing Node.js")
         return False
 
 
@@ -353,8 +353,9 @@ def check_node_npm() -> tuple[bool, str]:  # (is_available, error_message)
                     elif result.stderr:
                         logger.debug(f"Failed to source nvm or run npm: {result.stderr.strip()}")
         except Exception as e:
-            logger.debug(f"Exception retrying node/npm check: {e!s}")
+            logger.debug(f"Exception retrying node/npm check: {e!s}", exc_info=True)
 
         return False, "Node.js/npm not found. Please install Node.js from https://nodejs.org/"
     except Exception as e:
+        logger.debug("Ignoring exception in check_node_npm", exc_info=True)
         return False, f"Error checking Node.js/npm: {e!s}"

--- a/cognee/api/v1/ui/ui.py
+++ b/cognee/api/v1/ui/ui.py
@@ -109,7 +109,9 @@ def _stream_process_output(
                     if line_text:
                         print(f"{color_code}{prefix}{reset_code} {line_text}", flush=True)
         except Exception:
-            pass
+            logger.debug(
+                "Ignoring exception in _stream_process_output.stream_reader", exc_info=True
+            )
         finally:
             if stream:
                 stream.close()
@@ -130,6 +132,7 @@ def _is_port_available(port: int) -> bool:
             result = sock.connect_ex(("localhost", port))
             return result != 0  # Port is available if connection fails
     except Exception:
+        logger.debug("Ignoring exception in _is_port_available", exc_info=True)
         return False
 
 
@@ -231,7 +234,7 @@ def download_frontend_assets(force: bool = False) -> bool:
                 if version_file.exists():
                     version_file.unlink()
         except Exception as e:
-            logger.debug(f"Error checking cached version: {e}")
+            logger.debug(f"Error checking cached version: {e}", exc_info=True)
             # Clear potentially corrupted cache
             if frontend_dir.exists():
                 shutil.rmtree(frontend_dir)
@@ -310,7 +313,7 @@ def download_frontend_assets(force: bool = False) -> bool:
         return False
     except Exception as e:
         logger.error(f"Failed to download frontend assets: {e!s}")
-        logger.error("You can still use cognee without the UI functionality.")
+        logger.exception("You can still use cognee without the UI functionality.")
         return False
 
 
@@ -370,8 +373,8 @@ def install_frontend_dependencies(frontend_path: Path) -> bool:
     except subprocess.TimeoutExpired:
         logger.error("Timeout installing frontend dependencies")
         return False
-    except Exception as e:
-        logger.error(f"Error installing frontend dependencies: {e!s}")
+    except Exception:
+        logger.exception("Error installing frontend dependencies")
         return False
 
 
@@ -395,6 +398,7 @@ def is_development_frontend(frontend_path: Path) -> bool:
 
         return "next" in dependencies or "next" in dev_dependencies
     except Exception:
+        logger.debug("Ignoring exception in is_development_frontend", exc_info=True)
         return False
 
 
@@ -581,8 +585,8 @@ def start_ui(
             logger.info(
                 f"✓ Cognee MCP server starting on http://127.0.0.1:{mcp_port}/sse ({mode_info})"
             )
-        except Exception as e:
-            logger.error(f"Failed to start MCP server with Docker: {e!s}")
+        except Exception:
+            logger.exception("Failed to start MCP server with Docker")
     # Start backend server if requested
     if start_backend:
         logger.info("Starting cognee backend API server...")
@@ -620,8 +624,8 @@ def start_ui(
 
             logger.info(f"✓ Backend API started at http://localhost:{backend_port}")
 
-        except Exception as e:
-            logger.error(f"Failed to start backend server: {e!s}")
+        except Exception:
+            logger.exception("Failed to start backend server")
             return None
 
     # Find frontend directory
@@ -744,7 +748,7 @@ def start_ui(
                 try:
                     webbrowser.open(f"http://localhost:{port}")
                 except Exception as e:
-                    logger.warning(f"Could not open browser automatically: {e}")
+                    logger.warning(f"Could not open browser automatically: {e}", exc_info=True)
 
             browser_thread = threading.Thread(target=open_browser_delayed, daemon=True)
             browser_thread.start()
@@ -759,7 +763,7 @@ def start_ui(
         logger.error(f"Failed to start frontend server: {e!s}")
         # Clean up backend process if it was started
         if backend_process:
-            logger.info("Cleaning up backend process due to frontend failure...")
+            logger.info("Cleaning up backend process due to frontend failure...", exc_info=True)
             try:
                 backend_process.terminate()
                 backend_process.wait(timeout=5)

--- a/cognee/api/v1/ui/ui.py
+++ b/cognee/api/v1/ui/ui.py
@@ -132,7 +132,7 @@ def _is_port_available(port: int) -> bool:
             result = sock.connect_ex(("localhost", port))
             return result != 0  # Port is available if connection fails
     except Exception:
-        logger.debug("Ignoring exception in _is_port_available", exc_info=True)
+        logger.debug("Falling back to False after error in _is_port_available", exc_info=True)
         return False
 
 
@@ -398,7 +398,7 @@ def is_development_frontend(frontend_path: Path) -> bool:
 
         return "next" in dependencies or "next" in dev_dependencies
     except Exception:
-        logger.debug("Ignoring exception in is_development_frontend", exc_info=True)
+        logger.debug("Falling back to False after error in is_development_frontend", exc_info=True)
         return False
 
 

--- a/cognee/api/v1/users/routers/get_visualize_router.py
+++ b/cognee/api/v1/users/routers/get_visualize_router.py
@@ -712,8 +712,8 @@ def get_visualize_router() -> APIRouter:
             html_visualization = await visualize_multi_user_graph(user_dataset_pairs)
             return HTMLResponse(html_visualization)
 
-        except Exception as error:
-            logger.error("Multi-user visualization request failed: %s", error)
+        except Exception:
+            logger.exception("Multi-user visualization request failed")
             return JSONResponse(
                 status_code=409, content={"error": "Unable to render visualization."}
             )

--- a/cognee/api/v1/visualize/memory_provenance.py
+++ b/cognee/api/v1/visualize/memory_provenance.py
@@ -311,7 +311,7 @@ async def _read_agents(user_ids: list[str]) -> list[AgentRecord]:
         try:
             connections += list(list_registered_agent_connections() or [])
         except Exception as error:  # pragma: no cover - defensive
-            logger.debug(f"registered agent enumeration skipped: {error}")
+            logger.debug(f"registered agent enumeration skipped: {error}", exc_info=True)
         try:
             connections += list(
                 await list_persisted_agent_connections(
@@ -320,9 +320,9 @@ async def _read_agents(user_ids: list[str]) -> list[AgentRecord]:
                 or []
             )
         except Exception as error:  # pragma: no cover - defensive
-            logger.debug(f"persisted agent enumeration skipped: {error}")
+            logger.debug(f"persisted agent enumeration skipped: {error}", exc_info=True)
     except Exception as error:  # pragma: no cover - module unavailable
-        logger.debug(f"agent registry unavailable: {error}")
+        logger.debug(f"agent registry unavailable: {error}", exc_info=True)
         return []
 
     agents: list[AgentRecord] = []
@@ -371,7 +371,7 @@ async def _read_sessions(user_ids: list[str], agents: list[AgentRecord]) -> list
                 }
             )
     except Exception as error:  # pragma: no cover - defensive
-        logger.debug(f"session enumeration skipped: {error}")
+        logger.debug(f"session enumeration skipped: {error}", exc_info=True)
     return sessions
 
 
@@ -395,7 +395,7 @@ async def _read_memory_relational(
         from cognee.modules.graph.models.Edge import Edge as EdgeRow
         from cognee.modules.graph.models.Node import Node as NodeRow
     except Exception as error:  # pragma: no cover - models unavailable
-        logger.debug(f"relational memory models unavailable: {error}")
+        logger.debug(f"relational memory models unavailable: {error}", exc_info=True)
         return None
 
     nodes: list[tuple[str, dict[str, Any]]] = []
@@ -433,7 +433,7 @@ async def _read_memory_relational(
                     continue
                 edges.append(EdgeData(src, dst, row.relationship_name or "related", {}))
     except Exception as error:  # pragma: no cover - defensive
-        logger.debug(f"relational memory read skipped: {error}")
+        logger.debug(f"relational memory read skipped: {error}", exc_info=True)
         return None
 
     if not nodes:

--- a/cognee/cli/_cognee.py
+++ b/cognee/cli/_cognee.py
@@ -24,6 +24,10 @@ from cognee.cli.config import CLI_DESCRIPTION
 from cognee.cli.exceptions import CliCommandException
 from cognee.cli.remediation import find_remediation
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 ACTION_EXECUTED = False
 
 
@@ -297,7 +301,7 @@ def main() -> int:
                         ["docker", "rm", "-f", docker_container], capture_output=True, check=False
                     )
                 except Exception:
-                    pass
+                    logger.debug("Ignoring exception in main.signal_handler", exc_info=True)
 
             # Then, stop regular processes
             for pid in spawned_pids:
@@ -436,7 +440,7 @@ def main() -> int:
             fmt.note(f"Please refer to our docs at '{docs_url}' for further assistance.")
 
             if debug.is_debug_enabled() and raiseable_exception:
-                raise raiseable_exception
+                raise raiseable_exception from ex
 
             return error_code
     else:

--- a/cognee/cli/_cognee.py
+++ b/cognee/cli/_cognee.py
@@ -23,7 +23,6 @@ from cognee.cli import DEFAULT_DOCS_URL, SupportsCliCommand, debug
 from cognee.cli.config import CLI_DESCRIPTION
 from cognee.cli.exceptions import CliCommandException
 from cognee.cli.remediation import find_remediation
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/cli/api_client.py
+++ b/cognee/cli/api_client.py
@@ -123,7 +123,7 @@ class CogneeApiClient:
         try:
             return r.json()
         except Exception:
-            logger.debug("Ignoring exception in CogneeApiClient.health", exc_info=True)
+            logger.debug("Falling back after error in CogneeApiClient.health", exc_info=True)
             return {"status_code": r.status_code, "text": r.text}
 
     # -- add -------------------------------------------------------------

--- a/cognee/cli/api_client.py
+++ b/cognee/cli/api_client.py
@@ -20,6 +20,10 @@ from urllib.parse import urljoin
 
 from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 
 def _import_httpx():
     """Import httpx lazily so the dependency is optional."""
@@ -100,6 +104,9 @@ class CogneeApiClient:
             try:
                 detail = resp.json()
             except Exception:
+                logger.debug(
+                    "Ignoring exception in CogneeApiClient._raise_for_status", exc_info=True
+                )
                 detail = resp.text
             raise RuntimeError(f"API error {resp.status_code}: {detail}")
 
@@ -117,6 +124,7 @@ class CogneeApiClient:
         try:
             return r.json()
         except Exception:
+            logger.debug("Ignoring exception in CogneeApiClient.health", exc_info=True)
             return {"status_code": r.status_code, "text": r.text}
 
     # -- add -------------------------------------------------------------

--- a/cognee/cli/api_client.py
+++ b/cognee/cli/api_client.py
@@ -19,7 +19,6 @@ from typing import Any, Optional
 from urllib.parse import urljoin
 
 from cognee.modules.data.constants import DEFAULT_DATASET_NAME
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/cli/commands/config_command.py
+++ b/cognee/cli/commands/config_command.py
@@ -8,6 +8,10 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
 from cognee.cli.reference import SupportsCliCommand
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 
 class ConfigCommand(SupportsCliCommand):
     command_string = "config"
@@ -103,6 +107,7 @@ Configuration changes will affect how cognee processes and stores data.
                     fmt.error(f"Configuration key '{args.key}' not found")
                     fmt.note("Use 'cognee config get' to see all available keys")
                 except Exception:
+                    logger.debug("Ignoring exception in ConfigCommand._handle_get", exc_info=True)
                     fmt.error(f"Configuration key '{args.key}' not found or retrieval failed")
             else:
                 # Get all configuration
@@ -135,6 +140,7 @@ Configuration changes will affect how cognee processes and stores data.
                         fmt.note(f"Created new .env file at {persist_info['path']}")
                     fmt.note(f"Persisted {persist_info['env_var']} to {persist_info['path']}")
             except Exception:
+                logger.debug("Ignoring exception in ConfigCommand._handle_set", exc_info=True)
                 fmt.error(f"Failed to set configuration key '{args.key}'")
 
         except Exception as e:
@@ -176,6 +182,7 @@ Configuration changes will affect how cognee processes and stores data.
                     cognee.config.set(args.key, default_value, persist=True)
                     fmt.success(f"Unset {args.key} (reset to default: {default_value})")
                 except Exception as e:
+                    logger.debug("Ignoring exception in ConfigCommand._handle_unset", exc_info=True)
                     fmt.error(f"Failed to unset '{args.key}': {e!s}")
             else:
                 fmt.error(f"Unknown configuration key '{args.key}'")

--- a/cognee/cli/commands/config_command.py
+++ b/cognee/cli/commands/config_command.py
@@ -7,7 +7,6 @@ from cognee.api.v1.exceptions.exceptions import InvalidConfigAttributeError
 from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
 from cognee.cli.reference import SupportsCliCommand
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/cli/commands/doctor_command.py
+++ b/cognee/cli/commands/doctor_command.py
@@ -7,7 +7,6 @@ import cognee.cli.echo as fmt
 from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.exceptions import CliCommandException
 from cognee.cli.reference import SupportsCliCommand
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/cli/commands/doctor_command.py
+++ b/cognee/cli/commands/doctor_command.py
@@ -8,6 +8,10 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.exceptions import CliCommandException
 from cognee.cli.reference import SupportsCliCommand
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 
 @contextmanager
 def _suppressed_error_logs():
@@ -120,6 +124,7 @@ Exits non-zero when any check fails, so it can gate CI and setup scripts.
                     await test_llm_connection()
                 fmt.echo("  ✓ LLM round-trip succeeded")
             except Exception as error:
+                logger.debug("Ignoring exception in DoctorCommand._run", exc_info=True)
                 fmt.error(f"  ✗ LLM round-trip failed: {error}")
                 failures += 1
 
@@ -128,6 +133,7 @@ Exits non-zero when any check fails, so it can gate CI and setup scripts.
                     dimensions = await test_embedding_connection()
                 fmt.echo(f"  ✓ Embedding round-trip succeeded (dimensions={dimensions})")
             except Exception as error:
+                logger.debug("Ignoring exception in DoctorCommand._run", exc_info=True)
                 fmt.error(f"  ✗ Embedding round-trip failed: {error}")
                 failures += 1
         else:

--- a/cognee/cli/commands/migrate_command.py
+++ b/cognee/cli/commands/migrate_command.py
@@ -16,7 +16,6 @@ import cognee.cli.echo as fmt
 from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.exceptions import CliCommandException
 from cognee.cli.reference import SupportsCliCommand
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/cli/commands/migrate_command.py
+++ b/cognee/cli/commands/migrate_command.py
@@ -17,6 +17,10 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.exceptions import CliCommandException
 from cognee.cli.reference import SupportsCliCommand
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 
 def _validate_revision(revision: str, keywords: tuple) -> None:
     """Error like alembic's "Can't locate revision" for unknown slugs."""
@@ -130,7 +134,8 @@ Examples:
 
         try:
             summaries = asyncio.run(run())
-        except Exception as error:  # noqa: BLE001 - translated to an actionable hint
+        except Exception as error:  # translated to an actionable hint
+            logger.debug("Ignoring exception in UpgradeCommand.execute", exc_info=True)
             _bookkeeping_guard(error)
         _print_summaries(
             summaries,
@@ -226,7 +231,8 @@ Examples:
 
         try:
             summaries = asyncio.run(run())
-        except Exception as error:  # noqa: BLE001 - translated to an actionable hint
+        except Exception as error:  # translated to an actionable hint
+            logger.debug("Ignoring exception in DowngradeCommand.execute", exc_info=True)
             _bookkeeping_guard(error)
         _print_summaries(
             summaries,
@@ -323,7 +329,8 @@ migration has been applied (everything pending).
 
         try:
             asyncio.run(run())
-        except Exception as error:  # noqa: BLE001 - translated to an actionable hint
+        except Exception as error:  # translated to an actionable hint
+            logger.debug("Ignoring exception in CurrentCommand.execute", exc_info=True)
             _bookkeeping_guard(error)
 
 
@@ -383,7 +390,8 @@ Examples:
 
         try:
             summaries = asyncio.run(run())
-        except Exception as error:  # noqa: BLE001 - translated to an actionable hint
+        except Exception as error:  # translated to an actionable hint
+            logger.debug("Ignoring exception in StampCommand.execute", exc_info=True)
             _bookkeeping_guard(error)
         if not summaries:
             fmt.note("No databases found — nothing stamped.")

--- a/cognee/cli/commands/serve_command.py
+++ b/cognee/cli/commands/serve_command.py
@@ -5,6 +5,10 @@ import cognee.cli.echo as fmt
 from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.reference import SupportsCliCommand
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 
 class ServeCommand(SupportsCliCommand):
     command_string = "serve"
@@ -64,6 +68,7 @@ async def _serve(url=None, api_key=None, management_url=None):
     except KeyboardInterrupt:
         fmt.warning("Authentication cancelled.")
     except Exception as e:
+        logger.debug("Ignoring exception in _serve", exc_info=True)
         fmt.error(f"Failed to connect: {e}")
 
 

--- a/cognee/cli/commands/serve_command.py
+++ b/cognee/cli/commands/serve_command.py
@@ -4,7 +4,6 @@ import asyncio
 import cognee.cli.echo as fmt
 from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.reference import SupportsCliCommand
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/cli/minimal_cli.py
+++ b/cognee/cli/minimal_cli.py
@@ -8,6 +8,10 @@ import sys
 from collections.abc import Sequence
 from typing import Any
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 # CRITICAL: Prevent verbose logging initialization for CLI-only usage
 # This must be set before any cognee imports to be effective
 os.environ["COGNEE_MINIMAL_LOGGING"] = "true"
@@ -33,6 +37,7 @@ def get_version() -> str:
 
         return importlib.metadata.version("cognee")
     except Exception:
+        logger.debug("Ignoring exception in get_version", exc_info=True)
         return "unknown"
 
 

--- a/cognee/cli/minimal_cli.py
+++ b/cognee/cli/minimal_cli.py
@@ -37,7 +37,7 @@ def get_version() -> str:
 
         return importlib.metadata.version("cognee")
     except Exception:
-        logger.debug("Ignoring exception in get_version", exc_info=True)
+        logger.debug("Falling back after error in get_version", exc_info=True)
         return "unknown"
 
 

--- a/cognee/eval_framework/answer_generation/beam_router.py
+++ b/cognee/eval_framework/answer_generation/beam_router.py
@@ -161,7 +161,7 @@ class BEAMRouter:
                 answer_text = search_results[0] if search_results else ""
 
             except Exception as e:
-                logger.error(f"Failed to answer '{query_text[:80]}...': {e}")
+                logger.exception(f"Failed to answer '{query_text[:80]}...'")
                 answer_text = f"ERROR: {e}"
                 retrieval_context = ""
 

--- a/cognee/eval_framework/beam/eval/metrics/beam_rubric.py
+++ b/cognee/eval_framework/beam/eval/metrics/beam_rubric.py
@@ -159,7 +159,7 @@ async def _judge_criterion(
             )
             score, reason = _parse_verdict(str(raw))
         except Exception as e:
-            logger.warning(f"BEAM judge failed for criterion '{criterion}': {e}")
+            logger.warning(f"BEAM judge failed for criterion '{criterion}': {e}", exc_info=True)
             score, reason = 0.0, f"ERROR: {e}"
 
     return {"criterion": criterion, "score": score, "reason": reason}

--- a/cognee/eval_framework/beam/eval/metrics/kendall_tau.py
+++ b/cognee/eval_framework/beam/eval/metrics/kendall_tau.py
@@ -266,7 +266,7 @@ class KendallTauMetric:
             return self.score
 
         except Exception as e:
-            logger.error(f"KendallTauMetric failed: {e}")
+            logger.exception("KendallTauMetric failed")
             self.score = 0.0
             self.reason = f"ERROR: {e}"
             return self.score

--- a/cognee/eval_framework/beam/preprocessing/compression.py
+++ b/cognee/eval_framework/beam/preprocessing/compression.py
@@ -16,6 +16,10 @@ from cognee.infrastructure.databases.vector.embeddings import get_embedding_engi
 from cognee.infrastructure.llm import get_llm_config
 from cognee.infrastructure.llm.LLMGateway import LLMGateway
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 PROMPT_VERSION = "conversation-message-tagged-compression-percent-v1"
 COMPRESSION_RETRY_VERSION = "beam-preprocess-compression-retry-v1"
 
@@ -528,6 +532,7 @@ async def compress_until_within_limit(
                     llm_semaphore=llm_semaphore,
                 )
             except Exception as exc:
+                logger.debug("Ignoring exception in compress_until_within_limit", exc_info=True)
                 attempts.append(
                     {
                         "role_compression_percents": role_percents,

--- a/cognee/eval_framework/beam/preprocessing/compression.py
+++ b/cognee/eval_framework/beam/preprocessing/compression.py
@@ -531,7 +531,9 @@ async def compress_until_within_limit(
                     llm_semaphore=llm_semaphore,
                 )
             except Exception as exc:
-                logger.debug("Ignoring exception in compress_until_within_limit", exc_info=True)
+                logger.debug(
+                    "Skipping item after error in compress_until_within_limit", exc_info=True
+                )
                 attempts.append(
                     {
                         "role_compression_percents": role_percents,

--- a/cognee/eval_framework/beam/preprocessing/compression.py
+++ b/cognee/eval_framework/beam/preprocessing/compression.py
@@ -15,7 +15,6 @@ from cognee.eval_framework.beam.preprocessing.conversation_preprocessing import 
 from cognee.infrastructure.databases.vector.embeddings import get_embedding_engine
 from cognee.infrastructure.llm import get_llm_config
 from cognee.infrastructure.llm.LLMGateway import LLMGateway
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/eval_framework/beam/preprocessing/conversation_preprocessing.py
+++ b/cognee/eval_framework/beam/preprocessing/conversation_preprocessing.py
@@ -7,6 +7,10 @@ import re
 from dataclasses import dataclass
 from functools import lru_cache
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 _TURN_START = re.compile(
     r"^(?:\[(?P<time_anchor>.*?)\]\s*)?(?P<role>User|Assistant):\s?(?P<content>.*)$"
 )
@@ -67,7 +71,7 @@ def estimate_tokens(text: str) -> int:
         if tokenizer:
             return max(1, tokenizer.count_tokens(text) * 2)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in estimate_tokens", exc_info=True)
 
     return max(1, len(text) // 4, len(text.split()) * 2)
 

--- a/cognee/eval_framework/beam/preprocessing/preprocess.py
+++ b/cognee/eval_framework/beam/preprocessing/preprocess.py
@@ -45,6 +45,10 @@ from cognee.eval_framework.beam.preprocessing.loaders import (
     load_beam_dataset,
 )
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 REPO_ROOT = Path(__file__).resolve().parents[4]
 DEFAULT_PROMPT_PATH = (
     Path(__file__).resolve().parent / "prompts" / "beam_turn_compression_prompt.txt"
@@ -351,6 +355,7 @@ async def process_turn(
         )
         counts.update(compression_counts)
     except Exception as exc:
+        logger.debug("Ignoring exception in process_turn", exc_info=True)
         counts["compression_failed_count"] += 1
         counts["failed_compression_turns"] += 1
         outlier["status"] = "compression_failed"

--- a/cognee/eval_framework/beam/preprocessing/preprocess.py
+++ b/cognee/eval_framework/beam/preprocessing/preprocess.py
@@ -354,7 +354,7 @@ async def process_turn(
         )
         counts.update(compression_counts)
     except Exception as exc:
-        logger.debug("Ignoring exception in process_turn", exc_info=True)
+        logger.debug("Falling back after error in process_turn", exc_info=True)
         counts["compression_failed_count"] += 1
         counts["failed_compression_turns"] += 1
         outlier["status"] = "compression_failed"

--- a/cognee/eval_framework/beam/preprocessing/preprocess.py
+++ b/cognee/eval_framework/beam/preprocessing/preprocess.py
@@ -44,7 +44,6 @@ from cognee.eval_framework.beam.preprocessing.loaders import (
     load_beam_10m_dataset,
     load_beam_dataset,
 )
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/eval_framework/benchmark_adapters/logistics_system_utils/corpus_generator/narrativize_corpus.py
+++ b/cognee/eval_framework/benchmark_adapters/logistics_system_utils/corpus_generator/narrativize_corpus.py
@@ -16,7 +16,6 @@ from cognee.eval_framework.benchmark_adapters.logistics_system_utils.utils.utils
     load_world,
 )
 from cognee.infrastructure.llm import LLMGateway
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/eval_framework/benchmark_adapters/logistics_system_utils/corpus_generator/narrativize_corpus.py
+++ b/cognee/eval_framework/benchmark_adapters/logistics_system_utils/corpus_generator/narrativize_corpus.py
@@ -17,6 +17,10 @@ from cognee.eval_framework.benchmark_adapters.logistics_system_utils.utils.utils
 )
 from cognee.infrastructure.llm import LLMGateway
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 BASE_PATH = Path(__file__).resolve().parent.parent
 WORLD_ENTITY_FOLDERS = ("carrier", "post_office", "retailer", "user")
 PACKAGE_FOLDER = "packages"
@@ -194,6 +198,7 @@ async def narrativize_corpus(
                 NarrativeOutput,
             )
         except Exception:
+            logger.debug("Ignoring exception in narrativize_corpus", exc_info=True)
             response = _fallback_world_narratives(world)
     else:
         response = _fallback_world_narratives(world)
@@ -207,6 +212,7 @@ async def narrativize_corpus(
                 PackageNarrativeOutput,
             )
         except Exception:
+            logger.debug("Ignoring exception in narrativize_corpus", exc_info=True)
             package_response = _fallback_package_narratives(world)
     else:
         package_response = _fallback_package_narratives(world)

--- a/cognee/eval_framework/evaluation/deep_eval_adapter.py
+++ b/cognee/eval_framework/evaluation/deep_eval_adapter.py
@@ -45,7 +45,7 @@ class DeepEvalAdapter(BaseEvalAdapter):
                 if attempt < self.n_retries - 1:
                     time.sleep(2**attempt)  # Exponential backoff
                 else:
-                    logger.error(
+                    logger.exception(
                         f"All {self.n_retries} attempts failed for metric '{metric}'. Returning None values."
                     )
 

--- a/cognee/eval_framework/evaluation/metrics/rubric.py
+++ b/cognee/eval_framework/evaluation/metrics/rubric.py
@@ -137,7 +137,9 @@ class RubricMetric:
                 )
 
             except Exception as e:
-                logger.warning(f"Rubric judge failed for criterion: {criterion}: {e}")
+                logger.warning(
+                    f"Rubric judge failed for criterion: {criterion}: {e}", exc_info=True
+                )
                 verdicts.append(
                     {
                         "criterion": criterion,

--- a/cognee/eval_framework/sweeps/retriever_sweep_runner.py
+++ b/cognee/eval_framework/sweeps/retriever_sweep_runner.py
@@ -214,12 +214,11 @@ async def _answer_single_fixed_retriever(
             )
             answer_text = normalize_answer_text(search_results)
         except Exception as exc:
-            logger.error(
-                "[%s][run %s] Failed to answer question_idx=%s: %s",
+            logger.exception(
+                "[%s][run %s] Failed to answer question_idx=%s",
                 retriever_name,
                 run_idx,
                 question["question_idx"],
-                exc,
             )
             answer_text = f"ERROR: {exc}"
             retrieval_context = ""

--- a/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
+++ b/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
@@ -757,4 +757,4 @@ class RedisAdapter(CacheDBInterface):
         try:
             await self.async_redis.aclose()
         except Exception as e:
-            logger.debug("Error closing Redis async connection: %s", e)
+            logger.debug("Error closing Redis async connection: %s", e, exc_info=True)

--- a/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
@@ -100,12 +100,12 @@ class _SqlAdvisoryLockHandle:
                 text("SELECT pg_advisory_unlock(:lock_id)"), {"lock_id": self.lock_id}
             )
         except Exception as error:
-            logger.debug("Error releasing Postgres advisory lock: %s", error)
+            logger.debug("Error releasing Postgres advisory lock: %s", error, exc_info=True)
         finally:
             try:
                 self.connection.close()
             except Exception as error:
-                logger.debug("Error closing advisory lock connection: %s", error)
+                logger.debug("Error closing advisory lock connection: %s", error, exc_info=True)
 
 
 class SqlCacheAdapter(CacheDBInterface):
@@ -327,7 +327,9 @@ class SqlCacheAdapter(CacheDBInterface):
                         )
                     )
         except Exception as error:
-            logger.debug("SQL cache TTL sweep failed (will retry next interval): %s", error)
+            logger.debug(
+                "SQL cache TTL sweep failed (will retry next interval): %s", error, exc_info=True
+            )
 
     @staticmethod
     def _build_qa_entry_dump(
@@ -478,7 +480,7 @@ class SqlCacheAdapter(CacheDBInterface):
             try:
                 connection.close()
             except Exception as error:
-                logger.debug("Error closing advisory lock connection: %s", error)
+                logger.debug("Error closing advisory lock connection: %s", error, exc_info=True)
             raise
 
     def release_lock(self, lock=None):
@@ -493,7 +495,7 @@ class SqlCacheAdapter(CacheDBInterface):
         try:
             handle.release()
         except Exception as error:
-            logger.debug("Error releasing Postgres advisory lock: %s", error)
+            logger.debug("Error releasing Postgres advisory lock: %s", error, exc_info=True)
         finally:
             if handle is self.lock:
                 self.lock = None
@@ -1218,11 +1220,11 @@ class SqlCacheAdapter(CacheDBInterface):
         try:
             await self.engine.dispose(close=True)
         except Exception as error:
-            logger.debug("Error closing SQL cache async engine: %s", error)
+            logger.debug("Error closing SQL cache async engine: %s", error, exc_info=True)
         if self._sync_lock_engine is not None:
             try:
                 self._sync_lock_engine.dispose(close=True)
             except Exception as error:
-                logger.debug("Error closing SQL cache sync lock engine: %s", error)
+                logger.debug("Error closing SQL cache sync lock engine: %s", error, exc_info=True)
             self._sync_lock_engine = None
         self._initialized = False

--- a/cognee/infrastructure/databases/cache/tapes/TapesCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/tapes/TapesCacheAdapter.py
@@ -134,7 +134,9 @@ class TapesCacheAdapter(FSCacheAdapter):
                     resp.text[:200],
                 )
         except Exception as e:
-            logger.warning("Tapes mirror failed, continuing with FS cache only: %s", e)
+            logger.warning(
+                "Tapes mirror failed, continuing with FS cache only: %s", e, exc_info=True
+            )
 
     async def create_qa_entry(
         self,
@@ -170,6 +172,6 @@ class TapesCacheAdapter(FSCacheAdapter):
             try:
                 await self._tapes_client.aclose()
             except Exception as e:
-                logger.debug("Error closing tapes HTTP client: %s", e)
+                logger.debug("Error closing tapes HTTP client: %s", e, exc_info=True)
             self._tapes_client = None
         await super().close()

--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -546,6 +546,9 @@ class LadybugAdapter(GraphDBInterface):
                 # miss it when offline, or when it cached to a different path).
                 # Try installing + loading directly on the real connection before
                 # giving up. INSTALL is idempotent and a no-op when already cached.
+                logger.debug(
+                    "Ignoring exception in LadybugAdapter._initialize_connection", exc_info=True
+                )
                 try:
                     self.connection.execute("INSTALL JSON;")
                     self.connection.execute("LOAD EXTENSION JSON;")
@@ -563,6 +566,7 @@ class LadybugAdapter(GraphDBInterface):
                         "pre-install it in your image, or run `INSTALL json; LOAD json;` "
                         "once against the database.",
                         e,
+                        exc_info=True,
                     )
 
             self._ensure_schema()
@@ -836,13 +840,13 @@ class LadybugAdapter(GraphDBInterface):
             try:
                 self.connection.close()
             except Exception as e:
-                logger.warning(f"Error closing Ladybug connection: {e}")
+                logger.warning(f"Error closing Ladybug connection: {e}", exc_info=True)
             self.connection = None
         if self.db is not None:
             try:
                 self.db.close()
             except Exception as e:
-                logger.warning(f"Error closing Ladybug database: {e}")
+                logger.warning(f"Error closing Ladybug database: {e}", exc_info=True)
             self.db = None
 
     def _rebuild_subprocess_proxies(self) -> None:
@@ -880,7 +884,7 @@ class LadybugAdapter(GraphDBInterface):
         try:
             self.connection.load_extension("JSON")
         except Exception as e:
-            logger.warning(f"Could not load JSON extension after reopen: {e}")
+            logger.warning(f"Could not load JSON extension after reopen: {e}", exc_info=True)
         # Recreate the Node/EDGE schema — ``delete_graph`` removed the
         # on-disk store, so the worker is now talking to a fresh empty
         # DB with no tables. Without this, the very next graph query
@@ -977,7 +981,7 @@ class LadybugAdapter(GraphDBInterface):
             try:
                 await asyncio.to_thread(self._session.shutdown)
             except Exception as e:
-                logger.warning(f"Error shutting down Ladybug subprocess: {e}")
+                logger.warning(f"Error shutting down Ladybug subprocess: {e}", exc_info=True)
             self._session = None
         logger.info("Ladybug database closed successfully")
 
@@ -1853,8 +1857,8 @@ class LadybugAdapter(GraphDBInterface):
                 node_data = self._parse_node(result[0][0])
                 return node_data
             return None
-        except Exception as e:
-            logger.error(f"Failed to extract node {node_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to extract node {node_id}")
             return None
 
     async def extract_nodes(self, node_ids: list[str]) -> list[dict[str, Any]]:
@@ -1891,8 +1895,8 @@ class LadybugAdapter(GraphDBInterface):
             # Parse each node using the same helper function
             nodes = [self._parse_node(row[0]) for row in results if row[0]]
             return nodes
-        except Exception as e:
-            logger.error(f"Failed to extract nodes: {e}")
+        except Exception:
+            logger.exception("Failed to extract nodes")
             return []
 
     # Edge Operations
@@ -2173,8 +2177,8 @@ class LadybugAdapter(GraphDBInterface):
                     target_node = self._parse_node_properties(row[2])
                     edges.append((source_node, row[1], target_node))
             return edges
-        except Exception as e:
-            logger.error(f"Failed to get edges for node {node_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get edges for node {node_id}")
             return []
 
     # Neighbor Operations
@@ -2211,8 +2215,8 @@ class LadybugAdapter(GraphDBInterface):
         try:
             result = await self.query(query_str, {"id": node_id})
             return [self._parse_node_properties(row[0]) for row in result] if result else []
-        except Exception as e:
-            logger.error(f"Failed to get neighbours for node {node_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get neighbours for node {node_id}")
             return []
 
     async def get_node(self, node_id: str) -> dict[str, Any] | None:
@@ -2248,8 +2252,8 @@ class LadybugAdapter(GraphDBInterface):
             if result and result[0]:
                 return self._parse_node(result[0][0])
             return None
-        except Exception as e:
-            logger.error(f"Failed to get node {node_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get node {node_id}")
             return None
 
     async def get_nodes(self, node_ids: list[str]) -> list[dict[str, Any]]:
@@ -2284,8 +2288,8 @@ class LadybugAdapter(GraphDBInterface):
         try:
             results = await self.query(query_str, {"node_ids": node_ids})
             return [self._parse_node(row[0]) for row in results if row[0]]
-        except Exception as e:
-            logger.error(f"Failed to get nodes: {e}")
+        except Exception:
+            logger.exception("Failed to get nodes")
             return []
 
     def _rows_to_dicts(self, rows: list, column_names: list[str]) -> list[dict[str, Any]]:
@@ -2674,8 +2678,8 @@ class LadybugAdapter(GraphDBInterface):
                 params = {"id": str(node_id)}
             result = await self.query(query_str, params)
             return [self._parse_node_properties(row[0]) for row in result] if result else []
-        except Exception as e:
-            logger.error(f"Failed to get predecessors for node {node_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get predecessors for node {node_id}")
             return []
 
     async def get_successors(
@@ -2728,8 +2732,8 @@ class LadybugAdapter(GraphDBInterface):
                 params = {"id": str(node_id)}
             result = await self.query(query_str, params)
             return [self._parse_node_properties(row[0]) for row in result] if result else []
-        except Exception as e:
-            logger.error(f"Failed to get successors for node {node_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get successors for node {node_id}")
             return []
 
     async def get_connections(
@@ -2794,8 +2798,8 @@ class LadybugAdapter(GraphDBInterface):
                         processed_rows.append(item)
                     edges.append(tuple(processed_rows))
             return edges if edges else []  # Always return a list, even if empty
-        except Exception as e:
-            logger.error(f"Failed to get connections for node {node_id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get connections for node {node_id}")
             return []  # Return empty list on error
 
     async def remove_connection_to_predecessors_of(
@@ -3416,8 +3420,8 @@ class LadybugAdapter(GraphDBInterface):
 
             return {**mandatory_metrics, **optional_metrics}
 
-        except Exception as e:
-            logger.error(f"Failed to get graph metrics: {e}")
+        except Exception:
+            logger.exception("Failed to get graph metrics")
             return {
                 "num_nodes": 0,
                 "num_edges": 0,

--- a/cognee/infrastructure/databases/graph/ladybug/remote_ladybug_adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/remote_ladybug_adapter.py
@@ -129,8 +129,8 @@ class RemoteLadybugAdapter(LadybugAdapter):
                 {"query": "MATCH (n:Node) RETURN COUNT(n) > 0", "parameters": {}},
             )
             return bool(response.get("data") and response["data"][0][0])
-        except Exception as e:
-            logger.error(f"Failed to check schema: {e}")
+        except Exception:
+            logger.exception("Failed to check schema")
             return False
 
     async def _create_schema(self):

--- a/cognee/infrastructure/databases/graph/neo4j_driver/Neo4jDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/Neo4jDatasetDatabaseHandler.py
@@ -18,6 +18,10 @@ from cognee.infrastructure.databases.graph.get_graph_engine import (
 )
 from cognee.modules.users.models import DatasetDatabase, User
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 NEO4J_DATASET_DATABASE_HANDLER = "neo4j"
 NEO4J_SYSTEM_DATABASE = "system"
 NEO4J_DATASET_DATABASE_PREFIX = "cognee"
@@ -168,6 +172,10 @@ class Neo4jDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
         try:
             records = await cls._run_system_query(driver, NEO4J_EDITION_QUERY)
         except Exception:
+            logger.debug(
+                "Ignoring exception in Neo4jDatasetDatabaseHandler._ensure_multi_database_support",
+                exc_info=True,
+            )
             return
 
         edition = records[0].get("edition", "") if records else ""

--- a/cognee/infrastructure/databases/graph/neo4j_driver/Neo4jDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/Neo4jDatasetDatabaseHandler.py
@@ -17,7 +17,6 @@ from cognee.infrastructure.databases.graph.get_graph_engine import (
     graph_engine_cache,
 )
 from cognee.modules.users.models import DatasetDatabase, User
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/infrastructure/databases/graph/neo4j_driver/Neo4jDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/Neo4jDatasetDatabaseHandler.py
@@ -172,7 +172,7 @@ class Neo4jDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
             records = await cls._run_system_query(driver, NEO4J_EDITION_QUERY)
         except Exception:
             logger.debug(
-                "Ignoring exception in Neo4jDatasetDatabaseHandler._ensure_multi_database_support",
+                "Giving up after error in Neo4jDatasetDatabaseHandler._ensure_multi_database_support",
                 exc_info=True,
             )
             return

--- a/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
@@ -219,7 +219,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Neptune Analytics query failed: {error_msg}")
-            raise Exception(f"Query execution failed: {error_msg}") from e
+            raise RuntimeError(f"Query execution failed: {error_msg}") from e
 
     async def add_node(self, node: DataPoint) -> None:
         """
@@ -252,7 +252,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to add node {node.id}: {error_msg}")
-            raise Exception(f"Failed to add node: {error_msg}") from e
+            raise RuntimeError(f"Failed to add node: {error_msg}") from e
 
     async def add_nodes(
         self,
@@ -300,14 +300,12 @@ class NeptuneGraphDB(GraphDBInterface):
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to add nodes in bulk: {error_msg}")
             # Fallback to individual node creation
-            logger.info("Falling back to individual node creation")
+            logger.info("Falling back to individual node creation", exc_info=True)
             for node in nodes:
                 try:
                     await self.add_node(node)
-                except Exception as node_error:
-                    logger.error(
-                        f"Failed to add individual node {node.id}: {format_neptune_error(node_error)}"
-                    )
+                except Exception:
+                    logger.exception(f"Failed to add individual node {node.id}")
                     continue
 
     async def delete_node(self, node_id: str) -> None:
@@ -334,7 +332,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to delete node {node_id}: {error_msg}")
-            raise Exception(f"Failed to delete node: {error_msg}") from e
+            raise RuntimeError(f"Failed to delete node: {error_msg}") from e
 
     async def delete_nodes(self, node_ids: list[str]) -> None:
         """
@@ -365,14 +363,12 @@ class NeptuneGraphDB(GraphDBInterface):
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to delete nodes in bulk: {error_msg}")
             # Fallback to individual node deletion
-            logger.info("Falling back to individual node deletion")
+            logger.info("Falling back to individual node deletion", exc_info=True)
             for node_id in node_ids:
                 try:
                     await self.delete_node(node_id)
-                except Exception as node_error:
-                    logger.error(
-                        f"Failed to delete individual node {node_id}: {format_neptune_error(node_error)}"
-                    )
+                except Exception:
+                    logger.exception(f"Failed to delete individual node {node_id}")
                     continue
 
     async def get_node(self, node_id: str) -> NodeData | None:
@@ -412,7 +408,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to get node {node_id}: {error_msg}")
-            raise Exception(f"Failed to get node: {error_msg}") from e
+            raise RuntimeError(f"Failed to get node: {error_msg}") from e
 
     async def get_nodes(self, node_ids: list[str]) -> list[NodeData]:
         """
@@ -454,17 +450,15 @@ class NeptuneGraphDB(GraphDBInterface):
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to get nodes in bulk: {error_msg}")
             # Fallback to individual node retrieval
-            logger.info("Falling back to individual node retrieval")
+            logger.info("Falling back to individual node retrieval", exc_info=True)
             nodes = []
             for node_id in node_ids:
                 try:
                     node_data = await self.get_node(node_id)
                     if node_data:
                         nodes.append(node_data)
-                except Exception as node_error:
-                    logger.error(
-                        f"Failed to get individual node {node_id}: {format_neptune_error(node_error)}"
-                    )
+                except Exception:
+                    logger.exception(f"Failed to get individual node {node_id}")
                     continue
             return nodes
 
@@ -562,7 +556,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to add edge {source_id} -> {target_id}: {error_msg}")
-            raise Exception(f"Failed to add edge: {error_msg}") from e
+            raise RuntimeError(f"Failed to add edge: {error_msg}") from e
 
     async def add_edges(
         self,
@@ -625,16 +619,14 @@ class NeptuneGraphDB(GraphDBInterface):
                 logger.error(
                     f"Failed to add edges for relationship {relationship_name}: {format_neptune_error(e)}"
                 )
-                logger.info("Falling back to individual edge creation")
+                logger.info("Falling back to individual edge creation", exc_info=True)
                 for edge in edges_for_relationship:
                     try:
                         source_id, target_id, relationship_name = edge[0], edge[1], edge[2]
                         properties = edge[3] if len(edge) > 3 else {}
                         await self.add_edge(source_id, target_id, relationship_name, properties)
-                    except Exception as edge_error:
-                        logger.error(
-                            f"Failed to add individual edge {edge[0]} -> {edge[1]}: {format_neptune_error(edge_error)}"
-                        )
+                    except Exception:
+                        logger.exception(f"Failed to add individual edge {edge[0]} -> {edge[1]}")
                         continue
 
         processed_count = 0
@@ -658,7 +650,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to delete graph: {error_msg}")
-            raise Exception(f"Failed to delete graph: {error_msg}") from e
+            raise RuntimeError(f"Failed to delete graph: {error_msg}") from e
 
     async def get_graph_data(self) -> tuple[list[Node], list[EdgeData]]:
         """
@@ -705,7 +697,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to get graph data: {error_msg}")
-            raise Exception(f"Failed to get graph data: {error_msg}") from e
+            raise RuntimeError(f"Failed to get graph data: {error_msg}") from e
 
     async def get_neighborhood(
         self,
@@ -774,7 +766,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to get neighborhood: {error_msg}")
-            raise Exception(f"Failed to get neighborhood: {error_msg}") from e
+            raise RuntimeError(f"Failed to get neighborhood: {error_msg}") from e
 
     async def is_empty(self) -> bool:
         """Return True if the graph contains no nodes."""
@@ -788,7 +780,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to check if graph is empty: {error_msg}")
-            raise Exception(f"Failed to check if graph is empty: {error_msg}") from e
+            raise RuntimeError(f"Failed to check if graph is empty: {error_msg}") from e
 
     async def get_graph_metrics(self, include_optional: bool = False) -> dict[str, Any]:
         """
@@ -875,7 +867,9 @@ class NeptuneGraphDB(GraphDBInterface):
 
         except Exception as e:
             error_msg = format_neptune_error(e)
-            logger.error(f"Failed to check edge existence {source_id} -> {target_id}: {error_msg}")
+            logger.exception(
+                f"Failed to check edge existence {source_id} -> {target_id}: {error_msg}"
+            )
             return False
 
     async def has_edges(self, edges: list[EdgeData]) -> list[EdgeData]:
@@ -965,7 +959,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to get edges for node {node_id}: {error_msg}")
-            raise Exception(f"Failed to get edges: {error_msg}") from e
+            raise RuntimeError(f"Failed to get edges: {error_msg}") from e
 
     async def get_disconnected_nodes(self) -> list[str]:
         """
@@ -1073,7 +1067,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to get neighbors for node {node_id}: {error_msg}")
-            raise Exception(f"Failed to get neighbors: {error_msg}") from e
+            raise RuntimeError(f"Failed to get neighbors: {error_msg}") from e
 
     async def get_nodeset_subgraph(
         self, node_type: type[Any], node_name: list[str]
@@ -1144,7 +1138,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to get nodeset subgraph for type {node_type}: {error_msg}")
-            raise Exception(f"Failed to get nodeset subgraph: {error_msg}") from e
+            raise RuntimeError(f"Failed to get nodeset subgraph: {error_msg}") from e
 
     async def get_connections(self, node_id: UUID) -> list:
         """
@@ -1195,7 +1189,7 @@ class NeptuneGraphDB(GraphDBInterface):
         except Exception as e:
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to get connections for node {node_id}: {error_msg}")
-            raise Exception(f"Failed to get connections: {error_msg}") from e
+            raise RuntimeError(f"Failed to get connections: {error_msg}") from e
 
     async def remove_connection_to_predecessors_of(self, node_ids: list[str], edge_label: str):
         """

--- a/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
+++ b/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
@@ -213,6 +213,10 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
             try:
                 self._client.query(query_string, params)
             except Exception as e:
+                logger.debug(
+                    "Ignoring exception in NeptuneAnalyticsAdapter.create_data_points",
+                    exc_info=True,
+                )
                 self._na_exception_handler(e, query_string)
 
     async def retrieve(self, collection_name: str, data_point_ids: list[str]):
@@ -245,6 +249,7 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
                 for item in result
             ]
         except Exception as e:
+            logger.debug("Ignoring exception in NeptuneAnalyticsAdapter.retrieve", exc_info=True)
             self._na_exception_handler(e, query_string)
 
     async def search(
@@ -368,6 +373,7 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
                 )
             return results
         except Exception as e:
+            logger.debug("Ignoring exception in NeptuneAnalyticsAdapter.search", exc_info=True)
             self._na_exception_handler(e, query_string)
 
     async def batch_search(
@@ -436,6 +442,9 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
         try:
             self._client.query(query_string, params)
         except Exception as e:
+            logger.debug(
+                "Ignoring exception in NeptuneAnalyticsAdapter.delete_data_points", exc_info=True
+            )
             self._na_exception_handler(e, query_string)
 
     async def create_vector_index(self, index_name: str, index_property_name: str):

--- a/cognee/infrastructure/databases/hybrid/postgres/adapter.py
+++ b/cognee/infrastructure/databases/hybrid/postgres/adapter.py
@@ -582,7 +582,9 @@ class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
                     if "does not exist" in error_msg or "relation" in error_msg:
                         logger.debug("Triplet_text table not found, skipping: %s", e)
                     else:
-                        logger.warning("Unexpected error deleting from Triplet_text: %s", e)
+                        logger.warning(
+                            "Unexpected error deleting from Triplet_text: %s", e, exc_info=True
+                        )
 
             await session.commit()
 

--- a/cognee/infrastructure/databases/unified/provenance_delete_planner.py
+++ b/cognee/infrastructure/databases/unified/provenance_delete_planner.py
@@ -223,9 +223,11 @@ async def _cleanup_orphaned_edge_types(
                     "EdgeType_relationship_name", orphaned_edge_type_ids
                 )
             except Exception as error:
-                logger.warning("EdgeType vector cleanup failed (non-fatal): %s", error)
+                logger.warning(
+                    "EdgeType vector cleanup failed (non-fatal): %s", error, exc_info=True
+                )
     except Exception as error:
-        logger.warning("EdgeType cleanup failed (non-fatal): %s", error)
+        logger.warning("EdgeType cleanup failed (non-fatal): %s", error, exc_info=True)
 
 
 async def _cleanup_orphaned_nodeset_tags(
@@ -250,9 +252,9 @@ async def _cleanup_orphaned_nodeset_tags(
     try:
         await graph_engine.remove_belongs_to_set_tags(tags_to_remove)
     except Exception as error:
-        logger.warning("Graph NodeSet tag cleanup failed (non-fatal): %s", error)
+        logger.warning("Graph NodeSet tag cleanup failed (non-fatal): %s", error, exc_info=True)
 
     try:
         await vector_engine.remove_belongs_to_set_tags(tags_to_remove)
     except Exception as error:
-        logger.warning("Vector NodeSet tag cleanup failed (non-fatal): %s", error)
+        logger.warning("Vector NodeSet tag cleanup failed (non-fatal): %s", error, exc_info=True)

--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -140,6 +140,7 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
             try:
                 parsed = urlparse(self.endpoint)
             except Exception:
+                logger.debug("Ignoring exception in LiteLLMEmbeddingEngine.__init__", exc_info=True)
                 parsed = None
             if not parsed or parsed.scheme not in ("http", "https") or not parsed.netloc:
                 logger.error(

--- a/cognee/infrastructure/databases/vector/embeddings/config.py
+++ b/cognee/infrastructure/databases/vector/embeddings/config.py
@@ -43,7 +43,7 @@ def _resolve_embedding_dimensions(provider: str | None, model: str | None) -> in
                     if dim:
                         return int(dim)
         except Exception:
-            pass
+            logger.debug("Ignoring exception in _resolve_embedding_dimensions", exc_info=True)
         # Fall through to litellm in case the model is dual-registered
         # (rare, but cheap to try).
 
@@ -55,7 +55,7 @@ def _resolve_embedding_dimensions(provider: str | None, model: str | None) -> in
             if info and "output_vector_size" in info:
                 return int(info["output_vector_size"])
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _resolve_embedding_dimensions", exc_info=True)
 
     return None
 

--- a/cognee/infrastructure/databases/vector/get_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/get_vector_engine.py
@@ -59,7 +59,8 @@ class _VectorEngineHandle:
                     return False
             except Exception:
                 logger.debug(
-                    "Ignoring exception in _VectorEngineHandle._pin_is_live", exc_info=True
+                    "Falling back to False after error in _VectorEngineHandle._pin_is_live",
+                    exc_info=True,
                 )
                 return False
         return not getattr(engine, "_permanently_closed", False)

--- a/cognee/infrastructure/databases/vector/get_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/get_vector_engine.py
@@ -3,6 +3,10 @@ import warnings
 from .config import get_vectordb_context_config
 from .create_vector_engine import create_vector_engine
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 
 class _VectorEngineHandle:
     """Stable reference to the current vector engine that survives cache invalidation.
@@ -54,6 +58,9 @@ class _VectorEngineHandle:
                 if not active():
                     return False
             except Exception:
+                logger.debug(
+                    "Ignoring exception in _VectorEngineHandle._pin_is_live", exc_info=True
+                )
                 return False
         return not getattr(engine, "_permanently_closed", False)
 

--- a/cognee/infrastructure/databases/vector/get_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/get_vector_engine.py
@@ -1,9 +1,9 @@
 import warnings
 
+from cognee.shared.logging_utils import get_logger
+
 from .config import get_vectordb_context_config
 from .create_vector_engine import create_vector_engine
-
-from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()
 

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -260,6 +260,7 @@ class LanceDBAdapter(VectorDBInterface):
                             logger.warning(
                                 "Error shutting down LanceDB subprocess after connect failure: %s",
                                 teardown_err,
+                                exc_info=True,
                             )
                     raise
             # Re-check the closed flag after the await — a concurrent
@@ -302,7 +303,7 @@ class LanceDBAdapter(VectorDBInterface):
         try:
             await stale.close()
         except Exception:
-            pass
+            logger.debug("Ignoring exception in LanceDBAdapter.get_connection", exc_info=True)
         if winner is None:
             raise RuntimeError(
                 "LanceDBAdapter is closed; a new adapter must be created "
@@ -469,6 +470,7 @@ class LanceDBAdapter(VectorDBInterface):
                             "belongs_to_set merge lookup failed for '%s': %s",
                             collection_name,
                             e,
+                            exc_info=True,
                         )
 
                 def create_lance_data_point(data_point: DataPoint, vector: list[float]):
@@ -658,6 +660,7 @@ class LanceDBAdapter(VectorDBInterface):
                     "Skipping row %s during migration (validation failed): %s",
                     row_id,
                     e,
+                    exc_info=True,
                 )
                 skipped += 1
                 failed_rows.append((row_id, str(e)))
@@ -952,6 +955,7 @@ class LanceDBAdapter(VectorDBInterface):
                     "_coerce_rows_to_typed_payload: validation fell back for id=%s: %s",
                     row.get("id"),
                     e,
+                    exc_info=True,
                 )
                 coerced.append(row)
                 continue
@@ -1254,6 +1258,7 @@ class LanceDBAdapter(VectorDBInterface):
                     "remove_belongs_to_set_tags: schema read failed for '%s': %s",
                     collection_name,
                     e,
+                    exc_info=True,
                 )
                 continue
 
@@ -1298,6 +1303,7 @@ class LanceDBAdapter(VectorDBInterface):
                         "remove_belongs_to_set_tags: row scan failed for '%s': %s",
                         collection_name,
                         e,
+                        exc_info=True,
                     )
                     continue
 
@@ -1522,7 +1528,7 @@ class LanceDBAdapter(VectorDBInterface):
                 if inspect.isawaitable(close_result):
                     await close_result
             except Exception as e:
-                logger.warning("Error closing LanceDB connection: %s", e)
+                logger.warning("Error closing LanceDB connection: %s", e, exc_info=True)
         if session is not None:
             # ``session.shutdown()`` is sync and joins/terminates/kills the
             # worker process — can take seconds. Offload to a worker thread
@@ -1530,4 +1536,4 @@ class LanceDBAdapter(VectorDBInterface):
             try:
                 await asyncio.to_thread(session.shutdown)
             except Exception as e:
-                logger.warning("Error shutting down LanceDB subprocess: %s", e)
+                logger.warning("Error shutting down LanceDB subprocess: %s", e, exc_info=True)

--- a/cognee/infrastructure/databases/vector/lancedb/subprocess/proxy.py
+++ b/cognee/infrastructure/databases/vector/lancedb/subprocess/proxy.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pyarrow as pa
 
+from cognee.shared.logging_utils import get_logger
 from cognee_db_workers.harness import (
     ReplayStep,
     Request,
@@ -36,8 +37,6 @@ from cognee_db_workers.lancedb_protocol import (
     OP_TABLE_VECTOR_SEARCH_EXECUTE,
 )
 from cognee_db_workers.lancedb_worker import worker_main
-
-from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()
 

--- a/cognee/infrastructure/databases/vector/lancedb/subprocess/proxy.py
+++ b/cognee/infrastructure/databases/vector/lancedb/subprocess/proxy.py
@@ -37,6 +37,10 @@ from cognee_db_workers.lancedb_protocol import (
 )
 from cognee_db_workers.lancedb_worker import worker_main
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 
 class LanceDBSubprocessSession(SubprocessSession):
     @classmethod
@@ -208,7 +212,9 @@ class RemoteLanceDBTable:
             try:
                 self._session.remove_replay_step(step)
             except Exception:
-                pass
+                logger.debug(
+                    "Ignoring exception in RemoteLanceDBTable._deregister_replay", exc_info=True
+                )
             self._replay_step = None
 
     async def release(self) -> None:
@@ -222,7 +228,7 @@ class RemoteLanceDBTable:
             await self._session.call_async(Request(op=OP_TABLE_RELEASE, handle_id=hid))
         except Exception:
             # Session already torn down; the handle dies with the worker.
-            pass
+            logger.debug("Ignoring exception in RemoteLanceDBTable.release", exc_info=True)
 
     def release_sync(self) -> None:
         """Sync variant for use in ``__del__`` / non-async contexts."""
@@ -234,7 +240,7 @@ class RemoteLanceDBTable:
         try:
             self._session.call(Request(op=OP_TABLE_RELEASE, handle_id=hid))
         except Exception:
-            pass
+            logger.debug("Ignoring exception in RemoteLanceDBTable.release_sync", exc_info=True)
 
     def __del__(self):
         # Best-effort; async release is preferred. Only try sync release if the
@@ -243,7 +249,7 @@ class RemoteLanceDBTable:
             if self._handle_id is not None and not self._session._closed_event.is_set():
                 self.release_sync()
         except Exception:
-            pass
+            logger.debug("Ignoring exception in RemoteLanceDBTable.__del__", exc_info=True)
 
     async def count_rows(self) -> int:
         resp = await self._session.call_async(

--- a/cognee/infrastructure/databases/vector/turso/TursoVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/turso/TursoVectorAdapter.py
@@ -493,8 +493,10 @@ class TursoVectorAdapter(VectorDBInterface):
             # errors here and is skipped quietly.
             try:
                 rows = await self._execute(select_sql, [tags_json] + scope_params, fetch=True)
-            except Exception as error:  # noqa: BLE001 - not a vector collection; skip
-                logger.debug("remove_belongs_to_set_tags skipped '%s': %s", table_name, error)
+            except Exception as error:  # not a vector collection; skip
+                logger.debug(
+                    "remove_belongs_to_set_tags skipped '%s': %s", table_name, error, exc_info=True
+                )
                 continue
 
             target_ids = [row[0] for row in rows or []]
@@ -520,9 +522,12 @@ class TursoVectorAdapter(VectorDBInterface):
             try:
                 await self._execute(update_sql, [tags_json] + target_ids, commit=True)
                 await self._execute(delete_sql, target_ids, commit=True)
-            except Exception as error:  # noqa: BLE001 - surface, but continue other tables
+            except Exception as error:  # surface, but continue other tables
                 logger.warning(
-                    "remove_belongs_to_set_tags failed to update '%s': %s", table_name, error
+                    "remove_belongs_to_set_tags failed to update '%s': %s",
+                    table_name,
+                    error,
+                    exc_info=True,
                 )
 
         return

--- a/cognee/infrastructure/engine/utils/parse_id.py
+++ b/cognee/infrastructure/engine/utils/parse_id.py
@@ -1,6 +1,10 @@
 from typing import Any
 from uuid import UUID
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 
 def parse_id(id: Any) -> Any:
     """
@@ -27,5 +31,5 @@ def parse_id(id: Any) -> Any:
         try:
             return UUID(id)
         except Exception:
-            pass
+            logger.debug("Ignoring exception in parse_id", exc_info=True)
     return id

--- a/cognee/infrastructure/files/storage/S3FileStorage.py
+++ b/cognee/infrastructure/files/storage/S3FileStorage.py
@@ -341,6 +341,9 @@ class S3FileStorage(Storage):
                 return relative_files
             except Exception:
                 # If directory doesn't exist or other error, return empty list
+                logger.debug(
+                    "Ignoring exception in S3FileStorage.list_files.list_files_sync", exc_info=True
+                )
                 return []
 
         return await run_async(list_files_sync)

--- a/cognee/infrastructure/files/storage/S3FileStorage.py
+++ b/cognee/infrastructure/files/storage/S3FileStorage.py
@@ -342,7 +342,8 @@ class S3FileStorage(Storage):
             except Exception:
                 # If directory doesn't exist or other error, return empty list
                 logger.debug(
-                    "Ignoring exception in S3FileStorage.list_files.list_files_sync", exc_info=True
+                    "Falling back to [] after error in S3FileStorage.list_files.list_files_sync",
+                    exc_info=True,
                 )
                 return []
 

--- a/cognee/infrastructure/llm/LLMGateway.py
+++ b/cognee/infrastructure/llm/LLMGateway.py
@@ -77,7 +77,7 @@ async def _record_session_usage_after(
             tokens_out_override=tokens_out,
         )
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _record_session_usage_after", exc_info=True)
     return result
 
 
@@ -185,7 +185,7 @@ class LLMGateway:
             )
 
             return bool(getattr(get_llm_client(), "supports_answer_streaming", False))
-        except Exception:  # noqa: BLE001 - a capability probe must not break a request
+        except Exception:  # a capability probe must not break a request
             logger.debug("Could not resolve answer-streaming support", exc_info=True)
             return False
 

--- a/cognee/infrastructure/llm/exceptions.py
+++ b/cognee/infrastructure/llm/exceptions.py
@@ -2,6 +2,10 @@ import re
 
 from cognee.exceptions.exceptions import CogneeValidationError
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 
 class ContentPolicyFilterError(CogneeValidationError):
     pass
@@ -90,7 +94,7 @@ def _is_budget_exhausted_link(e: BaseException) -> bool:
                 if isinstance(error, dict) and error.get("type") == "budget_exceeded":
                     return True
             except Exception:
-                pass
+                logger.debug("Ignoring exception in _is_budget_exhausted_link", exc_info=True)
 
     # Case 4: message text, the wrapper-proof fallback. ``str()`` is guarded
     # because this runs inside tenacity's retry predicate, where an exception
@@ -98,6 +102,7 @@ def _is_budget_exhausted_link(e: BaseException) -> bool:
     try:
         text = str(e)
     except Exception:
+        logger.debug("Ignoring exception in _is_budget_exhausted_link", exc_info=True)
         return False
     return _has_budget_message(text)
 
@@ -141,6 +146,7 @@ def budget_exhaustion_detail(e: BaseException) -> str | None:
         try:
             text = str(current)
         except Exception:
+            logger.debug("Ignoring exception in budget_exhaustion_detail", exc_info=True)
             text = ""
         match = _BUDGET_SENTENCE_RE.search(text)
         if match:

--- a/cognee/infrastructure/llm/exceptions.py
+++ b/cognee/infrastructure/llm/exceptions.py
@@ -1,7 +1,6 @@
 import re
 
 from cognee.exceptions.exceptions import CogneeValidationError
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/infrastructure/llm/exceptions.py
+++ b/cognee/infrastructure/llm/exceptions.py
@@ -101,7 +101,9 @@ def _is_budget_exhausted_link(e: BaseException) -> bool:
     try:
         text = str(e)
     except Exception:
-        logger.debug("Ignoring exception in _is_budget_exhausted_link", exc_info=True)
+        logger.debug(
+            "Falling back to False after error in _is_budget_exhausted_link", exc_info=True
+        )
         return False
     return _has_budget_message(text)
 

--- a/cognee/infrastructure/llm/prompts/read_query_prompt.py
+++ b/cognee/infrastructure/llm/prompts/read_query_prompt.py
@@ -39,6 +39,6 @@ def read_query_prompt(prompt_file_name: str, base_directory: str | None = None) 
     except FileNotFoundError:
         logger.error(f"Error: Prompt file not found. Attempted to read: {file_path}")
         return None
-    except Exception as e:
-        logger.error(f"An error occurred: {e}")
+    except Exception:
+        logger.exception("An error occurred")
         return None

--- a/cognee/infrastructure/llm/structured_output_framework/baml/baml_client/runtime.py
+++ b/cognee/infrastructure/llm/structured_output_framework/baml/baml_client/runtime.py
@@ -133,7 +133,7 @@ class DoNotUseDirectlyCallManager:
             resolved_options.abort_controller is not None
             and resolved_options.abort_controller.aborted
         ):
-            raise Exception("BamlAbortError: Operation was aborted")
+            raise RuntimeError("BamlAbortError: Operation was aborted")
 
         return await __runtime__.call_function(
             function_name,
@@ -162,7 +162,7 @@ class DoNotUseDirectlyCallManager:
             resolved_options.abort_controller is not None
             and resolved_options.abort_controller.aborted
         ):
-            raise Exception("BamlAbortError: Operation was aborted")
+            raise RuntimeError("BamlAbortError: Operation was aborted")
 
         ctx = __ctx__manager__.get()
         return __runtime__.call_function_sync(

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -73,7 +73,7 @@ def _enrich_llm_span(model: str, name: str) -> None:
             if stage:
                 current_span.set_attribute(COGNEE_PIPELINE_STAGE, stage)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _enrich_llm_span", exc_info=True)
 
 
 class GenericAPIAdapter(LLMInterface):

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_native/get_native_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_native/get_native_client.py
@@ -64,7 +64,7 @@ def _qualify_model(model: str, provider: str) -> str:
         litellm.get_llm_provider(model=model)
         return model
     except Exception:
-        logger.debug("Ignoring exception in _qualify_model", exc_info=True)
+        logger.debug("Falling back after error in _qualify_model", exc_info=True)
         prefix = _LITELLM_PROVIDER_PREFIX.get((provider or "").lower())
         return f"{prefix}/{model}" if prefix else model
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_native/get_native_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_native/get_native_client.py
@@ -15,6 +15,10 @@ from cognee.infrastructure.llm.structured_output_framework.litellm_native.native
     NativeLiteLLMAdapter,
 )
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 # Providers that do not require ``llm_api_key`` (mirrors get_llm_client): Bedrock
 # authenticates with AWS credentials and llama.cpp runs locally.
 _NO_API_KEY_PROVIDERS = {"bedrock", "llama_cpp"}
@@ -61,6 +65,7 @@ def _qualify_model(model: str, provider: str) -> str:
         litellm.get_llm_provider(model=model)
         return model
     except Exception:
+        logger.debug("Ignoring exception in _qualify_model", exc_info=True)
         prefix = _LITELLM_PROVIDER_PREFIX.get((provider or "").lower())
         return f"{prefix}/{model}" if prefix else model
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_native/get_native_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_native/get_native_client.py
@@ -14,7 +14,6 @@ from cognee.infrastructure.llm.exceptions import LLMAPIKeyNotSetError
 from cognee.infrastructure.llm.structured_output_framework.litellm_native.native_adapter import (
     NativeLiteLLMAdapter,
 )
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_native/native_adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_native/native_adapter.py
@@ -120,6 +120,7 @@ def _supports_native_schema(model_name: str) -> bool:
     try:
         return bool(litellm.supports_response_schema(model=model_name))
     except Exception:
+        logger.debug("Ignoring exception in _supports_native_schema", exc_info=True)
         return False
 
 
@@ -151,7 +152,7 @@ def _enrich_llm_span(model: str, name: str) -> None:
             if stage:
                 current_span.set_attribute(COGNEE_PIPELINE_STAGE, stage)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _enrich_llm_span", exc_info=True)
 
 
 class NativeLiteLLMAdapter:

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_native/native_adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_native/native_adapter.py
@@ -120,7 +120,7 @@ def _supports_native_schema(model_name: str) -> bool:
     try:
         return bool(litellm.supports_response_schema(model=model_name))
     except Exception:
-        logger.debug("Ignoring exception in _supports_native_schema", exc_info=True)
+        logger.debug("Falling back to False after error in _supports_native_schema", exc_info=True)
         return False
 
 

--- a/cognee/infrastructure/llm/tokenizer/resolver.py
+++ b/cognee/infrastructure/llm/tokenizer/resolver.py
@@ -74,6 +74,7 @@ def _fastembed_hf_repo(model: str | None) -> str | None:
     except Exception:
         # fastembed not installed here (e.g. CI unit tests): best-effort treat a
         # namespaced id as an HF repo, otherwise give up so the caller warns.
+        logger.debug("Ignoring exception in _fastembed_hf_repo", exc_info=True)
         return model if "/" in model else None
 
     bare = _bare_model(model)
@@ -109,6 +110,7 @@ def _load_or_tiktoken_fallback(
             context,
             error,
             _MISMATCH_HINT,
+            exc_info=True,
         )
         return TikTokenTokenizer(model=None, max_completion_tokens=max_completion_tokens)
 

--- a/cognee/infrastructure/llm/tokenizer/resolver.py
+++ b/cognee/infrastructure/llm/tokenizer/resolver.py
@@ -74,7 +74,7 @@ def _fastembed_hf_repo(model: str | None) -> str | None:
     except Exception:
         # fastembed not installed here (e.g. CI unit tests): best-effort treat a
         # namespaced id as an HF repo, otherwise give up so the caller warns.
-        logger.debug("Ignoring exception in _fastembed_hf_repo", exc_info=True)
+        logger.debug("Falling back after error in _fastembed_hf_repo", exc_info=True)
         return model if "/" in model else None
 
     bare = _bare_model(model)

--- a/cognee/infrastructure/loaders/core/image_loader.py
+++ b/cognee/infrastructure/loaders/core/image_loader.py
@@ -256,7 +256,10 @@ class ImageLoader(LoaderInterface):
             with Image.open(file_path) as img:
                 exif_data = img._getexif()  # ty:ignore[unresolved-attribute]
         except Exception:
-            logger.debug("Ignoring exception in ImageLoader._extract_exif_metadata", exc_info=True)
+            logger.debug(
+                "Falling back to None after error in ImageLoader._extract_exif_metadata",
+                exc_info=True,
+            )
             return None
 
         if exif_data is None:
@@ -320,7 +323,8 @@ class ImageLoader(LoaderInterface):
                 return _dhash(img)
         except Exception:
             logger.debug(
-                "Ignoring exception in ImageLoader._compute_perceptual_hash", exc_info=True
+                "Falling back to None after error in ImageLoader._compute_perceptual_hash",
+                exc_info=True,
             )
             return None
 
@@ -394,7 +398,7 @@ def _format_gps_info(gps_dict: dict) -> str | None:
         lat = _to_decimal(gps_dict.get(2), gps_dict.get(1, "N"))  # GPSLatitude, GPSLatitudeRef
         lon = _to_decimal(gps_dict.get(4), gps_dict.get(3, "E"))  # GPSLongitude, GPSLongitudeRef
     except Exception:
-        logger.debug("Ignoring exception in _format_gps_info", exc_info=True)
+        logger.debug("Falling back to None after error in _format_gps_info", exc_info=True)
         return None
 
     parts = []

--- a/cognee/infrastructure/loaders/core/image_loader.py
+++ b/cognee/infrastructure/loaders/core/image_loader.py
@@ -223,8 +223,8 @@ class ImageLoader(LoaderInterface):
         try:
             # RapidOCR is blocking CPU work; offload it so the event loop stays free.
             ocr_result, _ = await asyncio.to_thread(engine, file_path)
-        except Exception as e:
-            logger.error(f"OCR failed for {file_path}: {e}")
+        except Exception:
+            logger.exception(f"OCR failed for {file_path}")
             return ""
         if not ocr_result:
             return ""
@@ -256,6 +256,7 @@ class ImageLoader(LoaderInterface):
             with Image.open(file_path) as img:
                 exif_data = img._getexif()  # ty:ignore[unresolved-attribute]
         except Exception:
+            logger.debug("Ignoring exception in ImageLoader._extract_exif_metadata", exc_info=True)
             return None
 
         if exif_data is None:
@@ -318,6 +319,9 @@ class ImageLoader(LoaderInterface):
             with Image.open(file_path) as img:
                 return _dhash(img)
         except Exception:
+            logger.debug(
+                "Ignoring exception in ImageLoader._compute_perceptual_hash", exc_info=True
+            )
             return None
 
     @classmethod
@@ -390,6 +394,7 @@ def _format_gps_info(gps_dict: dict) -> str | None:
         lat = _to_decimal(gps_dict.get(2), gps_dict.get(1, "N"))  # GPSLatitude, GPSLatitudeRef
         lon = _to_decimal(gps_dict.get(4), gps_dict.get(3, "E"))  # GPSLongitude, GPSLongitudeRef
     except Exception:
+        logger.debug("Ignoring exception in _format_gps_info", exc_info=True)
         return None
 
     parts = []

--- a/cognee/infrastructure/loaders/core/video_loader.py
+++ b/cognee/infrastructure/loaders/core/video_loader.py
@@ -232,6 +232,7 @@ class VideoLoader(LoaderInterface):
             logger.debug(
                 "Segmented transcription request failed (%s); retrying without it.",
                 error,
+                exc_info=True,
             )
             result = await LLMGateway.create_transcript(audio_path)
 

--- a/cognee/infrastructure/loaders/create_loader_engine.py
+++ b/cognee/infrastructure/loaders/create_loader_engine.py
@@ -28,6 +28,6 @@ def create_loader_engine() -> LoaderEngine:
             engine.register_loader(loader_instance)
         except Exception as e:
             # Log but don't fail - allow engine to continue with other loaders
-            logger.warning(f"Failed to register loader {loader_name}: {e}")
+            logger.warning(f"Failed to register loader {loader_name}: {e}", exc_info=True)
 
     return engine

--- a/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
+++ b/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
@@ -108,7 +108,7 @@ class AdvancedPdfLoader(LoaderInterface):
             return await store_derived_text(storage, storage_file_name, full_content)
 
         except Exception as exc:
-            logger.warning("Failed to process PDF with AdvancedPdfLoader: %s", exc)
+            logger.warning("Failed to process PDF with AdvancedPdfLoader: %s", exc, exc_info=True)
             return await self._fallback(file_path, **kwargs)
 
     async def _fallback(self, file_path: str, **kwargs: Any) -> str | LoaderResult:
@@ -213,7 +213,7 @@ class AdvancedPdfLoader(LoaderInterface):
             if hasattr(element, "to_dict"):
                 return element.to_dict()
         except Exception:
-            pass
+            logger.debug("Ignoring exception in AdvancedPdfLoader._safe_to_dict", exc_info=True)
         fallback_type = getattr(element, "category", None)
         if not fallback_type:
             fallback_type = getattr(element, "__class__", type("", (), {})).__name__

--- a/cognee/infrastructure/loaders/external/pypdf_loader.py
+++ b/cognee/infrastructure/loaders/external/pypdf_loader.py
@@ -78,7 +78,9 @@ class PyPdfLoader(LoaderInterface):
                             page_texts.append(page_text)
                             content_parts.append(f"Page {page_num}:\n{page_text}\n")
                     except Exception as e:
-                        logger.warning(f"Failed to extract text from page {page_num}: {e}")
+                        logger.warning(
+                            f"Failed to extract text from page {page_num}: {e}", exc_info=True
+                        )
                         continue
 
                 # Combine all content
@@ -95,4 +97,4 @@ class PyPdfLoader(LoaderInterface):
 
         except Exception as e:
             logger.error(f"Failed to process PDF {file_path}: {e}")
-            raise Exception(f"PDF processing failed: {e}") from e
+            raise RuntimeError(f"PDF processing failed: {e}") from e

--- a/cognee/infrastructure/loaders/external/unstructured_loader.py
+++ b/cognee/infrastructure/loaders/external/unstructured_loader.py
@@ -125,4 +125,4 @@ class UnstructuredLoader(LoaderInterface):
 
         except Exception as e:
             logger.error(f"Failed to process document {file_path}: {e}")
-            raise Exception(f"Document processing failed: {e}") from e
+            raise RuntimeError(f"Document processing failed: {e}") from e

--- a/cognee/infrastructure/session/agent_context_extraction.py
+++ b/cognee/infrastructure/session/agent_context_extraction.py
@@ -139,7 +139,7 @@ async def extract_live_agent_context(
             candidates=candidates,
         )
     except Exception as error:
-        logger.warning("Live agent-context extraction failed open: %s", error)
+        logger.warning("Live agent-context extraction failed open: %s", error, exc_info=True)
         return []
 
 
@@ -335,7 +335,7 @@ async def extract_batch_agent_context(
             traces=traces,
         )
     except Exception as error:
-        logger.warning("Batch agent-context extraction failed open: %s", error)
+        logger.warning("Batch agent-context extraction failed open: %s", error, exc_info=True)
         return []
 
 
@@ -391,5 +391,5 @@ async def extract_pending_agent_context(
         )
         return touched
     except Exception as error:
-        logger.warning("Pending agent-context extraction failed open: %s", error)
+        logger.warning("Pending agent-context extraction failed open: %s", error, exc_info=True)
         return []

--- a/cognee/infrastructure/session/feedback_detection.py
+++ b/cognee/infrastructure/session/feedback_detection.py
@@ -33,7 +33,7 @@ def _render_served_context(served_context) -> str:
                 continue
             lines.append(f"{str(entry_id).strip()}: {str(content).strip()}")
     except Exception:
-        logger.debug("Ignoring exception in _render_served_context", exc_info=True)
+        logger.debug("Falling back to  after error in _render_served_context", exc_info=True)
         return ""
     return "\n".join(lines)
 

--- a/cognee/infrastructure/session/feedback_detection.py
+++ b/cognee/infrastructure/session/feedback_detection.py
@@ -33,6 +33,7 @@ def _render_served_context(served_context) -> str:
                 continue
             lines.append(f"{str(entry_id).strip()}: {str(content).strip()}")
     except Exception:
+        logger.debug("Ignoring exception in _render_served_context", exc_info=True)
         return ""
     return "\n".join(lines)
 
@@ -107,7 +108,7 @@ async def analyze_turn_for_session_context(
         logger.warning(
             "Session turn analysis failed, proceeding with empty analysis: %s",
             e,
-            exc_info=False,
+            exc_info=True,
         )
         return SessionTurnAnalysis()
 

--- a/cognee/infrastructure/session/session_agent_trace.py
+++ b/cognee/infrastructure/session/session_agent_trace.py
@@ -75,6 +75,6 @@ async def generate_agent_trace_feedback(
         logger.warning(
             "Agent trace feedback generation failed, using fallback: %s",
             e,
-            exc_info=False,
+            exc_info=True,
         )
         return fallback_feedback

--- a/cognee/infrastructure/session/session_concurrent_turn.py
+++ b/cognee/infrastructure/session/session_concurrent_turn.py
@@ -163,7 +163,7 @@ async def load_turn_context(
             ),
         )
     except Exception as error:
-        logger.warning("Concurrent turn context load failed open: %s", error)
+        logger.warning("Concurrent turn context load failed open: %s", error, exc_info=True)
         return SessionTurnContext(raw_message=raw_message)
 
 
@@ -187,7 +187,7 @@ async def analyze_turn(snapshot: SessionTurnContext) -> SessionTurnAnalysis:
             timeout=ANALYSIS_TIMEOUT_SECONDS,
         )
     except Exception as error:
-        logger.warning("Concurrent turn analysis failed open: %s", error)
+        logger.warning("Concurrent turn analysis failed open: %s", error, exc_info=True)
         return SessionTurnAnalysis()
 
 
@@ -261,4 +261,4 @@ async def commit_turn(
             used_session_context_ids=list(snapshot.active_context_ids) or None,
         )
     except Exception as error:
-        logger.warning("Concurrent turn QA write failed open: %s", error)
+        logger.warning("Concurrent turn QA write failed open: %s", error, exc_info=True)

--- a/cognee/infrastructure/session/session_context_builder.py
+++ b/cognee/infrastructure/session/session_context_builder.py
@@ -304,7 +304,7 @@ async def _stamp_served_entries(*, session_manager, user_id, session_id, entry_i
                 merge={"last_served_at": served_at},
             )
         except Exception:
-            logger.debug("Ignoring exception in _stamp_served_entries", exc_info=True)
+            logger.debug("Skipping item after error in _stamp_served_entries", exc_info=True)
             continue
 
 
@@ -400,7 +400,7 @@ async def build_active_context_block(
         return block, served_ids
     except Exception:
         # Fail-open: never block answer generation.
-        logger.debug("Ignoring exception in build_active_context_block", exc_info=True)
+        logger.debug("Falling back after error in build_active_context_block", exc_info=True)
         return "", []
 
 
@@ -544,9 +544,9 @@ async def apply_candidate_updates(
                     touched.append(entry_id)
             except Exception:
                 # Per-candidate fail-open: skip this candidate, keep going.
-                logger.debug("Ignoring exception in apply_candidate_updates", exc_info=True)
+                logger.debug("Skipping item after error in apply_candidate_updates", exc_info=True)
                 continue
         return touched
     except Exception:
-        logger.debug("Ignoring exception in apply_candidate_updates", exc_info=True)
+        logger.debug("Falling back after error in apply_candidate_updates", exc_info=True)
         return touched

--- a/cognee/infrastructure/session/session_context_builder.py
+++ b/cognee/infrastructure/session/session_context_builder.py
@@ -28,6 +28,10 @@ from cognee.infrastructure.session.session_context_models import (
     valid_sections_for,
 )
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 _AGENT_CANDIDATE_ADAPTER = TypeAdapter(AgentCandidateContextUpdateVariant)
 
 # Default budgets. Kept conservative so the rendered block never bloats the prompt.
@@ -301,6 +305,7 @@ async def _stamp_served_entries(*, session_manager, user_id, session_id, entry_i
                 merge={"last_served_at": served_at},
             )
         except Exception:
+            logger.debug("Ignoring exception in _stamp_served_entries", exc_info=True)
             continue
 
 
@@ -396,6 +401,7 @@ async def build_active_context_block(
         return block, served_ids
     except Exception:
         # Fail-open: never block answer generation.
+        logger.debug("Ignoring exception in build_active_context_block", exc_info=True)
         return "", []
 
 
@@ -539,7 +545,9 @@ async def apply_candidate_updates(
                     touched.append(entry_id)
             except Exception:
                 # Per-candidate fail-open: skip this candidate, keep going.
+                logger.debug("Ignoring exception in apply_candidate_updates", exc_info=True)
                 continue
         return touched
     except Exception:
+        logger.debug("Ignoring exception in apply_candidate_updates", exc_info=True)
         return touched

--- a/cognee/infrastructure/session/session_context_builder.py
+++ b/cognee/infrastructure/session/session_context_builder.py
@@ -27,7 +27,6 @@ from cognee.infrastructure.session.session_context_models import (
     normalize_content,
     valid_sections_for,
 )
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/infrastructure/session/session_embeddings.py
+++ b/cognee/infrastructure/session/session_embeddings.py
@@ -112,7 +112,7 @@ async def index_session_qa(
         )
         await index_data_points([point])
     except Exception as error:
-        logger.warning("Session QA vector indexing failed open: %s", error)
+        logger.warning("Session QA vector indexing failed open: %s", error, exc_info=True)
 
 
 async def search_session_qa_ids(
@@ -141,7 +141,7 @@ async def search_session_qa_ids(
         logger.debug("Session QA vector collection is not initialized yet.")
         return []
     except Exception as error:
-        logger.warning("Session QA vector search failed open: %s", error)
+        logger.warning("Session QA vector search failed open: %s", error, exc_info=True)
         return []
 
     return [str(result.id) for result in results or [] if getattr(result, "id", None) is not None]
@@ -155,7 +155,7 @@ async def delete_session_qa_vector(*, qa_id: str) -> None:
         vector_engine = await get_vector_engine_async()
         await vector_engine.delete_data_points(SESSION_QA_VECTOR_COLLECTION, [UUID(qa_id)])
     except Exception as error:
-        logger.warning("Session QA vector delete failed open: %s", error)
+        logger.warning("Session QA vector delete failed open: %s", error, exc_info=True)
 
 
 async def delete_session_qa_vectors(*, user_id: str, session_id: str) -> None:
@@ -168,4 +168,4 @@ async def delete_session_qa_vectors(*, user_id: str, session_id: str) -> None:
             [session_scope_tag(user_id, session_id)],
         )
     except Exception as error:
-        logger.warning("Session QA vector session cleanup failed open: %s", error)
+        logger.warning("Session QA vector session cleanup failed open: %s", error, exc_info=True)

--- a/cognee/infrastructure/session/session_manager.py
+++ b/cognee/infrastructure/session/session_manager.py
@@ -302,7 +302,7 @@ class SessionManager:
                 session_id=session_id,
             )
         except Exception as error:
-            logger.warning("Agent-context extraction skipped: %s", error)
+            logger.warning("Agent-context extraction skipped: %s", error, exc_info=True)
 
     def is_session_available_for_completion(self, user_id: str | None) -> bool:
         """Return True if session (history + save) is available for completion."""
@@ -787,7 +787,9 @@ class SessionManager:
             await self._cache.create_session_context_entry(user_id, session_id, entry_dump)
             return True
         except Exception as e:
-            logger.warning("SessionManager: create_session_context_entry failed: %s", e)
+            logger.warning(
+                "SessionManager: create_session_context_entry failed: %s", e, exc_info=True
+            )
             return False
 
     async def get_session_context_entries(
@@ -811,7 +813,9 @@ class SessionManager:
         try:
             return await self._cache.get_session_context_entries(user_id, session_id)
         except Exception as e:
-            logger.warning("SessionManager: get_session_context_entries failed: %s", e)
+            logger.warning(
+                "SessionManager: get_session_context_entries failed: %s", e, exc_info=True
+            )
             return []
 
     async def update_session_context_entry(
@@ -839,7 +843,9 @@ class SessionManager:
                 user_id, session_id, entry_id, merge
             )
         except Exception as e:
-            logger.warning("SessionManager: update_session_context_entry failed: %s", e)
+            logger.warning(
+                "SessionManager: update_session_context_entry failed: %s", e, exc_info=True
+            )
             return False
 
     async def delete_session_context_entry(
@@ -864,7 +870,9 @@ class SessionManager:
         try:
             return await self._cache.delete_session_context_entry(user_id, session_id, entry_id)
         except Exception as e:
-            logger.warning("SessionManager: delete_session_context_entry failed: %s", e)
+            logger.warning(
+                "SessionManager: delete_session_context_entry failed: %s", e, exc_info=True
+            )
             return False
 
     async def delete_session_context(
@@ -888,7 +896,7 @@ class SessionManager:
         try:
             return await self._cache.delete_session_context(user_id, session_id)
         except Exception as e:
-            logger.warning("SessionManager: delete_session_context failed: %s", e)
+            logger.warning("SessionManager: delete_session_context failed: %s", e, exc_info=True)
             return False
 
     async def delete_session(self, *, user_id: str, session_id: str | None = None) -> bool:
@@ -917,18 +925,20 @@ class SessionManager:
                 try:
                     del self._cache._cache[graph_key]
                 except Exception:
-                    pass
+                    logger.debug(
+                        "Ignoring exception in SessionManager.delete_session", exc_info=True
+                    )
             except Exception:
-                pass
+                logger.debug("Ignoring exception in SessionManager.delete_session", exc_info=True)
         except Exception:
-            pass
+            logger.debug("Ignoring exception in SessionManager.delete_session", exc_info=True)
 
         # Also clear the active session-context list (fail-open; adapter.delete_session may also
         # clear it, but this guarantees no leak if the adapter does not).
         try:
             await self._cache.delete_session_context(user_id, session_id)
         except Exception:
-            pass
+            logger.debug("Ignoring exception in SessionManager.delete_session", exc_info=True)
 
         deleted = await self._cache.delete_session(
             user_id=user_id,

--- a/cognee/infrastructure/session/session_turn.py
+++ b/cognee/infrastructure/session/session_turn.py
@@ -332,7 +332,9 @@ async def apply_served_context_ratings(
                 )
                 counts[entry_id] = next_counts
             except Exception:
-                logger.debug("Ignoring exception in apply_served_context_ratings", exc_info=True)
+                logger.debug(
+                    "Skipping item after error in apply_served_context_ratings", exc_info=True
+                )
                 continue
     except Exception as e:
         logger.warning("Session turn: served-context rating update failed: %s", e, exc_info=True)

--- a/cognee/infrastructure/session/session_turn.py
+++ b/cognee/infrastructure/session/session_turn.py
@@ -73,7 +73,7 @@ async def load_preference_lines_safe() -> list[str]:
     try:
         return await load_active_preference_lines()
     except Exception as error:
-        logger.debug("Session turn: preference lookup failed open: %s", error)
+        logger.debug("Session turn: preference lookup failed open: %s", error, exc_info=True)
         return []
 
 
@@ -128,7 +128,7 @@ async def select_session_history(
                 include_context=False,
             )
     except Exception as error:
-        logger.warning("Session history: hybrid selection failed open: %s", error)
+        logger.warning("Session history: hybrid selection failed open: %s", error, exc_info=True)
 
     history = await session_manager.get_session(
         user_id=user_id,
@@ -253,7 +253,7 @@ async def build_active_context_block_safe(
             stamp_served=stamp_served,
         )
     except Exception as e:
-        logger.warning("Active session-context block failed: %s", e)
+        logger.warning("Active session-context block failed: %s", e, exc_info=True)
         return "", []
 
 
@@ -282,7 +282,7 @@ async def load_served_context_payload(
                 by_id[str(entry_id)] = row.get("content", "")
         return [{"id": cid, "content": by_id[cid]} for cid in served_ids if cid in by_id]
     except Exception as e:
-        logger.warning("Session turn: load served context failed: %s", e)
+        logger.warning("Session turn: load served context failed: %s", e, exc_info=True)
         return []
 
 
@@ -332,9 +332,10 @@ async def apply_served_context_ratings(
                 )
                 counts[entry_id] = next_counts
             except Exception:
+                logger.debug("Ignoring exception in apply_served_context_ratings", exc_info=True)
                 continue
     except Exception as e:
-        logger.warning("Session turn: served-context rating update failed: %s", e)
+        logger.warning("Session turn: served-context rating update failed: %s", e, exc_info=True)
 
 
 async def apply_session_turn_analysis(
@@ -399,7 +400,7 @@ async def apply_session_turn_analysis(
         )
         return touched_ids
     except Exception as e:
-        logger.warning("Session turn: feedback application failed: %s", e)
+        logger.warning("Session turn: feedback application failed: %s", e, exc_info=True)
         return []
 
 
@@ -461,7 +462,7 @@ async def prepare_session_turn(
             served_context=served_context,
         )
     except Exception as error:
-        logger.warning("Session turn preparation failed open: %s", error)
+        logger.warning("Session turn preparation failed open: %s", error, exc_info=True)
         return _empty_turn_preparation(query)
 
     try:
@@ -475,7 +476,7 @@ async def prepare_session_turn(
             served_ids=[str(entry_id) for entry_id in previous_served_ids],
         )
     except Exception as error:
-        logger.warning("Session turn analysis application failed open: %s", error)
+        logger.warning("Session turn analysis application failed open: %s", error, exc_info=True)
         accepted_context_ids = []
 
     query_to_answer = (analysis.query_to_answer or "").strip()

--- a/cognee/infrastructure/utils/run_sync.py
+++ b/cognee/infrastructure/utils/run_sync.py
@@ -3,6 +3,10 @@ import threading
 from collections.abc import Coroutine
 from typing import Any, TypeVar
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 T = TypeVar("T")
 
 
@@ -27,6 +31,7 @@ def run_sync(
                 result = asyncio.run(coro)
 
         except Exception as e:
+            logger.debug("Ignoring exception in run_sync.runner", exc_info=True)
             exception = e
 
     thread = threading.Thread(target=runner)

--- a/cognee/modules/agent_memory/runtime.py
+++ b/cognee/modules/agent_memory/runtime.py
@@ -430,7 +430,7 @@ async def retrieve_cognee_memory_context(context: AgentMemoryContext) -> str:
                 "Agent memory retrieval failed for %s: %s",
                 context.origin_function,
                 error,
-                exc_info=False,
+                exc_info=True,
             )
             span.set_attribute("cognee.agent_memory.retrieval_failed", True)
             return ""
@@ -459,7 +459,7 @@ async def retrieve_session_memory_context(context: AgentMemoryContext) -> str:
             "Session agent memory retrieval failed for %s: %s",
             context.origin_function,
             error,
-            exc_info=False,
+            exc_info=True,
         )
         return ""
 
@@ -501,7 +501,7 @@ async def persist_trace(context: AgentMemoryContext) -> None:
             "Agent trace persistence failed for %s: %s",
             context.origin_function,
             error,
-            exc_info=False,
+            exc_info=True,
         )
         return
 
@@ -541,7 +541,7 @@ async def persist_trace(context: AgentMemoryContext) -> None:
             "Agent trace memify persistence failed for %s: %s",
             context.origin_function,
             error,
-            exc_info=False,
+            exc_info=True,
         )
 
 

--- a/cognee/modules/agents/operations.py
+++ b/cognee/modules/agents/operations.py
@@ -231,7 +231,9 @@ async def get_agent_connection_detail(
             recent_traces = [_entry_to_dict(entry) for entry in traces[-20:]]
             recent_sessions = [{"session_id": agent.session_id, "user_id": agent.user_id}]
         except Exception as error:
-            logger.debug("Failed to hydrate agent detail from session cache: %s", error)
+            logger.debug(
+                "Failed to hydrate agent detail from session cache: %s", error, exc_info=True
+            )
 
     return AgentDetailResponse(
         agent=agent,

--- a/cognee/modules/agents/registry.py
+++ b/cognee/modules/agents/registry.py
@@ -184,8 +184,8 @@ async def register_agent_connection(
             from cognee.modules.session_lifecycle.metrics import set_session_agent
 
             await set_session_agent(session_id=session_id, user_id=user_id, agent_id=connection.id)
-        except Exception as error:  # noqa: BLE001 — attribution must not break registration
-            logger.debug("Session agent attribution skipped: %s", error)
+        except Exception as error:  # — attribution must not break registration
+            logger.debug("Session agent attribution skipped: %s", error, exc_info=True)
 
     return connection
 

--- a/cognee/modules/cloud/operations/check_api_key.py
+++ b/cognee/modules/cloud/operations/check_api_key.py
@@ -25,4 +25,4 @@ async def check_api_key(auth_token: str):
                     )
 
     except Exception as e:
-        raise CloudConnectionError(f"Failed to connect to cloud instance: {e!s}")
+        raise CloudConnectionError(f"Failed to connect to cloud instance: {e!s}") from e

--- a/cognee/modules/cognify/estimator.py
+++ b/cognee/modules/cognify/estimator.py
@@ -184,7 +184,7 @@ def _llm_tokenizer() -> TikTokenTokenizer:
         return TikTokenTokenizer(model=model)
     except Exception:
         # Model unknown to tiktoken — fall back to its default encoding.
-        logger.debug("Ignoring exception in _llm_tokenizer", exc_info=True)
+        logger.debug("Falling back after error in _llm_tokenizer", exc_info=True)
         return TikTokenTokenizer(model=None)
 
 

--- a/cognee/modules/cognify/estimator.py
+++ b/cognee/modules/cognify/estimator.py
@@ -184,6 +184,7 @@ def _llm_tokenizer() -> TikTokenTokenizer:
         return TikTokenTokenizer(model=model)
     except Exception:
         # Model unknown to tiktoken — fall back to its default encoding.
+        logger.debug("Ignoring exception in _llm_tokenizer", exc_info=True)
         return TikTokenTokenizer(model=None)
 
 

--- a/cognee/modules/cognify/recovery.py
+++ b/cognee/modules/cognify/recovery.py
@@ -63,7 +63,7 @@ async def recover_stale_cognify_runs_on_startup() -> None:
             if run.status == PipelineRunStatus.DATASET_PROCESSING_STARTED
         ]
     except Exception:
-        logger.error("Failed to recover latest cognify run which did not successfully finish.")
+        logger.exception("Failed to recover latest cognify run which did not successfully finish.")
         return
 
     for pipeline_run in recovery_candidates:

--- a/cognee/modules/data/methods/get_datasets_graph_counts.py
+++ b/cognee/modules/data/methods/get_datasets_graph_counts.py
@@ -85,7 +85,9 @@ async def _count_and_cache(dataset: Dataset, pipeline_run_id: UUID) -> DatasetGr
             graph_engine = await get_graph_engine()
             graph_metrics = await graph_engine.get_graph_metrics(include_optional=False) or {}
     except Exception as error:
-        logger.warning("Failed to compute graph metrics for dataset %s: %s", dataset.id, error)
+        logger.warning(
+            "Failed to compute graph metrics for dataset %s: %s", dataset.id, error, exc_info=True
+        )
         return DatasetGraphCounts(pipeline_run_id=pipeline_run_id)
 
     num_nodes = graph_metrics.get("num_nodes") or 0
@@ -122,8 +124,8 @@ async def _count_and_cache(dataset: Dataset, pipeline_run_id: UUID) -> DatasetGr
         computed_at = datetime.now(timezone.utc)
     except IntegrityError as error:
         logger.warning("Lost the caching race for dataset %s: %s", dataset.id, error)
-    except Exception as error:
-        logger.error("Failed to cache graph metrics for dataset %s: %s", dataset.id, error)
+    except Exception:
+        logger.exception("Failed to cache graph metrics for dataset %s", dataset.id)
 
     return DatasetGraphCounts(
         pipeline_run_id=pipeline_run_id,

--- a/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
+++ b/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
@@ -110,6 +110,7 @@ async def delete_data_nodes_and_edges(
                 "Shared-slug graph detag failed for dataset %s (non-fatal): %s",
                 dataset_id,
                 e,
+                exc_info=True,
             )
         try:
             vector_engine = await get_vector_engine_async()
@@ -121,6 +122,7 @@ async def delete_data_nodes_and_edges(
                 "Shared-slug vector detag failed for dataset %s (non-fatal): %s",
                 dataset_id,
                 e,
+                exc_info=True,
             )
 
     return DeletedGraphElements.from_ledger_rows(affected_nodes or [], affected_edges or [])

--- a/cognee/modules/graph/methods/delete_from_graph_and_vector.py
+++ b/cognee/modules/graph/methods/delete_from_graph_and_vector.py
@@ -113,7 +113,7 @@ async def delete_from_graph_and_vector(
                 await vector_engine.delete_data_points("Triplet_text", triplet_ids)
             except Exception:
                 # Triplet collection might not exist if triplet embedding was never enabled
-                pass
+                logger.debug("Ignoring exception in delete_from_graph_and_vector", exc_info=True)
 
     # Clean up orphaned EdgeType nodes from the graph.
     # EdgeType nodes are created by index_graph_edges for each unique edge
@@ -149,7 +149,7 @@ async def delete_from_graph_and_vector(
                     len(orphaned_edge_type_ids),
                 )
         except Exception as e:
-            logger.warning("EdgeType cleanup failed (non-fatal): %s", e)
+            logger.warning("EdgeType cleanup failed (non-fatal): %s", e, exc_info=True)
 
     # Strip now-orphaned NodeSet tags from surviving rows/nodes so shared
     # entities stop advertising membership in a dataset that no longer
@@ -162,12 +162,12 @@ async def delete_from_graph_and_vector(
                 graph_engine = await get_graph_engine()
             await graph_engine.remove_belongs_to_set_tags(tags_to_remove)
         except Exception as e:
-            logger.warning("Graph NodeSet tag cleanup failed (non-fatal): %s", e)
+            logger.warning("Graph NodeSet tag cleanup failed (non-fatal): %s", e, exc_info=True)
 
         try:
             await vector_engine.remove_belongs_to_set_tags(tags_to_remove)
         except Exception as e:
-            logger.warning("Vector NodeSet tag cleanup failed (non-fatal): %s", e)
+            logger.warning("Vector NodeSet tag cleanup failed (non-fatal): %s", e, exc_info=True)
 
     # Mark ledger entries as deleted
     await mark_ledger_nodes_as_deleted([node.slug for node in non_legacy_nodes])

--- a/cognee/modules/graph/utils/unwrap_transparent_nodes.py
+++ b/cognee/modules/graph/utils/unwrap_transparent_nodes.py
@@ -42,6 +42,7 @@ def _warn_dropped_field(data_point: DataPoint, field_name: str, value: Any) -> N
     try:
         carries = bool(value)
     except Exception:
+        logger.debug("Ignoring exception in _warn_dropped_field", exc_info=True)
         carries = True
 
     key = (type(data_point).__qualname__, field_name)

--- a/cognee/modules/memify/skill_improvement.py
+++ b/cognee/modules/memify/skill_improvement.py
@@ -300,7 +300,7 @@ async def _load_nodes_by_type(model):
     try:
         graph_engine = await get_graph_engine()
     except Exception:
-        logger.debug("Ignoring exception in _load_nodes_by_type", exc_info=True)
+        logger.debug("Falling back to [] after error in _load_nodes_by_type", exc_info=True)
         return []
 
     get_by_type = getattr(graph_engine, "get_nodes_by_type", None)
@@ -347,5 +347,5 @@ def _coerce_model(raw, model):
     try:
         return model.model_validate(data)
     except Exception:
-        logger.debug("Ignoring exception in _coerce_model", exc_info=True)
+        logger.debug("Falling back to None after error in _coerce_model", exc_info=True)
         return None

--- a/cognee/modules/memify/skill_improvement.py
+++ b/cognee/modules/memify/skill_improvement.py
@@ -137,6 +137,7 @@ async def improve_skill(
 
             model_name = get_llm_config().llm_model
         except Exception:
+            logger.debug("Ignoring exception in improve_skill", exc_info=True)
             model_name = ""
         proposal = SkillImprovementProposal(
             proposal_id=str(uuid4()),
@@ -293,11 +294,13 @@ async def _load_nodes_by_type(model):
     try:
         from cognee.infrastructure.databases.graph import get_graph_engine
     except Exception:
+        logger.debug("Optional import unavailable, continuing without it", exc_info=True)
         return []
 
     try:
         graph_engine = await get_graph_engine()
     except Exception:
+        logger.debug("Ignoring exception in _load_nodes_by_type", exc_info=True)
         return []
 
     get_by_type = getattr(graph_engine, "get_nodes_by_type", None)
@@ -305,7 +308,7 @@ async def _load_nodes_by_type(model):
         try:
             return await get_by_type(node_type=model)
         except Exception as exc:
-            logger.warning("Skill improvement lookup failed: %s", exc)
+            logger.warning("Skill improvement lookup failed: %s", exc, exc_info=True)
             return []
 
     get_nodeset = getattr(graph_engine, "get_nodeset_subgraph", None)
@@ -315,7 +318,7 @@ async def _load_nodes_by_type(model):
             if nodes:
                 return nodes
         except Exception as exc:
-            logger.warning("Skill improvement nodeset lookup failed: %s", exc)
+            logger.warning("Skill improvement nodeset lookup failed: %s", exc, exc_info=True)
 
     get_graph_data = getattr(graph_engine, "get_graph_data", None)
     if get_graph_data is None:
@@ -324,7 +327,7 @@ async def _load_nodes_by_type(model):
         nodes, _ = await get_graph_data()
         return nodes
     except Exception as exc:
-        logger.warning("Skill improvement full graph lookup failed: %s", exc)
+        logger.warning("Skill improvement full graph lookup failed: %s", exc, exc_info=True)
         return []
 
 
@@ -344,4 +347,5 @@ def _coerce_model(raw, model):
     try:
         return model.model_validate(data)
     except Exception:
+        logger.debug("Ignoring exception in _coerce_model", exc_info=True)
         return None

--- a/cognee/modules/migration/export.py
+++ b/cognee/modules/migration/export.py
@@ -127,8 +127,10 @@ async def _stored_migration_revision(dataset_id) -> str | None:
         async with db_engine.get_async_session() as session:
             record = await session.get(GlobalDatabaseVersion, GLOBAL_DATABASE_VERSION_ROW_ID)
         return record.global_migration_revision if record else None
-    except Exception as error:  # noqa: BLE001 — manifest metadata is best effort
-        logger.debug("Could not determine migration revision for manifest: %s", error)
+    except Exception as error:  # — manifest metadata is best effort
+        logger.debug(
+            "Could not determine migration revision for manifest: %s", error, exc_info=True
+        )
         return None
 
 
@@ -271,8 +273,10 @@ async def export_dataset(
             )
 
             embedding_model = get_embedding_context_config().embedding_model
-        except Exception as error:  # noqa: BLE001 — manifest metadata is best effort
-            logger.debug("Could not determine embedding model for manifest: %s", error)
+        except Exception as error:  # — manifest metadata is best effort
+            logger.debug(
+                "Could not determine embedding model for manifest: %s", error, exc_info=True
+            )
         _write_cogx(
             nodes,
             edges,

--- a/cognee/modules/migration/snapshot.py
+++ b/cognee/modules/migration/snapshot.py
@@ -26,6 +26,10 @@ from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny, create_model,
 
 from cognee.infrastructure.engine import DataPoint
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 # Edge properties that are internal bookkeeping rather than knowledge content.
 _SKIP_EDGE_KEYS = ("source_node_id", "target_node_id", "relationship_name")
 
@@ -127,8 +131,8 @@ def rehydrate_node(
     if known is not None:
         try:
             return known(**props)
-        except Exception:  # noqa: BLE001 — fall back to a dynamic model
-            pass
+        except Exception:  # — fall back to a dynamic model
+            logger.debug("Ignoring exception in rehydrate_node", exc_info=True)
 
     # Carry the record's properties and embeddable fields onto the dynamic
     # CLASS so they survive downstream field iteration and copy_model
@@ -139,8 +143,8 @@ def rehydrate_node(
     try:
         # Created lazily: only when the registered class is absent or fails.
         return _dynamic_model(type_name, props, index_fields)(**props)
-    except Exception:  # noqa: BLE001 — final fallback below
-        pass
+    except Exception:  # — final fallback below
+        logger.debug("Ignoring exception in rehydrate_node", exc_info=True)
 
     base_safe = {key: value for key, value in props.items() if key in _BASE_FIELDS}
     return _dynamic_model(type_name, base_safe, index_fields)(**base_safe)

--- a/cognee/modules/migration/snapshot.py
+++ b/cognee/modules/migration/snapshot.py
@@ -25,7 +25,6 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny, create_model, field_validator
 
 from cognee.infrastructure.engine import DataPoint
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/modules/migrations/versions/_vector_rekey.py
+++ b/cognee/modules/migrations/versions/_vector_rekey.py
@@ -141,8 +141,8 @@ async def rekey_lancedb(vector_engine, collection: str, id_map: dict) -> None:
         optimize = getattr(fresh_table, "optimize", None)
         if optimize is not None:
             await optimize()
-    except Exception as exc:  # noqa: BLE001 - compaction is an optimization
-        logger.warning("Post-re-key compaction skipped for %s: %s", collection, exc)
+    except Exception as exc:  # compaction is an optimization
+        logger.warning("Post-re-key compaction skipped for %s: %s", collection, exc, exc_info=True)
 
 
 async def rekey_pgvector(vector_engine, collection: str, id_map: dict) -> None:

--- a/cognee/modules/migrations/versions/namespace_entity_type_node_ids.py
+++ b/cognee/modules/migrations/versions/namespace_entity_type_node_ids.py
@@ -794,6 +794,7 @@ async def _edges_needing_reassert(graph_engine, at_risk: list) -> list:
             "%d at-risk edge(s)",
             error,
             len(at_risk),
+            exc_info=True,
         )
         return at_risk
 

--- a/cognee/modules/migrations/versions/rekey_fork_document_ids.py
+++ b/cognee/modules/migrations/versions/rekey_fork_document_ids.py
@@ -190,6 +190,7 @@ async def _fast_move_provenance_ladybug(graph_engine, old_key: str, new_key: str
             "rekey_fork_document_ids: fast provenance move unavailable (%s), "
             "using the generic path",
             error,
+            exc_info=True,
         )
         return False
     return True

--- a/cognee/modules/observability/get_observe.py
+++ b/cognee/modules/observability/get_observe.py
@@ -66,7 +66,7 @@ def _generation_input_payload(func, args, kwargs):
         }
         return json.dumps(payload, default=str) if payload else None
     except Exception:
-        logger.debug("Ignoring exception in _generation_input_payload", exc_info=True)
+        logger.debug("Falling back to None after error in _generation_input_payload", exc_info=True)
         return None
 
 

--- a/cognee/modules/observability/get_observe.py
+++ b/cognee/modules/observability/get_observe.py
@@ -5,6 +5,10 @@ from cognee.base_config import get_base_config
 from .exceptions import UnsupportedObserverError
 from .observers import Observer
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 # Cap span input/output like the DB adapters cap query text (redact_secrets(query[:500])).
 _MAX_OBSERVED_CHARS = 8000
 
@@ -63,6 +67,7 @@ def _generation_input_payload(func, args, kwargs):
         }
         return json.dumps(payload, default=str) if payload else None
     except Exception:
+        logger.debug("Ignoring exception in _generation_input_payload", exc_info=True)
         return None
 
 
@@ -83,7 +88,7 @@ def _set_generation_output(span, result) -> None:
             LANGFUSE_OBSERVATION_OUTPUT, redact_secrets(output[:_MAX_OBSERVED_CHARS])
         )
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _set_generation_output", exc_info=True)
 
 
 def _wrap_with_otel(inner_decorator):

--- a/cognee/modules/observability/get_observe.py
+++ b/cognee/modules/observability/get_observe.py
@@ -1,11 +1,10 @@
 import functools
 
 from cognee.base_config import get_base_config
+from cognee.shared.logging_utils import get_logger
 
 from .exceptions import UnsupportedObserverError
 from .observers import Observer
-
-from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()
 

--- a/cognee/modules/observability/trace_context.py
+++ b/cognee/modules/observability/trace_context.py
@@ -10,6 +10,10 @@ from cognee.modules.observability.tracing import (
     shutdown_tracing,
 )
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 _tracing_enabled: bool = False
 
 
@@ -28,13 +32,13 @@ def enable_tracing(console_output: bool = False) -> None:
 
         setup_metrics(console_output=console_output)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in enable_tracing", exc_info=True)
     try:
         from cognee.modules.observability.logs import setup_log_bridge
 
         setup_log_bridge(console_output=console_output)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in enable_tracing", exc_info=True)
     _tracing_enabled = True
 
 
@@ -47,13 +51,13 @@ def disable_tracing() -> None:
 
         shutdown_metrics()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in disable_tracing", exc_info=True)
     try:
         from cognee.modules.observability.logs import shutdown_log_bridge
 
         shutdown_log_bridge()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in disable_tracing", exc_info=True)
     _tracing_enabled = False
 
 

--- a/cognee/modules/observability/trace_context.py
+++ b/cognee/modules/observability/trace_context.py
@@ -9,7 +9,6 @@ from cognee.modules.observability.tracing import (
     setup_tracing,
     shutdown_tracing,
 )
-
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()

--- a/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
+++ b/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
@@ -85,6 +85,7 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
                                 "Failed to parse ontology file object '%s': %s",
                                 self._get_file_object_name(file_obj),
                                 str(e),
+                                exc_info=True,
                             )
 
                     if not loaded_objects:
@@ -190,6 +191,9 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
             try:
                 parsed_graph.parse(data=content, format=rdf_format)
             except Exception as error:
+                logger.debug(
+                    "Ignoring exception in RDFLibOntologyResolver._parse_file_object", exc_info=True
+                )
                 parse_errors.append(f"{rdf_format}: {error}")
                 continue
 

--- a/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
+++ b/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
@@ -192,7 +192,8 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
                 parsed_graph.parse(data=content, format=rdf_format)
             except Exception as error:
                 logger.debug(
-                    "Ignoring exception in RDFLibOntologyResolver._parse_file_object", exc_info=True
+                    "Skipping item after error in RDFLibOntologyResolver._parse_file_object",
+                    exc_info=True,
                 )
                 parse_errors.append(f"{rdf_format}: {error}")
                 continue

--- a/cognee/modules/operations/record_operation.py
+++ b/cognee/modules/operations/record_operation.py
@@ -198,4 +198,5 @@ async def record_operation(
                     "record_operation: failed to persist %s record (%s)",
                     operation_name,
                     write_error,
+                    exc_info=True,
                 )

--- a/cognee/modules/provenance/edge_evidence/cleanup.py
+++ b/cognee/modules/provenance/edge_evidence/cleanup.py
@@ -50,5 +50,6 @@ async def delete_edge_evidence(dataset_id: UUID, data_id: UUID | None = None) ->
             dataset_id,
             data_id,
             error,
+            exc_info=True,
         )
         return 0

--- a/cognee/modules/provenance/edge_evidence/lookup.py
+++ b/cognee/modules/provenance/edge_evidence/lookup.py
@@ -108,7 +108,7 @@ async def get_edge_evidence_records(
     except Exception as error:
         # References are optional and existing databases may briefly serve
         # traffic before their migration completes. Never fail the answer.
-        logger.debug("Unable to resolve graph edge evidence: %s", error)
+        logger.debug("Unable to resolve graph edge evidence: %s", error, exc_info=True)
         return []
 
     counts: dict[UUID, int] = {}

--- a/cognee/modules/recall/methods/graph_warmup.py
+++ b/cognee/modules/recall/methods/graph_warmup.py
@@ -219,7 +219,9 @@ async def assess_memory_readiness(user, dataset_ids: list[UUID] | None) -> Warmu
             _warmup_cache[key] = (probe, time.monotonic() + config.recall_warmup_cache_ttl)
         return probe
     except Exception as error:
-        logger.warning("Graph warm-up probe failed; treating memory as warm: %s", error)
+        logger.warning(
+            "Graph warm-up probe failed; treating memory as warm: %s", error, exc_info=True
+        )
         return WarmupProbe(STATE_WARM, _WARM_COUNT)
 
 

--- a/cognee/modules/retrieval/agentic_retriever.py
+++ b/cognee/modules/retrieval/agentic_retriever.py
@@ -148,7 +148,9 @@ class AgenticRetriever(GraphCompletionRetriever):
             graph_engine = await get_graph_engine()
             _, edges = await graph_engine.get_graph_data()
         except Exception as exc:
-            logger.warning("Unable to inspect graph edges before agentic retrieval: %s", exc)
+            logger.warning(
+                "Unable to inspect graph edges before agentic retrieval: %s", exc, exc_info=True
+            )
             return True
         return bool(edges)
 
@@ -363,7 +365,9 @@ class AgenticRetriever(GraphCompletionRetriever):
         try:
             await add_data_points(runs, ctx=ctx)
         except Exception as exc:
-            logger.warning("Failed to record SkillRun(s) after agentic retrieval: %s", exc)
+            logger.warning(
+                "Failed to record SkillRun(s) after agentic retrieval: %s", exc, exc_info=True
+            )
 
     async def _get_session_history(self) -> str:
         """Return formatted session history for the active user, if caching is available."""
@@ -389,7 +393,7 @@ class AgenticRetriever(GraphCompletionRetriever):
             )
             return history if isinstance(history, str) else ""
         except Exception as exc:
-            logger.warning("Failed to load agentic session history: %s", exc)
+            logger.warning("Failed to load agentic session history: %s", exc, exc_info=True)
             return ""
 
     async def _maybe_active_context_block(self, query: str | None) -> tuple[str, list]:
@@ -427,7 +431,7 @@ class AgenticRetriever(GraphCompletionRetriever):
                 query=query or "",
             )
         except Exception as exc:
-            logger.warning("Agentic active session-context block failed: %s", exc)
+            logger.warning("Agentic active session-context block failed: %s", exc, exc_info=True)
             return "", []
 
     async def _store_session_qa(
@@ -464,7 +468,7 @@ class AgenticRetriever(GraphCompletionRetriever):
                 used_session_context_ids=served_ids,
             )
         except Exception as exc:
-            logger.warning("Failed to store agentic session QA: %s", exc)
+            logger.warning("Failed to store agentic session QA: %s", exc, exc_info=True)
 
     async def _run_tool_loop(
         self,

--- a/cognee/modules/retrieval/base_retriever.py
+++ b/cognee/modules/retrieval/base_retriever.py
@@ -1,6 +1,10 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 if TYPE_CHECKING:
     from cognee.modules.search.models.EvidenceReference import EvidenceReference
 
@@ -134,6 +138,10 @@ class BaseRetriever(ABC):
                 query=query,
             )
         except Exception:
+            logger.debug(
+                "Ignoring exception in BaseRetriever.prepare_session_turn_for_retrieval",
+                exc_info=True,
+            )
             from cognee.infrastructure.session.session_manager import SessionTurnPreparation
 
             return SessionTurnPreparation(should_answer=True, effective_query=query or "")

--- a/cognee/modules/retrieval/base_retriever.py
+++ b/cognee/modules/retrieval/base_retriever.py
@@ -139,7 +139,7 @@ class BaseRetriever(ABC):
             )
         except Exception:
             logger.debug(
-                "Ignoring exception in BaseRetriever.prepare_session_turn_for_retrieval",
+                "Falling back after error in BaseRetriever.prepare_session_turn_for_retrieval",
                 exc_info=True,
             )
             from cognee.infrastructure.session.session_manager import SessionTurnPreparation

--- a/cognee/modules/retrieval/completion_retriever.py
+++ b/cognee/modules/retrieval/completion_retriever.py
@@ -67,7 +67,7 @@ async def _weights_matching_collection(
     try:
         rows = await vector_engine.retrieve(collection_name, list(weights))
     except Exception as error:
-        logger.debug("Preference weight collection check failed open: %s", error)
+        logger.debug("Preference weight collection check failed open: %s", error, exc_info=True)
         return weights
 
     present = set()

--- a/cognee/modules/retrieval/context_preview.py
+++ b/cognee/modules/retrieval/context_preview.py
@@ -152,7 +152,7 @@ async def load_read_only_session_prompt(
         )
         return prompt
     except Exception as error:
-        logger.warning("Only-context session prompt failed open: %s", error)
+        logger.warning("Only-context session prompt failed open: %s", error, exc_info=True)
         return ""
 
 

--- a/cognee/modules/retrieval/graph_completion_cot_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_cot_retriever.py
@@ -173,7 +173,7 @@ class GraphCompletionCotRetriever(GraphCompletionRetriever):
             )
             return block or ""
         except Exception as exc:
-            logger.warning("CoT active session-context block failed: %s", exc)
+            logger.warning("CoT active session-context block failed: %s", exc, exc_info=True)
             return ""
 
     # -- CoT orchestrator --

--- a/cognee/modules/retrieval/graph_completion_decomposition_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_decomposition_retriever.py
@@ -103,7 +103,7 @@ class GraphCompletionDecompositionRetriever(GraphCompletionRetriever):
             logger.warning(
                 "Query decomposition failed, falling back to original query: %s",
                 error,
-                exc_info=False,
+                exc_info=True,
             )
             return [query]
 

--- a/cognee/modules/retrieval/graph_report_retriever.py
+++ b/cognee/modules/retrieval/graph_report_retriever.py
@@ -54,7 +54,7 @@ def _pagerank(graph: nx.DiGraph) -> dict[str, float]:
     try:
         return nx.pagerank(graph)
     except Exception as exc:  # scipy missing or numerical issue
-        logger.warning("PageRank unavailable, ranking hubs by degree only: %s", exc)
+        logger.warning("PageRank unavailable, ranking hubs by degree only: %s", exc, exc_info=True)
         return {}
 
 
@@ -213,7 +213,9 @@ class GraphReportRetriever(BaseRetriever):
             )
             questions = resp.questions
         except Exception as exc:
-            logger.warning("GraphReportRetriever: suggested-questions call failed: %s", exc)
+            logger.warning(
+                "GraphReportRetriever: suggested-questions call failed: %s", exc, exc_info=True
+            )
             questions = ["What are the main topics in this knowledge graph?"]
 
         lines = [

--- a/cognee/modules/retrieval/hybrid/entities.py
+++ b/cognee/modules/retrieval/hybrid/entities.py
@@ -34,7 +34,9 @@ async def search_entities(
             query_vector=query_vector,
         )
     except Exception as error:
-        logger.warning("Entity_name search failed; continuing without entities: %s", error)
+        logger.warning(
+            "Entity_name search failed; continuing without entities: %s", error, exc_info=True
+        )
         return []
 
 
@@ -58,7 +60,9 @@ async def build_entities(
         nodes, edges = await graph_engine.get_neighborhood(entity_ids, depth=1)
     except Exception as error:
         logger.warning(
-            "Graph neighborhood retrieval failed; returning entities without edges: %s", error
+            "Graph neighborhood retrieval failed; returning entities without edges: %s",
+            error,
+            exc_info=True,
         )
         return entities, set()
 

--- a/cognee/modules/retrieval/hybrid/truth.py
+++ b/cognee/modules/retrieval/hybrid/truth.py
@@ -60,7 +60,9 @@ async def build_truth_context(
         truth_state_by_id = await unified_engine.graph.get_node_truth_state(candidate_chunk_ids)
         return TruthContext(q_coords, truth_state_by_id, current_truth_epoch)
     except Exception as error:
-        logger.debug("Truth-subspace lookup failed; using baseline ranking: %s", error)
+        logger.debug(
+            "Truth-subspace lookup failed; using baseline ranking: %s", error, exc_info=True
+        )
         return TruthContext()
 
 

--- a/cognee/modules/retrieval/lexical_retriever.py
+++ b/cognee/modules/retrieval/lexical_retriever.py
@@ -63,7 +63,7 @@ class LexicalRetriever(BaseRetriever):
                 try:
                     chunk_id, document = node
                 except Exception:
-                    logger.warning("Skipping node with unexpected shape: %r", node)
+                    logger.warning("Skipping node with unexpected shape: %r", node, exc_info=True)
                     continue
 
                 if document.get("type") == "DocumentChunk" and document.get("text"):
@@ -78,8 +78,8 @@ class LexicalRetriever(BaseRetriever):
                         self.chunks[document_id] = tokens
                         self.payloads[document_id] = document
                         chunk_count += 1
-                    except Exception as e:
-                        logger.error("Tokenizer failed for chunk %s: %s", chunk_id, str(e))
+                    except Exception:
+                        logger.exception("Tokenizer failed for chunk %s", chunk_id)
 
             if chunk_count == 0:
                 logger.error("Initialization completed but no valid chunks were loaded.")
@@ -99,8 +99,8 @@ class LexicalRetriever(BaseRetriever):
 
         try:
             query_tokens = self.tokenizer(query)
-        except Exception as e:
-            logger.error("Failed to tokenize query: %s", str(e))
+        except Exception:
+            logger.exception("Failed to tokenize query")
             return []
 
         if not query_tokens:
@@ -114,8 +114,8 @@ class LexicalRetriever(BaseRetriever):
                 if not isinstance(score, (int, float)):
                     logger.warning("Non-numeric score for chunk %s → treated as 0.0", chunk_id)
                     score = 0.0
-            except Exception as e:
-                logger.error("Scorer failed for chunk %s: %s", chunk_id, str(e))
+            except Exception:
+                logger.exception("Scorer failed for chunk %s", chunk_id)
                 score = 0.0
             results.append((chunk_id, score))
 

--- a/cognee/modules/retrieval/natural_language_retriever.py
+++ b/cognee/modules/retrieval/natural_language_retriever.py
@@ -154,7 +154,7 @@ class NaturalLanguageRetriever(BaseRetriever):
 
             except Exception as e:
                 previous_attempts += f"Query: {cypher_query if 'cypher_query' in locals() else 'Not generated'} -> Executed with error: {e}\n"
-                logger.error(f"Error executing query: {e!s}")
+                logger.exception("Error executing query")
 
         logger.warning(
             f"Failed to get results after {self.max_attempts} attempts for query: '{query[:50]}...'"

--- a/cognee/modules/retrieval/utils/brute_force_triplet_search.py
+++ b/cognee/modules/retrieval/utils/brute_force_triplet_search.py
@@ -110,8 +110,8 @@ async def get_memory_fragment(
             )
     except EntityNotFoundError:
         pass
-    except Exception as e:
-        logger.error(f"Error during memory fragment creation: {e!s}")
+    except Exception:
+        logger.exception("Error during memory fragment creation")
 
     return memory_fragment
 

--- a/cognee/modules/retrieval/utils/references.py
+++ b/cognee/modules/retrieval/utils/references.py
@@ -419,7 +419,7 @@ async def build_answer_grounded_chunk_references(
             include_payload=True,
         )
     except Exception as error:
-        logger.debug(f"Answer-grounded chunk search failed: {error}")
+        logger.debug(f"Answer-grounded chunk search failed: {error}", exc_info=True)
         return ""
 
     return format_chunk_references(found_chunks, answer=cleaned_answer, limit=limit)
@@ -463,7 +463,7 @@ async def append_answer_grounded_evidence(completions: list[Any], enabled: bool)
 
         vector_engine = await get_vector_engine_async()
     except Exception as error:
-        logger.debug(f"Unable to obtain vector engine for references: {error}")
+        logger.debug(f"Unable to obtain vector engine for references: {error}", exc_info=True)
         return completions
 
     appended: list[Any] = []

--- a/cognee/modules/search/methods/get_retriever_output.py
+++ b/cognee/modules/search/methods/get_retriever_output.py
@@ -62,7 +62,7 @@ def _context_evidence(retriever_instance, retrieved_objects, kwargs: dict) -> li
     try:
         return evidence_method(retrieved_objects, dataset_id=getattr(dataset, "id", None))
     except Exception as error:
-        logger.warning("Unable to build structured context evidence: %s", error)
+        logger.warning("Unable to build structured context evidence: %s", error, exc_info=True)
         return []
 
 
@@ -120,7 +120,7 @@ async def get_retriever_output(
                 evidence.extend(await graph_source_evidence(evidence, getattr(dataset, "id", None)))
                 completion = append_source_evidence_text(completion, evidence)
             except Exception as error:
-                logger.warning("Unable to resolve graph source evidence: %s", error)
+                logger.warning("Unable to resolve graph source evidence: %s", error, exc_info=True)
 
     return SearchResultPayload(
         result_object=retrieved_objects,

--- a/cognee/modules/search/methods/hybrid_deferral.py
+++ b/cognee/modules/search/methods/hybrid_deferral.py
@@ -71,6 +71,6 @@ async def hybrid_deferral_reason(kwargs: dict, *, graph_is_empty: bool) -> str |
         if not await vector_engine.has_collection(_DOCUMENT_CHUNK_COLLECTION):
             return f"{_DOCUMENT_CHUNK_COLLECTION} collection missing"
     except Exception as error:
-        logger.debug("Hybrid collection check failed; running hybrid: %s", error)
+        logger.debug("Hybrid collection check failed; running hybrid: %s", error, exc_info=True)
 
     return None

--- a/cognee/modules/search/operations/select_search_type.py
+++ b/cognee/modules/search/operations/select_search_type.py
@@ -48,6 +48,6 @@ async def select_search_type(
         # If the response is not a valid search type, return the default search type
         logger.info(f"LLM gives an invalid search type: {response.upper()}")
         return default_search_type
-    except Exception as e:
-        logger.error(f"Failed to select search type intelligently from LLM: {e!s}")
+    except Exception:
+        logger.exception("Failed to select search type intelligently from LLM")
         return default_search_type

--- a/cognee/modules/session_distillation/distill.py
+++ b/cognee/modules/session_distillation/distill.py
@@ -189,7 +189,7 @@ async def curate_batch(batch_text: str) -> list[ProposedLesson]:
         )
         return list(result.lessons)
     except Exception as error:
-        logger.warning("Distillation curator batch failed open: %s", error)
+        logger.warning("Distillation curator batch failed open: %s", error, exc_info=True)
         return []
 
 
@@ -229,7 +229,7 @@ async def search_payload_texts(
             node_name=node_name,
         )
     except Exception as error:
-        logger.debug("Distillation search on %s failed open: %s", collection, error)
+        logger.debug("Distillation search on %s failed open: %s", collection, error, exc_info=True)
         return []
 
     texts: list[str] = []
@@ -289,7 +289,7 @@ async def write_or_reject(
             response_model=WrittenLesson,
         )
     except Exception as error:
-        logger.warning("Distillation writer call failed open: %s", error)
+        logger.warning("Distillation writer call failed open: %s", error, exc_info=True)
         return None
 
 

--- a/cognee/modules/session_lifecycle/invalidate_sessions.py
+++ b/cognee/modules/session_lifecycle/invalidate_sessions.py
@@ -62,6 +62,7 @@ async def invalidate_sessions_for_dataset(dataset_id: UUID) -> dict:
                 session_id,
                 user_id,
                 error,
+                exc_info=True,
             )
 
     if sessions:
@@ -128,6 +129,7 @@ async def invalidate_sessions_for_deleted_data(
                 session_id,
                 user_id,
                 error,
+                exc_info=True,
             )
 
     if totals["qa_entries_deleted"] or totals["context_entries_deleted"]:

--- a/cognee/modules/session_lifecycle/metrics.py
+++ b/cognee/modules/session_lifecycle/metrics.py
@@ -57,7 +57,7 @@ def _dialect_name(bind) -> str:
     try:
         return bind.dialect.name
     except Exception:
-        logger.debug("Ignoring exception in _dialect_name", exc_info=True)
+        logger.debug("Falling back to  after error in _dialect_name", exc_info=True)
         return ""
 
 

--- a/cognee/modules/session_lifecycle/metrics.py
+++ b/cognee/modules/session_lifecycle/metrics.py
@@ -57,6 +57,7 @@ def _dialect_name(bind) -> str:
     try:
         return bind.dialect.name
     except Exception:
+        logger.debug("Ignoring exception in _dialect_name", exc_info=True)
         return ""
 
 
@@ -584,4 +585,4 @@ async def record_session_activity(
                 exc,
             )
         else:
-            logger.debug("session_records write failed (%s)", exc)
+            logger.debug("session_records write failed (%s)", exc, exc_info=True)

--- a/cognee/modules/session_lifecycle/usage_tracking.py
+++ b/cognee/modules/session_lifecycle/usage_tracking.py
@@ -182,4 +182,4 @@ async def record_llm_call(
             model=model,
         )
     except Exception as exc:
-        logger.debug("record_llm_call: accumulate failed (%s)", exc)
+        logger.debug("record_llm_call: accumulate failed (%s)", exc, exc_info=True)

--- a/cognee/modules/tools/registry.py
+++ b/cognee/modules/tools/registry.py
@@ -158,5 +158,5 @@ def _coerce_tool(raw) -> Tool | None:
     try:
         return Tool.model_validate(data)
     except Exception:
-        logger.debug("Ignoring exception in _coerce_tool", exc_info=True)
+        logger.debug("Falling back to None after error in _coerce_tool", exc_info=True)
         return None

--- a/cognee/modules/tools/registry.py
+++ b/cognee/modules/tools/registry.py
@@ -97,13 +97,17 @@ async def _query_tool_nodes(dataset_id: UUID | None) -> list[Tool]:
     try:
         from cognee.infrastructure.databases.graph import get_graph_engine
     except Exception as exc:
-        logger.warning("Unable to import graph engine while resolving tools: %s", exc)
+        logger.warning(
+            "Unable to import graph engine while resolving tools: %s", exc, exc_info=True
+        )
         return []
 
     try:
         graph_engine = await get_graph_engine()
     except Exception as exc:
-        logger.warning("Unable to initialize graph engine while resolving tools: %s", exc)
+        logger.warning(
+            "Unable to initialize graph engine while resolving tools: %s", exc, exc_info=True
+        )
         return []
 
     get_by_type = getattr(graph_engine, "get_nodes_by_type", None)
@@ -118,7 +122,7 @@ async def _query_tool_nodes(dataset_id: UUID | None) -> list[Tool]:
         else:
             raw_nodes, _ = await get_graph_data()
     except Exception as exc:
-        logger.warning("Graph-backed Tool lookup failed: %s", exc)
+        logger.warning("Graph-backed Tool lookup failed: %s", exc, exc_info=True)
         return []
     if isinstance(raw_nodes, tuple) and len(raw_nodes) == 2:
         raw_nodes = raw_nodes[0]
@@ -154,4 +158,5 @@ def _coerce_tool(raw) -> Tool | None:
     try:
         return Tool.model_validate(data)
     except Exception:
+        logger.debug("Ignoring exception in _coerce_tool", exc_info=True)
         return None

--- a/cognee/modules/tools/resolve_skills.py
+++ b/cognee/modules/tools/resolve_skills.py
@@ -77,11 +77,13 @@ async def _load_skill_nodes(name: str | None = None):
     try:
         from cognee.infrastructure.databases.graph import get_graph_engine
     except Exception:
+        logger.debug("Optional import unavailable, continuing without it", exc_info=True)
         return []
 
     try:
         graph_engine = await get_graph_engine()
     except Exception:
+        logger.debug("Ignoring exception in _load_skill_nodes", exc_info=True)
         return []
 
     get_by_type = getattr(graph_engine, "get_nodes_by_type", None)
@@ -89,7 +91,7 @@ async def _load_skill_nodes(name: str | None = None):
         try:
             return await get_by_type(node_type=Skill)
         except Exception as exc:
-            logger.warning("Skill lookup by type failed: %s", exc)
+            logger.warning("Skill lookup by type failed: %s", exc, exc_info=True)
             return []
 
     get_nodeset = getattr(graph_engine, "get_nodeset_subgraph", None)
@@ -99,7 +101,7 @@ async def _load_skill_nodes(name: str | None = None):
             if nodes:
                 return nodes
         except Exception as exc:
-            logger.warning("Skill lookup by nodeset failed: %s", exc)
+            logger.warning("Skill lookup by nodeset failed: %s", exc, exc_info=True)
 
     get_graph_data = getattr(graph_engine, "get_graph_data", None)
     if get_graph_data is None:
@@ -108,7 +110,7 @@ async def _load_skill_nodes(name: str | None = None):
         nodes, _ = await get_graph_data()
         return nodes
     except Exception as exc:
-        logger.warning("Skill lookup by full graph scan failed: %s", exc)
+        logger.warning("Skill lookup by full graph scan failed: %s", exc, exc_info=True)
         return []
 
 
@@ -128,4 +130,5 @@ def _coerce_skill(raw) -> Skill | None:
     try:
         return Skill.model_validate(data)
     except Exception:
+        logger.debug("Ignoring exception in _coerce_skill", exc_info=True)
         return None

--- a/cognee/modules/tools/resolve_skills.py
+++ b/cognee/modules/tools/resolve_skills.py
@@ -83,7 +83,7 @@ async def _load_skill_nodes(name: str | None = None):
     try:
         graph_engine = await get_graph_engine()
     except Exception:
-        logger.debug("Ignoring exception in _load_skill_nodes", exc_info=True)
+        logger.debug("Falling back to [] after error in _load_skill_nodes", exc_info=True)
         return []
 
     get_by_type = getattr(graph_engine, "get_nodes_by_type", None)
@@ -130,5 +130,5 @@ def _coerce_skill(raw) -> Skill | None:
     try:
         return Skill.model_validate(data)
     except Exception:
-        logger.debug("Ignoring exception in _coerce_skill", exc_info=True)
+        logger.debug("Falling back to None after error in _coerce_skill", exc_info=True)
         return None

--- a/cognee/modules/tools/text_to_sql/engine.py
+++ b/cognee/modules/tools/text_to_sql/engine.py
@@ -130,7 +130,7 @@ async def run_text_to_sql(
             max_tables=config.text_to_sql_max_schema_tables,
         )
     except Exception as error:
-        logger.error("Schema introspection failed for '%s': %s", connection_name, error)
+        logger.exception("Schema introspection failed for '%s'", connection_name)
         result.error = f"Could not read the database schema: {error}"
         return result
 
@@ -152,7 +152,7 @@ async def run_text_to_sql(
             continue
         except Exception as error:
             previous_attempts += f"Query: <not generated> -> Error: {error}\n"
-            logger.error("SQL generation failed on attempt %d: %s", attempt, error)
+            logger.exception("SQL generation failed on attempt %d", attempt)
             result.error = f"SQL generation failed: {error}"
             continue
 
@@ -161,7 +161,7 @@ async def run_text_to_sql(
             rows, truncated = await execute_readonly(engine, sql, max_rows)
         except Exception as error:
             previous_attempts += f"Query: {sql} -> Executed with error: {error}\n"
-            logger.warning("SQL execution failed on attempt %d: %s", attempt, error)
+            logger.warning("SQL execution failed on attempt %d: %s", attempt, error, exc_info=True)
             result.error = f"SQL execution failed: {error}"
             continue
 

--- a/cognee/modules/tools/text_to_sql/write_proposals.py
+++ b/cognee/modules/tools/text_to_sql/write_proposals.py
@@ -158,7 +158,7 @@ async def _draft_update(
             estimated_rows = await _dry_run_update(write_engine, sql)
         except Exception as error:
             previous_attempts += f"Query: {sql} -> Executed with error: {error}\n"
-            logger.warning("Write dry-run failed on attempt %d: %s", attempt, error)
+            logger.warning("Write dry-run failed on attempt %d: %s", attempt, error, exc_info=True)
             last_error = error
             continue
 
@@ -365,6 +365,7 @@ async def apply_write_proposal(user_id: UUID, proposal_id: UUID) -> dict[str, An
                 else:
                     await db_connection.commit()
         except Exception as error:
+            logger.debug("Ignoring exception in apply_write_proposal", exc_info=True)
             error_message = f"Rolled back: execution failed: {error}"
 
         row.applied_rows = affected if error_message is None else None

--- a/cognee/modules/truth_subspace/build.py
+++ b/cognee/modules/truth_subspace/build.py
@@ -67,7 +67,7 @@ async def _fetch_learning_statements(graph_engine, session_ids: list[str] | None
             node_name=_truth_node_sets(session_ids),
         )
     except Exception as error:
-        logger.warning("truth_subspace: learning lookup failed open: %s", error)
+        logger.warning("truth_subspace: learning lookup failed open: %s", error, exc_info=True)
         return []
 
     statements: list[str] = []
@@ -93,7 +93,9 @@ async def _embed_in_batches(embedding_engine, texts: list[str]) -> list[list[flo
         try:
             vectors.extend(await embedding_engine.embed_text(batch))
         except Exception as error:
-            logger.warning("truth_subspace: node embedding batch failed open: %s", error)
+            logger.warning(
+                "truth_subspace: node embedding batch failed open: %s", error, exc_info=True
+            )
             # Keep alignment: pad failed batch with empty vectors (NEUTRAL coords).
             vectors.extend([[] for _ in batch])
     return vectors
@@ -136,7 +138,7 @@ async def build_truth_subspace(
         try:
             existing_centroids = await load_centroids(vector_engine, str(dataset_obj.id), k)
         except Exception as error:
-            logger.debug("truth_subspace: centroid load failed open: %s", error)
+            logger.debug("truth_subspace: centroid load failed open: %s", error, exc_info=True)
             existing_centroids = []
 
         previous_epoch = max((centroid.truth_epoch for centroid in existing_centroids), default=0)
@@ -156,7 +158,9 @@ async def build_truth_subspace(
         try:
             learning_vecs = await embedding_engine.embed_text(learning_texts)
         except Exception as error:
-            logger.warning("truth_subspace: learning embedding failed open: %s", error)
+            logger.warning(
+                "truth_subspace: learning embedding failed open: %s", error, exc_info=True
+            )
             return {
                 "anchors": len(existing_centroids),
                 "nodes_scored": 0,
@@ -195,7 +199,9 @@ async def build_truth_subspace(
             try:
                 await upsert_centroids(vector_engine, centroids)
             except Exception as error:
-                logger.warning("truth_subspace: centroid upsert failed open: %s", error)
+                logger.warning(
+                    "truth_subspace: centroid upsert failed open: %s", error, exc_info=True
+                )
                 return {
                     "anchors": len(centroids),
                     "nodes_scored": 0,
@@ -219,7 +225,7 @@ async def build_truth_subspace(
         try:
             nodes, _edges = await graph_engine.get_graph_data()
         except Exception as error:
-            logger.warning("truth_subspace: node load failed open: %s", error)
+            logger.warning("truth_subspace: node load failed open: %s", error, exc_info=True)
             return {
                 "anchors": len(centroids),
                 "nodes_scored": 0,
@@ -260,7 +266,9 @@ async def build_truth_subspace(
                 }
             except Exception as error:
                 # Per-node fail-open: one bad node never sinks the batch.
-                logger.debug("truth_subspace: coords failed for node %s: %s", node_id, error)
+                logger.debug(
+                    "truth_subspace: coords failed for node %s: %s", node_id, error, exc_info=True
+                )
 
         if not scored:
             return {
@@ -274,7 +282,9 @@ async def build_truth_subspace(
         try:
             write_result = await graph_engine.set_node_truth_state(scored)
         except Exception as error:
-            logger.warning("truth_subspace: persisting alignments failed open: %s", error)
+            logger.warning(
+                "truth_subspace: persisting alignments failed open: %s", error, exc_info=True
+            )
             return {
                 "anchors": len(centroids),
                 "nodes_scored": 0,

--- a/cognee/modules/user_preferences/lookup.py
+++ b/cognee/modules/user_preferences/lookup.py
@@ -87,7 +87,7 @@ async def _load_raw_preferences() -> tuple[str, dict[str, float]]:
         _active_preferences_cache.set((cache_key, result))
         return result
     except Exception as error:
-        logger.debug("Preference lookup failed open: %s", error)
+        logger.debug("Preference lookup failed open: %s", error, exc_info=True)
         return "", {}
 
 

--- a/cognee/modules/user_preferences/update.py
+++ b/cognee/modules/user_preferences/update.py
@@ -350,7 +350,7 @@ async def _run_preference_update(
             await write_prefers_edges(scope.user_id, scope.dataset_id, pending_writes, turn_counter)
             edges_written = len(pending_writes)
         except Exception as error:
-            logger.warning("Preference update: prefers-edge write failed: %s", error)
+            logger.warning("Preference update: prefers-edge write failed: %s", error, exc_info=True)
             write_ok = False
 
     # Step 6: prune whenever the counter moved — the clock advances on unrated

--- a/cognee/modules/users/api_key/create_api_key.py
+++ b/cognee/modules/users/api_key/create_api_key.py
@@ -48,8 +48,8 @@ async def create_api_key(user: User, name: str | None = None):
             await session.commit()
             user_api_key.api_key = api_key  # return raw key so caller can show it once
             return user_api_key
-        except Exception as error:
-            logger.error(f"Failed to create API key for user {user.id}: {error!s}")
+        except Exception:
+            logger.exception(f"Failed to create API key for user {user.id}")
             await session.rollback()
             raise ApiKeyCreationError("Failed to create API key, please try again.")
 

--- a/cognee/modules/users/api_key/delete_api_key.py
+++ b/cognee/modules/users/api_key/delete_api_key.py
@@ -28,8 +28,8 @@ async def delete_api_key(user: User, api_key_id: UUID):
             await session.delete(user_api_key)
 
             await session.commit()
-        except Exception as error:
-            logger.error(f"Failed to delete API key for user {user.id}: {error!s}")
+        except Exception:
+            logger.exception(f"Failed to delete API key for user {user.id}")
             await session.rollback()
 
             raise ApiKeyDeletionError(f"Failed to delete API key for user {user.id}.")

--- a/cognee/modules/users/api_key/get_api_keys.py
+++ b/cognee/modules/users/api_key/get_api_keys.py
@@ -22,7 +22,7 @@ async def get_api_keys(user: User):
             )
 
             return user_api_keys
-        except Exception as error:
-            logger.error(f"Failed to get API keys for user {user.id}: {error!s}")
+        except Exception:
+            logger.exception(f"Failed to get API keys for user {user.id}")
 
             raise ApiKeyQueryError(f"Failed to get API keys for user {user.id}.")

--- a/cognee/modules/users/get_user_manager.py
+++ b/cognee/modules/users/get_user_manager.py
@@ -106,7 +106,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             try:
                 await self._touch_api_key_last_used(session, user_api_key)
             except Exception as error:
-                logger.warning("Failed to update API key last_used_at: %s", error)
+                logger.warning("Failed to update API key last_used_at: %s", error, exc_info=True)
 
             return user
 

--- a/cognee/modules/visualization/cognee_network_visualization.py
+++ b/cognee/modules/visualization/cognee_network_visualization.py
@@ -62,7 +62,11 @@ async def _semantic_payload(pre) -> tuple[dict | None, dict | None]:
         clusters = compute_clusters(nodes, embeddings)
         return positions, clusters
     except Exception as exc:
-        logger.warning("Semantic map: payload computation failed (%s); tab shows empty state.", exc)
+        logger.warning(
+            "Semantic map: payload computation failed (%s); tab shows empty state.",
+            exc,
+            exc_info=True,
+        )
         return None, None
 
 

--- a/cognee/modules/visualization/embedding_join.py
+++ b/cognee/modules/visualization/embedding_join.py
@@ -166,7 +166,9 @@ async def fetch_node_embeddings(
                 continue
             found = await _fetch_for_collection(vector_engine, collection, type_nodes, field)
         except Exception as exc:  # never let a vector-store failure break the render
-            logger.warning("fetch_node_embeddings: fetch failed for %s: %s", collection, exc)
+            logger.warning(
+                "fetch_node_embeddings: fetch failed for %s: %s", collection, exc, exc_info=True
+            )
             continue
         if found:
             hit_collections += 1

--- a/cognee/modules/visualization/session_events.py
+++ b/cognee/modules/visualization/session_events.py
@@ -176,8 +176,10 @@ async def collect_session_events(
                 session_ids = await _list_recent_session_ids(
                     user.id, max_sessions, dataset_id=dataset_id
                 )
-            except Exception as error:  # noqa: BLE001 — lifecycle table may not exist
-                logger.debug("Session listing unavailable (%s); no events collected.", error)
+            except Exception as error:  # — lifecycle table may not exist
+                logger.debug(
+                    "Session listing unavailable (%s); no events collected.", error, exc_info=True
+                )
                 return []
 
         events: list[dict[str, Any]] = []
@@ -190,6 +192,8 @@ async def collect_session_events(
         if events:
             logger.info("Collected %d session operation events for the Memory tab.", len(events))
         return events
-    except Exception as error:  # noqa: BLE001 — visualization must never fail on this
-        logger.warning("Session event collection failed; rendering without them: %s", error)
+    except Exception as error:  # — visualization must never fail on this
+        logger.warning(
+            "Session event collection failed; rendering without them: %s", error, exc_info=True
+        )
         return []

--- a/cognee/shared/cache.py
+++ b/cognee/shared/cache.py
@@ -95,7 +95,7 @@ class StorageAwareCache:
                 cached_version = (await asyncio.to_thread(f.read)).strip()
                 return cached_version == version_or_hash
         except Exception as e:
-            logger.debug(f"Error checking cache validity: {e}")
+            logger.debug(f"Error checking cache validity: {e}", exc_info=True)
             return False
 
     async def _clear_cache(self, cache_dir: str) -> None:
@@ -103,7 +103,7 @@ class StorageAwareCache:
         try:
             await self.storage_manager.remove_all(cache_dir)
         except Exception as e:
-            logger.debug(f"Error clearing cache directory {cache_dir}: {e}")
+            logger.debug(f"Error clearing cache directory {cache_dir}: {e}", exc_info=True)
 
     async def _check_remote_content_freshness(
         self, url: str, cache_dir: str
@@ -151,7 +151,7 @@ class StorageAwareCache:
                 return False, remote_identifier
 
         except Exception as e:
-            logger.debug(f"Could not check remote freshness: {e}")
+            logger.debug(f"Could not check remote freshness: {e}", exc_info=True)
             return True, None  # Assume fresh if we can't check
 
     async def download_and_extract_zip(
@@ -273,7 +273,7 @@ class StorageAwareCache:
                 return full_paths
 
         except Exception as e:
-            logger.debug(f"Error listing files in {directory_path}: {e}")
+            logger.debug(f"Error listing files in {directory_path}: {e}", exc_info=True)
             return []
 
 

--- a/cognee/shared/logging_utils.py
+++ b/cognee/shared/logging_utils.py
@@ -118,7 +118,7 @@ def resolve_logs_dir() -> Path | None:
         logs_root_directory.mkdir(parents=True, exist_ok=True)
         if os.access(logs_root_directory, os.W_OK):
             return logs_root_directory
-    except Exception:
+    except OSError:  # not writable here, try the next candidate
         pass
 
     try:
@@ -126,7 +126,7 @@ def resolve_logs_dir() -> Path | None:
         tmp_log_path.mkdir(parents=True, exist_ok=True)
         if os.access(tmp_log_path, os.W_OK):
             return tmp_log_path
-    except Exception:
+    except OSError:  # not writable here, fall through to the next candidate
         pass
 
     return None
@@ -299,7 +299,7 @@ def log_database_configuration(logger) -> None:
         logger.info(f"Database storage: {databases_path}")
 
     except Exception as e:
-        logger.debug(f"Could not retrieve database configuration: {e!s}")
+        logger.debug(f"Could not retrieve database configuration: {e!s}", exc_info=True)
 
 
 def cleanup_old_logs(logs_dir, max_files) -> bool:
@@ -328,17 +328,17 @@ def cleanup_old_logs(logs_dir, max_files) -> bool:
                     # Only log individual files in non-CLI mode
                     if os.getenv("COGNEE_CLI_MODE") != "true":
                         logger.info(f"Deleted old log file: {old_file}")
-                except Exception as e:
+                except Exception:
                     # Always log errors
-                    logger.error(f"Failed to delete old log file {old_file}: {e}")
+                    logger.exception(f"Failed to delete old log file {old_file}")
 
             # In CLI mode, show compact summary
             if os.getenv("COGNEE_CLI_MODE") == "true" and deleted_count > 0:
                 logger.info(f"Cleaned up {deleted_count} old log files")
 
         return True
-    except Exception as e:
-        logger.error(f"Error cleaning up log files: {e}")
+    except Exception:
+        logger.exception("Error cleaning up log files")
         return False
 
 
@@ -495,6 +495,9 @@ def setup_logging(log_level=None, name=None) -> bool:
                 exc_info=(exc_type, exc_value, tb),
             )
         except Exception:
+            logging.debug(
+                "Rich traceback rendering failed, printing the plain traceback", exc_info=True
+            )
             print("\n[Warning] Could not render rich traceback. Falling back to plain traceback.\n")
             traceback.print_exception(exc_type, exc_value, tb)
             sys.__excepthook__(exc_type, exc_value, tb)
@@ -592,7 +595,8 @@ def setup_logging(log_level=None, name=None) -> bool:
         except Exception as e:
             # Logging to file is not mandatory — warn on console and continue.
             root_logger.warning(
-                f"Warning: Could not create log file handler at {log_file_path}: {e}"
+                f"Warning: Could not create log file handler at {log_file_path}: {e}",
+                exc_info=True,
             )
 
     if log_level > logging.DEBUG:
@@ -645,6 +649,7 @@ def _log_deferred_info(logger) -> None:
         base_config = get_base_config()
         databases_path = os.path.join(base_config.system_root_directory, "databases")
     except Exception:
+        logger.debug("Could not resolve the databases path for the startup log", exc_info=True)
         databases_path = "unknown"
 
     logger.info(
@@ -679,7 +684,7 @@ def get_timestamp_format() -> str:
         datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f")
         return "%Y-%m-%dT%H:%M:%S.%f"
     except Exception as e:
-        logger.debug(f"Exception caught: {e}")
+        logger.debug(f"Exception caught: {e}", exc_info=True)
         logger.debug(
             "Could not use microseconds for the logging timestamp, defaulting to use hours minutes and seconds only"
         )

--- a/cognee/shared/usage_logger.py
+++ b/cognee/shared/usage_logger.py
@@ -25,7 +25,7 @@ def _sanitize_value(value: Any) -> Any:
             return f"<cannot be serialized: {type(value).__name__}>"
         return str_repr
     except Exception:
-        logger.debug("Ignoring exception in _sanitize_value", exc_info=True)
+        logger.debug("Falling back after error in _sanitize_value", exc_info=True)
         return f"<cannot be serialized: {type(value).__name__}>"
 
 
@@ -88,7 +88,7 @@ def _get_param_names(func: Callable) -> list[str]:
     try:
         return list(inspect.signature(func).parameters.keys())
     except Exception:
-        logger.debug("Ignoring exception in _get_param_names", exc_info=True)
+        logger.debug("Falling back to [] after error in _get_param_names", exc_info=True)
         return []
 
 
@@ -102,7 +102,7 @@ def _get_param_defaults(func: Callable) -> dict[str, Any]:
                 defaults[param_name] = param.default
         return defaults
     except Exception:
-        logger.debug("Ignoring exception in _get_param_defaults", exc_info=True)
+        logger.debug("Falling back to {} after error in _get_param_defaults", exc_info=True)
         return {}
 
 
@@ -129,7 +129,7 @@ def _extract_user_id(args: tuple, kwargs: dict, param_names: list[str]) -> str |
                     return str(user.id)
         return None
     except Exception:
-        logger.debug("Ignoring exception in _extract_user_id", exc_info=True)
+        logger.debug("Falling back to None after error in _extract_user_id", exc_info=True)
         return None
 
 

--- a/cognee/shared/usage_logger.py
+++ b/cognee/shared/usage_logger.py
@@ -25,6 +25,7 @@ def _sanitize_value(value: Any) -> Any:
             return f"<cannot be serialized: {type(value).__name__}>"
         return str_repr
     except Exception:
+        logger.debug("Ignoring exception in _sanitize_value", exc_info=True)
         return f"<cannot be serialized: {type(value).__name__}>"
 
 
@@ -87,6 +88,7 @@ def _get_param_names(func: Callable) -> list[str]:
     try:
         return list(inspect.signature(func).parameters.keys())
     except Exception:
+        logger.debug("Ignoring exception in _get_param_names", exc_info=True)
         return []
 
 
@@ -100,6 +102,7 @@ def _get_param_defaults(func: Callable) -> dict[str, Any]:
                 defaults[param_name] = param.default
         return defaults
     except Exception:
+        logger.debug("Ignoring exception in _get_param_defaults", exc_info=True)
         return {}
 
 
@@ -126,6 +129,7 @@ def _extract_user_id(args: tuple, kwargs: dict, param_names: list[str]) -> str |
                     return str(user.id)
         return None
     except Exception:
+        logger.debug("Ignoring exception in _extract_user_id", exc_info=True)
         return None
 
 
@@ -261,7 +265,7 @@ def _wrap_streaming_result(result: Any, emit, function_name: str):
         try:
             async for chunk in inner:
                 yield chunk
-        except BaseException as streaming_error:  # noqa: BLE001 - logged, then re-raised
+        except BaseException as streaming_error:  # logged, then re-raised
             success = False
             error = str(streaming_error) or type(streaming_error).__name__
             raise
@@ -274,7 +278,7 @@ def _wrap_streaming_result(result: Any, emit, function_name: str):
             if aclose is not None:
                 try:
                     await aclose()
-                except BaseException:  # noqa: BLE001 - cleanup must not mask the outcome
+                except BaseException:  # cleanup must not mask the outcome
                     logger.debug("Failed to close streaming body", exc_info=True)
             # Shielded because the common ending is a client disconnect, which
             # cancels this scope: an unshielded await would be cancelled at its
@@ -283,7 +287,7 @@ def _wrap_streaming_result(result: Any, emit, function_name: str):
             # for the same reason — CancelledError is not an Exception.
             try:
                 await asyncio.shield(asyncio.ensure_future(emit(None, success, error)))
-            except BaseException:  # noqa: BLE001
+            except BaseException:
                 logger.exception(
                     f"Failed to log usage for {function_name}",
                 )

--- a/cognee/shared/utils.py
+++ b/cognee/shared/utils.py
@@ -86,7 +86,7 @@ def get_anonymous_id() -> str:
         else:
             anonymous_id = _ANON_ID_FILE.read_text(encoding="utf-8").strip()
     except Exception as e:
-        logger.warning("Could not create or read anonymous id file: %s", e)
+        logger.warning("Could not create or read anonymous id file: %s", e, exc_info=True)
         return "unknown-anonymous-id"
     return anonymous_id
 
@@ -118,7 +118,7 @@ def get_persistent_id() -> str:
         _PERSISTENT_ID_FILE.write_text(persistent_id, encoding="utf-8")
         return persistent_id
     except Exception as e:
-        logger.warning("Could not create or read persistent id file: %s", e)
+        logger.warning("Could not create or read persistent id file: %s", e, exc_info=True)
         return get_anonymous_id()
 
 
@@ -186,7 +186,7 @@ async def _get_telemetry_session() -> aiohttp.ClientSession:
                 try:
                     await _telemetry_session.close()
                 except Exception:
-                    pass
+                    logger.debug("Ignoring exception in _get_telemetry_session", exc_info=True)
             timeout = aiohttp.ClientTimeout(total=TELEMETRY_REQUEST_TIMEOUT)
             _telemetry_session = aiohttp.ClientSession(timeout=timeout)
             _telemetry_session_loop = loop
@@ -208,7 +208,7 @@ async def close_telemetry_session() -> None:
         try:
             await asyncio.gather(*list(_TELEMETRY_TASKS), return_exceptions=True)
         except Exception:
-            pass
+            logger.debug("Ignoring exception in close_telemetry_session", exc_info=True)
     session = _telemetry_session
     _telemetry_session = None
     _telemetry_session_loop = None
@@ -216,7 +216,7 @@ async def close_telemetry_session() -> None:
         try:
             await session.close()
         except Exception:
-            pass
+            logger.debug("Ignoring exception in close_telemetry_session", exc_info=True)
 
 
 _telemetry_atexit_registered = False
@@ -239,7 +239,10 @@ def _register_telemetry_session_atexit() -> None:
         try:
             asyncio.run(close_telemetry_session())
         except Exception:
-            pass
+            logger.debug(
+                "Ignoring exception in _register_telemetry_session_atexit._close_at_exit",
+                exc_info=True,
+            )
 
     atexit.register(_close_at_exit)
 
@@ -314,11 +317,13 @@ def _resolve_identity(user) -> tuple[str, str | None]:
     try:
         resolved_id = str(getattr(user, "id", user))
     except Exception:
+        logger.debug("Ignoring exception in _resolve_identity", exc_info=True)
         resolved_id = "unknown-user"
     try:
         tenant_id = getattr(user, "tenant_id", None)
         resolved_tenant = str(tenant_id) if tenant_id else None
     except Exception:
+        logger.debug("Ignoring exception in _resolve_identity", exc_info=True)
         resolved_tenant = None
     return resolved_id, resolved_tenant
 

--- a/cognee/tasks/chunks/create_chunk_associations.py
+++ b/cognee/tasks/chunks/create_chunk_associations.py
@@ -66,7 +66,7 @@ async def _compare_chunks(
             response_model=ChunkSimilarity,
         )
     except Exception as e:
-        logger.warning(f"LLM comparison failed: {e}")
+        logger.warning(f"LLM comparison failed: {e}", exc_info=True)
         return ChunkSimilarity(
             are_similar=False, similarity_score=0.0, reasoning="LLM error", association_type=None
         )
@@ -165,7 +165,9 @@ async def create_chunk_associations(
                 chunk_id = str(results[0].id)
                 id_to_text[chunk_id] = chunk_text
         except Exception as e:
-            logger.warning(f"Failed to find chunk ID for text: {chunk_text[:50]}... Error: {e}")
+            logger.warning(
+                f"Failed to find chunk ID for text: {chunk_text[:50]}... Error: {e}", exc_info=True
+            )
 
     logger.info(f"Found {len(id_to_text)} chunk IDs from vector search")
 
@@ -180,7 +182,9 @@ async def create_chunk_associations(
                 "DocumentChunk_text", chunk_text, limit=search_limit
             )
         except Exception as e:
-            logger.warning(f"Vector search failed for chunk: {chunk_text[:50]}... Error: {e}")
+            logger.warning(
+                f"Vector search failed for chunk: {chunk_text[:50]}... Error: {e}", exc_info=True
+            )
             continue
 
         for candidate in candidates:

--- a/cognee/tasks/cleanup/cleanup_unused_data.py
+++ b/cognee/tasks/cleanup/cleanup_unused_data.py
@@ -159,8 +159,8 @@ async def _cleanup_via_sql(
             )
             deleted_count += 1
             logger.info(f"Deleted document {data.id} from dataset {data.dataset_id}")
-        except Exception as e:
-            logger.error(f"Failed to delete document {data.id}: {e}")
+        except Exception:
+            logger.exception(f"Failed to delete document {data.id}")
 
     logger.info("Cleanup completed", deleted_count=deleted_count)
 

--- a/cognee/tasks/code_graph/extract_code_graph.py
+++ b/cognee/tasks/code_graph/extract_code_graph.py
@@ -547,7 +547,9 @@ async def extract_code_graph(
             stored_id = await _stored_snapshot_identity(fallback_repo)
         except Exception as error:
             # The skip check is an optimization; never let it break ingestion.
-            logger.warning("Could not read the stored snapshot id (%s); loading fully.", error)
+            logger.warning(
+                "Could not read the stored snapshot id (%s); loading fully.", error, exc_info=True
+            )
             stored_id = None
         if stored_id == snapshot_id:
             logger.info(

--- a/cognee/tasks/codingagents/coding_rule_associations.py
+++ b/cognee/tasks/codingagents/coding_rule_associations.py
@@ -84,7 +84,7 @@ async def get_origin_edges(data: str, rules: list[Rule]) -> list[Any]:
                         )
                     )
             except Exception as e:
-                logger.info(f"Warning: Skipping invalid rule due to error: {e}")
+                logger.info(f"Warning: Skipping invalid rule due to error: {e}", exc_info=True)
     else:
         logger.info("No valid origin_id or rules provided.")
 

--- a/cognee/tasks/entity_completion/entity_extractors/llm_entity_extractor.py
+++ b/cognee/tasks/entity_completion/entity_extractors/llm_entity_extractor.py
@@ -67,6 +67,6 @@ class LLMEntityExtractor(BaseEntityExtractor):
             logger.info(f"Extracted {len(response.entities)} entities")
             return response.entities
 
-        except Exception as e:
-            logger.error(f"Entity extraction failed: {e!s}")
+        except Exception:
+            logger.exception("Entity extraction failed")
             return []

--- a/cognee/tasks/entity_completion/entity_extractors/regex_entity_extractor.py
+++ b/cognee/tasks/entity_completion/entity_extractors/regex_entity_extractor.py
@@ -67,6 +67,6 @@ class RegexEntityExtractor(BaseEntityExtractor):
         try:
             logger.info(f"Extracting entities from text: {text[:100]}...")
             return self._text_to_entities(text)
-        except Exception as e:
-            logger.error(f"Entity extraction failed: {e!s}")
+        except Exception:
+            logger.exception("Entity extraction failed")
             return []

--- a/cognee/tasks/graph/detect_contradictions.py
+++ b/cognee/tasks/graph/detect_contradictions.py
@@ -238,6 +238,6 @@ async def detect_contradictions(data_points: list[DataPoint], **kwargs) -> list[
             logger.info("Flagged %s contradiction(s) in the graph.", len(contradiction_edges))
     except Exception as error:
         # Contradiction detection is auxiliary and must never break ingestion.
-        logger.warning("Contradiction detection skipped due to an error: %s", error)
+        logger.warning("Contradiction detection skipped due to an error: %s", error, exc_info=True)
 
     return data_points

--- a/cognee/tasks/graph/resolve_temporal_contradictions.py
+++ b/cognee/tasks/graph/resolve_temporal_contradictions.py
@@ -109,6 +109,8 @@ async def resolve_temporal_contradictions(
     except Exception as error:
         # The graph is already persisted at this point; an advisory pass must
         # never fail the ingestion run.
-        logger.warning("Temporal contradiction resolution skipped due to an error: %s", error)
+        logger.warning(
+            "Temporal contradiction resolution skipped due to an error: %s", error, exc_info=True
+        )
 
     return data_points

--- a/cognee/tasks/ingestion/purge_stale_dlt_source_artifacts.py
+++ b/cognee/tasks/ingestion/purge_stale_dlt_source_artifacts.py
@@ -66,7 +66,9 @@ async def purge_stale_dlt_source_artifacts(
                 user_id=ctx.user.id,
             )
         except Exception as error:
-            logger.warning("Session invalidation after DLT purge failed (non-fatal): %s", error)
+            logger.warning(
+                "Session invalidation after DLT purge failed (non-fatal): %s", error, exc_info=True
+            )
         logger.info(
             "Purged prior derived artifacts of DLT source data item %s before re-emission.",
             doc.id,

--- a/cognee/tasks/ingestion/utils.py
+++ b/cognee/tasks/ingestion/utils.py
@@ -5,6 +5,10 @@ from typing import Any, Optional
 
 from cognee.tasks.ingestion.data_item import DataItem
 
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
 
 def _normalize_filename(filename: str | None, index: int) -> str:
     if not filename:
@@ -22,7 +26,7 @@ async def _read_stream_bytes(stream: Any) -> bytes:
         try:
             stream.seek(0)
         except Exception:
-            pass
+            logger.debug("Ignoring exception in _read_stream_bytes", exc_info=True)
 
     data = stream.read()
     if inspect.isawaitable(data):

--- a/cognee/tasks/ingestion/utils.py
+++ b/cognee/tasks/ingestion/utils.py
@@ -3,9 +3,8 @@ from tempfile import SpooledTemporaryFile
 from types import SimpleNamespace
 from typing import Any, Optional
 
-from cognee.tasks.ingestion.data_item import DataItem
-
 from cognee.shared.logging_utils import get_logger
+from cognee.tasks.ingestion.data_item import DataItem
 
 logger = get_logger()
 

--- a/cognee/tasks/memify/cognify_agent_trace_feedback.py
+++ b/cognee/tasks/memify/cognify_agent_trace_feedback.py
@@ -68,7 +68,7 @@ async def cognify_agent_trace_feedback(
     except CogneeValidationError:
         raise
     except Exception as error:
-        logger.error("Error cognifying agent trace content: %s", error)
+        logger.exception("Error cognifying agent trace content")
         raise CogneeSystemError(
             message=f"Failed to cognify agent trace content: {error}",
             log=False,

--- a/cognee/tasks/memify/cognify_session.py
+++ b/cognee/tasks/memify/cognify_session.py
@@ -98,5 +98,5 @@ async def cognify_session(
             )
 
     except Exception as e:
-        logger.error(f"Error cognifying session data: {e!s}")
+        logger.exception("Error cognifying session data")
         raise CogneeSystemError(message=f"Failed to cognify session data: {e!s}", log=False)

--- a/cognee/tasks/memify/consolidate_entities.py
+++ b/cognee/tasks/memify/consolidate_entities.py
@@ -423,12 +423,13 @@ def _build_canonical_entity(
 
     try:
         entity = Entity.from_dict(props)
-    except Exception as error:  # noqa: BLE001 - reconstruction is best-effort
+    except Exception as error:  # reconstruction is best-effort
         logger.warning(
             "consolidate_entities: could not rebuild canonical %s (%s); "
             "leaving its properties unchanged.",
             canonical.get("id"),
             error,
+            exc_info=True,
         )
         return None
 

--- a/cognee/tasks/memify/cross_connect_entities.py
+++ b/cognee/tasks/memify/cross_connect_entities.py
@@ -202,7 +202,7 @@ async def _infer_relation(
             response_model=InferredRelation,
         )
     except Exception as error:
-        logger.warning("Relation inference failed: %s", error)
+        logger.warning("Relation inference failed: %s", error, exc_info=True)
         return InferredRelation(related=False, relationship_name="", confidence=0.0)
 
 

--- a/cognee/tasks/memify/extract_agent_trace_feedbacks.py
+++ b/cognee/tasks/memify/extract_agent_trace_feedbacks.py
@@ -117,6 +117,7 @@ async def extract_agent_trace_feedbacks(
                         content_label,
                         session_id,
                         error,
+                        exc_info=True,
                     )
                     continue
         else:
@@ -127,7 +128,7 @@ async def extract_agent_trace_feedbacks(
     except CogneeSystemError:
         raise
     except Exception as error:
-        logger.error("Error extracting agent trace feedbacks: %s", error)
+        logger.exception("Error extracting agent trace feedbacks")
         raise CogneeSystemError(
             message=f"Failed to extract agent trace feedbacks: {error}",
             log=False,

--- a/cognee/tasks/memify/extract_user_sessions.py
+++ b/cognee/tasks/memify/extract_user_sessions.py
@@ -109,7 +109,7 @@ async def extract_user_sessions(
                         persisted_qa_count=len(qa_data),
                     )
                 except Exception as e:
-                    logger.warning(f"Failed to extract session {session_id}: {e!s}")
+                    logger.warning(f"Failed to extract session {session_id}: {e!s}", exc_info=True)
                     continue
         else:
             logger.info(
@@ -119,5 +119,5 @@ async def extract_user_sessions(
     except CogneeSystemError:
         raise
     except Exception as e:
-        logger.error(f"Error extracting user sessions: {e!s}")
+        logger.exception("Error extracting user sessions")
         raise CogneeSystemError(message=f"Failed to extract user sessions: {e!s}", log=False)

--- a/cognee/tasks/memify/get_triplet_datapoints.py
+++ b/cognee/tasks/memify/get_triplet_datapoints.py
@@ -251,7 +251,8 @@ async def get_triplet_datapoints(
                 except Exception as e:
                     logger.warning(
                         f"Error processing triplet at offset {offset + idx}: {e}. "
-                        f"Skipping this triplet and continuing."
+                        f"Skipping this triplet and continuing.",
+                        exc_info=True,
                     )
                     skipped_count += 1
                     continue

--- a/cognee/tasks/provenance/record_provenance.py
+++ b/cognee/tasks/provenance/record_provenance.py
@@ -275,6 +275,8 @@ async def record_provenance(
 
         await batch.commit()
     except Exception as error:
-        logger.warning("Provenance recording failed; ingestion unaffected: %s", error)
+        logger.warning(
+            "Provenance recording failed; ingestion unaffected: %s", error, exc_info=True
+        )
 
     return data_points

--- a/cognee/tasks/translation/detect_language.py
+++ b/cognee/tasks/translation/detect_language.py
@@ -160,7 +160,7 @@ def detect_language(
         logger.warning(f"Language detection failed: {e}")
         raise LanguageDetectionError(f"Language detection failed: {e}", original_error=e)
     except Exception as e:
-        logger.error(f"Unexpected error during language detection: {e}")
+        logger.exception("Unexpected error during language detection")
         raise LanguageDetectionError(
             f"Unexpected error during language detection: {e}", original_error=e
         )

--- a/cognee/tasks/translation/providers/azure_provider.py
+++ b/cognee/tasks/translation/providers/azure_provider.py
@@ -99,7 +99,7 @@ class AzureTranslationProvider(TranslationProvider):
             )
 
         except Exception as e:
-            logger.error(f"Azure translation failed: {e}")
+            logger.exception("Azure translation failed")
             raise TranslationProviderError(
                 provider=self.provider_name,
                 message=f"Translation failed: {e}",
@@ -184,7 +184,7 @@ class AzureTranslationProvider(TranslationProvider):
                         )
 
         except Exception as e:
-            logger.error(f"Azure batch translation failed: {e}")
+            logger.exception("Azure batch translation failed")
             raise TranslationProviderError(
                 provider=self.provider_name,
                 message=f"Batch translation failed: {e}",

--- a/cognee/tasks/translation/providers/google_provider.py
+++ b/cognee/tasks/translation/providers/google_provider.py
@@ -49,7 +49,7 @@ class GoogleTranslationProvider(TranslationProvider):
             self._get_client()
             return True
         except Exception as e:
-            logger.debug(f"Google Translate not available: {e}")
+            logger.debug(f"Google Translate not available: {e}", exc_info=True)
             return False
 
     async def translate(

--- a/cognee/tasks/translation/providers/llm_provider.py
+++ b/cognee/tasks/translation/providers/llm_provider.py
@@ -140,4 +140,5 @@ class LLMTranslationProvider(TranslationProvider):
             # Check if API key is configured (required for most providers)
             return bool(llm_config.llm_api_key)
         except Exception:
+            logger.debug("Ignoring exception in LLMTranslationProvider.is_available", exc_info=True)
             return False

--- a/cognee/tasks/translation/providers/llm_provider.py
+++ b/cognee/tasks/translation/providers/llm_provider.py
@@ -140,5 +140,8 @@ class LLMTranslationProvider(TranslationProvider):
             # Check if API key is configured (required for most providers)
             return bool(llm_config.llm_api_key)
         except Exception:
-            logger.debug("Ignoring exception in LLMTranslationProvider.is_available", exc_info=True)
+            logger.debug(
+                "Falling back to False after error in LLMTranslationProvider.is_available",
+                exc_info=True,
+            )
             return False

--- a/cognee/tasks/translation/translate_content.py
+++ b/cognee/tasks/translation/translate_content.py
@@ -171,8 +171,8 @@ async def translate_content(
         except TranslationError as e:
             logger.error(f"Translation failed for chunk {chunk.id}: {e}")
             processed_chunks.append(chunk)
-        except Exception as e:
-            logger.error(f"Unexpected error processing chunk {chunk.id}: {e}")
+        except Exception:
+            logger.exception(f"Unexpected error processing chunk {chunk.id}")
             processed_chunks.append(chunk)
 
     logger.info(f"Translation task completed for {len(processed_chunks)} chunks")

--- a/cognee/tasks/web_scraper/default_url_crawler.py
+++ b/cognee/tasks/web_scraper/default_url_crawler.py
@@ -124,6 +124,7 @@ class DefaultUrlCrawler:
         try:
             return urlparse(url).netloc
         except Exception:
+            logger.debug("Ignoring exception in DefaultUrlCrawler._domain_from_url", exc_info=True)
             return url
 
     @lru_cache(maxsize=1024)
@@ -205,7 +206,7 @@ class DefaultUrlCrawler:
                 resp = await self._client.get(robots_url, timeout=5.0)
                 content = resp.text if resp.status_code == 200 else ""
             except Exception as e:
-                logger.debug(f"Failed to fetch robots.txt from {domain_root}: {e}")
+                logger.debug(f"Failed to fetch robots.txt from {domain_root}: {e}", exc_info=True)
                 content = ""
 
             protego = Protego.parse(content) if content.strip() else None
@@ -253,7 +254,7 @@ class DefaultUrlCrawler:
             agent = next((v for k, v in self.headers.items() if k.lower() == "user-agent"), "*")
             return cache.protego.can_fetch(agent, url) or cache.protego.can_fetch("*", url)
         except Exception as e:
-            logger.debug(f"Error checking robots.txt for {url}: {e}")
+            logger.debug(f"Error checking robots.txt for {url}: {e}", exc_info=True)
             return True
 
     async def _get_crawl_delay(self, url: str) -> float:
@@ -275,6 +276,7 @@ class DefaultUrlCrawler:
                 cache = await self._fetch_and_cache_robots(domain_root)
             return cache.crawl_delay
         except Exception:
+            logger.debug("Ignoring exception in DefaultUrlCrawler._get_crawl_delay", exc_info=True)
             return self.crawl_delay
 
     async def _fetch_httpx(self, url: str) -> str:
@@ -442,8 +444,8 @@ class DefaultUrlCrawler:
 
                     return url, html
 
-                except Exception as e:
-                    logger.error(f"Error processing {url}: {e}")
+                except Exception:
+                    logger.exception(f"Error processing {url}")
                     return url, ""
 
         logger.info(f"Creating {len(urls)} async tasks for concurrent fetching")

--- a/cognee/tasks/web_scraper/default_url_crawler.py
+++ b/cognee/tasks/web_scraper/default_url_crawler.py
@@ -124,7 +124,9 @@ class DefaultUrlCrawler:
         try:
             return urlparse(url).netloc
         except Exception:
-            logger.debug("Ignoring exception in DefaultUrlCrawler._domain_from_url", exc_info=True)
+            logger.debug(
+                "Falling back after error in DefaultUrlCrawler._domain_from_url", exc_info=True
+            )
             return url
 
     @lru_cache(maxsize=1024)
@@ -276,7 +278,9 @@ class DefaultUrlCrawler:
                 cache = await self._fetch_and_cache_robots(domain_root)
             return cache.crawl_delay
         except Exception:
-            logger.debug("Ignoring exception in DefaultUrlCrawler._get_crawl_delay", exc_info=True)
+            logger.debug(
+                "Falling back after error in DefaultUrlCrawler._get_crawl_delay", exc_info=True
+            )
             return self.crawl_delay
 
     async def _fetch_httpx(self, url: str) -> str:

--- a/cognee/tests/api/test_conditional_authentication_endpoints.py
+++ b/cognee/tests/api/test_conditional_authentication_endpoints.py
@@ -6,6 +6,10 @@ from uuid import uuid4
 import pytest
 from fastapi.testclient import TestClient
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 with patch("dotenv.load_dotenv"):
     # This prevents the .env file from ever loading during tests
 
@@ -177,7 +181,10 @@ with patch("dotenv.load_dotenv"):
                     assert "authenticate" not in error_detail.lower()
                     assert "unauthorized" not in error_detail.lower()
                 except Exception:
-                    pass  # If response is not JSON, that's fine
+                    logger.debug(
+                        "Ignoring exception in TestConditionalAuthenticationBehavior.test_get_endpoints_work_without_auth",
+                        exc_info=True,
+                    )
 
         gsm_mod = importlib.import_module("cognee.modules.settings.get_settings")
 

--- a/cognee/tests/api/test_conditional_authentication_endpoints.py
+++ b/cognee/tests/api/test_conditional_authentication_endpoints.py
@@ -1,12 +1,11 @@
 import importlib
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/cli_tests/cli_unit_tests/test_push_command.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_push_command.py
@@ -244,7 +244,7 @@ class TestPushCommand:
 
         def fail(coro):
             coro.close()  # avoid "coroutine never awaited" warnings
-            raise Exception("Push error")
+            raise RuntimeError("Push error")
 
         mock_asyncio_run.side_effect = fail
 

--- a/cognee/tests/conftest.py
+++ b/cognee/tests/conftest.py
@@ -1,3 +1,6 @@
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
 """Top-level test config.
 
 ``test_subprocess_rss.py`` is a standalone benchmark script, not a pytest
@@ -25,4 +28,4 @@ def pytest_sessionfinish(session, exitstatus):
             child.terminate()
             child.join(timeout=5)
         except Exception:
-            pass
+            logger.debug("Ignoring exception in pytest_sessionfinish", exc_info=True)

--- a/cognee/tests/deployment/mcp_harness.py
+++ b/cognee/tests/deployment/mcp_harness.py
@@ -8,14 +8,13 @@ with guaranteed teardown, and an MCP streamable-HTTP client session.
 from __future__ import annotations
 
 import contextlib
+import logging
 import shutil
 import socket
 import subprocess
 import time
 from collections.abc import AsyncIterator, Iterator
 from typing import Optional
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/deployment/mcp_harness.py
+++ b/cognee/tests/deployment/mcp_harness.py
@@ -15,6 +15,10 @@ import time
 from collections.abc import AsyncIterator, Iterator
 from typing import Optional
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 # Port the MCP server listens on inside the container (entrypoint default).
 CONTAINER_HTTP_PORT = 8000
 
@@ -64,7 +68,8 @@ def wait_for_health(url: str, timeout: float = 120.0) -> None:
             response = httpx.get(url, timeout=5)
             if response.status_code == 200:
                 return
-        except Exception as exc:  # noqa: BLE001 - poller intentionally tolerant
+        except Exception as exc:  # poller intentionally tolerant
+            logger.debug("Ignoring exception in wait_for_health", exc_info=True)
             last_error = exc
         time.sleep(1.0)
     raise TimeoutError(

--- a/cognee/tests/e2e/postgres/test_postgres_hybrid_adapter.py
+++ b/cognee/tests/e2e/postgres/test_postgres_hybrid_adapter.py
@@ -15,6 +15,10 @@ from cognee.infrastructure.databases.hybrid.postgres.adapter import PostgresHybr
 from cognee.infrastructure.databases.vector.embeddings import get_embedding_engine
 from cognee.infrastructure.databases.vector.pgvector.PGVectorAdapter import PGVectorAdapter
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 # -- Session-scoped event loop so async engines stay on a single loop.
 
 
@@ -70,7 +74,7 @@ async def adapter():
     try:
         await a.delete_graph()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in adapter", exc_info=True)
 
     # Drop any vector collection tables created during the test
     try:
@@ -85,7 +89,7 @@ async def adapter():
                 await session.execute(sa_text(f'DROP TABLE IF EXISTS "{table_name}" CASCADE'))
             await session.commit()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in adapter", exc_info=True)
 
 
 # -- Helpers --

--- a/cognee/tests/e2e/postgres/test_postgres_hybrid_adapter.py
+++ b/cognee/tests/e2e/postgres/test_postgres_hybrid_adapter.py
@@ -5,6 +5,7 @@ Connection defaults: DB_HOST=localhost, DB_PORT=5432,
 DB_USERNAME=cognee, DB_PASSWORD=cognee, DB_NAME=cognee_db.
 """
 
+import logging
 import os
 
 import pytest
@@ -14,8 +15,6 @@ from cognee.infrastructure.databases.graph.postgres_demo.adapter import Postgres
 from cognee.infrastructure.databases.hybrid.postgres.adapter import PostgresHybridAdapter
 from cognee.infrastructure.databases.vector.embeddings import get_embedding_engine
 from cognee.infrastructure.databases.vector.pgvector.PGVectorAdapter import PGVectorAdapter
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/e2e/postgres/test_shared_schema_isolation.py
+++ b/cognee/tests/e2e/postgres/test_shared_schema_isolation.py
@@ -12,6 +12,7 @@ Postgres relational backend (DB_PROVIDER=postgres), since the shared handlers
 anchor to the relational configuration; it skips otherwise.
 """
 
+import logging
 import os
 import uuid
 
@@ -25,8 +26,6 @@ from cognee.infrastructure.databases.postgres import (
     dataset_schema_name,
     drop_pg_schema_if_exists,
 )
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/e2e/postgres/test_shared_schema_isolation.py
+++ b/cognee/tests/e2e/postgres/test_shared_schema_isolation.py
@@ -26,6 +26,10 @@ from cognee.infrastructure.databases.postgres import (
     drop_pg_schema_if_exists,
 )
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def _db() -> dict:
     return {
@@ -69,6 +73,7 @@ async def _postgres_reachable() -> bool:
             await conn.execute(text("SELECT 1"))
         return True
     except Exception:
+        logger.debug("Ignoring exception in _postgres_reachable", exc_info=True)
         return False
     finally:
         await engine.dispose()

--- a/cognee/tests/e2e/postgres/test_shared_schema_isolation.py
+++ b/cognee/tests/e2e/postgres/test_shared_schema_isolation.py
@@ -72,7 +72,7 @@ async def _postgres_reachable() -> bool:
             await conn.execute(text("SELECT 1"))
         return True
     except Exception:
-        logger.debug("Ignoring exception in _postgres_reachable", exc_info=True)
+        logger.debug("Falling back to False after error in _postgres_reachable", exc_info=True)
         return False
     finally:
         await engine.dispose()

--- a/cognee/tests/integration/infrastructure/graph/test_graph_provenance_adapter_contract.py
+++ b/cognee/tests/integration/infrastructure/graph/test_graph_provenance_adapter_contract.py
@@ -25,6 +25,10 @@ from cognee.infrastructure.databases.provenance import (
 )
 from cognee.infrastructure.engine import DataPoint
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 try:
     from cognee.infrastructure.databases.graph.ladybug.adapter import LadybugAdapter
 
@@ -67,6 +71,7 @@ async def _make_postgres_adapter():
             await conn.run_sync(_meta.drop_all)
         await adapter.initialize()
     except Exception as exc:  # pragma: no cover - environment dependent
+        logger.debug("Ignoring exception in _make_postgres_adapter", exc_info=True)
         await adapter.close()
         pytest.skip(f"postgres graph backend not reachable: {exc}")
     return adapter
@@ -100,6 +105,7 @@ async def _make_neo4j_adapter():
         await adapter.initialize()
         await adapter.query("MATCH (n) DETACH DELETE n")
     except Exception as exc:  # pragma: no cover - environment dependent
+        logger.debug("Ignoring exception in _make_neo4j_adapter", exc_info=True)
         await adapter.close()
         pytest.skip(f"neo4j graph backend not reachable: {exc}")
     return adapter

--- a/cognee/tests/integration/infrastructure/graph/test_graph_provenance_adapter_contract.py
+++ b/cognee/tests/integration/infrastructure/graph/test_graph_provenance_adapter_contract.py
@@ -9,6 +9,7 @@ specific tests.
 from __future__ import annotations
 
 import asyncio
+import logging
 from uuid import UUID, uuid4
 
 import pytest
@@ -24,8 +25,6 @@ from cognee.infrastructure.databases.provenance import (
     make_source_run_ref,
 )
 from cognee.infrastructure.engine import DataPoint
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
+++ b/cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
@@ -7,6 +7,7 @@ main process.
 """
 
 import json
+import logging
 import os
 from pathlib import Path
 
@@ -16,8 +17,6 @@ import pytest_asyncio
 from cognee.infrastructure.databases.graph.get_graph_engine import create_graph_engine
 from cognee.infrastructure.databases.graph.kuzu.adapter import KuzuAdapter
 from cognee.shared.data_models import KnowledgeGraph
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
+++ b/cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
@@ -17,6 +17,10 @@ from cognee.infrastructure.databases.graph.get_graph_engine import create_graph_
 from cognee.infrastructure.databases.graph.kuzu.adapter import KuzuAdapter
 from cognee.shared.data_models import KnowledgeGraph
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 DEMO_KG_PATH = os.path.join(os.path.dirname(__file__), "test_kg.json")
 
 
@@ -33,7 +37,7 @@ async def _close_adapter(a) -> None:
     try:
         await a.close()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _close_adapter", exc_info=True)
 
 
 @pytest_asyncio.fixture
@@ -849,6 +853,10 @@ async def test_query_racing_with_close_does_not_leak_executor_error(kuzu_adapter
         except RuntimeError as exc:
             errors_seen.append(exc)
         except Exception as exc:  # pragma: no cover - any other type is a regression
+            logger.debug(
+                "Ignoring exception in test_query_racing_with_close_does_not_leak_executor_error.fire_query",
+                exc_info=True,
+            )
             errors_seen.append(exc)
 
     async def fire_close():

--- a/cognee/tests/integration/infrastructure/session/test_session_persistence_memify_integration.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_persistence_memify_integration.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import pathlib
 import sys
@@ -21,8 +22,6 @@ from cognee.memify_pipelines.persist_sessions_in_knowledge_graph import (
 )
 from cognee.modules.engine.models import NodeSet
 from cognee.modules.users.methods import get_default_user
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/infrastructure/session/test_session_persistence_memify_integration.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_persistence_memify_integration.py
@@ -22,6 +22,10 @@ from cognee.memify_pipelines.persist_sessions_in_knowledge_graph import (
 from cognee.modules.engine.models import NodeSet
 from cognee.modules.users.methods import get_default_user
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def _reset_cache_backend_caches():
     from cognee.infrastructure.databases.cache.config import get_cache_config
@@ -39,7 +43,7 @@ async def _reset_engines_and_prune() -> None:
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _reset_engines_and_prune", exc_info=True)
 
     from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
     from cognee.infrastructure.databases.relational.create_relational_engine import (
@@ -166,7 +170,7 @@ async def session_persistence_env(event_loop):
         try:
             await _reset_engines_and_prune()
         except Exception:
-            pass
+            logger.debug("Ignoring exception in session_persistence_env", exc_info=True)
         finally:
             _reset_cache_backend_caches()
 

--- a/cognee/tests/integration/modules/agent_memory/test_agent_memory_integration.py
+++ b/cognee/tests/integration/modules/agent_memory/test_agent_memory_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for the public cognee.agent_memory decorator behavior."""
 
 import importlib
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -18,8 +19,6 @@ from cognee.modules.engine.models import NodeSet
 from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.users.methods import create_user, get_default_user
 from cognee.modules.users.permissions.methods import authorized_give_permission_on_datasets
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/modules/agent_memory/test_agent_memory_integration.py
+++ b/cognee/tests/integration/modules/agent_memory/test_agent_memory_integration.py
@@ -19,6 +19,10 @@ from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.users.methods import create_user, get_default_user
 from cognee.modules.users.permissions.methods import authorized_give_permission_on_datasets
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 async def _reset_engines_and_prune() -> None:
     """Reset database engine caches and clear persisted test state."""
@@ -29,7 +33,7 @@ async def _reset_engines_and_prune() -> None:
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _reset_engines_and_prune", exc_info=True)
 
     from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
     from cognee.infrastructure.databases.relational.create_relational_engine import (

--- a/cognee/tests/integration/modules/user_preferences/test_preference_full_loop_default_stack.py
+++ b/cognee/tests/integration/modules/user_preferences/test_preference_full_loop_default_stack.py
@@ -11,6 +11,7 @@ when ``LLM_API_KEY`` is not set.
 
 from __future__ import annotations
 
+import logging
 import os
 import pathlib
 from uuid import uuid4
@@ -29,8 +30,6 @@ from cognee.modules.search.types import SearchType
 from cognee.modules.user_preferences.constants import NEUTRAL_WEIGHT, PREFERS_RELATIONSHIP
 from cognee.modules.user_preferences.store import preference_node_id
 from cognee.modules.users.methods import get_default_user
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/modules/user_preferences/test_preference_full_loop_default_stack.py
+++ b/cognee/tests/integration/modules/user_preferences/test_preference_full_loop_default_stack.py
@@ -30,6 +30,10 @@ from cognee.modules.user_preferences.constants import NEUTRAL_WEIGHT, PREFERS_RE
 from cognee.modules.user_preferences.store import preference_node_id
 from cognee.modules.users.methods import get_default_user
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 try:
     import ladybug  # noqa: F401
 
@@ -112,7 +116,7 @@ async def default_stack_env(request, tmp_path, monkeypatch):
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in default_stack_env", exc_info=True)
     _clear_engine_caches()
     get_base_config.cache_clear()
 

--- a/cognee/tests/integration/retrieval/test_bm25_retriever.py
+++ b/cognee/tests/integration/retrieval/test_bm25_retriever.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import pytest
@@ -9,8 +10,6 @@ from cognee.modules.chunking.models import DocumentChunk
 from cognee.modules.data.processing.document_types import TextDocument
 from cognee.modules.retrieval.bm25_retriever import BM25ChunksRetriever
 from cognee.tasks.storage import add_data_points
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/retrieval/test_bm25_retriever.py
+++ b/cognee/tests/integration/retrieval/test_bm25_retriever.py
@@ -10,6 +10,10 @@ from cognee.modules.data.processing.document_types import TextDocument
 from cognee.modules.retrieval.bm25_retriever import BM25ChunksRetriever
 from cognee.tasks.storage import add_data_points
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 ALPHA_TEXT = "orion orion logistics common"
 BETA_TEXT = "orion logistics logistics logistics common"
 GAMMA_TEXT = "nebula archive common"
@@ -65,7 +69,7 @@ async def setup_bm25_corpus():
         await cognee.prune.prune_system(metadata=True)
         _clear_engine_caches()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_bm25_corpus", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/retrieval/test_brute_force_triplet_search_with_cognify.py
+++ b/cognee/tests/integration/retrieval/test_brute_force_triplet_search_with_cognify.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import pytest
@@ -9,8 +10,6 @@ from cognee.low_level import setup
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
 from cognee.modules.retrieval.utils.brute_force_triplet_search import brute_force_triplet_search
 from cognee.tasks.storage import add_data_points
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/retrieval/test_brute_force_triplet_search_with_cognify.py
+++ b/cognee/tests/integration/retrieval/test_brute_force_triplet_search_with_cognify.py
@@ -10,6 +10,10 @@ from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
 from cognee.modules.retrieval.utils.brute_force_triplet_search import brute_force_triplet_search
 from cognee.tasks.storage import add_data_points
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @pytest_asyncio.fixture
 async def clean_environment():
@@ -30,7 +34,7 @@ async def clean_environment():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in clean_environment", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/retrieval/test_chunks_retriever.py
+++ b/cognee/tests/integration/retrieval/test_chunks_retriever.py
@@ -15,6 +15,10 @@ from cognee.modules.engine.models import Entity
 from cognee.modules.retrieval.chunks_retriever import ChunksRetriever
 from cognee.tasks.storage import add_data_points
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class DocumentChunkWithEntities(DataPoint):
     text: str
@@ -105,7 +109,9 @@ async def setup_test_environment_with_chunks_simple():
         _create_vector_engine.cache_clear()
         create_relational_engine.cache_clear()
     except Exception:
-        pass
+        logger.debug(
+            "Ignoring exception in setup_test_environment_with_chunks_simple", exc_info=True
+        )
 
 
 @pytest_asyncio.fixture
@@ -218,7 +224,9 @@ async def setup_test_environment_with_chunks_complex():
         _create_vector_engine.cache_clear()
         create_relational_engine.cache_clear()
     except Exception:
-        pass
+        logger.debug(
+            "Ignoring exception in setup_test_environment_with_chunks_complex", exc_info=True
+        )
 
 
 @pytest_asyncio.fixture
@@ -262,7 +270,7 @@ async def setup_test_environment_empty():
         _create_vector_engine.cache_clear()
         create_relational_engine.cache_clear()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_empty", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/retrieval/test_chunks_retriever.py
+++ b/cognee/tests/integration/retrieval/test_chunks_retriever.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 from typing import List
@@ -14,8 +15,6 @@ from cognee.modules.data.processing.document_types import Document, TextDocument
 from cognee.modules.engine.models import Entity
 from cognee.modules.retrieval.chunks_retriever import ChunksRetriever
 from cognee.tasks.storage import add_data_points
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/retrieval/test_graph_completion_decomposition_retriever.py
+++ b/cognee/tests/integration/retrieval/test_graph_completion_decomposition_retriever.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,8 +15,6 @@ from cognee.modules.retrieval.graph_completion_decomposition_retriever import (
     QueryDecomposition,
 )
 from cognee.tasks.storage import add_data_points
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/retrieval/test_graph_completion_decomposition_retriever.py
+++ b/cognee/tests/integration/retrieval/test_graph_completion_decomposition_retriever.py
@@ -15,6 +15,10 @@ from cognee.modules.retrieval.graph_completion_decomposition_retriever import (
 )
 from cognee.tasks.storage import add_data_points
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 ORIGINAL_QUERY = "Who works at Figma and who works at Canva?"
 SUBQUERIES = ["Who works at Figma?", "Who works at Canva?"]
 
@@ -107,7 +111,7 @@ async def setup_test_environment_simple():
         await cognee.prune.prune_system(metadata=True)
         _clear_engine_caches()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_simple", exc_info=True)
 
 
 @pytest_asyncio.fixture
@@ -140,7 +144,7 @@ async def setup_test_environment_empty():
         await cognee.prune.prune_system(metadata=True)
         _clear_engine_caches()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_empty", exc_info=True)
 
 
 @pytest.fixture

--- a/cognee/tests/integration/retrieval/test_graph_completion_retriever.py
+++ b/cognee/tests/integration/retrieval/test_graph_completion_retriever.py
@@ -10,6 +10,10 @@ from cognee.low_level import DataPoint, setup
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.tasks.storage import add_data_points
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def _detailed_context_check(context: str):
     # Ensure the top-level sections are present
@@ -130,7 +134,7 @@ async def setup_test_environment_simple():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_simple", exc_info=True)
 
 
 @pytest_asyncio.fixture
@@ -200,7 +204,7 @@ async def setup_test_environment_complex():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_complex", exc_info=True)
 
 
 @pytest_asyncio.fixture
@@ -227,7 +231,7 @@ async def setup_test_environment_empty():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_empty", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/retrieval/test_graph_completion_retriever.py
+++ b/cognee/tests/integration/retrieval/test_graph_completion_retriever.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 from typing import Optional, Union
@@ -9,8 +10,6 @@ import cognee
 from cognee.low_level import DataPoint, setup
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.tasks.storage import add_data_points
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/retrieval/test_graph_completion_retriever_context_extension.py
+++ b/cognee/tests/integration/retrieval/test_graph_completion_retriever_context_extension.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 from typing import Optional, Union
@@ -12,8 +13,6 @@ from cognee.modules.retrieval.graph_completion_context_extension_retriever impor
     GraphCompletionContextExtensionRetriever,
 )
 from cognee.tasks.storage import add_data_points
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/retrieval/test_graph_completion_retriever_context_extension.py
+++ b/cognee/tests/integration/retrieval/test_graph_completion_retriever_context_extension.py
@@ -13,6 +13,10 @@ from cognee.modules.retrieval.graph_completion_context_extension_retriever impor
 )
 from cognee.tasks.storage import add_data_points
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @pytest_asyncio.fixture
 async def setup_test_environment_simple():
@@ -57,7 +61,7 @@ async def setup_test_environment_simple():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_simple", exc_info=True)
 
 
 @pytest_asyncio.fixture
@@ -134,7 +138,7 @@ async def setup_test_environment_complex():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_complex", exc_info=True)
 
 
 @pytest_asyncio.fixture
@@ -161,7 +165,7 @@ async def setup_test_environment_empty():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_empty", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/retrieval/test_graph_completion_retriever_cot.py
+++ b/cognee/tests/integration/retrieval/test_graph_completion_retriever_cot.py
@@ -10,6 +10,10 @@ from cognee.low_level import DataPoint, setup
 from cognee.modules.retrieval.graph_completion_cot_retriever import GraphCompletionCotRetriever
 from cognee.tasks.storage import add_data_points
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @pytest_asyncio.fixture
 async def setup_test_environment_simple():
@@ -52,7 +56,7 @@ async def setup_test_environment_simple():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_simple", exc_info=True)
 
 
 @pytest_asyncio.fixture
@@ -124,7 +128,7 @@ async def setup_test_environment_complex():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_complex", exc_info=True)
 
 
 @pytest_asyncio.fixture
@@ -151,7 +155,7 @@ async def setup_test_environment_empty():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_empty", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/retrieval/test_graph_completion_retriever_cot.py
+++ b/cognee/tests/integration/retrieval/test_graph_completion_retriever_cot.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 from typing import Optional, Union
 
@@ -9,8 +10,6 @@ from cognee.exceptions import CogneeValidationError
 from cognee.low_level import DataPoint, setup
 from cognee.modules.retrieval.graph_completion_cot_retriever import GraphCompletionCotRetriever
 from cognee.tasks.storage import add_data_points
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
+++ b/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
@@ -16,6 +16,10 @@ from cognee.modules.retrieval.completion_retriever import CompletionRetriever
 from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.tasks.storage import add_data_points
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class DocumentChunkWithEntities(DataPoint):
     text: str
@@ -96,7 +100,9 @@ async def setup_test_environment_with_chunks_simple():
         _create_vector_engine.cache_clear()
         create_relational_engine.cache_clear()
     except Exception:
-        pass
+        logger.debug(
+            "Ignoring exception in setup_test_environment_with_chunks_simple", exc_info=True
+        )
 
 
 @pytest_asyncio.fixture
@@ -199,7 +205,9 @@ async def setup_test_environment_with_chunks_complex():
         _create_vector_engine.cache_clear()
         create_relational_engine.cache_clear()
     except Exception:
-        pass
+        logger.debug(
+            "Ignoring exception in setup_test_environment_with_chunks_complex", exc_info=True
+        )
 
 
 @pytest_asyncio.fixture
@@ -247,7 +255,7 @@ async def setup_test_environment_empty():
         _create_vector_engine.cache_clear()
         create_relational_engine.cache_clear()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_empty", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
+++ b/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 from typing import List
@@ -15,8 +16,6 @@ from cognee.modules.engine.models import Entity
 from cognee.modules.retrieval.completion_retriever import CompletionRetriever
 from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.tasks.storage import add_data_points
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/retrieval/test_structured_output.py
+++ b/cognee/tests/integration/retrieval/test_structured_output.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import pathlib
 
@@ -19,8 +20,6 @@ from cognee.modules.retrieval.graph_completion_cot_retriever import GraphComplet
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.modules.retrieval.temporal_retriever import TemporalRetriever
 from cognee.tasks.storage import add_data_points
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/retrieval/test_structured_output.py
+++ b/cognee/tests/integration/retrieval/test_structured_output.py
@@ -20,6 +20,10 @@ from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionR
 from cognee.modules.retrieval.temporal_retriever import TemporalRetriever
 from cognee.tasks.storage import add_data_points
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class TestAnswer(BaseModel):
     answer: str
@@ -221,7 +225,7 @@ async def setup_test_environment():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/retrieval/test_summaries_retriever.py
+++ b/cognee/tests/integration/retrieval/test_summaries_retriever.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 
@@ -13,8 +14,6 @@ from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.modules.retrieval.summaries_retriever import SummariesRetriever
 from cognee.tasks.storage import add_data_points
 from cognee.tasks.summarization.models import TextSummary
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/retrieval/test_summaries_retriever.py
+++ b/cognee/tests/integration/retrieval/test_summaries_retriever.py
@@ -14,6 +14,10 @@ from cognee.modules.retrieval.summaries_retriever import SummariesRetriever
 from cognee.tasks.storage import add_data_points
 from cognee.tasks.summarization.models import TextSummary
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @pytest_asyncio.fixture
 async def setup_test_environment_with_summaries():
@@ -145,7 +149,7 @@ async def setup_test_environment_with_summaries():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_with_summaries", exc_info=True)
 
 
 @pytest_asyncio.fixture
@@ -167,7 +171,7 @@ async def setup_test_environment_empty():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_empty", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/retrieval/test_temporal_retriever.py
+++ b/cognee/tests/integration/retrieval/test_temporal_retriever.py
@@ -12,6 +12,10 @@ from cognee.modules.engine.models.Timestamp import Timestamp
 from cognee.modules.retrieval.temporal_retriever import TemporalRetriever
 from cognee.tasks.storage import add_data_points
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @pytest_asyncio.fixture
 async def setup_test_environment_with_events():
@@ -125,7 +129,7 @@ async def setup_test_environment_with_events():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_with_events", exc_info=True)
 
 
 @pytest_asyncio.fixture
@@ -168,7 +172,7 @@ async def setup_test_environment_with_graph_data():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_with_graph_data", exc_info=True)
 
 
 @pytest_asyncio.fixture
@@ -191,7 +195,7 @@ async def setup_test_environment_empty():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_empty", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/retrieval/test_temporal_retriever.py
+++ b/cognee/tests/integration/retrieval/test_temporal_retriever.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 
@@ -11,8 +12,6 @@ from cognee.modules.engine.models.Interval import Interval
 from cognee.modules.engine.models.Timestamp import Timestamp
 from cognee.modules.retrieval.temporal_retriever import TemporalRetriever
 from cognee.tasks.storage import add_data_points
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/retrieval/test_triplet_retriever.py
+++ b/cognee/tests/integration/retrieval/test_triplet_retriever.py
@@ -11,6 +11,10 @@ from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.modules.retrieval.triplet_retriever import TripletRetriever
 from cognee.tasks.storage import add_data_points
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @pytest_asyncio.fixture
 async def setup_test_environment_with_triplets():
@@ -46,7 +50,7 @@ async def setup_test_environment_with_triplets():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_with_triplets", exc_info=True)
 
 
 @pytest_asyncio.fixture
@@ -72,7 +76,7 @@ async def setup_test_environment_empty():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in setup_test_environment_empty", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/retrieval/test_triplet_retriever.py
+++ b/cognee/tests/integration/retrieval/test_triplet_retriever.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 
@@ -10,8 +11,6 @@ from cognee.modules.engine.models import Triplet
 from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.modules.retrieval.triplet_retriever import TripletRetriever
 from cognee.tasks.storage import add_data_points
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/shared/test_usage_logger_integration.py
+++ b/cognee/tests/integration/shared/test_usage_logger_integration.py
@@ -16,6 +16,10 @@ from cognee.infrastructure.databases.cache.get_cache_engine import (
 )
 from cognee.shared.usage_logger import log_usage
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @pytest.fixture
 def usage_logging_config():
@@ -57,6 +61,7 @@ def redis_adapter():
     try:
         yield RedisAdapter(host=host, port=6379, log_key="test_usage_logs")
     except Exception as e:
+        logger.debug("Ignoring exception in redis_adapter", exc_info=True)
         pytest.skip(f"Redis not available: {e}")
 
 

--- a/cognee/tests/integration/shared/test_usage_logger_integration.py
+++ b/cognee/tests/integration/shared/test_usage_logger_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for usage logger with real Redis components."""
 
 import asyncio
+import logging
 import os
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -15,8 +16,6 @@ from cognee.infrastructure.databases.cache.get_cache_engine import (
     get_cache_engine,
 )
 from cognee.shared.usage_logger import log_usage
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/tasks/test_add_data_points.py
+++ b/cognee/tests/integration/tasks/test_add_data_points.py
@@ -13,6 +13,10 @@ from cognee.low_level import setup
 from cognee.tasks.storage.add_data_points import add_data_points
 from cognee.tasks.storage.exceptions import InvalidDataPointsInAddDataPointsError
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class Person(DataPoint):
     name: str
@@ -64,7 +68,7 @@ async def clean_test_environment(request):
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in clean_test_environment", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/tasks/test_add_data_points.py
+++ b/cognee/tests/integration/tasks/test_add_data_points.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 import re
 import shutil
@@ -12,8 +13,6 @@ from cognee.infrastructure.engine import DataPoint
 from cognee.low_level import setup
 from cognee.tasks.storage.add_data_points import add_data_points
 from cognee.tasks.storage.exceptions import InvalidDataPointsInAddDataPointsError
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/tasks/test_add_foreground_orphan_cleanup.py
+++ b/cognee/tests/integration/tasks/test_add_foreground_orphan_cleanup.py
@@ -7,6 +7,7 @@ path for every DLT connector. This drives the real add pipeline twice against
 local stores (no LLM) and asserts a hard-deleted row is purged from cognee.
 """
 
+import logging
 import pathlib
 
 import pytest
@@ -18,8 +19,6 @@ from cognee.modules.data.methods import get_authorized_existing_datasets
 from cognee.modules.data.methods.get_dataset_data import get_dataset_data
 from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.users.methods import get_default_user
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/tasks/test_add_foreground_orphan_cleanup.py
+++ b/cognee/tests/integration/tasks/test_add_foreground_orphan_cleanup.py
@@ -19,6 +19,10 @@ from cognee.modules.data.methods.get_dataset_data import get_dataset_data
 from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.users.methods import get_default_user
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 DATASET = "widgets_ds"
 
 
@@ -59,7 +63,7 @@ async def clean_env(tmp_path, monkeypatch):
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in clean_env", exc_info=True)
 
 
 def _dlt_source(rows):

--- a/cognee/tests/integration/tasks/test_add_s3_call_counts.py
+++ b/cognee/tests/integration/tasks/test_add_s3_call_counts.py
@@ -18,6 +18,7 @@ either is absent. Local run:
 
 import collections
 import io
+import logging
 import shutil
 import socket
 import subprocess
@@ -27,8 +28,6 @@ import time
 from pathlib import Path
 
 import pytest
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/tasks/test_add_s3_call_counts.py
+++ b/cognee/tests/integration/tasks/test_add_s3_call_counts.py
@@ -28,6 +28,10 @@ from pathlib import Path
 
 import pytest
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 moto = pytest.importorskip("moto", reason="requires moto[server] (pip install 'moto[server]')")
 s3fs = pytest.importorskip("s3fs", reason="requires s3fs (pip install 'cognee[aws]')")
 
@@ -70,6 +74,7 @@ def s3_env():
             client.list_buckets()
             break
         except Exception:
+            logger.debug("Ignoring exception in s3_env", exc_info=True)
             time.sleep(0.25)
     else:
         moto_proc.terminate()

--- a/cognee/tests/integration/tasks/test_cognify_rollback_recovery.py
+++ b/cognee/tests/integration/tasks/test_cognify_rollback_recovery.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib
+import logging
 import pathlib
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
@@ -31,8 +32,6 @@ from cognee.modules.users.methods import create_user, get_default_user
 from cognee.tasks.storage.add_data_points import add_data_points
 from cognee.tests.utils.assert_graph_nodes_not_present import assert_graph_nodes_not_present
 from cognee.tests.utils.assert_graph_nodes_present import assert_graph_nodes_present
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/tasks/test_cognify_rollback_recovery.py
+++ b/cognee/tests/integration/tasks/test_cognify_rollback_recovery.py
@@ -32,6 +32,10 @@ from cognee.tasks.storage.add_data_points import add_data_points
 from cognee.tests.utils.assert_graph_nodes_not_present import assert_graph_nodes_not_present
 from cognee.tests.utils.assert_graph_nodes_present import assert_graph_nodes_present
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class Person(DataPoint):
     name: str
@@ -113,7 +117,7 @@ async def clean_test_environment(request, tmp_path, monkeypatch):
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in clean_test_environment", exc_info=True)
 
 
 async def _get_data_record(data_id):

--- a/cognee/tests/integration/tasks/test_consolidate_entities_integration.py
+++ b/cognee/tests/integration/tasks/test_consolidate_entities_integration.py
@@ -35,6 +35,10 @@ from cognee.modules.pipelines.layers.resolve_authorized_user_datasets import (
 )
 from cognee.tasks.storage.index_data_points import index_data_points
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 DATASET = "consolidate_entities_integration"
 DUPLICATE_NAMES = {"New York City", "NYC"}
 
@@ -60,7 +64,7 @@ async def clean_test_environment():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in clean_test_environment", exc_info=True)
 
 
 async def _seed(graph):

--- a/cognee/tests/integration/tasks/test_consolidate_entities_integration.py
+++ b/cognee/tests/integration/tasks/test_consolidate_entities_integration.py
@@ -17,6 +17,7 @@ Locally it can be run against the offline fastembed embedder, e.g.::
     uv run pytest cognee/tests/integration/tasks/test_consolidate_entities_integration.py -v
 """
 
+import logging
 import pathlib
 
 import pytest
@@ -34,8 +35,6 @@ from cognee.modules.pipelines.layers.resolve_authorized_user_datasets import (
     resolve_authorized_user_datasets,
 )
 from cognee.tasks.storage.index_data_points import index_data_points
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/tasks/test_dlt_background_mixed.py
+++ b/cognee/tests/integration/tasks/test_dlt_background_mixed.py
@@ -9,6 +9,7 @@ pins it end-to-end. Offline: LLM and embeddings are mocked.
 """
 
 import asyncio
+import logging
 import pathlib
 from unittest.mock import patch
 
@@ -25,8 +26,6 @@ from cognee.modules.data.methods import get_authorized_existing_datasets
 from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunStarted
 from cognee.modules.users.methods import get_default_user
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/tasks/test_dlt_background_mixed.py
+++ b/cognee/tests/integration/tasks/test_dlt_background_mixed.py
@@ -26,6 +26,10 @@ from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunStarted
 from cognee.modules.users.methods import get_default_user
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 DATASET = "background_mixed_ds"
 COMPLETION_TIMEOUT_SECONDS = 120
 
@@ -97,7 +101,7 @@ async def clean_env(tmp_path, monkeypatch):
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in clean_env", exc_info=True)
 
 
 def _dlt_source():

--- a/cognee/tests/integration/tasks/test_dlt_csv_loader_route.py
+++ b/cognee/tests/integration/tasks/test_dlt_csv_loader_route.py
@@ -26,6 +26,10 @@ from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.users.methods import get_default_user
 from cognee.tasks.ingestion.dlt_utils import is_dlt_source_manifest
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 DATASET = "csv_loader_ds"
 CSV_CONTENT = "id,name,section\n1,anemometer,weather\n2,barometer,weather\n3,seismograph,geology\n"
 
@@ -75,7 +79,7 @@ async def clean_env(tmp_path, monkeypatch):
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in clean_env", exc_info=True)
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/tasks/test_dlt_csv_loader_route.py
+++ b/cognee/tests/integration/tasks/test_dlt_csv_loader_route.py
@@ -9,6 +9,7 @@ mocked embeddings (the DLT route makes no LLM calls).
 """
 
 import json
+import logging
 import pathlib
 from unittest.mock import patch
 
@@ -25,8 +26,6 @@ from cognee.modules.data.methods.get_dataset_data import get_dataset_data
 from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.users.methods import get_default_user
 from cognee.tasks.ingestion.dlt_utils import is_dlt_source_manifest
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/tasks/test_dlt_orphan_graph_vector_purge.py
+++ b/cognee/tests/integration/tasks/test_dlt_orphan_graph_vector_purge.py
@@ -19,6 +19,7 @@ credentials, no network.
 """
 
 import hashlib
+import logging
 import pathlib
 
 import pytest
@@ -34,8 +35,6 @@ from cognee.modules.data.methods import get_authorized_existing_datasets
 from cognee.modules.data.methods.get_dataset_data import get_dataset_data
 from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.users.methods import get_default_user
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/tasks/test_dlt_orphan_graph_vector_purge.py
+++ b/cognee/tests/integration/tasks/test_dlt_orphan_graph_vector_purge.py
@@ -35,6 +35,10 @@ from cognee.modules.data.methods.get_dataset_data import get_dataset_data
 from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.users.methods import get_default_user
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 DATASET = "dlt_purge_ac_ds"
 
 
@@ -90,7 +94,7 @@ async def clean_env(tmp_path, monkeypatch):
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in clean_env", exc_info=True)
 
 
 def _mock_llm():
@@ -181,6 +185,7 @@ async def _store_counts(dataset):
         try:
             vec = await (await ve.get_collection("DltRow_text")).count_rows()
         except Exception:
+            logger.debug("Ignoring exception in _store_counts", exc_info=True)
             vec = 0
     return len(nodes), vec
 

--- a/cognee/tests/integration/tasks/test_dlt_stable_id_reprocess.py
+++ b/cognee/tests/integration/tasks/test_dlt_stable_id_reprocess.py
@@ -27,6 +27,10 @@ from cognee.modules.data.methods.get_dataset_data import get_dataset_data
 from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.users.methods import get_default_user
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 DATASET = "gadgets_ds"
 # Separate identity for the second test: dlt keeps process-global pipeline
 # state keyed by name, so tests in one process must not share dataset names.
@@ -75,7 +79,7 @@ async def clean_env(tmp_path, monkeypatch):
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in clean_env", exc_info=True)
 
 
 def _dlt_source(rows, name="gadgets"):

--- a/cognee/tests/integration/tasks/test_dlt_stable_id_reprocess.py
+++ b/cognee/tests/integration/tasks/test_dlt_stable_id_reprocess.py
@@ -11,6 +11,7 @@ Real add + cognify against local stores; the DLT route is LLM-free, and
 embeddings are mocked so the vector store works offline.
 """
 
+import logging
 import pathlib
 from unittest.mock import patch
 
@@ -26,8 +27,6 @@ from cognee.modules.data.methods import get_authorized_existing_datasets
 from cognee.modules.data.methods.get_dataset_data import get_dataset_data
 from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.users.methods import get_default_user
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/integration/web_url_crawler/test_url_adding_e2e.py
+++ b/cognee/tests/integration/web_url_crawler/test_url_adding_e2e.py
@@ -9,6 +9,10 @@ from cognee.infrastructure.loaders.external.beautiful_soup_loader import Beautif
 from cognee.infrastructure.loaders.LoaderEngine import LoaderEngine
 from cognee.tasks.ingestion import save_data_item_to_storage
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @pytest.mark.asyncio
 async def test_url_saves_as_html_file():
@@ -23,6 +27,7 @@ async def test_url_saves_as_html_file():
         assert file.exists()
         assert file.stat().st_size > 0
     except Exception as e:
+        logger.debug("Ignoring exception in test_url_saves_as_html_file", exc_info=True)
         pytest.fail(f"Failed to save data item to storage: {e}")
 
 
@@ -62,6 +67,7 @@ async def test_saved_html_is_valid():
         )
         assert has_html_elements, "File should contain common HTML elements"
     except Exception as e:
+        logger.debug("Ignoring exception in test_saved_html_is_valid", exc_info=True)
         pytest.fail(f"Failed to save data item to storage: {e}")
 
 
@@ -100,6 +106,9 @@ async def test_add_url_without_incremental_loading():
             incremental_loading=False,
         )
     except Exception as e:
+        logger.debug(
+            "Ignoring exception in test_add_url_without_incremental_loading", exc_info=True
+        )
         pytest.fail(f"Failed to add url: {e}")
 
 
@@ -114,6 +123,7 @@ async def test_add_url_with_incremental_loading():
             incremental_loading=True,
         )
     except Exception as e:
+        logger.debug("Ignoring exception in test_add_url_with_incremental_loading", exc_info=True)
         pytest.fail(f"Failed to add url: {e}")
 
 
@@ -146,6 +156,7 @@ async def test_add_url_with_extraction_rules():
             preferred_loaders={"beautiful_soup_loader": {"extraction_rules": extraction_rules}},
         )
     except Exception as e:
+        logger.debug("Ignoring exception in test_add_url_with_extraction_rules", exc_info=True)
         pytest.fail(f"Failed to add url: {e}")
 
 
@@ -177,6 +188,7 @@ async def test_loader_is_none_by_default():
 
         assert loader is None
     except Exception as e:
+        logger.debug("Ignoring exception in test_loader_is_none_by_default", exc_info=True)
         pytest.fail(f"Failed to save data item to storage: {e}")
 
 
@@ -210,6 +222,10 @@ async def test_beautiful_soup_loader_is_selected_loader_if_preferred_loader_prov
 
         assert loader == bs_loader
     except Exception as e:
+        logger.debug(
+            "Ignoring exception in test_beautiful_soup_loader_is_selected_loader_if_preferred_loader_provided",
+            exc_info=True,
+        )
         pytest.fail(f"Failed to save data item to storage: {e}")
 
 
@@ -246,6 +262,10 @@ async def test_beautiful_soup_loader_works_with_and_without_arguments():
             preferred_loaders=preferred_loaders,
         )
     except Exception as e:
+        logger.debug(
+            "Ignoring exception in test_beautiful_soup_loader_works_with_and_without_arguments",
+            exc_info=True,
+        )
         pytest.fail(f"Failed to save data item to storage: {e}")
 
 
@@ -277,6 +297,10 @@ async def test_beautiful_soup_loader_successfully_loads_file_if_required_args_pr
             preferred_loaders=preferred_loaders,
         )
     except Exception as e:
+        logger.debug(
+            "Ignoring exception in test_beautiful_soup_loader_successfully_loads_file_if_required_args_present",
+            exc_info=True,
+        )
         pytest.fail(f"Failed to save data item to storage: {e}")
 
 
@@ -330,4 +354,7 @@ async def test_beautiful_soup_loads_file_successfully():
             f"Expected same base name: {original_basename} vs {extracted_basename}"
         )
     except Exception as e:
+        logger.debug(
+            "Ignoring exception in test_beautiful_soup_loads_file_successfully", exc_info=True
+        )
         pytest.fail(f"Failed to save data item to storage: {e}")

--- a/cognee/tests/integration/web_url_crawler/test_url_adding_e2e.py
+++ b/cognee/tests/integration/web_url_crawler/test_url_adding_e2e.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -8,8 +9,6 @@ from cognee.infrastructure.files.utils.get_data_file_path import get_data_file_p
 from cognee.infrastructure.loaders.external.beautiful_soup_loader import BeautifulSoupLoader
 from cognee.infrastructure.loaders.LoaderEngine import LoaderEngine
 from cognee.tasks.ingestion import save_data_item_to_storage
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/performance/statistics_percentile/bench_cognee.py
+++ b/cognee/tests/performance/statistics_percentile/bench_cognee.py
@@ -42,6 +42,10 @@ from cognee.tests.utils.mock_ingestion import (
     load_mock_data as _load_mock_data,
 )
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 # ── Defaults ─────────────────────────────────────────────────────────────────
 
 DEFAULT_MEMORIES_FILE = Path(__file__).with_name("memories.json")
@@ -261,6 +265,7 @@ async def run_benchmark(
         t_prune = time.time() - t_prune_start
         print(f"  Prune completed in {t_prune:.2f}s")
     except Exception as e:
+        logger.debug("Ignoring exception in run_benchmark", exc_info=True)
         t_prune = time.time() - t_prune_start
         status["prune"] = f"failed: {e}"
         print(f"  Prune FAILED: {e}")
@@ -273,6 +278,7 @@ async def run_benchmark(
         await setup()
         t_db_setup = time.time() - t_db_setup_start
     except Exception as e:
+        logger.debug("Ignoring exception in run_benchmark", exc_info=True)
         t_db_setup = time.time() - t_db_setup_start
         status["db_setup"] = f"failed: {e}"
         print(f"  DB setup FAILED: {e}")
@@ -286,6 +292,7 @@ async def run_benchmark(
         await cognee.add(text_list, dataset_name=DATASET_NAME)
         t_add = time.time() - t_add_start
     except Exception as e:
+        logger.debug("Ignoring exception in run_benchmark", exc_info=True)
         t_add = time.time() - t_add_start
         status["add"] = f"failed: {e}"
         print(f"  Add FAILED: {e}")
@@ -297,6 +304,7 @@ async def run_benchmark(
         await cognee.cognify(data_per_batch=n, chunks_per_batch=10000)
         t_cognify = time.time() - t_cognify_start
     except Exception as e:
+        logger.debug("Ignoring exception in run_benchmark", exc_info=True)
         t_cognify = time.time() - t_cognify_start
         status["cognify"] = f"failed: {e}"
         print(f"  Cognify FAILED: {e}")
@@ -321,6 +329,7 @@ async def run_benchmark(
                 )
                 t_search[metric_key] = time.time() - t_q_start
             except Exception as e:
+                logger.debug("Ignoring exception in run_benchmark", exc_info=True)
                 t_search[metric_key] = time.time() - t_q_start
                 status[f"search_{metric_key}"] = f"failed: {_err(e)}"
                 print(f"  Search {search_type} FAILED: {_err(e)}")
@@ -343,6 +352,7 @@ async def run_benchmark(
         t_dataset_delete = time.time() - t_dataset_delete_start
         print(f"  Dataset deleted in {t_dataset_delete:.2f}s")
     except Exception as e:
+        logger.debug("Ignoring exception in run_benchmark", exc_info=True)
         t_dataset_delete = time.time() - t_dataset_delete_start
         status["dataset_delete"] = f"failed: {e}"
         print(f"  Dataset delete FAILED: {e}")
@@ -738,6 +748,7 @@ async def run_benchmark_cloud(
         except Exception as e:
             # Record elapsed-until-failure like every other phase (0.0 would
             # skew failed-run percentiles low).
+            logger.debug("Ignoring exception in run_benchmark_cloud", exc_info=True)
             t_tenant_create = time.time() - t_tenant_create_start
             # TenantCreateFailed carries the id of whatever exists; without
             # this, teardown (gated on tenant_id) was unreachable on exactly
@@ -772,6 +783,7 @@ async def run_benchmark_cloud(
                 t_prune = time.time() - t_prune_start
                 print(f"  Prune completed in {t_prune:.2f}s")
             except Exception as e:
+                logger.debug("Ignoring exception in run_benchmark_cloud", exc_info=True)
                 t_prune = time.time() - t_prune_start
                 status["prune"] = f"failed: {_err(e)}"
                 print(f"  Prune FAILED: {_err(e)}")
@@ -784,6 +796,7 @@ async def run_benchmark_cloud(
             await client.add(text_list, dataset_name=dataset_name)
             t_add = time.time() - t_add_start
         except Exception as e:
+            logger.debug("Ignoring exception in run_benchmark_cloud", exc_info=True)
             t_add = time.time() - t_add_start
             status["add"] = f"failed: {_err(e)}"
             print(f"  Add FAILED: {_err(e)}")
@@ -798,6 +811,7 @@ async def run_benchmark_cloud(
             await _wait_for_cloud_cognify(client, cognify_response)
             t_cognify = time.time() - t_cognify_start
         except Exception as e:
+            logger.debug("Ignoring exception in run_benchmark_cloud", exc_info=True)
             t_cognify = time.time() - t_cognify_start
             status["cognify"] = f"failed: {_err(e)}"
             print(f"  Cognify FAILED: {_err(e)}")
@@ -821,6 +835,7 @@ async def run_benchmark_cloud(
                     )
                     t_search[metric_key] = time.time() - t_q_start
                 except Exception as e:
+                    logger.debug("Ignoring exception in run_benchmark_cloud", exc_info=True)
                     t_search[metric_key] = time.time() - t_q_start
                     status[f"search_{metric_key}"] = f"failed: {_err(e)}"
                     print(f"  Search {search_type} FAILED: {_err(e)}")
@@ -837,6 +852,7 @@ async def run_benchmark_cloud(
                 t_dataset_delete = time.time() - t_dataset_delete_start
                 print(f"  Dataset deleted in {t_dataset_delete:.2f}s")
             except Exception as e:
+                logger.debug("Ignoring exception in run_benchmark_cloud", exc_info=True)
                 t_dataset_delete = time.time() - t_dataset_delete_start
                 status["dataset_delete"] = f"failed: {_err(e)}"
                 print(f"  Dataset deletion FAILED: {_err(e)}")
@@ -855,6 +871,7 @@ async def run_benchmark_cloud(
             )
             print(f"  Tenant deleted in {t_tenant_delete:.2f}s")
         except Exception as e:
+            logger.debug("Ignoring exception in run_benchmark_cloud", exc_info=True)
             t_tenant_delete = time.time() - t_tenant_delete_start
             status["tenant_delete"] = f"failed: {_err(e)}"
             print(f"  Tenant deletion FAILED (manual cleanup needed for {tenant_id}): {e}")

--- a/cognee/tests/performance/statistics_percentile/bench_cognee.py
+++ b/cognee/tests/performance/statistics_percentile/bench_cognee.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 import os
 import sys
 import time
@@ -41,8 +42,6 @@ from cognee.tests.utils.mock_ingestion import (
 from cognee.tests.utils.mock_ingestion import (
     load_mock_data as _load_mock_data,
 )
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/performance/statistics_percentile/build_corpus.py
+++ b/cognee/tests/performance/statistics_percentile/build_corpus.py
@@ -29,11 +29,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import re
 import sys
 from pathlib import Path
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/performance/statistics_percentile/build_corpus.py
+++ b/cognee/tests/performance/statistics_percentile/build_corpus.py
@@ -33,6 +33,10 @@ import re
 import sys
 from pathlib import Path
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 TEXT_SUFFIXES = {".txt", ".md", ".markdown"}
 PDF_SUFFIXES = {".pdf"}
 SUPPORTED = TEXT_SUFFIXES | PDF_SUFFIXES
@@ -57,6 +61,7 @@ def extract_pdf_text(path: Path) -> str:
         try:
             pages.append(page.extract_text() or "")
         except Exception as exc:  # a single broken page must not kill the corpus
+            logger.debug("Ignoring exception in extract_pdf_text", exc_info=True)
             print(f"  warn: {path.name}: page extraction failed ({type(exc).__name__})")
             pages.append("")
     return "\n\n".join(pages)

--- a/cognee/tests/test_agent_memory_e2e.py
+++ b/cognee/tests/test_agent_memory_e2e.py
@@ -16,6 +16,10 @@ from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.users.methods import create_user
 from cognee.modules.users.permissions.methods import authorized_give_permission_on_datasets
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 async def _reset_engines_and_prune() -> None:
     """Reset cached engines and clear persisted test state."""
@@ -26,7 +30,7 @@ async def _reset_engines_and_prune() -> None:
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _reset_engines_and_prune", exc_info=True)
 
     from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
     from cognee.infrastructure.databases.relational.create_relational_engine import (

--- a/cognee/tests/test_agent_memory_e2e.py
+++ b/cognee/tests/test_agent_memory_e2e.py
@@ -1,5 +1,6 @@
 """End-to-end tests for the public cognee.agent_memory feature."""
 
+import logging
 import os
 from pathlib import Path
 from uuid import uuid4
@@ -15,8 +16,6 @@ from cognee.modules.data.methods import create_authorized_dataset, get_datasets_
 from cognee.modules.engine.operations.setup import setup as engine_setup
 from cognee.modules.users.methods import create_user
 from cognee.modules.users.permissions.methods import authorized_give_permission_on_datasets
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/test_chunk_associations.py
+++ b/cognee/tests/test_chunk_associations.py
@@ -11,6 +11,10 @@ from cognee.modules.pipelines.tasks.task import Task
 from cognee.tasks.chunks.create_chunk_associations import create_chunk_associations
 from cognee.tasks.memify.extract_subgraph_chunks import extract_subgraph_chunks
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @pytest_asyncio.fixture
 async def clean_test_environment():
@@ -31,7 +35,7 @@ async def clean_test_environment():
         await cognee.prune.prune_data()
         await cognee.prune.prune_system(metadata=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in clean_test_environment", exc_info=True)
 
 
 def _get_association_edges(edges):

--- a/cognee/tests/test_chunk_associations.py
+++ b/cognee/tests/test_chunk_associations.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import pytest
@@ -10,8 +11,6 @@ from cognee.low_level import setup
 from cognee.modules.pipelines.tasks.task import Task
 from cognee.tasks.chunks.create_chunk_associations import create_chunk_associations
 from cognee.tasks.memify.extract_subgraph_chunks import extract_subgraph_chunks
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/test_delete_by_id.py
+++ b/cognee/tests/test_delete_by_id.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 from uuid import uuid4
@@ -8,7 +9,6 @@ from cognee.modules.data.methods import get_dataset_data, get_datasets_by_name
 from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.modules.users.methods import create_user, get_default_user
 from cognee.modules.users.permissions.methods import authorized_give_permission_on_datasets
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/test_delete_by_id.py
+++ b/cognee/tests/test_delete_by_id.py
@@ -8,9 +8,9 @@ from cognee.modules.data.methods import get_dataset_data, get_datasets_by_name
 from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.modules.users.methods import create_user, get_default_user
 from cognee.modules.users.permissions.methods import authorized_give_permission_on_datasets
-from cognee.shared.logging_utils import get_logger
+import logging
 
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 async def main():
@@ -157,6 +157,7 @@ async def main():
         delete_permission_error = True
         print("✅ Delete correctly denied for user without permission")
     except Exception as e:
+        logger.debug("Ignoring exception in main", exc_info=True)
         print(f"❌ Unexpected error type: {e}")
 
     assert delete_permission_error, "Delete should fail for user without permission"
@@ -174,6 +175,7 @@ async def main():
         data_not_found_error = True
         print("✅ Delete correctly failed for non-existent data_id")
     except Exception as e:
+        logger.debug("Ignoring exception in main", exc_info=True)
         print(f"❌ Unexpected error type: {e}")
 
     assert data_not_found_error, "Delete should fail for non-existent data_id"
@@ -193,6 +195,7 @@ async def main():
         dataset_not_found_error = True
         print("✅ Delete correctly failed for non-existent dataset_id")
     except Exception as e:
+        logger.debug("Ignoring exception in main", exc_info=True)
         print(f"❌ Unexpected error type: {e}")
 
     assert dataset_not_found_error, "Delete should fail for non-existent dataset_id"
@@ -219,6 +222,7 @@ async def main():
         data_not_in_dataset_error = True
         print("✅ Delete correctly failed for data not in specified dataset")
     except Exception as e:
+        logger.debug("Ignoring exception in main", exc_info=True)
         print(f"❌ Unexpected error type: {e}")
 
     assert data_not_in_dataset_error, "Delete should fail when data doesn't belong to dataset"

--- a/cognee/tests/test_permissions.py
+++ b/cognee/tests/test_permissions.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import pathlib
 from unittest.mock import AsyncMock, patch
@@ -24,8 +25,6 @@ from cognee.modules.users.tenants.methods import (
     remove_user_from_tenant,
     select_tenant,
 )
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/test_permissions.py
+++ b/cognee/tests/test_permissions.py
@@ -25,6 +25,10 @@ from cognee.modules.users.tenants.methods import (
     select_tenant,
 )
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 pytestmark = pytest.mark.asyncio
 
 
@@ -42,7 +46,7 @@ async def _reset_engines_and_prune() -> None:
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _reset_engines_and_prune", exc_info=True)
 
     from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
     from cognee.infrastructure.databases.relational.create_relational_engine import (

--- a/cognee/tests/test_search_db.py
+++ b/cognee/tests/test_search_db.py
@@ -28,9 +28,9 @@ from cognee.modules.retrieval.temporal_retriever import TemporalRetriever
 from cognee.modules.retrieval.triplet_retriever import TripletRetriever
 from cognee.modules.search.types import SearchType
 from cognee.modules.users.methods import get_default_user
-from cognee.shared.logging_utils import get_logger
+import logging
 
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 async def _reset_engines_and_prune() -> None:
@@ -49,7 +49,7 @@ async def _reset_engines_and_prune() -> None:
             await vector_engine.engine.dispose(close=True)
     except Exception:
         # Engine might not exist yet
-        pass
+        logger.debug("Ignoring exception in _reset_engines_and_prune", exc_info=True)
 
     from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
     from cognee.infrastructure.databases.relational.create_relational_engine import (

--- a/cognee/tests/test_search_db.py
+++ b/cognee/tests/test_search_db.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import pathlib
 from collections import Counter
@@ -28,7 +29,6 @@ from cognee.modules.retrieval.temporal_retriever import TemporalRetriever
 from cognee.modules.retrieval.triplet_retriever import TripletRetriever
 from cognee.modules.search.types import SearchType
 from cognee.modules.users.methods import get_default_user
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/test_shared_node_preservation.py
+++ b/cognee/tests/test_shared_node_preservation.py
@@ -466,7 +466,7 @@ async def test_dataset_deletion_removes_files():
         deleted_dataset = await get_dataset(dataset_id)
         assert deleted_dataset is None, "Dataset should be deleted"
     except Exception as e:
-        logger.info(f"✅ Dataset correctly deleted: {type(e).__name__}")
+        logger.info(f"✅ Dataset correctly deleted: {type(e).__name__}", exc_info=True)
 
     # Verify data records are deleted
     data_1_after = await get_data(data_1_id)

--- a/cognee/tests/test_subprocess_rss.py
+++ b/cognee/tests/test_subprocess_rss.py
@@ -100,6 +100,7 @@ os.environ["DATABASE_MAX_LRU_CACHE_SIZE"] = str(ARGS.lru_cache_size)
 
 import asyncio  # noqa: E402
 import gc  # noqa: E402
+import logging  # noqa: E402
 import pathlib  # noqa: E402
 import tempfile  # noqa: E402
 import urllib.request  # noqa: E402
@@ -109,8 +110,6 @@ import psutil  # noqa: E402
 import cognee  # noqa: E402
 from cognee.modules.search.types import SearchType  # noqa: E402
 from cognee_db_workers.harness import collect_garbage_in_all_workers  # noqa: E402
-
-import logging  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/test_subprocess_rss.py
+++ b/cognee/tests/test_subprocess_rss.py
@@ -110,6 +110,10 @@ import cognee  # noqa: E402
 from cognee.modules.search.types import SearchType  # noqa: E402
 from cognee_db_workers.harness import collect_garbage_in_all_workers  # noqa: E402
 
+import logging  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
 # Twenty distinct public-domain Gutenberg books (each roughly 400 KB – 1.5 MB).
 # One is used per large-round cycle; with ``--cycles 20`` we use all of them.
 LARGE_TEXTS: list[tuple[str, str]] = [
@@ -181,7 +185,7 @@ def print_rss(label: str) -> None:
 
         _pa.default_memory_pool().release_unused()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in print_rss", exc_info=True)
 
     proc = psutil.Process(os.getpid())
     parent_mb = proc.memory_info().rss / (1024 * 1024)

--- a/cognee/tests/test_usage_logger_e2e.py
+++ b/cognee/tests/test_usage_logger_e2e.py
@@ -11,6 +11,10 @@ from cognee.infrastructure.databases.cache.config import get_cache_config
 from cognee.infrastructure.databases.cache.get_cache_engine import create_cache_engine
 from cognee.modules.users.methods import get_authenticated_user, get_default_user
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 async def _reset_engines_and_prune():
     """Reset db engine caches and prune data/system."""
@@ -21,7 +25,7 @@ async def _reset_engines_and_prune():
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _reset_engines_and_prune", exc_info=True)
 
     await cognee.prune.prune_data()
     await cognee.prune.prune_system(metadata=True)

--- a/cognee/tests/test_usage_logger_e2e.py
+++ b/cognee/tests/test_usage_logger_e2e.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 
 import pytest
@@ -10,8 +11,6 @@ from cognee.api.client import app
 from cognee.infrastructure.databases.cache.config import get_cache_config
 from cognee.infrastructure.databases.cache.get_cache_engine import create_cache_engine
 from cognee.modules.users.methods import get_authenticated_user, get_default_user
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/unit/conftest.py
+++ b/cognee/tests/unit/conftest.py
@@ -18,6 +18,10 @@ import asyncio
 
 import pytest
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @pytest.fixture(autouse=True, scope="session")
 def _relational_db_for_unit_tests():
@@ -28,6 +32,7 @@ def _relational_db_for_unit_tests():
         try:
             await run_migrations()
         except Exception:
+            logger.debug("Ignoring exception in _relational_db_for_unit_tests._run", exc_info=True)
             db_engine = get_relational_engine()
             await db_engine.create_database()
             await run_migrations()

--- a/cognee/tests/unit/conftest.py
+++ b/cognee/tests/unit/conftest.py
@@ -15,10 +15,9 @@ Tests that never touch the relational database are unaffected.
 """
 
 import asyncio
+import logging
 
 import pytest
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/unit/exceptions/test_cognee_error_contract.py
+++ b/cognee/tests/unit/exceptions/test_cognee_error_contract.py
@@ -27,6 +27,10 @@ import pytest
 import cognee
 from cognee.exceptions import CogneeApiError
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 # The single root of the Cognee error hierarchy, read off the class itself so it
 # can never drift from the source. Every other error class is *discovered* from
 # here by name (see ``_family_classes_in_repo``): seeding the fixpoint with just
@@ -199,6 +203,7 @@ def _import_family_modules():
             # Modules behind optional extras (codegraph, scraping, neptune, ...)
             # may not import in a minimal environment. The static test above
             # already covers them; here we simply skip what we cannot load.
+            logger.debug("Ignoring exception in _import_family_modules", exc_info=True)
             continue
 
 

--- a/cognee/tests/unit/exceptions/test_cognee_error_contract.py
+++ b/cognee/tests/unit/exceptions/test_cognee_error_contract.py
@@ -202,7 +202,7 @@ def _import_family_modules():
             # Modules behind optional extras (codegraph, scraping, neptune, ...)
             # may not import in a minimal environment. The static test above
             # already covers them; here we simply skip what we cannot load.
-            logger.debug("Ignoring exception in _import_family_modules", exc_info=True)
+            logger.debug("Skipping item after error in _import_family_modules", exc_info=True)
             continue
 
 

--- a/cognee/tests/unit/exceptions/test_cognee_error_contract.py
+++ b/cognee/tests/unit/exceptions/test_cognee_error_contract.py
@@ -20,14 +20,13 @@ Two complementary checks keep the whole bug class from returning:
 import ast
 import importlib
 import inspect
+import logging
 from pathlib import Path
 
 import pytest
 
 import cognee
 from cognee.exceptions import CogneeApiError
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/unit/infrastructure/databases/test_index_schema_reference_fields.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_schema_reference_fields.py
@@ -6,9 +6,9 @@ an adapter silently dropping ``document_id`` / ``document_name`` / ``chunk_index
 from its payload — which would make chunk Evidence render empty on that backend.
 """
 
-import pytest
-
 import logging
+
+import pytest
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/unit/infrastructure/databases/test_index_schema_reference_fields.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_schema_reference_fields.py
@@ -8,6 +8,10 @@ from its payload — which would make chunk Evidence render empty on that backen
 
 import pytest
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 REFERENCE_FIELDS = ("document_id", "document_name", "chunk_index", "source_chunk_id")
 
 
@@ -30,7 +34,7 @@ def _index_schema_classes():
 
         classes.append(("pgvector", PGVectorIndexSchema))
     except Exception:  # pragma: no cover - depends on optional extras
-        pass
+        logger.debug("Ignoring exception in _index_schema_classes", exc_info=True)
 
     try:
         from cognee.infrastructure.databases.hybrid.neptune_analytics.NeptuneAnalyticsAdapter import (
@@ -39,7 +43,7 @@ def _index_schema_classes():
 
         classes.append(("neptune", NeptuneIndexSchema))
     except Exception:  # pragma: no cover - depends on optional extras
-        pass
+        logger.debug("Ignoring exception in _index_schema_classes", exc_info=True)
 
     return classes
 

--- a/cognee/tests/unit/infrastructure/databases/test_subprocess_session_concurrent.py
+++ b/cognee/tests/unit/infrastructure/databases/test_subprocess_session_concurrent.py
@@ -11,6 +11,7 @@ Uses a small async-capable worker so the worker-side concurrent dispatch
 from __future__ import annotations
 
 import asyncio
+import logging
 import multiprocessing as mp
 import pickle
 import sys
@@ -27,8 +28,6 @@ from cognee_db_workers.harness import (
     run_worker_loop,
     spawn_without_main,
 )
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/unit/infrastructure/databases/test_subprocess_session_concurrent.py
+++ b/cognee/tests/unit/infrastructure/databases/test_subprocess_session_concurrent.py
@@ -28,6 +28,10 @@ from cognee_db_workers.harness import (
     spawn_without_main,
 )
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 # These tests construct subprocess workers explicitly, so the
 # *_SUBPROCESS_ENABLED=false the Windows CI jobs set cannot keep them from
 # spawning. On Windows the spawned child intermittently deadlocks at
@@ -248,6 +252,10 @@ def test_sync_and_async_calls_interleave_on_one_session():
                     r = session.call(Request(op=OP_ECHO_FAST, args=(f"s{i}",)))
                     sync_results.append(r.result)
             except Exception as e:
+                logger.debug(
+                    "Ignoring exception in test_sync_and_async_calls_interleave_on_one_session.do_sync",
+                    exc_info=True,
+                )
                 errors.append(e)
 
         async def do_async():

--- a/cognee/tests/unit/infrastructure/databases/test_subprocess_session_failures.py
+++ b/cognee/tests/unit/infrastructure/databases/test_subprocess_session_failures.py
@@ -28,6 +28,10 @@ from cognee_db_workers.harness import (
     spawn_without_main,
 )
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 # These tests construct subprocess workers explicitly, so the
 # *_SUBPROCESS_ENABLED=false the Windows CI jobs set cannot keep them from
 # spawning. On Windows the spawned child intermittently deadlocks at
@@ -519,7 +523,9 @@ async def test_kuzu_adapter_rejects_use_after_close(tmp_path):
         try:
             await adapter.close()
         except Exception:
-            pass
+            logger.debug(
+                "Ignoring exception in test_kuzu_adapter_rejects_use_after_close", exc_info=True
+            )
 
 
 # --- retry / replay -------------------------------------------------------
@@ -873,6 +879,10 @@ def test_concurrent_shutdown_with_inflight_call_does_not_hang():
                         TimeoutError("call() timed out — response likely stolen by shutter")
                     )
             except Exception as exc:
+                logger.debug(
+                    "Ignoring exception in test_concurrent_shutdown_with_inflight_call_does_not_hang.caller",
+                    exc_info=True,
+                )
                 with errors_lock:
                     errors.append(exc)
 
@@ -880,6 +890,10 @@ def test_concurrent_shutdown_with_inflight_call_does_not_hang():
             try:
                 s.shutdown(timeout=1.0)
             except Exception as exc:
+                logger.debug(
+                    "Ignoring exception in test_concurrent_shutdown_with_inflight_call_does_not_hang.shutter",
+                    exc_info=True,
+                )
                 with errors_lock:
                     errors.append(exc)
 

--- a/cognee/tests/unit/infrastructure/databases/test_subprocess_session_failures.py
+++ b/cognee/tests/unit/infrastructure/databases/test_subprocess_session_failures.py
@@ -11,6 +11,7 @@ Covers the scenarios that used to silently hang or leak:
 
 from __future__ import annotations
 
+import logging
 import multiprocessing as mp
 import sys
 import time
@@ -27,8 +28,6 @@ from cognee_db_workers.harness import (
     run_worker_loop,
     spawn_without_main,
 )
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/unit/infrastructure/llm/test_budget_exhaustion.py
+++ b/cognee/tests/unit/infrastructure/llm/test_budget_exhaustion.py
@@ -283,7 +283,8 @@ class TestCauseChainWalk:
         try:
             try:
                 raise _rate_limit_error(LITELLM_BUDGET_MESSAGES[0])
-            except Exception:
+            except litellm.RateLimitError:
+                # Deliberately unchained: the test needs __context__ without __cause__.
                 raise ValueError("secondary failure during cleanup")
         except ValueError as e:
             unrelated = e

--- a/cognee/tests/unit/infrastructure/mock_embedding_engine.py
+++ b/cognee/tests/unit/infrastructure/mock_embedding_engine.py
@@ -44,7 +44,7 @@ class MockEmbeddingEngine(LiteLLMEmbeddingEngine):
 
         # Simulate failures if configured
         if self.fail_every_n_requests > 0 and self.request_count % self.fail_every_n_requests == 0:
-            raise Exception(f"Mock failure on request #{self.request_count}")
+            raise RuntimeError(f"Mock failure on request #{self.request_count}")
 
         # Return mock embeddings of the correct dimension
         async with embedding_rate_limiter_context_manager():

--- a/cognee/tests/unit/infrastructure/test_embedding_rate_limiting_realistic.py
+++ b/cognee/tests/unit/infrastructure/test_embedding_rate_limiting_realistic.py
@@ -60,7 +60,7 @@ async def test_embedding_rate_limiting_realistic():
             logger.info(f"Request #{i + 1} succeeded with embedding size: {len(embedding[0])}")
             return True
         except Exception as e:
-            logger.info(f"Request #{i + 1} rate limited: {e}")
+            logger.info(f"Request #{i + 1} rate limited: {e}", exc_info=True)
             return False
 
     # Batch 1: Send 10 concurrent requests (expect 3 to succeed, 7 to be rate limited)
@@ -127,7 +127,7 @@ async def test_embedding_rate_limiting_realistic():
             logger.info(f"Request #{i + 1} succeeded with embedding size: {len(embedding[0])}")
             batch_successes += 1
         except Exception as e:
-            logger.info(f"Request #{i + 1} rate limited: {e}")
+            logger.info(f"Request #{i + 1} rate limited: {e}", exc_info=True)
             batch_rate_limited += 1
 
     batch_end = time.time()
@@ -185,7 +185,7 @@ async def test_with_mock_failures():
 
             logger.info(f"Request #{i + 1} succeeded for {embedding!s}")
         except Exception as e:
-            logger.info(f"Request #{i + 1} failed as expected: {e}")
+            logger.info(f"Request #{i + 1} failed as expected: {e}", exc_info=True)
 
     # Reset environment variables
     os.environ.pop("EMBEDDING_RATE_LIMIT_ENABLED", None)

--- a/cognee/tests/unit/infrastructure/test_rate_limiting_retry.py
+++ b/cognee/tests/unit/infrastructure/test_rate_limiting_retry.py
@@ -6,9 +6,9 @@ from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.ll
     sleep_and_retry_async,
     sleep_and_retry_sync,
 )
-from cognee.shared.logging_utils import get_logger
+import logging
 
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 # Test function to be decorated
@@ -23,7 +23,7 @@ def test_function_sync():
     if test_function_sync.counter <= 2:
         error_msg = "429 Too Many Requests: Rate limit exceeded"
         logger.info(f"Attempt {test_function_sync.counter}: Raising rate limit error")
-        raise Exception(error_msg)
+        raise RuntimeError(error_msg)
 
     logger.info(f"Attempt {test_function_sync.counter}: Success!")
     return f"Success on attempt {test_function_sync.counter}"
@@ -41,7 +41,7 @@ async def test_function_async():
     if test_function_async.counter <= 2:
         error_msg = "429 Too Many Requests: Rate limit exceeded"
         logger.info(f"Attempt {test_function_async.counter}: Raising rate limit error")
-        raise Exception(error_msg)
+        raise RuntimeError(error_msg)
 
     logger.info(f"Attempt {test_function_async.counter}: Success!")
     return f"Success on attempt {test_function_async.counter}"
@@ -164,13 +164,14 @@ async def test_retry_max_exceeded():
         """A function that always raises a rate limit error."""
         error_msg = "429 Too Many Requests: Rate limit always exceeded"
         logger.info(f"Always fails with: {error_msg}")
-        raise Exception(error_msg)
+        raise RuntimeError(error_msg)
 
     try:
         # This should fail after 2 retries (3 attempts total)
         await always_fails()
         print("❌ FAIL: Function should have failed but succeeded")
     except Exception as e:
+        logger.debug("Ignoring exception in test_retry_max_exceeded", exc_info=True)
         print(f"Expected error after max retries: {e!s}")
         print("✅ PASS: Function correctly failed after max retries exceeded")
 

--- a/cognee/tests/unit/infrastructure/test_rate_limiting_retry.py
+++ b/cognee/tests/unit/infrastructure/test_rate_limiting_retry.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import time
 
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.rate_limiter import (
@@ -6,7 +7,6 @@ from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.ll
     sleep_and_retry_async,
     sleep_and_retry_sync,
 )
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/unit/modules/graph/test_graph_methods.py
+++ b/cognee/tests/unit/modules/graph/test_graph_methods.py
@@ -36,9 +36,9 @@ from cognee.modules.graph.methods import (
 )
 from cognee.modules.graph.models import Edge, Node
 from cognee.modules.users.methods import get_default_user
-from cognee.shared.logging_utils import get_logger
+import logging
 
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -51,7 +51,7 @@ async def _dispose_relational_engine_after_test():
         if engine is not None:
             await engine.dispose(close=True)
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _dispose_relational_engine_after_test", exc_info=True)
 
     create_relational_engine.cache_clear()
 

--- a/cognee/tests/unit/modules/graph/test_graph_methods.py
+++ b/cognee/tests/unit/modules/graph/test_graph_methods.py
@@ -8,6 +8,7 @@ Test Coverage:
 - test_delete_data_nodes_and_edges_removes_from_all_systems: Verify complete cleanup
 """
 
+import logging
 import os
 import pathlib
 from contextlib import AsyncExitStack
@@ -36,7 +37,6 @@ from cognee.modules.graph.methods import (
 )
 from cognee.modules.graph.models import Edge, Node
 from cognee.modules.users.methods import get_default_user
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/unit/modules/observability/test_memory_semconv.py
+++ b/cognee/tests/unit/modules/observability/test_memory_semconv.py
@@ -4,11 +4,10 @@ Validates that the core memory operations emit correct spans (with memory.*
 attributes), metrics, and that the log bridge attaches without error.
 """
 
+import logging
 import time
 
 import pytest
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/unit/modules/observability/test_memory_semconv.py
+++ b/cognee/tests/unit/modules/observability/test_memory_semconv.py
@@ -8,6 +8,10 @@ import time
 
 import pytest
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -22,7 +26,7 @@ def _clean_otel_state():
 
         disable_tracing()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _clean_otel_state", exc_info=True)
 
 
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/modules/retrieval/graph_completion_retriever_cot_test.py
+++ b/cognee/tests/unit/modules/retrieval/graph_completion_retriever_cot_test.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -8,8 +9,6 @@ from cognee.modules.retrieval.graph_completion_cot_retriever import (
     GraphCompletionCotRetriever,
     _as_answer_text,
 )
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/unit/modules/retrieval/graph_completion_retriever_cot_test.py
+++ b/cognee/tests/unit/modules/retrieval/graph_completion_retriever_cot_test.py
@@ -37,7 +37,9 @@ def _no_real_llm_calls():
         try:
             return response_model.model_construct()
         except Exception:
-            logger.debug("Ignoring exception in _no_real_llm_calls._structured", exc_info=True)
+            logger.debug(
+                "Falling back after error in _no_real_llm_calls._structured", exc_info=True
+            )
             return "reasoning"
 
     with patch.object(

--- a/cognee/tests/unit/modules/retrieval/graph_completion_retriever_cot_test.py
+++ b/cognee/tests/unit/modules/retrieval/graph_completion_retriever_cot_test.py
@@ -9,6 +9,10 @@ from cognee.modules.retrieval.graph_completion_cot_retriever import (
     _as_answer_text,
 )
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @pytest.fixture(autouse=True)
 def _no_real_llm_calls():
@@ -34,6 +38,7 @@ def _no_real_llm_calls():
         try:
             return response_model.model_construct()
         except Exception:
+            logger.debug("Ignoring exception in _no_real_llm_calls._structured", exc_info=True)
             return "reasoning"
 
     with patch.object(

--- a/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from datetime import datetime
 from types import SimpleNamespace
@@ -8,8 +9,6 @@ import pytest
 from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.retrieval.temporal_retriever import TemporalRetriever
 from cognee.tasks.temporal_graph.models import QueryInterval, Timestamp
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
@@ -36,7 +36,9 @@ def _no_real_llm_calls():
         try:
             return response_model.model_construct()
         except Exception:
-            logger.debug("Ignoring exception in _no_real_llm_calls._structured", exc_info=True)
+            logger.debug(
+                "Falling back after error in _no_real_llm_calls._structured", exc_info=True
+            )
             return QueryInterval()
 
     with patch.object(

--- a/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
@@ -9,6 +9,10 @@ from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.retrieval.temporal_retriever import TemporalRetriever
 from cognee.tasks.temporal_graph.models import QueryInterval, Timestamp
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @pytest.fixture(autouse=True)
 def _no_real_llm_calls():
@@ -33,6 +37,7 @@ def _no_real_llm_calls():
         try:
             return response_model.model_construct()
         except Exception:
+            logger.debug("Ignoring exception in _no_real_llm_calls._structured", exc_info=True)
             return QueryInterval()
 
     with patch.object(

--- a/cognee_db_workers/_kuzu_helpers.py
+++ b/cognee_db_workers/_kuzu_helpers.py
@@ -19,6 +19,9 @@ import os
 import sys
 import tempfile
 from typing import Optional
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def _safe_close(obj) -> None:
@@ -27,7 +30,7 @@ def _safe_close(obj) -> None:
     try:
         obj.close()
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _safe_close", exc_info=True)
 
 
 def install_json_extension_local(
@@ -72,6 +75,7 @@ def install_json_extension_local(
                 # the live connection), but say why it failed — a silent
                 # swallow here made "has not been installed" errors at LOAD
                 # time impossible to diagnose from CI logs.
+                logger.debug("Ignoring exception in install_json_extension_local", exc_info=True)
                 print(
                     f"[ladybug worker] warm-up INSTALL JSON failed: {error!r}",
                     file=sys.stderr,
@@ -79,6 +83,7 @@ def install_json_extension_local(
         except Exception as error:
             # Best-effort install: missing/incompatible JSON extension and
             # init failures all surface here. The cleanup below still runs.
+            logger.debug("Ignoring exception in install_json_extension_local", exc_info=True)
             print(
                 f"[ladybug worker] warm-up JSON install setup failed: {error!r}",
                 file=sys.stderr,

--- a/cognee_db_workers/_kuzu_helpers.py
+++ b/cognee_db_workers/_kuzu_helpers.py
@@ -15,11 +15,11 @@ avoids surprising contributors.
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import tempfile
 from typing import Optional
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee_db_workers/harness.py
+++ b/cognee_db_workers/harness.py
@@ -12,6 +12,7 @@ import concurrent.futures
 import ctypes
 import ctypes.util
 import itertools
+import logging
 import os
 import pickle
 import queue as std_queue
@@ -25,7 +26,6 @@ import weakref
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from typing import Any, Dict, Optional
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee_db_workers/harness.py
+++ b/cognee_db_workers/harness.py
@@ -265,7 +265,7 @@ def set_pdeathsig() -> bool:
         rc = libc.prctl(PR_SET_PDEATHSIG, signal.SIGTERM, 0, 0, 0)
         return rc == 0
     except Exception:
-        logger.debug("Ignoring exception in set_pdeathsig", exc_info=True)
+        logger.debug("Falling back to False after error in set_pdeathsig", exc_info=True)
         return False
 
 
@@ -295,7 +295,7 @@ def start_parent_liveness_watchdog(poll_interval: float = 1.0) -> None:
     try:
         original_ppid = os.getppid()
     except Exception:
-        logger.debug("Ignoring exception in start_parent_liveness_watchdog", exc_info=True)
+        logger.debug("Giving up after error in start_parent_liveness_watchdog", exc_info=True)
         return
 
     def _watch() -> None:
@@ -304,7 +304,8 @@ def start_parent_liveness_watchdog(poll_interval: float = 1.0) -> None:
                 current_ppid = os.getppid()
             except Exception:
                 logger.debug(
-                    "Ignoring exception in start_parent_liveness_watchdog._watch", exc_info=True
+                    "Giving up after error in start_parent_liveness_watchdog._watch",
+                    exc_info=True,
                 )
                 return
             if current_ppid != original_ppid:
@@ -315,7 +316,8 @@ def start_parent_liveness_watchdog(poll_interval: float = 1.0) -> None:
                 time.sleep(poll_interval)
             except Exception:
                 logger.debug(
-                    "Ignoring exception in start_parent_liveness_watchdog._watch", exc_info=True
+                    "Giving up after error in start_parent_liveness_watchdog._watch",
+                    exc_info=True,
                 )
                 return
 
@@ -465,7 +467,7 @@ def run_worker_loop(
             init(registry)
         resp_q.put(Response(result=_READY_SENTINEL))
     except Exception as e:
-        logger.debug("Ignoring exception in run_worker_loop", exc_info=True)
+        logger.debug("Giving up after error in run_worker_loop", exc_info=True)
         resp_q.put(Response(error=traceback.format_exc(), exception=_safe_pickle_exception(e)))
         return
 
@@ -523,7 +525,7 @@ def run_worker_loop(
             try:
                 result = handler(registry, msg)
             except Exception as e:
-                logger.debug("Ignoring exception in run_worker_loop.serve", exc_info=True)
+                logger.debug("Skipping item after error in run_worker_loop.serve", exc_info=True)
                 _emit_error(rid, e)
                 continue
 
@@ -548,7 +550,7 @@ def _safe_pickle_exception(e: BaseException) -> BaseException | None:
         pickle.dumps(e)
         return e
     except Exception:
-        logger.debug("Ignoring exception in _safe_pickle_exception", exc_info=True)
+        logger.debug("Falling back to None after error in _safe_pickle_exception", exc_info=True)
         return None
 
 
@@ -599,7 +601,9 @@ def collect_garbage_in_all_workers(timeout: float = 5.0) -> int:
             session.call(Request(op=OP_GC_COLLECT), timeout=timeout)
             collected += 1
         except Exception:
-            logger.debug("Ignoring exception in collect_garbage_in_all_workers", exc_info=True)
+            logger.debug(
+                "Skipping item after error in collect_garbage_in_all_workers", exc_info=True
+            )
             continue
     return collected
 
@@ -1525,5 +1529,5 @@ def get_process_rss_bytes(pid: int) -> int:
         )
         return int(out.strip()) * 1024
     except Exception:
-        logger.debug("Ignoring exception in get_process_rss_bytes", exc_info=True)
+        logger.debug("Falling back to 0 after error in get_process_rss_bytes", exc_info=True)
         return 0

--- a/cognee_db_workers/harness.py
+++ b/cognee_db_workers/harness.py
@@ -25,6 +25,9 @@ import weakref
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from typing import Any, Dict, Optional
+import logging
+
+logger = logging.getLogger(__name__)
 
 SHUTDOWN = "__SUBPROCESS_HARNESS_SHUTDOWN__"
 _DEFAULT_SHUTDOWN_TIMEOUT = 10.0
@@ -262,6 +265,7 @@ def set_pdeathsig() -> bool:
         rc = libc.prctl(PR_SET_PDEATHSIG, signal.SIGTERM, 0, 0, 0)
         return rc == 0
     except Exception:
+        logger.debug("Ignoring exception in set_pdeathsig", exc_info=True)
         return False
 
 
@@ -291,6 +295,7 @@ def start_parent_liveness_watchdog(poll_interval: float = 1.0) -> None:
     try:
         original_ppid = os.getppid()
     except Exception:
+        logger.debug("Ignoring exception in start_parent_liveness_watchdog", exc_info=True)
         return
 
     def _watch() -> None:
@@ -298,6 +303,9 @@ def start_parent_liveness_watchdog(poll_interval: float = 1.0) -> None:
             try:
                 current_ppid = os.getppid()
             except Exception:
+                logger.debug(
+                    "Ignoring exception in start_parent_liveness_watchdog._watch", exc_info=True
+                )
                 return
             if current_ppid != original_ppid:
                 # Parent is gone; exit fast without running atexit handlers
@@ -306,6 +314,9 @@ def start_parent_liveness_watchdog(poll_interval: float = 1.0) -> None:
             try:
                 time.sleep(poll_interval)
             except Exception:
+                logger.debug(
+                    "Ignoring exception in start_parent_liveness_watchdog._watch", exc_info=True
+                )
                 return
 
     t = threading.Thread(target=_watch, name="parent-liveness-watchdog", daemon=True)
@@ -342,11 +353,15 @@ class spawn_without_main:
                 try:
                     main_mod.__spec__ = None
                 except Exception:
-                    pass
+                    logger.debug(
+                        "Ignoring exception in spawn_without_main.__enter__", exc_info=True
+                    )
                 try:
                     main_mod.__file__ = None
                 except Exception:
-                    pass
+                    logger.debug(
+                        "Ignoring exception in spawn_without_main.__enter__", exc_info=True
+                    )
         except BaseException:
             _MAIN_MODULE_MUTATION_LOCK.release()
             raise
@@ -359,11 +374,11 @@ class spawn_without_main:
             try:
                 self._main.__spec__ = self._saved_spec
             except Exception:
-                pass
+                logger.debug("Ignoring exception in spawn_without_main.__exit__", exc_info=True)
             try:
                 self._main.__file__ = self._saved_file
             except Exception:
-                pass
+                logger.debug("Ignoring exception in spawn_without_main.__exit__", exc_info=True)
             return False
         finally:
             _MAIN_MODULE_MUTATION_LOCK.release()
@@ -396,7 +411,7 @@ def _enable_faulthandler() -> None:
         # Best-effort: if faulthandler can't be enabled (no usable stderr,
         # etc.) we just lose this diagnostic. Don't crash the worker over a
         # debugging aid.
-        pass
+        logger.debug("Ignoring exception in _enable_faulthandler", exc_info=True)
 
 
 def run_worker_loop(
@@ -450,6 +465,7 @@ def run_worker_loop(
             init(registry)
         resp_q.put(Response(result=_READY_SENTINEL))
     except Exception as e:
+        logger.debug("Ignoring exception in run_worker_loop", exc_info=True)
         resp_q.put(Response(error=traceback.format_exc(), exception=_safe_pickle_exception(e)))
         return
 
@@ -481,6 +497,7 @@ def run_worker_loop(
             try:
                 _emit(rid, await coro)
             except Exception as e:
+                logger.debug("Ignoring exception in run_worker_loop._run_async", exc_info=True)
                 _emit_error(rid, e)
 
     async def serve() -> None:
@@ -506,6 +523,7 @@ def run_worker_loop(
             try:
                 result = handler(registry, msg)
             except Exception as e:
+                logger.debug("Ignoring exception in run_worker_loop.serve", exc_info=True)
                 _emit_error(rid, e)
                 continue
 
@@ -522,7 +540,7 @@ def run_worker_loop(
         try:
             loop.close()
         except Exception:
-            pass
+            logger.debug("Ignoring exception in run_worker_loop", exc_info=True)
 
 
 def _safe_pickle_exception(e: BaseException) -> BaseException | None:
@@ -530,6 +548,7 @@ def _safe_pickle_exception(e: BaseException) -> BaseException | None:
         pickle.dumps(e)
         return e
     except Exception:
+        logger.debug("Ignoring exception in _safe_pickle_exception", exc_info=True)
         return None
 
 
@@ -580,6 +599,7 @@ def collect_garbage_in_all_workers(timeout: float = 5.0) -> int:
             session.call(Request(op=OP_GC_COLLECT), timeout=timeout)
             collected += 1
         except Exception:
+            logger.debug("Ignoring exception in collect_garbage_in_all_workers", exc_info=True)
             continue
     return collected
 
@@ -603,7 +623,7 @@ def _reap_all_sessions_atexit() -> None:
         try:
             session._terminate(timeout=2.0)
         except Exception:
-            pass
+            logger.debug("Ignoring exception in _reap_all_sessions_atexit", exc_info=True)
 
 
 atexit.register(_reap_all_sessions_atexit)
@@ -720,14 +740,17 @@ class SubprocessSession:
         try:
             pid = self._proc.pid
         except Exception:
+            logger.debug("Ignoring exception in SubprocessSession._init_diagnostics", exc_info=True)
             pid = None
         try:
             exitcode = self._proc.exitcode
         except Exception:
+            logger.debug("Ignoring exception in SubprocessSession._init_diagnostics", exc_info=True)
             exitcode = None
         try:
             alive = self._proc.is_alive()
         except Exception:
+            logger.debug("Ignoring exception in SubprocessSession._init_diagnostics", exc_info=True)
             alive = None
         return f"pid={pid} exitcode={_describe_exitcode(exitcode)} alive={alive}"
 
@@ -899,6 +922,9 @@ class SubprocessSession:
                     # type that slipped past the targeted clauses above
                     # would bubble out and leave callers waiting on
                     # futures forever.
+                    logger.debug(
+                        "Ignoring exception in SubprocessSession._reader_loop", exc_info=True
+                    )
                     transport_err = SubprocessTransportError(
                         f"Subprocess reader internal error: {e!r}"
                     )
@@ -1407,7 +1433,7 @@ class SubprocessSession:
                     except std_queue.Empty:
                         pass
             except Exception:
-                pass
+                logger.debug("Ignoring exception in SubprocessSession.shutdown", exc_info=True)
 
         # ``_terminate`` reaps the worker process, which closes the
         # multiprocessing queue's underlying pipe; that unblocks any
@@ -1473,13 +1499,13 @@ class SubprocessSession:
                 while self._proc.is_alive() and time.monotonic() < deadline:
                     self._proc.join(timeout=0.05)
             except Exception:
-                pass
+                logger.debug("Ignoring exception in SubprocessSession._terminate", exc_info=True)
 
     def __del__(self) -> None:
         try:
             self.shutdown(timeout=2.0)
         except Exception:
-            pass
+            logger.debug("Ignoring exception in SubprocessSession.__del__", exc_info=True)
 
 
 def get_process_rss_bytes(pid: int) -> int:
@@ -1499,4 +1525,5 @@ def get_process_rss_bytes(pid: int) -> int:
         )
         return int(out.strip()) * 1024
     except Exception:
+        logger.debug("Ignoring exception in get_process_rss_bytes", exc_info=True)
         return 0

--- a/cognee_db_workers/kuzu_worker.py
+++ b/cognee_db_workers/kuzu_worker.py
@@ -9,6 +9,8 @@ working without churn.
 
 from __future__ import annotations
 
+import logging
+
 from ._kuzu_helpers import install_json_extension_local
 from .harness import (
     DEFAULT_DISPATCH,
@@ -27,7 +29,6 @@ from .kuzu_protocol import (
     OP_OPEN_CONNECTION,
     OP_OPEN_DATABASE,
 )
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee_db_workers/kuzu_worker.py
+++ b/cognee_db_workers/kuzu_worker.py
@@ -27,6 +27,9 @@ from .kuzu_protocol import (
     OP_OPEN_CONNECTION,
     OP_OPEN_DATABASE,
 )
+import logging
+
+logger = logging.getLogger(__name__)
 
 _LOCK_HELD_MARKER = "could not set lock on file"
 
@@ -119,7 +122,7 @@ def _db_close(registry: HandleRegistry, req: Request) -> None:
         try:
             db.close()
         except Exception:
-            pass
+            logger.debug("Ignoring exception in _db_close", exc_info=True)
 
 
 def _open_connection(registry: HandleRegistry, req: Request) -> HandleResult:
@@ -137,7 +140,7 @@ def _conn_close(registry: HandleRegistry, req: Request) -> None:
         try:
             conn.close()
         except Exception:
-            pass
+            logger.debug("Ignoring exception in _conn_close", exc_info=True)
 
 
 def _conn_execute_fetch_all(registry: HandleRegistry, req: Request):
@@ -167,7 +170,7 @@ def _conn_execute_fetch_all(registry: HandleRegistry, req: Request):
             try:
                 result.close()
             except Exception:
-                pass
+                logger.debug("Ignoring exception in _conn_execute_fetch_all", exc_info=True)
     return rows
 
 

--- a/cognee_db_workers/lancedb_worker.py
+++ b/cognee_db_workers/lancedb_worker.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from .harness import (
     DEFAULT_DISPATCH,
     HandleRegistry,
@@ -28,7 +30,6 @@ from .lancedb_protocol import (
     OP_TABLE_TO_ARROW,
     OP_TABLE_VECTOR_SEARCH_EXECUTE,
 )
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/cognee_db_workers/lancedb_worker.py
+++ b/cognee_db_workers/lancedb_worker.py
@@ -223,7 +223,7 @@ async def _op_merge_insert_execute(registry: HandleRegistry, req: Request):
             "num_deleted_rows": getattr(result, "num_deleted_rows", None),
         }
     except Exception:
-        logger.debug("Ignoring exception in _op_merge_insert_execute", exc_info=True)
+        logger.debug("Falling back to None after error in _op_merge_insert_execute", exc_info=True)
         return None
 
 

--- a/cognee_db_workers/lancedb_worker.py
+++ b/cognee_db_workers/lancedb_worker.py
@@ -28,6 +28,9 @@ from .lancedb_protocol import (
     OP_TABLE_TO_ARROW,
     OP_TABLE_VECTOR_SEARCH_EXECUTE,
 )
+import logging
+
+logger = logging.getLogger(__name__)
 
 # The connection is stored at a fixed handle id (0) since there is exactly one
 # per worker.
@@ -219,6 +222,7 @@ async def _op_merge_insert_execute(registry: HandleRegistry, req: Request):
             "num_deleted_rows": getattr(result, "num_deleted_rows", None),
         }
     except Exception:
+        logger.debug("Ignoring exception in _op_merge_insert_execute", exc_info=True)
         return None
 
 

--- a/distributed/deploy/daytona_sandbox.py
+++ b/distributed/deploy/daytona_sandbox.py
@@ -18,6 +18,7 @@ Usage:
 """
 
 import asyncio
+import logging
 import os
 import sys
 import time
@@ -30,7 +31,6 @@ from daytona import (  # type: ignore[import-untyped]
     Resources,
     SessionExecuteRequest,
 )
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/deploy/daytona_sandbox.py
+++ b/distributed/deploy/daytona_sandbox.py
@@ -30,6 +30,9 @@ from daytona import (  # type: ignore[import-untyped]
     Resources,
     SessionExecuteRequest,
 )
+import logging
+
+logger = logging.getLogger(__name__)
 
 DAYTONA_API_URL = "https://app.daytona.io/api"
 
@@ -125,6 +128,7 @@ def deploy_cognee():
             result = sandbox.process.exec("python /tmp/healthcheck.py", timeout=10)
             status = result.result.strip()
         except Exception:
+            logger.debug("Ignoring exception in deploy_cognee", exc_info=True)
             status = "WAITING"
         if "OK" in status:
             print("Server is ready!")
@@ -136,7 +140,7 @@ def deploy_cognee():
             log = sandbox.process.exec("tail -30 /tmp/cognee-server.log", timeout=5)
             print(f"\nServer log:\n{log.result}")
         except Exception:
-            pass
+            logger.debug("Ignoring exception in deploy_cognee", exc_info=True)
         print("WARNING: Server may not be ready yet.")
 
     # Generate a signed preview URL (no auth headers needed)

--- a/evals/old/comparative_eval/helpers/calculate_aggregate_metrics.py
+++ b/evals/old/comparative_eval/helpers/calculate_aggregate_metrics.py
@@ -25,8 +25,8 @@ def calculate_aggregates_for_files(json_paths: list[str]) -> None:
             logger.info(f"Calculating aggregate metrics for {json_path}")
             calculate_metrics_statistics(json_path, output_path)
             logger.info(f"Saved aggregate metrics to {output_path}")
-        except Exception as e:
-            logger.error(f"Failed to calculate metrics for {json_path}: {e}")
+        except Exception:
+            logger.exception(f"Failed to calculate metrics for {json_path}")
 
 
 if __name__ == "__main__":

--- a/evals/old/comparative_eval/helpers/convert_metrics.py
+++ b/evals/old/comparative_eval/helpers/convert_metrics.py
@@ -4,6 +4,9 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import pandas as pd
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def convert_metrics_file(json_path: str, metrics: list[str] | None = None) -> dict[str, Any]:
@@ -71,6 +74,7 @@ def process_multiple_files(
             results.append(converted)
             print(f"Processed: {json_path}")
         except Exception as e:
+            logger.debug("Ignoring exception in process_multiple_files", exc_info=True)
             print(f"Error processing {json_path}: {e}")
 
     # Save JSON results

--- a/evals/old/comparative_eval/helpers/convert_metrics.py
+++ b/evals/old/comparative_eval/helpers/convert_metrics.py
@@ -1,10 +1,10 @@
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List
 
 import pandas as pd
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/evals/old/falkor_01042025/hotpot_qa_falkor_graphrag_sdk.py
+++ b/evals/old/falkor_01042025/hotpot_qa_falkor_graphrag_sdk.py
@@ -8,6 +8,9 @@ from graphrag_sdk import KnowledgeGraph, Ontology
 from graphrag_sdk.model_config import KnowledgeGraphModelConfig
 from graphrag_sdk.models.litellm import LiteModel
 from graphrag_sdk.source import STRING, URL
+import logging
+
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 
@@ -141,6 +144,7 @@ def answer_questions(
         try:
             response = chat.send_message(question)
         except Exception as e:
+            logger.debug("Ignoring exception in answer_questions", exc_info=True)
             print(f"Error processing question: {e!s}")
             response = "Error: Unable to generate answer due to an internal error."
 

--- a/evals/old/falkor_01042025/hotpot_qa_falkor_graphrag_sdk.py
+++ b/evals/old/falkor_01042025/hotpot_qa_falkor_graphrag_sdk.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from dataclasses import dataclass
 
@@ -8,7 +9,6 @@ from graphrag_sdk import KnowledgeGraph, Ontology
 from graphrag_sdk.model_config import KnowledgeGraphModelConfig
 from graphrag_sdk.models.litellm import LiteModel
 from graphrag_sdk.source import STRING, URL
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/evals/old/hotpot_qa_24_2025/src/analysis/get_results.py
+++ b/evals/old/hotpot_qa_24_2025/src/analysis/get_results.py
@@ -2,6 +2,9 @@ import json
 import os
 from pathlib import Path
 from typing import Any, Dict, List
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def read_results(dir_path: str) -> dict[str, Any]:
@@ -19,6 +22,7 @@ def read_results(dir_path: str) -> dict[str, Any]:
         except json.JSONDecodeError as e:
             print(f"Error reading {file_path}: {e}")
         except Exception as e:
+            logger.debug("Ignoring exception in read_results", exc_info=True)
             print(f"Error processing {file_path}: {e}")
 
     return results

--- a/evals/old/hotpot_qa_24_2025/src/analysis/get_results.py
+++ b/evals/old/hotpot_qa_24_2025/src/analysis/get_results.py
@@ -1,8 +1,8 @@
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/evals/old/hotpot_qa_24_2025/src/create_benchmark_summary_json.py
+++ b/evals/old/hotpot_qa_24_2025/src/create_benchmark_summary_json.py
@@ -203,7 +203,9 @@ def process_single_benchmark(
             )
             metric_values[metric] = {"mean": mean, "confidence_interval": confidence_interval}
         except Exception as e:
-            logger.debug("Ignoring exception in process_single_benchmark", exc_info=True)
+            logger.debug(
+                "Falling back to None after error in process_single_benchmark", exc_info=True
+            )
             print(f"❌ Error processing {metric} for {benchmark_name}: {e}")
             return None
 
@@ -519,7 +521,7 @@ def main():
             print("⚠️  No benchmarks found in CSV")
 
     except Exception as e:
-        logger.debug("Ignoring exception in main", exc_info=True)
+        logger.debug("Giving up after error in main", exc_info=True)
         print(f"❌ Error loading cross-benchmark data: {e}")
         return
 
@@ -536,7 +538,7 @@ def main():
         print(f"\n🎉 Success! JSON saved to: {OUTPUT_PATH}")
         print("📄 You can now use the benchmark summary JSON file")
     except Exception as e:
-        logger.debug("Ignoring exception in main", exc_info=True)
+        logger.debug("Giving up after error in main", exc_info=True)
         print(f"❌ Error saving results: {e}")
         return
 

--- a/evals/old/hotpot_qa_24_2025/src/create_benchmark_summary_json.py
+++ b/evals/old/hotpot_qa_24_2025/src/create_benchmark_summary_json.py
@@ -5,13 +5,13 @@ Converts CSV data into JSON format with confidence intervals.
 """
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import pandas as pd
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/evals/old/hotpot_qa_24_2025/src/create_benchmark_summary_json.py
+++ b/evals/old/hotpot_qa_24_2025/src/create_benchmark_summary_json.py
@@ -11,6 +11,9 @@ from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import pandas as pd
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def validate_csv_exists(csv_path: str) -> bool:
@@ -200,6 +203,7 @@ def process_single_benchmark(
             )
             metric_values[metric] = {"mean": mean, "confidence_interval": confidence_interval}
         except Exception as e:
+            logger.debug("Ignoring exception in process_single_benchmark", exc_info=True)
             print(f"❌ Error processing {metric} for {benchmark_name}: {e}")
             return None
 
@@ -377,6 +381,7 @@ def process_all_benchmarks(temp_dir: str, max_benchmarks: int = 3) -> list[dict[
                 error_count += 1
 
         except Exception as e:
+            logger.debug("Ignoring exception in process_all_benchmarks", exc_info=True)
             handle_processing_errors(benchmark_name, e)
             error_count += 1
 
@@ -514,6 +519,7 @@ def main():
             print("⚠️  No benchmarks found in CSV")
 
     except Exception as e:
+        logger.debug("Ignoring exception in main", exc_info=True)
         print(f"❌ Error loading cross-benchmark data: {e}")
         return
 
@@ -530,6 +536,7 @@ def main():
         print(f"\n🎉 Success! JSON saved to: {OUTPUT_PATH}")
         print("📄 You can now use the benchmark summary JSON file")
     except Exception as e:
+        logger.debug("Ignoring exception in main", exc_info=True)
         print(f"❌ Error saving results: {e}")
         return
 

--- a/evals/old/hotpot_qa_24_2025/src/helpers/calculate_aggregate_metrics.py
+++ b/evals/old/hotpot_qa_24_2025/src/helpers/calculate_aggregate_metrics.py
@@ -25,8 +25,8 @@ def calculate_aggregates_for_files(json_paths: list[str]) -> None:
             logger.info(f"Calculating aggregate metrics for {json_path}")
             calculate_metrics_statistics(json_path, output_path)
             logger.info(f"Saved aggregate metrics to {output_path}")
-        except Exception as e:
-            logger.error(f"Failed to calculate metrics for {json_path}: {e}")
+        except Exception:
+            logger.exception(f"Failed to calculate metrics for {json_path}")
 
 
 if __name__ == "__main__":

--- a/evals/old/hotpot_qa_24_2025/src/helpers/convert_metrics.py
+++ b/evals/old/hotpot_qa_24_2025/src/helpers/convert_metrics.py
@@ -4,6 +4,9 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import pandas as pd
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def convert_metrics_file(json_path: str, metrics: list[str] | None = None) -> dict[str, Any]:
@@ -71,6 +74,7 @@ def process_multiple_files(
             results.append(converted)
             print(f"Processed: {json_path}")
         except Exception as e:
+            logger.debug("Ignoring exception in process_multiple_files", exc_info=True)
             print(f"Error processing {json_path}: {e}")
 
     # Save JSON results

--- a/evals/old/hotpot_qa_24_2025/src/helpers/convert_metrics.py
+++ b/evals/old/hotpot_qa_24_2025/src/helpers/convert_metrics.py
@@ -1,10 +1,10 @@
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List
 
 import pandas as pd
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/evals/old/hotpot_qa_24_2025/src/modal_apps/modal_evaluate_qa.py
+++ b/evals/old/hotpot_qa_24_2025/src/modal_apps/modal_evaluate_qa.py
@@ -1,6 +1,9 @@
 import modal
 
 from modal_apps.modal_image import image
+import logging
+
+logger = logging.getLogger(__name__)
 
 APP_NAME = "volume-reader"
 VOLUME_NAME = "qa-benchmarks"
@@ -51,6 +54,7 @@ def get_answers_files(benchmark_folder: str):
         print("📭 Answers folder is empty or doesn't exist")
         return []
     except Exception as e:
+        logger.debug("Ignoring exception in get_answers_files", exc_info=True)
         print(f"❌ Error reading answers folder: {e}")
         return []
 
@@ -193,6 +197,7 @@ def calculate_qa_metrics(benchmark_folder: str, filename: str):
     except json.JSONDecodeError as e:
         print(f"❌ Invalid JSON in {filename}: {e}")
     except Exception as e:
+        logger.debug("Ignoring exception in calculate_qa_metrics", exc_info=True)
         print(f"❌ Error processing {filename}: {e}")
 
 

--- a/evals/old/hotpot_qa_24_2025/src/modal_apps/modal_evaluate_qa.py
+++ b/evals/old/hotpot_qa_24_2025/src/modal_apps/modal_evaluate_qa.py
@@ -55,7 +55,7 @@ def get_answers_files(benchmark_folder: str):
         print("📭 Answers folder is empty or doesn't exist")
         return []
     except Exception as e:
-        logger.debug("Ignoring exception in get_answers_files", exc_info=True)
+        logger.debug("Falling back to [] after error in get_answers_files", exc_info=True)
         print(f"❌ Error reading answers folder: {e}")
         return []
 

--- a/evals/old/hotpot_qa_24_2025/src/modal_apps/modal_evaluate_qa.py
+++ b/evals/old/hotpot_qa_24_2025/src/modal_apps/modal_evaluate_qa.py
@@ -1,7 +1,8 @@
+import logging
+
 import modal
 
 from modal_apps.modal_image import image
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_base.py
+++ b/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_base.py
@@ -6,6 +6,9 @@ from typing import Any, Dict, List, Optional
 
 from dotenv import load_dotenv
 from tqdm import tqdm
+import logging
+
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 
@@ -99,6 +102,7 @@ class QABenchmarkRAG(ABC):
             try:
                 answer = await self.query_rag(question)
             except Exception as e:
+                logger.debug("Ignoring exception in QABenchmarkRAG.answer_questions", exc_info=True)
                 print(f"Error processing question {i + 1}: {e}")
                 answer = f"Error: {e!s}"
 

--- a/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_base.py
+++ b/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_base.py
@@ -1,12 +1,12 @@
 import asyncio
 import json
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from dotenv import load_dotenv
 from tqdm import tqdm
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_cognee.py
+++ b/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_cognee.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -15,7 +16,6 @@ from cognee.eval_framework.corpus_builder.corpus_builder_executor import CorpusB
 from cognee.eval_framework.corpus_builder.task_getters.TaskGetters import TaskGetters
 
 from .qa_benchmark_base import QABenchmarkConfig, QABenchmarkRAG
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_cognee.py
+++ b/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_cognee.py
@@ -155,7 +155,7 @@ class QABenchmarkCognee(QABenchmarkRAG):
                 return "No relevant information found."
 
         except Exception as e:
-            logger.debug("Ignoring exception in QABenchmarkCognee.query_rag", exc_info=True)
+            logger.debug("Falling back after error in QABenchmarkCognee.query_rag", exc_info=True)
             print(f"Error during retrieval: {e}")
             return f"Error: {e!s}"
 

--- a/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_cognee.py
+++ b/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_cognee.py
@@ -15,6 +15,9 @@ from cognee.eval_framework.corpus_builder.corpus_builder_executor import CorpusB
 from cognee.eval_framework.corpus_builder.task_getters.TaskGetters import TaskGetters
 
 from .qa_benchmark_base import QABenchmarkConfig, QABenchmarkRAG
+import logging
+
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 
@@ -152,6 +155,7 @@ class QABenchmarkCognee(QABenchmarkRAG):
                 return "No relevant information found."
 
         except Exception as e:
+            logger.debug("Ignoring exception in QABenchmarkCognee.query_rag", exc_info=True)
             print(f"Error during retrieval: {e}")
             return f"Error: {e!s}"
 

--- a/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_graphiti.py
+++ b/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_graphiti.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -12,7 +13,6 @@ from graphiti_core.nodes import EpisodeType
 from langchain_openai import ChatOpenAI
 
 from .qa_benchmark_base import QABenchmarkConfig, QABenchmarkRAG
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_graphiti.py
+++ b/evals/old/hotpot_qa_24_2025/src/qa/qa_benchmark_graphiti.py
@@ -12,6 +12,9 @@ from graphiti_core.nodes import EpisodeType
 from langchain_openai import ChatOpenAI
 
 from .qa_benchmark_base import QABenchmarkConfig, QABenchmarkRAG
+import logging
+
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 
@@ -68,6 +71,7 @@ class QABenchmarkGraphiti(QABenchmarkRAG):
             for record in indexes_result.records:
                 print(f"  - {record.get('name', 'unnamed')}: {record.get('type', 'unknown')}")
         except Exception as e:
+            logger.debug("Ignoring exception in QABenchmarkGraphiti.initialize_rag", exc_info=True)
             print(f"❌ Error checking schema: {e}")
 
         # Initialize LLM for final answer generation
@@ -82,6 +86,7 @@ class QABenchmarkGraphiti(QABenchmarkRAG):
             await graphiti.driver.execute_query("MATCH (n) DETACH DELETE n")
             print("Database cleared successfully")
         except Exception as e:
+            logger.debug("Ignoring exception in QABenchmarkGraphiti._clear_database", exc_info=True)
             print(f"Warning: Could not clear database: {e}")
 
     async def cleanup_rag(self) -> None:

--- a/evals/old/hotpot_qa_24_2025/src/run_cross_benchmark_analysis.py
+++ b/evals/old/hotpot_qa_24_2025/src/run_cross_benchmark_analysis.py
@@ -113,7 +113,7 @@ def process_single_benchmark(benchmark_folder: str, volume_path: str) -> bool:
         print(f"✅ Successfully processed: {benchmark_folder}")
         return True
     except Exception as e:
-        logger.debug("Ignoring exception in process_single_benchmark", exc_info=True)
+        logger.debug("Falling back to False after error in process_single_benchmark", exc_info=True)
         print(f"❌ Error processing {benchmark_folder}: {e}")
         return False
 

--- a/evals/old/hotpot_qa_24_2025/src/run_cross_benchmark_analysis.py
+++ b/evals/old/hotpot_qa_24_2025/src/run_cross_benchmark_analysis.py
@@ -11,6 +11,9 @@ from pathlib import Path
 
 import pandas as pd
 from analysis.analyze_single_benchmark import analyze_single_benchmark_folder
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def download_modal_volume(volume_name: str, download_path: str) -> None:
@@ -110,6 +113,7 @@ def process_single_benchmark(benchmark_folder: str, volume_path: str) -> bool:
         print(f"✅ Successfully processed: {benchmark_folder}")
         return True
     except Exception as e:
+        logger.debug("Ignoring exception in process_single_benchmark", exc_info=True)
         print(f"❌ Error processing {benchmark_folder}: {e}")
         return False
 
@@ -175,6 +179,7 @@ def create_cross_benchmark_summary(volume_path: str, results: dict) -> None:
                 print(f"  ✅ Added {benchmark_folder}: {len(df)} questions")
 
             except Exception as e:
+                logger.debug("Ignoring exception in create_cross_benchmark_summary", exc_info=True)
                 print(f"  ❌ Error reading {benchmark_folder}: {e}")
         else:
             print(f"  ⚠️  No aggregate file found for {benchmark_folder}")

--- a/evals/old/hotpot_qa_24_2025/src/run_cross_benchmark_analysis.py
+++ b/evals/old/hotpot_qa_24_2025/src/run_cross_benchmark_analysis.py
@@ -4,6 +4,7 @@ Cross-benchmark analysis orchestration script.
 Downloads qa-benchmarks volume and processes each benchmark folder.
 """
 
+import logging
 import os
 import subprocess
 import sys
@@ -11,7 +12,6 @@ from pathlib import Path
 
 import pandas as pd
 from analysis.analyze_single_benchmark import analyze_single_benchmark_folder
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/examples/demos/sessions/agentic_session_context_demo.py
+++ b/examples/demos/sessions/agentic_session_context_demo.py
@@ -48,11 +48,12 @@ os.environ["AUTO_FEEDBACK"] = "true"
 os.environ["ENABLE_BACKEND_ACCESS_CONTROL"] = "false"
 os.environ.setdefault("LOG_LEVEL", "ERROR")
 
+import logging
+
 import cognee
 from cognee.infrastructure.session.get_session_manager import get_session_manager
 from cognee.memory import TraceEntry
 from cognee.modules.users.methods import get_default_user
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/examples/demos/sessions/agentic_session_context_demo.py
+++ b/examples/demos/sessions/agentic_session_context_demo.py
@@ -192,7 +192,7 @@ async def run_distillation_act(user) -> dict:
             "cognified_documents": result.documents,
         }
     except Exception as exc:
-        logger.debug("Ignoring exception in run_distillation_act", exc_info=True)
+        logger.debug("Falling back after error in run_distillation_act", exc_info=True)
         progress(f"Act 2 failed: {exc}")
         return {
             "flush_touched_entry_ids": [],

--- a/examples/demos/sessions/agentic_session_context_demo.py
+++ b/examples/demos/sessions/agentic_session_context_demo.py
@@ -52,6 +52,9 @@ import cognee
 from cognee.infrastructure.session.get_session_manager import get_session_manager
 from cognee.memory import TraceEntry
 from cognee.modules.users.methods import get_default_user
+import logging
+
+logger = logging.getLogger(__name__)
 
 DATASET_NAME = "agentic_session_context_demo"
 SESSION_ID = "agentic_demo_session"
@@ -188,6 +191,7 @@ async def run_distillation_act(user) -> dict:
             "cognified_documents": result.documents,
         }
     except Exception as exc:
+        logger.debug("Ignoring exception in run_distillation_act", exc_info=True)
         progress(f"Act 2 failed: {exc}")
         return {
             "flush_touched_entry_ids": [],

--- a/examples/demos/sessions/session_feedback_lifecycle_demo/backend/app.py
+++ b/examples/demos/sessions/session_feedback_lifecycle_demo/backend/app.py
@@ -12,6 +12,8 @@ os.environ.setdefault("CACHE_BACKEND", "fs")
 os.environ.setdefault("AUTO_FEEDBACK", "true")
 os.environ.setdefault("ENV", "dev")
 
+import logging
+
 import uvicorn
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import FileResponse
@@ -25,7 +27,6 @@ from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.memify_pipelines.apply_feedback_weights import apply_feedback_weights_pipeline
 from cognee.modules.data.methods import get_authorized_existing_datasets
 from cognee.modules.users.methods import get_default_user
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/examples/demos/sessions/session_feedback_lifecycle_demo/backend/app.py
+++ b/examples/demos/sessions/session_feedback_lifecycle_demo/backend/app.py
@@ -238,7 +238,7 @@ async def _safe_search(question: str, session_id: str, top_k: int = 5) -> str:
             if results:
                 break
         except Exception:
-            logger.debug("Ignoring exception in _safe_search", exc_info=True)
+            logger.debug("Skipping item after error in _safe_search", exc_info=True)
             continue
 
     if not results:

--- a/examples/demos/sessions/session_feedback_lifecycle_demo/backend/app.py
+++ b/examples/demos/sessions/session_feedback_lifecycle_demo/backend/app.py
@@ -25,6 +25,9 @@ from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.memify_pipelines.apply_feedback_weights import apply_feedback_weights_pipeline
 from cognee.modules.data.methods import get_authorized_existing_datasets
 from cognee.modules.users.methods import get_default_user
+import logging
+
+logger = logging.getLogger(__name__)
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 FRONTEND_DIR = BASE_DIR / "frontend"
@@ -234,6 +237,7 @@ async def _safe_search(question: str, session_id: str, top_k: int = 5) -> str:
             if results:
                 break
         except Exception:
+            logger.debug("Ignoring exception in _safe_search", exc_info=True)
             continue
 
     if not results:

--- a/examples/integrations/docker-sandbox-kit/demo/supervisor_worker_handover.py
+++ b/examples/integrations/docker-sandbox-kit/demo/supervisor_worker_handover.py
@@ -75,7 +75,7 @@ async def get_or_create_user(email: str, password: str):
     try:
         return await create_user(email, password)
     except Exception:  # UserAlreadyExists on re-runs
-        logger.debug("Ignoring exception in get_or_create_user", exc_info=True)
+        logger.debug("Falling back after error in get_or_create_user", exc_info=True)
         return await get_user_by_email(email)
 
 

--- a/examples/integrations/docker-sandbox-kit/demo/supervisor_worker_handover.py
+++ b/examples/integrations/docker-sandbox-kit/demo/supervisor_worker_handover.py
@@ -40,13 +40,14 @@ from uuid import UUID
 # The auth posture is resolved when cognee is imported — configure it first.
 os.environ.setdefault("ENABLE_BACKEND_ACCESS_CONTROL", "true")
 
+import logging
+
 import cognee
 from cognee.infrastructure.databases.relational import create_db_and_tables
 from cognee.modules.data.methods import get_datasets
 from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.modules.users.methods import create_user, get_user_by_email
 from cognee.modules.users.permissions.methods import authorized_give_permission_on_datasets
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/examples/integrations/docker-sandbox-kit/demo/supervisor_worker_handover.py
+++ b/examples/integrations/docker-sandbox-kit/demo/supervisor_worker_handover.py
@@ -46,6 +46,9 @@ from cognee.modules.data.methods import get_datasets
 from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.modules.users.methods import create_user, get_user_by_email
 from cognee.modules.users.permissions.methods import authorized_give_permission_on_datasets
+import logging
+
+logger = logging.getLogger(__name__)
 
 SUPERVISOR_EMAIL = "supervisor@handover.demo"
 WORKER_EMAIL = "worker@handover.demo"
@@ -71,6 +74,7 @@ async def get_or_create_user(email: str, password: str):
     try:
         return await create_user(email, password)
     except Exception:  # UserAlreadyExists on re-runs
+        logger.debug("Ignoring exception in get_or_create_user", exc_info=True)
         return await get_user_by_email(email)
 
 
@@ -146,6 +150,7 @@ async def phase_work(token_file: Path) -> None:
     except PermissionDeniedError as err:
         print(f"[worker] correctly denied: {type(err).__name__}: {err}")
     except Exception as err:
+        logger.debug("Ignoring exception in phase_work", exc_info=True)
         print(f"[worker] correctly not found: {type(err).__name__}: {err}")
 
     print("[worker] writing the completion report back into the shared dataset...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -325,6 +325,10 @@ extend-immutable-calls = [
 # Package init order is load-bearing (side-effect registration, circular-import
 # avoidance); sorting these breaks `import cognee`.
 "__init__.py" = ["I001"]
+# Logging handlers and filters must never log or raise from inside emit()/filter():
+# doing so re-enters the logging machinery. They swallow broadly and report via
+# Handler.handleError, the same shape the stdlib handlers use.
+"cognee/shared/logging_utils.py" = ["BLE001", "S110"]
 
 [tool.ty.src]
 # TODO: Gradually add more directories to include until we have type hints for all modules

--- a/tests/test_exif_perceptualhash.py
+++ b/tests/test_exif_perceptualhash.py
@@ -69,7 +69,7 @@ def _format_gps_info(gps_dict: dict) -> str | None:
         lat = _to_decimal(gps_dict.get(2), gps_dict.get(1, "N"))
         lon = _to_decimal(gps_dict.get(4), gps_dict.get(3, "E"))
     except Exception:
-        logger.debug("Ignoring exception in _format_gps_info", exc_info=True)
+        logger.debug("Falling back to None after error in _format_gps_info", exc_info=True)
         return None
 
     parts = []
@@ -90,7 +90,7 @@ def _extract_exif_metadata(file_path: str) -> str | None:
         with Image.open(file_path) as img:
             exif_data = img._getexif()
     except Exception:
-        logger.debug("Ignoring exception in _extract_exif_metadata", exc_info=True)
+        logger.debug("Falling back to None after error in _extract_exif_metadata", exc_info=True)
         return None
 
     if exif_data is None:

--- a/tests/test_exif_perceptualhash.py
+++ b/tests/test_exif_perceptualhash.py
@@ -2,12 +2,12 @@
 Standalone tests for EXIF and perceptual-hash helpers extracted from ImageLoader.
 """
 
+import logging
 import os
 import tempfile
 
 import pytest
 from PIL import Image
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_exif_perceptualhash.py
+++ b/tests/test_exif_perceptualhash.py
@@ -7,6 +7,9 @@ import tempfile
 
 import pytest
 from PIL import Image
+import logging
+
+logger = logging.getLogger(__name__)
 
 # ------------------------------------------------------------------
 #  Standalone helper functions (copied from what would be added to image_loader.py)
@@ -66,6 +69,7 @@ def _format_gps_info(gps_dict: dict) -> str | None:
         lat = _to_decimal(gps_dict.get(2), gps_dict.get(1, "N"))
         lon = _to_decimal(gps_dict.get(4), gps_dict.get(3, "E"))
     except Exception:
+        logger.debug("Ignoring exception in _format_gps_info", exc_info=True)
         return None
 
     parts = []
@@ -86,6 +90,7 @@ def _extract_exif_metadata(file_path: str) -> str | None:
         with Image.open(file_path) as img:
             exif_data = img._getexif()
     except Exception:
+        logger.debug("Ignoring exception in _extract_exif_metadata", exc_info=True)
         return None
 
     if exif_data is None:
@@ -180,6 +185,7 @@ def jpeg_with_exif():
             img.save(f, format="JPEG", exif=exif.tobytes())
         except Exception:
             # Fallback: save without EXIF
+            logger.debug("Ignoring exception in jpeg_with_exif", exc_info=True)
             img.save(f, format="JPEG")
         path = f.name
     yield path

--- a/tools/check_router_docstrings.py
+++ b/tools/check_router_docstrings.py
@@ -316,7 +316,7 @@ def main() -> int:
     try:
         reports = check_routes()
     except Exception as exc:
-        logger.debug("Ignoring exception in main", exc_info=True)
+        logger.debug("Exiting with status 2 after error in main", exc_info=True)
         print(f"Failed to import cognee API app: {exc}", file=sys.stderr)
         return 2
 

--- a/tools/check_router_docstrings.py
+++ b/tools/check_router_docstrings.py
@@ -33,12 +33,12 @@ from __future__ import annotations
 
 import argparse
 import inspect
+import logging
 import os
 import re
 import sys
 import typing
 from dataclasses import dataclass, field
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/tools/check_router_docstrings.py
+++ b/tools/check_router_docstrings.py
@@ -38,6 +38,9 @@ import re
 import sys
 import typing
 from dataclasses import dataclass, field
+import logging
+
+logger = logging.getLogger(__name__)
 
 # Markdown-style sections ("## Request Parameters") and Google-style ones ("Args:")
 PARAM_SECTION_RE = re.compile(
@@ -313,6 +316,7 @@ def main() -> int:
     try:
         reports = check_routes()
     except Exception as exc:
+        logger.debug("Ignoring exception in main", exc_info=True)
         print(f"Failed to import cognee API app: {exc}", file=sys.stderr)
         return 2
 

--- a/tools/check_spec_extras.py
+++ b/tools/check_spec_extras.py
@@ -112,7 +112,7 @@ def main() -> int:
     try:
         spec = load_app_schema()
     except Exception as exc:
-        logger.debug("Ignoring exception in main", exc_info=True)
+        logger.debug("Exiting with status 2 after error in main", exc_info=True)
         print(f"Failed to import cognee API app: {exc}", file=sys.stderr)
         return 2
 

--- a/tools/check_spec_extras.py
+++ b/tools/check_spec_extras.py
@@ -31,11 +31,11 @@ Exit codes mirror ``check_router_docstrings.py``:
 from __future__ import annotations
 
 import argparse
+import logging
 import os
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/tools/check_spec_extras.py
+++ b/tools/check_spec_extras.py
@@ -35,6 +35,9 @@ import os
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
+import logging
+
+logger = logging.getLogger(__name__)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -109,6 +112,7 @@ def main() -> int:
     try:
         spec = load_app_schema()
     except Exception as exc:
+        logger.debug("Ignoring exception in main", exc_info=True)
         print(f"Failed to import cognee API app: {exc}", file=sys.stderr)
         return 2
 

--- a/tools/describe_router_params.py
+++ b/tools/describe_router_params.py
@@ -26,6 +26,9 @@ import sys
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
 
 PLACEHOLDER = "No description provided in code yet."
 BULLET_RE = re.compile(
@@ -238,6 +241,7 @@ def main() -> int:
     try:
         descriptions = generate_descriptions(placeholders)
     except Exception as exc:
+        logger.debug("Ignoring exception in main", exc_info=True)
         print(f"Description generation failed: {exc}", file=sys.stderr)
         return 1
 

--- a/tools/describe_router_params.py
+++ b/tools/describe_router_params.py
@@ -20,13 +20,13 @@ from __future__ import annotations
 
 import ast
 import json
+import logging
 import os
 import re
 import sys
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/tools/describe_router_params.py
+++ b/tools/describe_router_params.py
@@ -241,7 +241,7 @@ def main() -> int:
     try:
         descriptions = generate_descriptions(placeholders)
     except Exception as exc:
-        logger.debug("Ignoring exception in main", exc_info=True)
+        logger.debug("Exiting with status 1 after error in main", exc_info=True)
         print(f"Description generation failed: {exc}", file=sys.stderr)
         return 1
 

--- a/tools/fix_router_docstrings.py
+++ b/tools/fix_router_docstrings.py
@@ -507,7 +507,7 @@ def main() -> int:
     try:
         fixes = collect_fixes()
     except Exception as exc:
-        logger.debug("Ignoring exception in main", exc_info=True)
+        logger.debug("Exiting with status 2 after error in main", exc_info=True)
         print(f"Failed to import cognee API app: {exc}", file=sys.stderr)
         return 2
 

--- a/tools/fix_router_docstrings.py
+++ b/tools/fix_router_docstrings.py
@@ -33,13 +33,14 @@ from dataclasses import dataclass, field
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+import logging
+
 from check_router_docstrings import (  # noqa: E402
     actual_params,
     documented_params,
     iter_api_routes,
     normalize,
 )
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/tools/fix_router_docstrings.py
+++ b/tools/fix_router_docstrings.py
@@ -39,6 +39,9 @@ from check_router_docstrings import (  # noqa: E402
     iter_api_routes,
     normalize,
 )
+import logging
+
+logger = logging.getLogger(__name__)
 
 PATH_SECTION = "Path Parameters"
 QUERY_SECTION = "Query Parameters"
@@ -503,6 +506,7 @@ def main() -> int:
     try:
         fixes = collect_fixes()
     except Exception as exc:
+        logger.debug("Ignoring exception in main", exc_info=True)
         print(f"Failed to import cognee API app: {exc}", file=sys.stderr)
         return 2
 

--- a/tools/fix_spec_extras.py
+++ b/tools/fix_spec_extras.py
@@ -39,10 +39,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import sys
 from pathlib import Path
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/tools/fix_spec_extras.py
+++ b/tools/fix_spec_extras.py
@@ -180,7 +180,7 @@ def main() -> int:
     try:
         spec = load_app_schema()
     except Exception as exc:
-        logger.debug("Ignoring exception in main", exc_info=True)
+        logger.debug("Exiting with status 2 after error in main", exc_info=True)
         print(f"Failed to import cognee API app: {exc}", file=sys.stderr)
         return 2
 

--- a/tools/fix_spec_extras.py
+++ b/tools/fix_spec_extras.py
@@ -42,6 +42,9 @@ import json
 import os
 import sys
 from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -177,6 +180,7 @@ def main() -> int:
     try:
         spec = load_app_schema()
     except Exception as exc:
+        logger.debug("Ignoring exception in main", exc_info=True)
         print(f"Failed to import cognee API app: {exc}", file=sys.stderr)
         return 2
 

--- a/tools/generate_release_notes.py
+++ b/tools/generate_release_notes.py
@@ -11,6 +11,7 @@ which can overwrite CI environment variables with .env file placeholders.
 
 import argparse
 import asyncio
+import logging
 import os
 import re
 import subprocess
@@ -18,7 +19,6 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/tools/generate_release_notes.py
+++ b/tools/generate_release_notes.py
@@ -18,6 +18,9 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def run_git_command(command: list[str]) -> str:
@@ -54,6 +57,7 @@ def get_latest_release_tag(exclude: str | None = None) -> str | None:
                 return tag
         return None
     except Exception:
+        logger.debug("Ignoring exception in get_latest_release_tag", exc_info=True)
         return None
 
 
@@ -133,7 +137,7 @@ def _parse_dependencies(pyproject_text: str) -> dict[str, str]:
                 deps[name] = spec
         return deps
     except Exception:
-        pass
+        logger.debug("Ignoring exception in _parse_dependencies", exc_info=True)
 
     # Fallback: extract the [project].dependencies = [ ... ] array textually.
     match = re.search(r"^dependencies\s*=\s*\[(.*?)\]", pyproject_text, re.DOTALL | re.MULTILINE)
@@ -155,6 +159,7 @@ def get_dependency_changes(base_ref: str, target_ref: str) -> dict[str, list[str
     except SystemExit:
         return changes
     except Exception:
+        logger.debug("Ignoring exception in get_dependency_changes", exc_info=True)
         return changes
 
     base_deps = _parse_dependencies(base_text)
@@ -177,9 +182,11 @@ def get_compatibility_info(target_ref: str) -> dict[str, str]:
     try:
         text = run_git_command(["git", "show", f"{target_ref}:pyproject.toml"])
     except Exception:
+        logger.debug("Ignoring exception in get_compatibility_info", exc_info=True)
         try:
             text = (Path(__file__).parent.parent / "pyproject.toml").read_text()
         except Exception:
+            logger.debug("Ignoring exception in get_compatibility_info", exc_info=True)
             return info
 
     py_match = re.search(r'^requires-python\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE)
@@ -327,6 +334,7 @@ Create engaging release notes that help users understand what's new and improved
         )
         return response
     except Exception as e:
+        logger.debug("Ignoring exception in generate_release_notes_with_llm", exc_info=True)
         print(f"Warning: LLM generation failed: {e}", file=sys.stderr)
         return None
 
@@ -522,6 +530,7 @@ async def main():
             else:
                 version = "unknown"
         except Exception as e:
+            logger.debug("Ignoring exception in main", exc_info=True)
             print(f"Warning: Could not extract version: {e}", file=sys.stderr)
             version = "unknown"
 

--- a/tools/generate_release_notes.py
+++ b/tools/generate_release_notes.py
@@ -57,7 +57,7 @@ def get_latest_release_tag(exclude: str | None = None) -> str | None:
                 return tag
         return None
     except Exception:
-        logger.debug("Ignoring exception in get_latest_release_tag", exc_info=True)
+        logger.debug("Falling back to None after error in get_latest_release_tag", exc_info=True)
         return None
 
 
@@ -159,7 +159,7 @@ def get_dependency_changes(base_ref: str, target_ref: str) -> dict[str, list[str
     except SystemExit:
         return changes
     except Exception:
-        logger.debug("Ignoring exception in get_dependency_changes", exc_info=True)
+        logger.debug("Falling back after error in get_dependency_changes", exc_info=True)
         return changes
 
     base_deps = _parse_dependencies(base_text)
@@ -186,7 +186,7 @@ def get_compatibility_info(target_ref: str) -> dict[str, str]:
         try:
             text = (Path(__file__).parent.parent / "pyproject.toml").read_text()
         except Exception:
-            logger.debug("Ignoring exception in get_compatibility_info", exc_info=True)
+            logger.debug("Falling back after error in get_compatibility_info", exc_info=True)
             return info
 
     py_match = re.search(r'^requires-python\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE)
@@ -334,7 +334,9 @@ Create engaging release notes that help users understand what's new and improved
         )
         return response
     except Exception as e:
-        logger.debug("Ignoring exception in generate_release_notes_with_llm", exc_info=True)
+        logger.debug(
+            "Falling back to None after error in generate_release_notes_with_llm", exc_info=True
+        )
         print(f"Warning: LLM generation failed: {e}", file=sys.stderr)
         return None
 


### PR DESCRIPTION
## Description
Completes the exception-handling sweep that #4969 set up ([SDK-583](https://linear.app/cognee/issue/SDK-583/fix-red-code-quality-ci-after-the-ruff-0160-bump)). The strict Code Quality step (`ruff check . --select BLE001,S110,S112,G201,TRY201,TRY002 --ignore-noqa`) goes from **748 findings to 0** on every tracked file, so it turns green on dev with this merge. The rest of the lint backlog is out of scope.

### Policy applied, per handler shape
Ruff credits a broad handler when it logs with the traceback, or re-raises, or chains a new exception with `from`. Each site got the smallest change that satisfies that, preserving the log level and the control flow:

| Shape found | Sites | Change |
|---|---|---|
| handler already logs, no traceback | 204 | `exc_info=True` added to that call (warning 138, debug 53, info 13) |
| handler logs at error level | 89 | becomes `logger.exception(...)`; the exception object is dropped from the message since the traceback carries it |
| handler logged with an explicit `exc_info=False` | 7 | flipped to `True` |
| handler swallows silently (`pass`, `return`, `continue`, assignment) | 302 | a debug-level traceback log inserted as the first statement; the behaviour is unchanged. The message says what the handler does next: "Ignoring exception in X" where the error is dropped, "Falling back to None after error in X" for fallback returns, "Giving up after error in X" for a bare return, "Skipping item after error in X" in loops, "Exiting with status N" in `main()` |
| handler returns an HTTP 500 response | 2 | `logger.exception("<endpoint> failed, returning HTTP 500")` at error level, since a 500 is a server failure the operator must see |
| handler raises a new exception without `from` | 4 | chained with `from <error>` |
| `raise Exception(...)` (TRY002) | 22 | `raise RuntimeError(...)`; every `except Exception` upstream still catches it |
| `# noqa` on these rules | 20 | removed (the strict step ignores them anyway) |

102 modules had no logger and got one: `get_logger()` inside `cognee/` library code, `logging.getLogger(__name__)` in tests and in packages that do not import cognee. 54 `except X as e` names that the changes left unused were dropped.

### Hand-fixed sites
- **`cognee/shared/logging_utils.py`**: the two handler `emit()` methods and the record filter must swallow broadly and report through `Handler.handleError`; logging or raising from inside the logging machinery re-enters it. Declared as a per-file ignore for `BLE001`/`S110` in `pyproject.toml`, the same shape the stdlib handlers use. The module's other nine handlers are fixed normally (traceback logging, stdlib logging in the excepthook fallback, `OSError` narrowing for the writable-directory probes).
- **`.github/scripts/motherduck_nightly_etl.py`**: narrowed to `duckdb.Error` and keeps `from None`. The DuckDB error text can carry the S3 secret, so neither chaining nor a traceback log is acceptable there.
- **`test_budget_exhaustion.py`**: one test builds an implicit `__context__` chain on purpose and asserts `__cause__` stays unset; it narrows its `except` instead of chaining.
- **Test modules use stdlib loggers.** Worker subprocesses import test modules to unpickle their init callables; importing cognee's logging there pulls the whole package into every spawned worker. Two subprocess-session timing tests went from 1.7 s to 5.5 s with `get_logger()` in the test module, and back with `logging.getLogger`.

### What did not change
No handler catches anything different, except the four narrowed sites named above. No handler stops swallowing: a debug-level traceback is recorded where an error used to vanish. Log levels are preserved everywhere except the 89 error-level calls, which move to `logger.exception` at the same level.

### Verification
- Strict step: 0 findings on tracked files (`--ignore-noqa`). Whole-tree `ruff check .` drops from 1978 to 1244; no new finding of any other rule on the touched files (TRY401, G201, F841, F541 all 0).
- `ruff format --check .` passes; pre-commit ruff 0.15.11 check and format pass on every touched file.
- Full unit suite and the incremental-update e2e suite pass locally with all extras installed; every cognee module imports exactly as on dev.

### Commits
Eight, by area, each revertable alone: the logging carve-out, infrastructure, modules, api, tasks/cli/shared, tests, the packages outside `cognee/`, and an import-sort pass over the modules that gained a logger.

## Type of Change
- [x] Code refactoring
- [x] Other (please specify): lint policy enforcement

### CI note
The strict step was never actually executing: the Code Quality job runs its steps in sequence and the general `ruff check` fails first, so the strict step, the format check and the type check were all skipped behind it, on this PR and on dev. The last commit gives the strict step `if: ${{ !cancelled() }}` so the gate reports on its own. The format and type-check steps still sit behind the general check; making them independent as well is a one-line change each if wanted.
