### PR TITLE
feat: Add organizing your data demo (RES-36)

### DIFF
--- a/examples/demos/organizing_your_data/data/api_reference.md
+++ b/examples/demos/organizing_your_data/data/api_reference.md
@@ -1,0 +1,10 @@
+# Acme API Reference — Rate Limits
+
+Every API key is rate limited to **100 requests per minute**. Requests beyond
+the limit receive an HTTP 429 response with a `Retry-After` header.
+
+Enterprise plans can raise the limit to **500 requests per minute per key**.
+No plan, including Enterprise, offers unlimited requests.
+
+Rate limits are enforced per key, not per account. Provision multiple keys to
+shard traffic across workloads.

--- a/examples/demos/organizing_your_data/data/architecture_guide.md
+++ b/examples/demos/organizing_your_data/data/architecture_guide.md
@@ -1,0 +1,9 @@
+# Acme Architecture Guide — Sync Engine
+
+The sync engine replicates data between regions asynchronously. Writes are
+acknowledged in the origin region first and propagate to the other regions
+with an **eventual-consistency window of up to 60 seconds**.
+
+Sync is therefore *not* real-time: a read in a remote region immediately
+after a write may return stale data. Applications that need read-after-write
+consistency must pin reads to the origin region.

--- a/examples/demos/organizing_your_data/data/sales_call_hooli.txt
+++ b/examples/demos/organizing_your_data/data/sales_call_hooli.txt
@@ -1,0 +1,12 @@
+Sales call transcript — Hooli, April 3
+
+Hooli (Platform Lead): We run active-active across three regions. Is the
+sync engine real-time?
+
+Acme (Account Executive): Sync is instant across all regions — the moment
+you write in one region it's readable everywhere else.
+
+Hooli (Platform Lead): Great, that means we can drop our own replication
+layer entirely.
+
+Acme (Account Executive): Exactly, that's what most of our customers do.

--- a/examples/demos/organizing_your_data/data/sales_call_initech.txt
+++ b/examples/demos/organizing_your_data/data/sales_call_initech.txt
@@ -1,0 +1,13 @@
+Sales call transcript — Initech, March 12
+
+Initech (VP Engineering): Our batch jobs burst hard. The 100 requests per
+minute cap would be a blocker for us.
+
+Acme (Account Executive): For an enterprise deal we can basically remove the
+rate limits. During the pilot phase you'd have unlimited requests — we won't
+throttle you at all while you evaluate.
+
+Initech (VP Engineering): Unlimited during the pilot works. Send that over
+in writing with the proposal.
+
+Acme (Account Executive): Absolutely, I'll include it in the proposal deck.

