### PR TITLE
fix(ui): skip MCP server instead of aborting when its port is busy

### DIFF
--- a/cognee/api/v1/ui/ui.py
+++ b/cognee/api/v1/ui/ui.py
@@ -478,13 +478,21 @@ def start_ui(
     """
     logger.info("Starting cognee UI...")
 
+    # The MCP server is optional: the UI and backend work fine without it, so a
+    # busy MCP port only disables the MCP server instead of aborting the whole
+    # launch — same graceful degradation as the Docker-unavailable path below.
     ports_to_check = [(port, "Frontend UI")]
 
     if start_backend:
         ports_to_check.append((backend_port, "Backend API"))
 
-    if start_mcp:
-        ports_to_check.append((mcp_port, "MCP Server"))
+    if start_mcp and not _is_port_available(mcp_port):
+        logger.warning(
+            f"Port {mcp_port} is already in use (possibly a leftover cognee MCP "
+            f"container), skipping the MCP server. The UI and backend will start "
+            f"without it. Stop whatever holds the port to get the MCP server back."
+        )
+        start_mcp = False
 
     logger.info("Checking port availability...")
     all_ports_available, unavailable_services = _check_required_ports(ports_to_check)

--- a/cognee/cli/_cognee.py
+++ b/cognee/cli/_cognee.py
@@ -367,8 +367,10 @@ def main() -> int:
                 fmt.echo(f"The interface is available at: http://localhost:{frontend_port}")
                 if start_backend:
                     fmt.echo(f"The API backend is available at: http://localhost:{backend_port}")
-                if start_mcp:
+                if start_mcp and docker_container:
                     fmt.echo(f"The MCP server is available at: http://localhost:{mcp_port}")
+                else:
+                    fmt.note("The MCP server was skipped (port busy or Docker unavailable).")
                 fmt.note("Press Ctrl+C to stop the server...")
 
                 try:

--- a/cognee/tests/unit/api/v1/ui/test_mcp_port_preflight.py
+++ b/cognee/tests/unit/api/v1/ui/test_mcp_port_preflight.py
@@ -1,0 +1,74 @@
+"""Tests for MCP port preflight handling in cognee.api.v1.ui.ui."""
+
+from unittest.mock import patch
+
+from cognee.api.v1.ui.ui import start_ui
+
+
+class TestStartUiMcpPortPreflight:
+    """Verify start_ui() treats a busy MCP port as optional, not fatal."""
+
+    @patch("cognee.api.v1.ui.ui.prompt_user_for_download", return_value=False)
+    @patch("cognee.api.v1.ui.ui.find_frontend_path", return_value=None)
+    @patch("cognee.api.v1.ui.ui._is_port_available", return_value=False)
+    @patch("cognee.api.v1.ui.ui._check_docker_available", return_value=(True, "ok"))
+    @patch("cognee.api.v1.ui.ui._check_required_ports", return_value=(True, []))
+    def test_busy_mcp_port_skips_mcp_not_the_launch(
+        self, mock_ports, mock_docker, mock_port_free, mock_frontend, mock_prompt
+    ):
+        """With the MCP port taken, no docker call happens but required ports are still checked."""
+        with patch("subprocess.run") as mock_run, patch("subprocess.Popen"):
+            result = start_ui(
+                pid_callback=lambda p: None,
+                start_mcp=True,
+                start_backend=False,
+            )
+
+        # start_ui returns None only because find_frontend_path is None here;
+        # the point is that it got past the port preflight at all.
+        assert result is None
+        mock_ports.assert_called_once()
+        checked = mock_ports.call_args[0][0]
+        assert ("Frontend UI", 3000) not in checked  # default port is free in this mock list
+        assert all(name != "MCP Server" for _, name in checked)
+        # The optional MCP server was dropped before the Docker preflight could run.
+        mock_docker.assert_not_called()
+        for c in mock_run.call_args_list:
+            args = c[0][0] if c[0] else c[1].get("args", [])
+            assert "docker" not in str(args), f"Unexpected docker call: {args}"
+
+    @patch("cognee.api.v1.ui.ui.prompt_user_for_download", return_value=False)
+    @patch("cognee.api.v1.ui.ui.find_frontend_path", return_value=None)
+    @patch("cognee.api.v1.ui.ui._is_port_available", return_value=True)
+    @patch("cognee.api.v1.ui.ui._check_docker_available", return_value=(True, "ok"))
+    @patch("cognee.api.v1.ui.ui._check_required_ports", return_value=(True, []))
+    def test_free_mcp_port_still_runs_docker_preflight(
+        self, mock_ports, mock_docker, mock_port_free, mock_frontend, mock_prompt
+    ):
+        """With the MCP port free, the Docker preflight runs as before."""
+        with patch("subprocess.run", return_value=None) as mock_run, patch("subprocess.Popen"):
+            start_ui(
+                pid_callback=lambda p: None,
+                start_mcp=True,
+                start_backend=False,
+            )
+
+        mock_docker.assert_called_once()
+
+    @patch("cognee.api.v1.ui.ui.prompt_user_for_download", return_value=False)
+    @patch("cognee.api.v1.ui.ui.find_frontend_path", return_value=None)
+    @patch("cognee.api.v1.ui.ui._check_docker_available", return_value=(True, "ok"))
+    @patch("cognee.api.v1.ui.ui._check_required_ports", return_value=(False, ["Frontend UI (port 3000)"]))
+    def test_busy_frontend_port_remains_fatal(
+        self, mock_ports, mock_docker, mock_frontend, mock_prompt
+    ):
+        """A busy frontend port must still abort the launch."""
+        with patch("subprocess.run") as mock_run, patch("subprocess.Popen") as mock_popen:
+            result = start_ui(
+                pid_callback=lambda p: None,
+                start_mcp=False,
+                start_backend=False,
+            )
+
+        assert result is None
+        mock_popen.assert_not_called()


### PR DESCRIPTION
Fixes #4959.

`cognee-cli -ui` treats all three ports as mandatory today, so an occupied MCP port (8001) aborts the whole launch even though the UI and backend work fine without MCP. The Docker preflight already degrades gracefully; this makes a busy MCP port do the same.

What changed:
- The MCP port no longer participates in the required-ports preflight. Frontend/backend conflicts stay fatal.
- If the MCP port is taken, one warning explains the likely cause (a leftover cognee MCP container) and the launch continues without MCP.
- The CLI summary now reports the MCP server from the actual container state (`docker_container` set via the pid callback), not from the flag it passed in — so a skipped MCP server prints "skipped (port busy or Docker unavailable)" instead of a stale "available at :8001".

What I deliberately didn't change:
- No post-start container health verification. The bind happens inside dockerd (`docker run -p`), so a Python-side try/except around EADDRINUSE would never fire; if `docker run` succeeds but the container dies immediately, the CLI can still over-report. That's pre-existing behavior and feels like its own change if you want it.

Tests: `uv run pytest cognee/tests/unit/api/v1/ui/ -q` — 11 passed (8 existing + 3 new covering: busy MCP port skips the Docker preflight, free MCP port still runs it, busy frontend port remains fatal).