### PR TITLE
chore: Clear the read-and-fix lint findings and fix three defects they exposed (SDK-583)

### DIFF
--- a/cognee/api/v1/ui/ui.py
+++ b/cognee/api/v1/ui/ui.py
@@ -572,7 +572,7 @@ def start_ui(
                 docker_cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+                start_new_session=True,
             )
 
             _stream_process_output(mcp_process, "stdout", "[MCP]", "\033[34m")  # Blue
@@ -606,7 +606,7 @@ def start_ui(
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+                start_new_session=True,
             )
 
             # Start threads to stream backend output with prefix
@@ -714,7 +714,7 @@ def start_ui(
                     env=env,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
-                    preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+                    start_new_session=True,
                 )
             else:
                 process = subprocess.Popen(
@@ -723,7 +723,7 @@ def start_ui(
                     env=env,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
-                    preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+                    start_new_session=True,
                 )
 
         # Start threads to stream frontend output with prefix

--- a/cognee/cli/debug.py
+++ b/cognee/cli/debug.py
@@ -17,5 +17,4 @@ def disable_debug() -> None:
 
 def is_debug_enabled() -> bool:
     """Check if debug mode is enabled"""
-    global _DEBUG_FLAG
     return _DEBUG_FLAG

--- a/cognee/cli/remediation.py
+++ b/cognee/cli/remediation.py
@@ -32,45 +32,57 @@ from __future__ import annotations
 _TABLE: tuple[tuple[tuple[str, ...], str], ...] = (
     (
         ("authenticationerror", "invalid api key", "incorrect api key"),
-        "The LLM provider rejected the API key. Fix: set LLM_API_KEY in "
-        "your .env to a valid key for the LLM_PROVIDER you configured "
-        "(default provider: openai).",
+        (
+            "The LLM provider rejected the API key. Fix: set LLM_API_KEY in "
+            "your .env to a valid key for the LLM_PROVIDER you configured "
+            "(default provider: openai)."
+        ),
     ),
     (
         ("permissiondeniederror", "insufficient_quota", "billing"),
-        "The LLM provider accepted the key but denied the request. Fix: "
-        "confirm the account has active billing and quota, or switch "
-        "LLM_PROVIDER/LLM_MODEL to one your account can use.",
+        (
+            "The LLM provider accepted the key but denied the request. Fix: "
+            "confirm the account has active billing and quota, or switch "
+            "LLM_PROVIDER/LLM_MODEL to one your account can use."
+        ),
     ),
     (
         # Real error: LLMAPIKeyNotSetError("LLM API key is not set.").
         ("llmapikeynotset", "api key is not set", "no api key"),
-        "LLM_API_KEY is not set. Fix: copy .env.template to .env and "
-        "populate LLM_API_KEY. Cognee defaults to the OpenAI provider "
-        "so an OpenAI key is the simplest starting point.",
+        (
+            "LLM_API_KEY is not set. Fix: copy .env.template to .env and "
+            "populate LLM_API_KEY. Cognee defaults to the OpenAI provider "
+            "so an OpenAI key is the simplest starting point."
+        ),
     ),
     (
         # Real raised messages: "Cannot connect to embedding endpoint. Check
         # EMBEDDING_ENDPOINT." and "Embedding request timed out. Check
         # EMBEDDING_ENDPOINT connectivity."
         ("embedding_endpoint", "cannot connect to embedding", "embedding request timed out"),
-        "The configured EMBEDDING_ENDPOINT is not reachable. Fix: verify "
-        "the URL, that the host is running, and that the port is open. "
-        "Unset EMBEDDING_ENDPOINT to fall back to the provider default.",
+        (
+            "The configured EMBEDDING_ENDPOINT is not reachable. Fix: verify "
+            "the URL, that the host is running, and that the port is open. "
+            "Unset EMBEDDING_ENDPOINT to fall back to the provider default."
+        ),
     ),
     (
         ("ontology file not found",),
-        "The --ontology-file path does not exist. Fix: pass an absolute "
-        "path to an .owl / .ttl file, or drop the flag to use the built-in "
-        "resolver.",
+        (
+            "The --ontology-file path does not exist. Fix: pass an absolute "
+            "path to an .owl / .ttl file, or drop the flag to use the built-in "
+            "resolver."
+        ),
     ),
     (
         # Real error: ProviderConfigMismatchError raised by the config
         # preflight in add()/remember(); its message names the exact env vars.
         ("providerconfigmismatch", "silently default to openai"),
-        "The LLM and embedding provider settings are inconsistent. Run "
-        "`cognee-cli doctor` for a full diagnosis, or set the env vars named "
-        "in the error above.",
+        (
+            "The LLM and embedding provider settings are inconsistent. Run "
+            "`cognee-cli doctor` for a full diagnosis, or set the env vars named "
+            "in the error above."
+        ),
     ),
 )
 

--- a/cognee/context_global_variables.py
+++ b/cognee/context_global_variables.py
@@ -3,6 +3,8 @@ import warnings
 from contextvars import ContextVar
 from uuid import UUID
 
+from typing_extensions import Self
+
 from cognee.base_config import get_base_config
 from cognee.exceptions import CogneeValidationError
 from cognee.infrastructure.databases.graph.config import get_graph_config, get_graph_context_config
@@ -364,7 +366,7 @@ class DatabaseContextManager:
         )
         return self._apply().__await__()
 
-    async def __aenter__(self) -> "DatabaseContextManager":
+    async def __aenter__(self) -> Self:
         await self._apply()
         return self
 

--- a/cognee/eval_framework/beam/eval/metrics/kendall_tau.py
+++ b/cognee/eval_framework/beam/eval/metrics/kendall_tau.py
@@ -241,14 +241,12 @@ class KendallTauMetric:
 
             # System ranks: based on alignment
             sys_rank_map = {}
