### PR TITLE
fix(api): map skill ingest failures to 400/500 instead of 409

### DIFF
--- a/cognee/api/v1/skills/routers/get_skills_router.py
+++ b/cognee/api/v1/skills/routers/get_skills_router.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from cognee import __version__ as cognee_version
+from cognee.exceptions import CogneeApiError
 from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 from cognee.modules.data.methods import get_authorized_existing_datasets
 from cognee.modules.users.exceptions import PermissionDeniedError
@@ -73,6 +74,8 @@ class ErrorResponse(BaseModel):
     """Generic API error response."""
 
     error: str
+    detail: str | None = None
+    exception_type: str | None = None
 
 
 def get_skills_router() -> APIRouter:
@@ -88,7 +91,11 @@ def get_skills_router() -> APIRouter:
     @router.post(
         "",
         response_model=dict,
-        responses={400: {"model": ErrorResponse}, 409: {"model": ErrorResponse}},
+        responses={
+            400: {"model": ErrorResponse},
+            409: {"model": ErrorResponse},
+            500: {"model": ErrorResponse},
+        },
     )
     async def ingest_skill(
         payload: SkillIngestRequest,
@@ -134,9 +141,31 @@ def get_skills_router() -> APIRouter:
                 **({"dataset_id": payload.dataset_id} if payload.dataset_id else {}),
             )
             return jsonable_encoder(result.to_dict())
-        except Exception:
+        except CogneeApiError:
+            # Typed API errors carry their own status (including 409 for genuine
+            # conflicts). Let the app-level handler map them instead of flattening
+            # every failure into 409.
+            raise
+        except (ValueError, PermissionError, FileNotFoundError) as error:
             logger.exception("ingest skill failed")