--- a/examples/demos/organizing_your_data/organizing_your_data_demo.py
+++ b/examples/demos/organizing_your_data/organizing_your_data_demo.py
@@ -1,0 +1,204 @@
+"""Organizing your data: one dataset, node sets, or separate datasets.
+
+Run with:
+
+    uv run python examples/demos/organizing_your_data/organizing_your_data_demo.py
+
+The scenario: you feed cognee a mix of content types — technical documentation
+AND sales-call transcripts — and answers start blending the two. A question
+about API rate limits comes back seasoned with whatever a sales rep promised a
+customer on a call. The graph is doing its job (linking related facts); the
+problem is that everything lives in one undifferentiated pile.
+
+This demo ingests the same small corpus (two docs, two call transcripts from
+``data/``) three ways and asks the same questions each time:
+
+    (1) ALL DATA IN ONE DATASET       simplest; retrieval sees everything at
+                                      once — this reproduces the confusion
+    (2) ONE DATASET, NODE SETS        every item tagged with one or more node
+                                      sets: soft, overlappable groups inside
+                                      one shared graph; recall can be scoped
+                                      per query, cross-domain links survive
+    (3) SEPARATE DATASETS             tech vs sales behind a hard boundary
+        (+ node sets inside each)     (own permissions, isolated storage,
+                                      independent forget); node sets still
+                                      slice finer inside each dataset
+
+Rule of thumb: node sets are tags, datasets are walls.
+
+Requires a configured LLM provider (see CLAUDE.md). Wording of answers varies
+by model.
+"""
+
+import asyncio
+from pathlib import Path
+
+import cognee
+from cognee import SearchType
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+
+TECH_DOCS = [
+    str(DATA_DIR / "api_reference.md"),
+    str(DATA_DIR / "architecture_guide.md"),
+]
+SALES_CALL_INITECH = str(DATA_DIR / "sales_call_initech.txt")
+SALES_CALL_HOOLI = str(DATA_DIR / "sales_call_hooli.txt")
+
+RATE_LIMIT_QUERY = "What rate limits does the Acme API enforce?"
+
+
+def banner(title: str) -> None:
+    print(f"\n{'=' * 78}\n{title}\n{'=' * 78}", flush=True)
+
+
+def show(query: str, scope: str, results, note: str = "") -> None:
+    """Print one recall as a comparable QUERY / SCOPE / ANSWER block."""
+    print(f"\n  QUERY : {query}", flush=True)
+    print(f"  SCOPE : {scope}", flush=True)
+    if note:
+        print(f"  NOTE  : {note}", flush=True)
+    for entry in results:
+        dataset = getattr(entry, "dataset_name", None)
+        prefix = f"[{dataset}] " if dataset else ""
+        text = str(entry.text).replace("\n", "\n          ")
+        print(f"  ANSWER: {prefix}{text}", flush=True)
+
+
+async def section_1_everything_in_one_dataset():
+    banner("(1) ALL DATA IN ONE DATASET — the setup that confuses the LLM")
+
+    await cognee.remember(
+        TECH_DOCS + [SALES_CALL_INITECH, SALES_CALL_HOOLI], self_improvement=False
+    )
+
+    answer = await cognee.recall(RATE_LIMIT_QUERY, query_type=SearchType.HYBRID_COMPLETION)
+    show(
+        RATE_LIMIT_QUERY,
+        "everything (no filter)",
+        answer,
+        note="docs and sales calls share one retrieval pool — the documented limit "
+        "(100/min) competes with the rep's 'unlimited requests' promise",
+    )
+
+
+async def section_2_one_dataset_with_node_sets():
+    banner("(2) ONE DATASET, SEPARATE NODE SETS — tags inside one shared graph")
+
+    # An item can carry several tags at once: everything here is also tagged
+    # "acme_api", so a shared grouping cuts across the docs/calls split.
+    await cognee.remember(TECH_DOCS, node_set=["tech_docs", "acme_api"], self_improvement=False)
+    await cognee.remember(
+        [SALES_CALL_INITECH, SALES_CALL_HOOLI],
+        node_set=["sales_calls", "acme_api"],
+        self_improvement=False,
+    )
+
+    docs_answer = await cognee.recall(
+        RATE_LIMIT_QUERY,
+        query_type=SearchType.HYBRID_COMPLETION,
+        node_name=["tech_docs"],
+    )
+    show(RATE_LIMIT_QUERY, "node_name=['tech_docs']", docs_answer, note="the documented truth only")
+
+    sales_query = "What did we promise customers about rate limits?"
+    sales_answer = await cognee.recall(
+        sales_query,
+        query_type=SearchType.HYBRID_COMPLETION,
+        node_name=["sales_calls"],
+    )
+    show(sales_query, "node_name=['sales_calls']", sales_answer, note="what the reps actually said")
+
+    # The graph is still ONE graph — cross-domain questions work when you
+    # want them to, by simply not filtering.
+    cross_query = "Where do our sales promises contradict the technical documentation?"
+    cross_answer = await cognee.recall(cross_query, query_type=SearchType.GRAPH_COMPLETION)
+    show(
+        cross_query,
+        "everything (no filter, on purpose)",
+        cross_answer,
+        note="a cross-domain question spanning both groups",
+    )
+
+
+async def section_3_separate_datasets():
+    banner("(3) SEPARATE DATASETS (tech vs sales) — hard walls, node sets inside")
+
+    # Graphs are built independently: a recall scoped to one dataset can never
+    # surface content from the other. Node sets still apply INSIDE a dataset —
+    # here the sales dataset tags each call by account.
+    await cognee.remember(
+        TECH_DOCS,
+        dataset_name="tech_docs",
+        node_set=["api_reference"],
+        self_improvement=False,
+    )
+    await cognee.remember(
+        SALES_CALL_INITECH,
+        dataset_name="sales_calls",
+        node_set=["initech"],
+        self_improvement=False,
+    )
+    await cognee.remember(
+        SALES_CALL_HOOLI,
+        dataset_name="sales_calls",
+        node_set=["hooli"],
+        self_improvement=False,
+    )
+
+    docs_answer = await cognee.recall(
+        RATE_LIMIT_QUERY,
+        query_type=SearchType.HYBRID_COMPLETION,
+        datasets=["tech_docs"],
+    )
+    show(RATE_LIMIT_QUERY, "datasets=['tech_docs']", docs_answer, note="sales calls cannot leak in")
+
+    initech_query = "What was discussed with Initech?"
+    initech_answer = await cognee.recall(
+        initech_query,
+        query_type=SearchType.HYBRID_COMPLETION,
+        datasets=["sales_calls"],
+        node_name=["initech"],
+    )
+    show(
+        initech_query,
+        "datasets=['sales_calls'] + node_name=['initech']",
+        initech_answer,
+        note="one account's calls only",
+    )
+
+    # Caution: recall() without `datasets` spans ALL datasets you can read —
+    # separating data at write time is not enough, queries must opt into the
+    # scope they want.
+    unscoped_answer = await cognee.recall(RATE_LIMIT_QUERY, query_type=SearchType.HYBRID_COMPLETION)
+    show(
+        RATE_LIMIT_QUERY,
+        "everything (no dataset filter)",
+        unscoped_answer,
+        note="spans both datasets again — scope must be chosen per query",
+    )
+
+
+async def main():
+    await cognee.forget(everything=True)
+    await section_1_everything_in_one_dataset()
+
+    await cognee.forget(everything=True)
+    await section_2_one_dataset_with_node_sets()
+
+    await cognee.forget(everything=True)
+    await section_3_separate_datasets()
+
+    banner("TAKEAWAY")
+    print(
+        "  Node sets are tags: soft groups inside one shared graph — scoped AND\n"
+        "  cross-domain questions both work. Datasets are walls: own permissions,\n"
+        "  isolated storage, independent forget — content never crosses over.\n"
+        "  Mixing docs and sales calls? Start with node sets; move the domains\n"
+        "  into separate datasets when they must never contaminate each other.",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Description

Adds `examples/demos/organizing_your_data/` — a narrated demo answering a recurring client question: *"I'm using a mix of our technical docs and sales calls, and my LLM is getting confused."*

The demo ingests the same four-file corpus (two markdown docs with real limits, two sales-call transcripts with a rep's over-promises, bundled under `data/`) three ways, running the same queries under each layout and printing every recall as a comparable `QUERY / SCOPE / NOTE / ANSWER` block:

1. **All data in one dataset** — unscoped retrieval reproduces the confusion
2. **One dataset, separate node sets** — `recall(node_name=[...])` scopes per query; an unfiltered recall still answers cross-domain questions (where do our promises contradict the docs?)
3. **Separate datasets (tech vs sales), node sets inside each** — hard isolation, combined `datasets` + `node_name` filters, and a closing caution that unscoped `recall()` spans all readable datasets

Takeaway the script prints: **node sets are tags, datasets are walls.**

Verified end-to-end on default settings (Ladybug + LanceDB + OpenAI), `self_improvement=False` throughout, `forget(everything=True)` between sections. Ruff-clean under the pre-commit-pinned ruff 0.15.11.

## Linked

- Linear: [RES-36](https://linear.app/cognee/issue/RES-36/ship-organizing-your-data-demo-and-docs-examples-article)
- Companion docs page (merge this PR first): topoteretes/cognee-docs#1619

## Note on CI

The `Community Tests / Code Quality` job currently fails for **all** PRs: `uv.lock` resolves ruff 0.16.0 while pre-commit pins 0.15.11, so the standalone `uv run ruff check .` step flags ~2k pre-existing repo-wide errors. The fix (`ruff==0.15.11` pin, commit `da6b3021b`) is on `feat/source-discovery-routing` but not yet on `dev`. This PR's own files are clean under both versions' shared rules; will update from dev once the pin lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)