-            sys_pos = 0
             for i in range(len(system_events)):
                 ref_idx = alignment.get(i, -1)
                 if ref_idx >= 0 and ref_idx < len(reference_events):
-                    sys_rank_map[ref_idx] = sys_pos
+                    sys_rank_map[ref_idx] = i
                 else:
-                    sys_rank_map[len(reference_events) + i] = sys_pos
-                sys_pos += 1
+                    sys_rank_map[len(reference_events) + i] = i
 
             sys_ranks = [sys_rank_map.get(u, tie_rank) for u in union]
 

--- a/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
+++ b/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
@@ -835,7 +835,9 @@ class SQLAlchemyAdapter:
                 for schema_name in schema_list:
                     # Get tables for the current schema via the inspector.
                     tables = await connection.run_sync(
-                        lambda sync_conn: inspect(sync_conn).get_table_names(schema=schema_name)
+                        lambda sync_conn, schema_name=schema_name: inspect(
+                            sync_conn
+                        ).get_table_names(schema=schema_name)
                     )
                     for table_name in tables:
                         # Optionally, qualify the table name with the schema if not in the default schema.

--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -347,10 +347,7 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
             # already bypasses the handlers below and propagates unwrapped.)
             raise
 
-        except (
-            litellm.exceptions.BadRequestError,
-            litellm.exceptions.NotFoundError,
-        ) as e:
+        except litellm.exceptions.NotFoundError as e:
             logger.error(f"Embedding error with model {self.model}: {e!s}")
             raise EmbeddingException(f"Failed to index data points using model {self.model}") from e
 

--- a/cognee/infrastructure/databases/vector/embeddings/config.py
+++ b/cognee/infrastructure/databases/vector/embeddings/config.py
@@ -106,7 +106,7 @@ class EmbeddingConfig(BaseSettings):
     embedding_rate_limit_tokens: int = 0  # max tokens per interval (0 = disabled)
     model_config = SettingsConfigDict(env_file=".env", extra="allow", populate_by_name=True)
 
-    def model_post_init(self, __context) -> None:
+    def model_post_init(self, context, /) -> None:
         if self.embedding_dimensions is None:
             derived = _resolve_embedding_dimensions(self.embedding_provider, self.embedding_model)
             if derived is not None:

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -6,7 +6,14 @@ import types
 from collections import OrderedDict
 from enum import Enum
 from os import path
-from typing import List, Optional, Union, get_args, get_origin, get_type_hints
+from typing import (  # noqa: UP035 - typing.List is a distinct origin key, not an annotation
+    List,
+    Optional,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 from uuid import UUID
 
 import lancedb

--- a/cognee/infrastructure/files/storage/LocalFileStorage.py
+++ b/cognee/infrastructure/files/storage/LocalFileStorage.py
@@ -217,7 +217,7 @@ class LocalFileStorage(Storage):
                     f"Requested file: '{file_path}'"
                 )
 