-            return JSONResponse(status_code=409, content={"error": "Failed to ingest skill"})
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": "Failed to ingest skill",
+                    "exception_type": type(error).__name__,
+                    "detail": str(error),
+                },
+            )
+        except Exception as error:
+            logger.exception("ingest skill failed")
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "error": "Failed to ingest skill",
+                    "exception_type": type(error).__name__,
+                    "detail": str(error),
+                },
+            )
 
     @router.get(
         "/",

--- a/cognee/tests/unit/api/test_skills_router.py
+++ b/cognee/tests/unit/api/test_skills_router.py
@@ -1,14 +1,23 @@
-"""Tests for the dataset-scoped skills router (DELETE /api/v1/skills/{skill_id})."""
+"""Tests for the dataset-scoped skills router.
+
+Covers DELETE /api/v1/skills/{skill_id} and POST /api/v1/skills error mapping
+(#4281): ingest failures must not all collapse to HTTP 409.
+"""
 
 from importlib import import_module
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
+
+from cognee.exceptions import CogneeApiError
 
 router_module = import_module("cognee.api.v1.skills.routers.get_skills_router")
 list_module = import_module("cognee.api.v1.skills.list_skills")
+remember_pkg = import_module("cognee.api.v1.remember")
 
 
 def _app() -> FastAPI:
@@ -92,3 +101,119 @@ def test_delete_skill_requires_dataset_query_param(monkeypatch):
     response = client.delete(f"/api/v1/skills/{uuid4()}")
 
     assert response.status_code == 422
+
+
+def _ingest_client(monkeypatch, *, remember_side_effect=None, remember_result=None) -> TestClient:
+    app = _app()
+
+    @app.exception_handler(CogneeApiError)
+    async def _cognee_api_error(_: Request, exc: CogneeApiError) -> JSONResponse:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": f"{exc.message} [{exc.name}]"},
+        )
+
+    app.dependency_overrides[router_module.get_authenticated_user] = lambda: SimpleNamespace(
+        id=uuid4(),
+        tenant_id=None,
+    )
+    monkeypatch.setattr(router_module, "send_telemetry", lambda *args, **kwargs: None)
+
+    mock_remember = AsyncMock()
+    if remember_side_effect is not None:
+        mock_remember.side_effect = remember_side_effect
+    else:
+        mock_remember.return_value = remember_result or SimpleNamespace(
+            to_dict=lambda: {"status": "completed"}
+        )
+    monkeypatch.setattr(remember_pkg, "remember", mock_remember)
+    return TestClient(app)
+
+
+def _ingest_payload(**overrides):
+    body = {
+        "skills_text": "---\nname: demo\n---\nDo the thing.",
+        "dataset_name": "skills_dataset",
+    }
+    body.update(overrides)
+    return body
+
+
+def test_ingest_skill_success(monkeypatch):
+    client = _ingest_client(monkeypatch)
+
+    response = client.post("/api/v1/skills", json=_ingest_payload())
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "completed"}
+
+
+def test_ingest_skill_requires_dataset(monkeypatch):
+    client = _ingest_client(monkeypatch)
+
+    response = client.post(
+        "/api/v1/skills",
+        json={"skills_text": "Do the thing."},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"error": "Either dataset_name or dataset_id is required"}
+
+
+def test_ingest_skill_malformed_input_returns_400(monkeypatch):
+    client = _ingest_client(
+        monkeypatch,
+        remember_side_effect=ValueError("Invalid skill filename: ../escape.md"),
+    )
+
+    response = client.post("/api/v1/skills", json=_ingest_payload())
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"] == "Failed to ingest skill"
+    assert body["exception_type"] == "ValueError"
+    assert "Invalid skill filename" in body["detail"]
+
+
+def test_ingest_skill_internal_error_returns_500(monkeypatch):
+    client = _ingest_client(
+        monkeypatch,
+        remember_side_effect=RuntimeError("Graph edge indexing error"),
+    )
+
+    response = client.post("/api/v1/skills", json=_ingest_payload())
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body["error"] == "Failed to ingest skill"
+    assert body["exception_type"] == "RuntimeError"
+    assert body["detail"] == "Graph edge indexing error"
+
+
+def test_ingest_skill_parse_keyerror_returns_500_with_type(monkeypatch):
+    client = _ingest_client(monkeypatch, remember_side_effect=KeyError("name"))
+
+    response = client.post("/api/v1/skills", json=_ingest_payload())
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body["error"] == "Failed to ingest skill"
+    assert body["exception_type"] == "KeyError"
+    assert "name" in body["detail"]
+
+
+def test_ingest_skill_conflict_preserves_409(monkeypatch):
+    client = _ingest_client(
+        monkeypatch,
+        remember_side_effect=CogneeApiError(
+            message="Skill already exists",
+            name="SkillConflictError",
+            status_code=409,
+            log=False,
+        ),
+    )
+
+    response = client.post("/api/v1/skills", json=_ingest_payload())
+
+    assert response.status_code == 409
+    assert "Skill already exists" in response.json()["detail"]


### PR DESCRIPTION
## Description

Fixes #4281.

`POST /api/v1/skills` wrapped the whole `remember()` call in `except Exception` and always returned HTTP 409 `{"error": "Failed to ingest skill"}`. Parse errors and graph-store failures therefore looked like duplicate conflicts, and callers could not tell them apart without server logs.

## Why This Change Was Made

- Re-raise `CogneeApiError` so typed errors keep their own status (including 409 for a genuine conflict).
- Return 400 for caller-controlled input errors (`ValueError`, `PermissionError`, `FileNotFoundError`).
- Return 500 for unexpected pipeline failures, with `exception_type` and `detail` in the body.

## User Impact

Clients of `POST /api/v1/skills` can distinguish malformed skill input from internal ingest failures instead of treating every error as a conflict.

## Evidence

```text
uv run pytest cognee/tests/unit/api/test_skills_router.py -v
======================= 10 passed, 15 warnings in 3.28s ========================
```

Covers success, missing dataset, malformed input → 400, `RuntimeError` / `KeyError` → 500 with type and message, and `CogneeApiError(status_code=409)` still mapping to 409.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.