-        with open(full_file_path, mode=mode, *args, **kwargs) as file:
+        with open(full_file_path, mode, *args, **kwargs) as file:
             file = FileBufferedReader(file, name=Path(full_file_path).as_uri())
 
             try:

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -307,7 +307,7 @@ class LLMConfig(BaseSettings):
         """
         return _apply_local_rate_limit_default(self)
 
-    def model_post_init(self, __context) -> None:
+    def model_post_init(self, context, /) -> None:
         """Initialize the BAML registry after the model is created."""
         # Check if BAML is selected as structured output framework but not available
         if self.structured_output_framework.lower() == "baml" and ClientRegistry is None:

--- a/cognee/modules/agents/agent_mode.py
+++ b/cognee/modules/agents/agent_mode.py
@@ -57,7 +57,6 @@ def _shutdown_server():
 
 
 def _watchdog():
-    global _active_count
     timer = threading.Timer(60.0, _watchdog)
     timer.daemon = True
     timer.start()

--- a/cognee/modules/migration/cogx.py
+++ b/cognee/modules/migration/cogx.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Literal, Union
 
 from pydantic import BaseModel, Field, TypeAdapter
+from typing_extensions import Self
 
 COGX_VERSION = "0.1"
 
@@ -234,7 +235,7 @@ class COGXArchiveWriter:
         self.migration_revision: str | None = None
         self._handles: dict[str, Any] = {}
 
-    def __enter__(self) -> "COGXArchiveWriter":
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:

--- a/cognee/modules/migrations/versions/rekey_fork_document_ids.py
+++ b/cognee/modules/migrations/versions/rekey_fork_document_ids.py
@@ -296,7 +296,7 @@ async def _rekey_chunk_scoped_provenance(graph_engine, fork_rows: list) -> None:
         except UnsupportedProvenanceCapability:
             return
 
-        def _forked_v2_refs(ref_map: dict) -> dict:
+        def _forked_v2_refs(ref_map: dict, *, dataset_id=dataset_id, id_map=id_map) -> dict:
             """old v2 ref key -> (new v2 ref key, holder ids)."""
             moves: dict = {}
             for holder, refs in ref_map.items():
@@ -542,9 +542,9 @@ async def _rekey_graph_nodes(
 
     # Graph last: re-key the document nodes themselves (also updates each
     # node's own document_id property when it mirrors the node id).
-    for old_id in id_map:
+    for old_id, new_id in id_map.items():
         if str(properties_by_id[old_id].get("document_id")) == old_id:
-            properties_by_id[old_id]["document_id"] = id_map[old_id]
+            properties_by_id[old_id]["document_id"] = new_id
     remapped_edges = await _migrate_graph(graph_engine, id_map, properties_by_id, normalized_edges)
     logger.info(
         "rekey_fork_document_ids: re-keyed %d fork document node(s), %d edge(s)",

--- a/cognee/modules/pipelines/layers/pipeline_execution_mode.py
+++ b/cognee/modules/pipelines/layers/pipeline_execution_mode.py
@@ -93,10 +93,10 @@ async def run_pipeline_as_background_process(
     async def handle_rest_of_the_run(pipeline_list):
         # Execute all provided pipelines one by one to avoid database write conflicts
         # TODO: Convert to async gather task instead of for loop when Queue mechanism for database is created
-        for pipeline in pipeline_list:
+        for pipeline_run in pipeline_list:
             while True:
                 try:
-                    pipeline_run_info = await anext(pipeline)
+                    pipeline_run_info = await anext(pipeline_run)
                     push_to_queue(pipeline_run_info.pipeline_run_id, pipeline_run_info)
                 except StopAsyncIteration:
                     break

--- a/cognee/modules/pipelines/models/PipelineRun.py
+++ b/cognee/modules/pipelines/models/PipelineRun.py
@@ -40,14 +40,13 @@ class PipelineRun(Base):
             "pipeline_name",
             "created_at",
         ),
+        # Readers of this table page newest-first with id as the tiebreaker
+        # (ORDER BY created_at DESC, id DESC) or range-scan a created_at window,
+        # so the two columns are indexed together. Composite, not created_at
+        # alone: without id, OFFSET paging re-serves rows sharing a timestamp.
+        # Mirrored by migration c4e8a1f6b3d7 for databases created before it.
+        Index("ix_pipeline_runs_created_at_id", "created_at", "id"),
     )
-
-    # Readers of this table page newest-first with id as the tiebreaker
-    # (ORDER BY created_at DESC, id DESC) or range-scan a created_at window,
-    # so the two columns are indexed together. Composite, not created_at
-    # alone: without id, OFFSET paging re-serves rows sharing a timestamp.
-    # Mirrored by migration c4e8a1f6b3d7 for databases created before it.
-    __table_args__ = (Index("ix_pipeline_runs_created_at_id", "created_at", "id"),)
 
     id = Column(UUID, primary_key=True, default=uuid4)
 

--- a/cognee/modules/retrieval/utils/description_to_codepart_search.py
+++ b/cognee/modules/retrieval/utils/description_to_codepart_search.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
         user = None
         try:
             results = await code_description_to_code_part_search(query, user)
-            logger.debug("Retrieved Code Parts:", results)
+            logger.debug("Retrieved Code Parts: %s", results)
         except Exception as e:
             logger.error(f"An error occurred: {e}")
             raise

--- a/cognee/modules/session_distillation/models.py
+++ b/cognee/modules/session_distillation/models.py
@@ -12,10 +12,6 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from cognee.infrastructure.session.session_context_models import (
-    MIN_GATE_CONFIDENCE as MIN_GATE_CONFIDENCE,
-)
-
 # -- Tunables ----------------------------------------------------------------
 
 # Gate: a context entry is distillable only when it passes the shared usability

--- a/cognee/modules/session_lifecycle/invalidate_sessions.py
+++ b/cognee/modules/session_lifecycle/invalidate_sessions.py
@@ -111,11 +111,11 @@ async def invalidate_sessions_for_deleted_data(
             sessions.append(candidate)
     totals["sessions_considered"] = len(sessions)
 
-    for user_id, session_id in sessions:
+    for session_user_id, session_id in sessions:
         try:
             counts = await _invalidate_session_entries(
                 session_manager,
-                user_id=str(user_id),
+                user_id=str(session_user_id),
                 session_id=session_id,
                 deleted_node_ids=deleted_node_ids,
                 deleted_edge_ids=deleted_edge_ids,
@@ -127,7 +127,7 @@ async def invalidate_sessions_for_deleted_data(
                 "Session invalidation: targeted cleanup failed for session %s, user %s "
                 "(non-fatal): %s",
                 session_id,
-                user_id,
+                session_user_id,
                 error,
                 exc_info=True,
             )

--- a/cognee/modules/tools/builtin/load_skill.py
+++ b/cognee/modules/tools/builtin/load_skill.py
@@ -37,7 +37,7 @@ async def handler(args: dict[str, Any], **_) -> str:
     if not name:
         raise ToolInvocationError("load_skill requires a 'name' argument")
 
-    skills = active_skills_var.get()
+    skills = active_skills_var.get({})
     skill = skills.get(name)
     if skill is None:
         available = ", ".join(sorted(skills)) or "(none in scope)"

--- a/cognee/modules/tools/context.py
+++ b/cognee/modules/tools/context.py
@@ -14,6 +14,6 @@ from contextvars import ContextVar
 
 from cognee.modules.engine.models import Skill
 
-active_skills_var: ContextVar[dict[str, Skill]] = ContextVar("cognee_active_skills", default={})
+active_skills_var: ContextVar[dict[str, Skill]] = ContextVar("cognee_active_skills")
 
 opened_skills_var: ContextVar[set[str] | None] = ContextVar("cognee_opened_skills", default=None)

--- a/cognee/modules/visualization/preprocessor.py
+++ b/cognee/modules/visualization/preprocessor.py
@@ -768,8 +768,8 @@ def extract_type_schema_graph_data(
             "out": [],
             "in": [],
         }
-    for type_name in instances_by_type:
-        instances_by_type[type_name].sort(key=lambda rec: rec["name"])
+    for records in instances_by_type.values():
+        records.sort(key=lambda rec: rec["name"])
     for link in links_list:
         source = str(link["source"])
         target = str(link["target"])

--- a/cognee/shared/SourceCodeGraph.py
+++ b/cognee/shared/SourceCodeGraph.py
@@ -68,7 +68,7 @@ class Expression(DataPoint):
     name: str
     description: str
     expression: str
-    members: list[Variable | Function | Operator | "Expression"]
+    members: list["Variable | Function | Operator | Expression"]
     metadata: dict = {"index_fields": ["name"]}
 
 

--- a/cognee/shared/graph_model_utils.py
+++ b/cognee/shared/graph_model_utils.py
@@ -141,7 +141,7 @@ def graph_schema_to_graph_model(pydantic_json_schema: dict) -> BaseModel:
     mod = types.ModuleType(module_name)
     sys.modules[module_name] = mod
 
-    exec(result, mod.__dict__)
+    exec(result, mod.__dict__)  # noqa: S102 - runs the generated model module source on purpose
     namespace = mod.__dict__
 
     # Extract the generated graph model class from the module's namespace

--- a/cognee/shared/logging_utils.py
+++ b/cognee/shared/logging_utils.py
@@ -136,8 +136,8 @@ def resolve_logs_dir() -> Path | None:
 MAX_LOG_FILES = 10
 
 # Log rotation defaults — override via COGNEE_LOG_MAX_BYTES / COGNEE_LOG_BACKUP_COUNT
-LOG_MAX_BYTES = int(os.getenv("COGNEE_LOG_MAX_BYTES", 50 * 1024 * 1024))  # 50 MB
-LOG_BACKUP_COUNT = int(os.getenv("COGNEE_LOG_BACKUP_COUNT", 5))  # 5 backups → 300 MB cap
+LOG_MAX_BYTES = int(os.getenv("COGNEE_LOG_MAX_BYTES", "52428800"))  # 50 MB
+LOG_BACKUP_COUNT = int(os.getenv("COGNEE_LOG_BACKUP_COUNT", "5"))  # 5 backups → 300 MB cap
 
 # Version information
 PYTHON_VERSION = platform.python_version()
@@ -450,7 +450,7 @@ def setup_logging(log_level=None, name=None) -> bool:
         if event_dict.get("exc_info"):
             # If it's already a tuple, use it directly
             if isinstance(event_dict["exc_info"], tuple):
-                exc_type, exc_value, tb = event_dict["exc_info"]
+                exc_type, exc_value, _tb = event_dict["exc_info"]
             else:
                 exc_type, exc_value, _tb = sys.exc_info()
 

--- a/cognee/tasks/web_scraper/config.py
+++ b/cognee/tasks/web_scraper/config.py
@@ -26,7 +26,7 @@ class DefaultCrawlerConfig(BaseModel):
     max_crawl_delay: float | None = (
         10.0  # Maximum crawl delay to respect from robots.txt (None = no limit)
     )
-    timeout: float = float(os.getenv("WEB_SCRAPER_TIMEOUT", 15.0))
+    timeout: float = float(os.getenv("WEB_SCRAPER_TIMEOUT", "15.0"))
     max_retries: int = 2
     retry_delay_factor: float = 0.5
     headers: dict[str, str] | None = None

--- a/cognee/tasks/web_scraper/default_url_crawler.py
+++ b/cognee/tasks/web_scraper/default_url_crawler.py
@@ -50,8 +50,8 @@ class DefaultUrlCrawler:
         *,
         concurrency: int = 5,
         crawl_delay: float = 0.5,
-        max_crawl_delay: float | None = float(os.getenv("WEB_SCRAPER_MAX_DELAY", 10.0)),
-        timeout: float = float(os.getenv("WEB_SCRAPER_TIMEOUT", 15.0)),
+        max_crawl_delay: float | None = float(os.getenv("WEB_SCRAPER_MAX_DELAY", "10.0")),
+        timeout: float = float(os.getenv("WEB_SCRAPER_TIMEOUT", "15.0")),
         max_retries: int = 2,
         retry_delay_factor: float = 0.5,
         headers: dict[str, str] | None = None,
@@ -111,8 +111,9 @@ class DefaultUrlCrawler:
         """Exit the context manager, closing the HTTP client."""
         await self.close()
 
+    @staticmethod
     @lru_cache(maxsize=1024)
-    def _domain_from_url(self, url: str) -> str:
+    def _domain_from_url(url: str) -> str:
         """Extract the domain (netloc) from a URL.
 
         Args:
@@ -129,8 +130,9 @@ class DefaultUrlCrawler:
             )
             return url
 
+    @staticmethod
     @lru_cache(maxsize=1024)
-    def _get_domain_root(self, url: str) -> str:
+    def _get_domain_root(url: str) -> str:
         """Get the root URL (scheme and netloc) from a URL.
 
         Args:
@@ -455,13 +457,11 @@ class DefaultUrlCrawler:
         logger.info(f"Creating {len(urls)} async tasks for concurrent fetching")
         tasks = [asyncio.create_task(_task(u, position)) for position, u in enumerate(urls, 1)]
         results = {}
-        completed = 0
         total = len(tasks)
 
-        for coro in asyncio.as_completed(tasks):
+        for completed, coro in enumerate(asyncio.as_completed(tasks), 1):
             url, html = await coro
             results[url] = html
-            completed += 1
             logger.info(f"Progress: {completed}/{total} URLs processed")
 
         logger.info(f"Completed fetching all {len(results)} URL(s)")

--- a/cognee/tests/e2e/serve_routing/test_serve_routing.py
+++ b/cognee/tests/e2e/serve_routing/test_serve_routing.py
@@ -112,7 +112,7 @@ def api_key():
         env=server_env,
         stdout=log_file,
         stderr=subprocess.STDOUT,
-        preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+        start_new_session=True,
     )
 
     deadline = time.time() + SERVER_BOOT_TIMEOUT

--- a/cognee/tests/test_cognee_server_start.py
+++ b/cognee/tests/test_cognee_server_start.py
@@ -26,7 +26,7 @@ class TestCogneeServerStart(unittest.TestCase):
                 "--port",
                 "8000",
             ],
-            preexec_fn=os.setsid,
+            start_new_session=True,
         )
         # Give the server some time to start
         time.sleep(120)

--- a/cognee/tests/unit/api/v1/recall/test_recall_tools.py
+++ b/cognee/tests/unit/api/v1/recall/test_recall_tools.py
@@ -5,7 +5,7 @@ import types
 from uuid import uuid4
 
 import pytest
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from cognee.exceptions import CogneeValidationError
 from cognee.memory.entries import normalize_scope
@@ -72,7 +72,7 @@ class TestResponseUnion:
 
     def test_unknown_source_rejected(self):
         adapter = TypeAdapter(list[RecallResponse])
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             adapter.validate_python([{"source": "nonsense", "text": "x"}])
 
 

--- a/cognee/tests/unit/infrastructure/databases/test_subprocess_session_failures.py
+++ b/cognee/tests/unit/infrastructure/databases/test_subprocess_session_failures.py
@@ -488,7 +488,7 @@ def test_unpicklable_return_surfaces_error():
         # The worker's pickle of the Response will fail when putting on the
         # queue. mp.Queue raises at put time. We just want to ensure it
         # doesn't hang the session.
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017 - transport or timeout error depending on platform; the test guards against a hang
             session.call(Request(op=OP_RETURN_UNPICKLABLE, args=()), timeout=5.0)
     finally:
         session.shutdown()

--- a/cognee/tests/unit/infrastructure/llm/test_budget_exhaustion.py
+++ b/cognee/tests/unit/infrastructure/llm/test_budget_exhaustion.py
@@ -74,8 +74,10 @@ LITELLM_BUDGET_MESSAGES = [
     # for ``_wrapped_budget_error`` and other tests key off its exact wording.
     # The key alias and key hint sit mid-sentence, which is the span the bounded
     # wildcard in ``_BUDGET_SENTENCE_RE`` has to cross.
-    "Budget has been exceeded! Key=my-key-alias (sk-...-VGw) "
-    "Current cost: 20.00066499999998, Max budget: 0.01",
+    (
+        "Budget has been exceeded! Key=my-key-alias (sk-...-VGw) "
+        "Current cost: 20.00066499999998, Max budget: 0.01"
+    ),
 ]
 
 # Prose that a cognified document could plausibly contain. None of it may be

--- a/cognee/tests/unit/modules/integrations/test_crypto.py
+++ b/cognee/tests/unit/modules/integrations/test_crypto.py
@@ -10,6 +10,7 @@ import base64
 import json
 
 import pytest
+from cryptography.exceptions import InvalidTag
 
 from cognee.modules.integrations.crypto import (
     CURRENT_ENCRYPTION_VERSION,
@@ -74,7 +75,7 @@ def test_tampered_ciphertext_raises():
     # GCM authenticates the ciphertext — a flipped byte must fail, not decode garbage.
     ciphertext, nonce, version, key_id = encrypt_credentials({"access_token": "x"})
     tampered = bytes([ciphertext[0] ^ 0xFF]) + ciphertext[1:]
-    with pytest.raises(Exception):
+    with pytest.raises(InvalidTag):
         decrypt_credentials(tampered, nonce, version, key_id)
 
 

--- a/cognee/tests/unit/modules/integrations/test_response_url.py
+++ b/cognee/tests/unit/modules/integrations/test_response_url.py
@@ -47,9 +47,11 @@ def test_accepts_real_slack_response_urls(url):
     [
         (
             "https://hooks.slack.com/services/T0/B0/tok",
-            "Incoming Webhook: same host, and it "
-            "accepts the exact body this module sends, so a forged payload would exfiltrate "
-            "the answer into an attacker's workspace",
+            (
+                "Incoming Webhook: same host, and it "
+                "accepts the exact body this module sends, so a forged payload would exfiltrate "
+                "the answer into an attacker's workspace"
+            ),
         ),
         ("https://hooks.slack.com.evil.com/commands/x", "suffix host"),
         ("https://hooks.slack.com@evil.com/commands/x", "userinfo host"),

--- a/cognee/tests/unit/modules/search/test_search_prepare_search_result_contract.py
+++ b/cognee/tests/unit/modules/search/test_search_prepare_search_result_contract.py
@@ -17,7 +17,10 @@ class DummyDataset(BaseModel):
     owner_id: object
 
 
-def _ds(name="ds1", tenant_id=uuid5(NAMESPACE_OID, "t1")):
+_TENANT_1 = uuid5(NAMESPACE_OID, "t1")
+
+
+def _ds(name="ds1", tenant_id=_TENANT_1):
     return DummyDataset(
         id=uuid5(NAMESPACE_OID, name), name=name, tenant_id=tenant_id, owner_id=uuid4()
     )

--- a/cognee/tests/unit/modules/user_preferences/test_preference_update.py
+++ b/cognee/tests/unit/modules/user_preferences/test_preference_update.py
@@ -562,7 +562,7 @@ class TestRefreshPreferenceText:
 
     def test_cap_drops_the_oldest_lines(self):
         # Enough old whole lines to overflow the cap once a new line lands.
-        old_lines = ["old line %03d" % index for index in range(200)]
+        old_lines = [f"old line {index:03d}" for index in range(200)]
         old_text = "\n".join(old_lines)
         assert len(old_text) > MAX_PREFERENCE_TEXT_CHARS - len("newest line\n")
         entries = [_context_entry("e1", "newest line", "2026-01-05T00:00:00")]

--- a/cognee/tests/unit/processing/chunks/chunk_by_paragraph_test.py
+++ b/cognee/tests/unit/processing/chunks/chunk_by_paragraph_test.py
@@ -64,9 +64,7 @@ Third paragraph is cut and is missing the dot at the end""",
     chunk_by_sentence_module, "get_embedding_engine", side_effect=mock_get_embedding_engine
 )
 def run_chunking_test(test_text, expected_chunks, mock_engine):
-    chunks = []
-    for chunk_data in chunk_by_paragraph(data=test_text, batch_paragraphs=False, max_chunk_size=12):
-        chunks.append(chunk_data)
+    chunks = list(chunk_by_paragraph(data=test_text, batch_paragraphs=False, max_chunk_size=12))
 
     assert len(chunks) == 3
 

--- a/cognee/tests/unit/test_embedding_budget_fastfail.py
+++ b/cognee/tests/unit/test_embedding_budget_fastfail.py
@@ -29,6 +29,7 @@ import httpx
 import litellm
 import openai
 import pytest
+from typing_extensions import Self
 
 from cognee.infrastructure.databases.exceptions import (
     EmbeddingCredentialsError,
@@ -365,7 +366,7 @@ class _FakeAiohttpResponse:
     async def json(self) -> dict:
         return self._payload
 
-    async def __aenter__(self) -> "_FakeAiohttpResponse":
+    async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(self, *exc_info) -> bool:

--- a/cognee/tests/utils/filter_overlapping_entities.py
+++ b/cognee/tests/utils/filter_overlapping_entities.py
@@ -9,9 +9,8 @@ def filter_overlapping_entities(*entity_groups):
             else:
                 entity_count[entity.id] += 1
 
-    index = 0
     grouped_entities = []
-    for group in entity_groups:
+    for index, group in enumerate(entity_groups):
         grouped_entities.append([])
 
         for entity in group:
@@ -20,7 +19,5 @@ def filter_overlapping_entities(*entity_groups):
             else:
                 if entity not in overlapping_entities:
                     overlapping_entities.append(entity)
-
-        index += 1
 
     return overlapping_entities, *grouped_entities

--- a/cognee/tests/utils/filter_overlapping_relationships.py
+++ b/cognee/tests/utils/filter_overlapping_relationships.py
@@ -14,9 +14,8 @@ def filter_overlapping_relationships(*relationship_groups):
             else:
                 relationship_count[relationship_id] += 1
 
-    index = 0
     grouped_relationships = []
-    for group in relationship_groups:
+    for index, group in enumerate(relationship_groups):
         grouped_relationships.append([])
 
         for relationship in group:
@@ -27,7 +26,5 @@ def filter_overlapping_relationships(*relationship_groups):
             else:
                 if relationship not in overlapping_relationships:
                     overlapping_relationships.append(relationship)
-
-        index += 1
 
     return overlapping_relationships, *grouped_relationships

--- a/cognee_db_workers/harness.py
+++ b/cognee_db_workers/harness.py
@@ -907,7 +907,7 @@ class SubprocessSession:
                         f"Subprocess response queue broken: {e!r}"
                     )
                     break
-                except (pickle.UnpicklingError, EOFError) as e:
+                except pickle.UnpicklingError as e:
                     # The worker emitted a value we couldn't deserialize
                     # (corrupted queue payload, partial write, etc.).
                     # Treat as a transport failure too — every pending

--- a/distributed/deploy/islo_sandbox.py
+++ b/distributed/deploy/islo_sandbox.py
@@ -241,8 +241,10 @@ def deploy_cognee():
         [
             "bash",
             "-lc",
-            f"nohup {VENV_PYTHON} -m uvicorn cognee.api.client:app --host 0.0.0.0 --port {API_PORT} "
-            "> /tmp/cognee-server.log 2>&1 & echo started",
+            (
+                f"nohup {VENV_PYTHON} -m uvicorn cognee.api.client:app --host 0.0.0.0 --port {API_PORT} "
+                "> /tmp/cognee-server.log 2>&1 & echo started"
+            ),
         ],
         timeout_secs=30,
         label="server",

--- a/examples/advanced_guides/session_distillation_demo.py
+++ b/examples/advanced_guides/session_distillation_demo.py
@@ -41,13 +41,19 @@ DATASET_NAME = "aurora_robotics_distillation_demo"
 SESSION_ID = "aurora_distillation_session"
 
 DOCUMENTS = [
-    "Aurora Robotics builds two products: the VoltaArm industrial gripper and the "
-    "TerraScout warehouse rover.",
-    "The VoltaArm gripper uses firmware version 4 and a calibration routine that maps "
-    "joint torque to grip strength.",
+    (
+        "Aurora Robotics builds two products: the VoltaArm industrial gripper and the "
+        "TerraScout warehouse rover."
+    ),
+    (
+        "The VoltaArm gripper uses firmware version 4 and a calibration routine that maps "
+        "joint torque to grip strength."
+    ),
     "The TerraScout rover navigates warehouses using lidar maps and charging dock beacons.",
-    "Aurora Robotics releases firmware through the HALT test suite, a hardware abuse "
-    "test that runs overnight.",
+    (
+        "Aurora Robotics releases firmware through the HALT test suite, a hardware abuse "
+        "test that runs overnight."
+    ),
     "Dana Voss leads the VoltaArm firmware team at Aurora Robotics.",
     "Calibration data for the VoltaArm gripper is stored in a battery-backed memory bank.",
 ]

--- a/examples/demos/sessions/live_session_context_feedback_demo.py
+++ b/examples/demos/sessions/live_session_context_feedback_demo.py
@@ -40,36 +40,66 @@ SESSION_ID = "northstar_live_session"
 DEMO_ROOT = Path(__file__).resolve().parents[2] / "temp" / "live_session_context_feedback_demo"
 
 DOCUMENTS = [
-    "Northstar Labs runs the Berlin office, the Lisbon office, the Toronto office, "
-    "and the Singapore office; each office owns one logistics intelligence project.",
-    "The Berlin office owns RoutePulse, a project that predicts delivery delays for "
-    "European freight operators.",
-    "The Lisbon office owns HarborLens, a project that monitors port congestion and "
-    "recommends alternate unloading windows.",
-    "The Toronto office owns FrostLine, a project that helps cold-chain teams track "
-    "temperature risk during winter shipments.",
-    "The Singapore office owns SkyBridge, a project that coordinates air-cargo handoffs "
-    "between regional carriers.",
-    "RoutePulse uses traffic feeds, weather alerts, and customs delay reports to estimate "
-    "arrival risk.",
-    "HarborLens uses vessel schedules, berth availability, and labor notices to forecast "
-    "port bottlenecks.",
-    "FrostLine uses sensor readings, weather forecasts, and route duration to warn about "
-    "spoiled-goods risk.",
-    "SkyBridge uses flight status, warehouse capacity, and customs clearance events to "
-    "recommend cargo transfer plans.",
-    "Northstar Labs asks customer-facing teams to explain project details in concise "
-    "operational language.",
-    "The Berlin office audit window is Monday morning, and the Berlin office audit should "
-    "review RoutePulse traffic feeds, weather alerts, and customs delay reports.",
-    "The Lisbon office audit window is Tuesday afternoon, and the Lisbon office audit should "
-    "review HarborLens vessel schedules, berth availability, and labor notices.",
-    "The Singapore office audit lead is Priya Tan, and Priya Tan is available Wednesday "
-    "morning for the Singapore office SkyBridge audit.",
-    "The Toronto office audit lead is Mateo Reed, and Mateo Reed is available Thursday "
-    "afternoon for the Toronto office FrostLine audit.",
-    "Northstar Labs audit trips should avoid unnecessary backtracking while still respecting "
-    "local office availability windows.",
+    (
+        "Northstar Labs runs the Berlin office, the Lisbon office, the Toronto office, "
+        "and the Singapore office; each office owns one logistics intelligence project."
+    ),
+    (
+        "The Berlin office owns RoutePulse, a project that predicts delivery delays for "
+        "European freight operators."
+    ),
+    (
+        "The Lisbon office owns HarborLens, a project that monitors port congestion and "
+        "recommends alternate unloading windows."
+    ),
+    (
+        "The Toronto office owns FrostLine, a project that helps cold-chain teams track "
+        "temperature risk during winter shipments."
+    ),
+    (
+        "The Singapore office owns SkyBridge, a project that coordinates air-cargo handoffs "
+        "between regional carriers."
+    ),
+    (
+        "RoutePulse uses traffic feeds, weather alerts, and customs delay reports to estimate "
+        "arrival risk."
+    ),
+    (
+        "HarborLens uses vessel schedules, berth availability, and labor notices to forecast "
+        "port bottlenecks."
+    ),
+    (
+        "FrostLine uses sensor readings, weather forecasts, and route duration to warn about "
+        "spoiled-goods risk."
+    ),
+    (
+        "SkyBridge uses flight status, warehouse capacity, and customs clearance events to "
+        "recommend cargo transfer plans."
+    ),
+    (
+        "Northstar Labs asks customer-facing teams to explain project details in concise "
+        "operational language."
+    ),
+    (
+        "The Berlin office audit window is Monday morning, and the Berlin office audit should "
+        "review RoutePulse traffic feeds, weather alerts, and customs delay reports."
+    ),
+    (
+        "The Lisbon office audit window is Tuesday afternoon, and the Lisbon office audit should "
+        "review HarborLens vessel schedules, berth availability, and labor notices."
+    ),
+    (
+        "The Singapore office audit lead is Priya Tan, and Priya Tan is available Wednesday "
+        "morning for the Singapore office SkyBridge audit."
+    ),
+    (
+        "The Toronto office audit lead is Mateo Reed, and Mateo Reed is available Thursday "
+        "afternoon for the Toronto office FrostLine audit."
+    ),
+    (
+        "Northstar Labs audit trips should avoid unnecessary backtracking while still respecting "
+        "local office availability windows."
+    ),
 ]
 
 TURNS = [

--- a/examples/demos/sessions/session_feedback_example.py
+++ b/examples/demos/sessions/session_feedback_example.py
@@ -18,12 +18,18 @@ async def main():
     print("Done.\n")
 
     texts = [
-        "Cognee builds knowledge graphs from text and provides session-based feedback APIs. "
-        "You can attach feedback (rating and comment) to each Q&A and later retract it.",
-        "Sessions group Q&A by conversation. Use a session_id in recall() to keep turns in one thread; "
-        "omit it to use the default_session.",
-        "Feedback helps improve answers: add_feedback stores a score and optional text, "
-        "delete_feedback clears it.",
+        (
+            "Cognee builds knowledge graphs from text and provides session-based feedback APIs. "
+            "You can attach feedback (rating and comment) to each Q&A and later retract it."
+        ),
+        (
+            "Sessions group Q&A by conversation. Use a session_id in recall() to keep turns in one thread; "
+            "omit it to use the default_session."
+        ),
+        (
+            "Feedback helps improve answers: add_feedback stores a score and optional text, "
+            "delete_feedback clears it."
+        ),
     ]
     await cognee.remember(texts, self_improvement=False)
 

--- a/examples/demos/sessions/session_flow_stepwise_demo.py
+++ b/examples/demos/sessions/session_flow_stepwise_demo.py
@@ -142,10 +142,14 @@ DATASET_NAME = "stepwise_remember_recall_demo"
 SESSION_ID = "stepwise_session"
 
 DOCUMENTS = [
-    "Aurora Robotics builds two products: the VoltaArm industrial gripper and the "
-    "TerraScout warehouse rover.",
-    "The VoltaArm gripper uses firmware version 4 and a calibration routine that maps "
-    "joint torque to grip strength.",
+    (
+        "Aurora Robotics builds two products: the VoltaArm industrial gripper and the "
+        "TerraScout warehouse rover."
+    ),
+    (
+        "The VoltaArm gripper uses firmware version 4 and a calibration routine that maps "
+        "joint torque to grip strength."
+    ),
     "The TerraScout rover navigates warehouses using lidar maps and charging dock beacons.",
     "Dana Voss leads the VoltaArm firmware team at Aurora Robotics.",
     "Calibration data for the VoltaArm gripper is stored in a battery-backed memory bank.",

--- a/tools/fix_router_docstrings.py
+++ b/tools/fix_router_docstrings.py
@@ -151,7 +151,7 @@ def format_annotation(annotation) -> str:
     name = getattr(annotation, "__name__", None)
     if name:
         return name
-    return re.sub(r"\w+(\.\w+)+\.", "", str(annotation))
+    return re.sub(r"\b\w+(\.\w+)+\.", "", str(annotation))
 
 
 @dataclass


### PR DESCRIPTION
## Description
Sixth PR for [SDK-583](https://linear.app/cognee/issue/SDK-583/fix-red-code-quality-ci-after-the-ruff-0160-bump): the read-and-fix group, 82 findings across 26 rules where each site had to be read rather than scripted. The general `ruff check` step goes from **338 findings to 259** on dev (after #4986 it will be 216 → 137). Three of the findings were real defects and get their own commit; the rest are behaviour-preserving and split into a test-only commit and a library commit.

### Commit 1: three defects (`fix:`)
| Site | What was wrong | Fix |
|---|---|---|
| `PipelineRun` model (PIE794) | `__table_args__` was assigned twice, so the second silently replaced the first and `create_all` never built the `dataset_id / pipeline_name / created_at` index on a fresh database; only the migration did. | Both indexes in one tuple. Verified: the ORM metadata now lists both. |
| code-part search (PLE1205) | `logger.debug("Retrieved Code Parts:", results)` had no placeholder, so logging raised a formatting error internally and the message was never emitted. | `%s` placeholder. |
| docstring-sync tool (PLE2510) | The prefix-stripping regex in `format_annotation` contained a literal backspace byte where `\b` was meant, so that fallback could never match. | `\b`. Measured effect on today's API: none. The fallback is only reached by an annotation with no `__name__` that is not a generic, and none of the 458 annotations the tool formats across the 126 routes reaches it; running the tool on dev and on this branch rewrites nothing on either. The fix matters for a future annotation of that shape, such as a string forward reference. |

### Commit 2: tests only
- **B017** blind `pytest.raises(Exception)`: two now name the class the test is about, pydantic `ValidationError` for the bad recall source and the AEAD `InvalidTag` for tampered credentials. The subprocess case keeps the broad catch with a reason, since the failure surfaces as a transport or a timeout error depending on the platform.
- **B008** a `uuid5` call in an argument default becomes a module constant; **SIM113** two manual counters become `enumerate`; **PERF402** a copy loop becomes `list()`; **UP031** one percent format becomes an f-string; **PYI034** a fake response returns `Self`; **ISC004** implicitly concatenated strings in two fixture lists are parenthesised.

### Commit 3: library, each behaviour-preserving
| Rule | Sites | Change |
|---|---|---|
| ISC004 | 30 | Implicitly concatenated strings inside lists and tuples are parenthesised. All 32 were read: every one is a deliberate line wrap, none a missing comma. The rule keeps catching the real case. |
| B019 | 2 | The two url helpers on the crawler are pure, so they become `@staticmethod` under `@lru_cache`: same cache, no longer holding every crawler instance alive through it. |
| B023 | 4 | Closures inside loops bind the variables they capture via default arguments. Both are invoked within the same iteration, so this changes nothing today and cannot break later. |
| B025 | 2 | Two exception names listed a second time in a later handler of the same `try`; the earlier handler already catches them (the LiteLLM one's own comment says so). The dead entries are removed. |
| B039 | 1 | The active-skills `ContextVar` loses its shared mutable default; its single reader passes `{}` to `get`. |
| B026, PLC0206, PLC0414, PLR1704, PLW0602, RUF059, SIM113 | 10 | Positional `mode` in the file open, `.items()` loops, an unused re-export import removed, loop variables renamed so they stop shadowing arguments, read-only `global` statements removed, an unused unpacked name prefixed, a counter replaced by `enumerate`. |
| PLW1508 | 5 | Environment-variable defaults are strings; numeric values unchanged. |
| PLW1509 | 6 | `preexec_fn=os.setsid` becomes `start_new_session=True`, the thread-safe spelling of the same thing, ignored on Windows like the guard it replaces. |
| PYI034, PYI063 | 4 | Enter methods return `Self` from `typing_extensions`, which eleven library modules already import; `model_post_init` uses PEP 570 spelling for the parameter pydantic passes positionally. |
| TC010 | 1 | `SourceCodeGraph` mixed a quoted forward reference into a runtime union, which raised at import, so the module has been dead on dev. The whole union is quoted now and the module imports; the import walk goes from seven failing modules to six. |
| S102, UP035 | 2 | Intentional and said on the line: the generated-model `exec`, and `typing.List` used as a runtime origin key. |

### Verification
- `ruff check .` 338 → 259; no rule count went up at any step; format check clean; every added `noqa` suppresses a real finding.
- Full unit suite and the incremental-update e2e suite pass locally with all extras; the subprocess-session, crypto and recall-tools suites that the test changes touch are in that run.
- Import walk: same failures as dev minus `SourceCodeGraph`.

### What is left after this PR
The four hand-work families: ASYNC230 64 and the rest of the ASYNC group 12, SIM115 25, the 21 non-plain SIM117/SIM102 sites, UP007/UP045 12; plus the type check's 21 pre-existing errors.

## Type of Change
- [x] Bug fix
- [x] Code refactoring
