### PR TITLE
fix: Survive concurrent first-use dataset provisioning (SDK-603)

### DIFF
--- a/.github/workflows/community_tests.yml
+++ b/.github/workflows/community_tests.yml
@@ -122,6 +122,7 @@ jobs:
             cognee/tests/unit/infrastructure/databases/vector/test_vector_db_config.py \
             cognee/tests/unit/infrastructure/databases/relational/ \
             cognee/tests/unit/infrastructure/databases/test_unified_store_engine.py \
+            cognee/tests/unit/infrastructure/databases/test_dataset_database_provisioning_race.py \
             cognee/tests/unit/infrastructure/session/ \
             cognee/tests/unit/infrastructure/llm/ \
             cognee/tests/unit/infrastructure/test_rate_limiting_retry.py \

--- a/.github/workflows/graph_db_tests.yml
+++ b/.github/workflows/graph_db_tests.yml
@@ -128,6 +128,15 @@ jobs:
           GRAPH_DATABASE_URL: "postgresql+asyncpg://cognee:cognee@localhost:5432/cognee_db"
         run: uv run pytest cognee/tests/e2e/postgres/test_shared_schema_isolation.py -v
 
+      - name: Run Postgres Admin Helper Concurrency Tests
+        env:
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_USERNAME: cognee
+          DB_PASSWORD: cognee
+          DB_NAME: cognee_db
+        run: uv run pytest cognee/tests/e2e/postgres/test_admin_helpers_concurrency.py -v
+
       - name: Run Postgres Graph E2E Test
         env:
           ENV: 'dev'

--- a/cognee/infrastructure/databases/postgres/admin.py
+++ b/cognee/infrastructure/databases/postgres/admin.py
@@ -18,6 +18,20 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.schema import DDLElement
 
 _MAINTENANCE_DB_NAME = "postgres"
+
+# Advisory locks that make the create helpers atomic across every process in
+# the cluster: a fixed namespace hash plus the hash of the resource being
+# provisioned. Session-level for CREATE DATABASE, which cannot run inside a
+# transaction; transaction-level for schema DDL, released with the transaction.
+_ACQUIRE_PROVISIONING_LOCK = (
+    "SELECT pg_advisory_lock(hashtext('cognee_provisioning'), hashtext(:key))"
+)
+_RELEASE_PROVISIONING_LOCK = (
+    "SELECT pg_advisory_unlock(hashtext('cognee_provisioning'), hashtext(:key))"
+)
+_ACQUIRE_PROVISIONING_XACT_LOCK = (
+    "SELECT pg_advisory_xact_lock(hashtext('cognee_provisioning'), hashtext(:key))"
+)
 # Dataset databases are named after dataset UUIDs (hyphens, leading digits), so
 # this is looser than an unquoted Postgres identifier; the compiled DDL below
 # always quotes the name via compiler.preparer.quote, which is what actually
@@ -138,6 +152,11 @@ async def create_pg_schema_if_not_exists(
     set the pgvector extension is ensured in the database (it installs into the
     database's ``public`` schema and is reachable from any schema via the
     search path).
+
+    Safe to call concurrently: IF NOT EXISTS is not race-free in Postgres (two
+    transactions that both pass the check collide on the catalog's unique
+    index), so creators are serialized on an advisory lock keyed by the shared
+    database, which also covers the extension.
     """
     engine = create_async_engine(
         _build_db_url(db_name, host, port, username, password),
@@ -145,6 +164,7 @@ async def create_pg_schema_if_not_exists(
     )
     try:
         async with engine.begin() as connection:
+            await connection.execute(text(_ACQUIRE_PROVISIONING_XACT_LOCK), {"key": db_name})
             if with_vector_extension:
                 await connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
             await connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}";'))
@@ -187,7 +207,11 @@ async def create_pg_database_if_not_exists(
     """Create a Postgres database if it does not already exist.
 
     Connects to the cluster's 'postgres' maintenance database in AUTOCOMMIT
-    mode and runs ``CREATE DATABASE`` guarded by an existence check.
+    mode and runs ``CREATE DATABASE`` guarded by an existence check. The check
+    and the create are made atomic with a session-level advisory lock on the
+    database name (``CREATE DATABASE`` has no ``IF NOT EXISTS``), so concurrent
+    callers create the database once; Postgres releases the lock if the
+    connection drops.
 
     Returns:
         True if the database was created, False if it already existed.
@@ -200,14 +224,18 @@ async def create_pg_database_if_not_exists(
         connection = await engine.connect()
         try:
             connection = await connection.execution_options(isolation_level="AUTOCOMMIT")
-            result = await connection.execute(
-                text("SELECT 1 FROM pg_database WHERE datname = :db"),
-                {"db": db_name},
-            )
-            if result.scalar():
-                return False
-            await connection.execute(CreateDatabase(db_name))
-            return True
+            await connection.execute(text(_ACQUIRE_PROVISIONING_LOCK), {"key": db_name})
+            try:
+                result = await connection.execute(
+                    text("SELECT 1 FROM pg_database WHERE datname = :db"),
+                    {"db": db_name},
+                )
+                if result.scalar():
+                    return False
+                await connection.execute(CreateDatabase(db_name))
+                return True
+            finally:
+                await connection.execute(text(_RELEASE_PROVISIONING_LOCK), {"key": db_name})
         finally:
             await connection.close()
     finally:

--- a/cognee/infrastructure/databases/utils/get_or_create_dataset_database.py
+++ b/cognee/infrastructure/databases/utils/get_or_create_dataset_database.py
@@ -70,7 +70,11 @@ async def get_or_create_dataset_database(
     Return the `DatasetDatabase` row for the given dataset; provision it on first use.
 
     • If the row already exists, it is fetched and returned.
-    • Otherwise a new one is created atomically and returned.
+    • Otherwise the physical databases are provisioned and a new row inserted.
+      Concurrent first-use callers (a query racing the first ingestion, or two
+      queries on a never-built dataset) all end up with the one row that won
+      the insert; dataset_id is the primary key, so losing the insert is not
+      an error.
 
     DatasetDatabase row contains connection and provider info for vector and graph databases.
 
@@ -116,12 +120,23 @@ async def get_or_create_dataset_database(
             **vector_config_dict,  # Unpack vector db config
         )
 
+        session.add(record)
         try:
-            session.add(record)
             await session.commit()
+        except IntegrityError as error:
+            await session.rollback()
+            insert_error = error
+        else:
             await session.refresh(record)
             return record
 
-        except IntegrityError:
-            await session.rollback()
-            raise
+    # Another caller provisioned this dataset between the existence check above
+    # and the insert. The handlers derive every name from the dataset id, so the
+    # databases both callers created are the same ones and the winner's row is
+    # the one to use. Read it outside the failed session: sessions must not nest.
+    # No row at all means the conflict was something else (an owner row gone),
+    # and that error stands.
+    existing_dataset_database = await _existing_dataset_database(dataset_id)
+    if existing_dataset_database is None:
+        raise insert_error
+    return existing_dataset_database

--- a/cognee/tests/e2e/postgres/test_admin_helpers_concurrency.py
+++ b/cognee/tests/e2e/postgres/test_admin_helpers_concurrency.py
@@ -1,0 +1,118 @@
+"""The Postgres create helpers must be idempotent under concurrent callers (SDK-603).
+
+``CREATE DATABASE`` has no ``IF NOT EXISTS`` in Postgres, and even
+``CREATE SCHEMA/EXTENSION IF NOT EXISTS`` can fail with a unique violation when
+two transactions race. Both helpers back the first-use provisioning of a
+dataset's databases, which a query can trigger at the same moment as the first
+ingestion, so concurrent calls must all succeed and create the resource once.
+
+Runs against a live Postgres (default: cognee:cognee@localhost:5432/cognee_db)
+and skips if it is unreachable.
+"""
+
+import asyncio
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from cognee.infrastructure.databases.postgres import (
+    create_pg_database_if_not_exists,
+    create_pg_schema_if_not_exists,
+    drop_pg_database_if_exists,
+    drop_pg_schema_if_exists,
+)
+
+CONCURRENCY = 6
+
+
+def _db() -> dict:
+    return {
+        "host": os.environ.get("DB_HOST", "localhost"),
+        "port": os.environ.get("DB_PORT", "5432"),
+        "username": os.environ.get("DB_USERNAME", "cognee"),
+        "password": os.environ.get("DB_PASSWORD", "cognee"),
+        "name": os.environ.get("DB_NAME", "cognee_db"),
+    }
+
+
+def _url(database: str) -> str:
+    d = _db()
+    return (
+        f"postgresql+asyncpg://{d['username']}:{d['password']}@{d['host']}:{d['port']}/{database}"
+    )
+
+
+async def _postgres_reachable() -> bool:
+    engine = create_async_engine(_url(_db()["name"]))
+    try:
+        async with engine.connect() as connection:
+            await connection.execute(text("SELECT 1"))
+        return True
+    except Exception:  # noqa: BLE001 - any connection failure means "skip"
+        return False
+    finally:
+        await engine.dispose()
+
+
+async def _count(database: str, query: str, **params) -> int:
+    engine = create_async_engine(_url(database))
+    try:
+        async with engine.connect() as connection:
+            return (await connection.execute(text(query), params)).scalar()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_create_database_creates_it_once():
+    if not await _postgres_reachable():
+        pytest.skip("Postgres not reachable")
+    d = _db()
+    creds = {k: d[k] for k in ("host", "port", "username", "password")}
+    db_name = f"sdk603_{uuid.uuid4().hex[:12]}"
+
+    try:
+        created = await asyncio.gather(
+            *(create_pg_database_if_not_exists(db_name, **creds) for _ in range(CONCURRENCY))
+        )
+
+        assert sorted(created) == [False] * (CONCURRENCY - 1) + [True]
+        assert (
+            await _count(
+                d["name"], "SELECT count(*) FROM pg_database WHERE datname = :n", n=db_name
+            )
+            == 1
+        )
+    finally:
+        await drop_pg_database_if_exists(db_name, **creds)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_create_schema_creates_it_once():
+    if not await _postgres_reachable():
+        pytest.skip("Postgres not reachable")
+    d = _db()
+    creds = {k: d[k] for k in ("host", "port", "username", "password")}
+    schema = f"ds_sdk603_{uuid.uuid4().hex[:12]}"
+
+    try:
+        await asyncio.gather(
+            *(
+                create_pg_schema_if_not_exists(
+                    d["name"], schema, with_vector_extension=True, **creds
+                )
+                for _ in range(CONCURRENCY)
+            )
+        )
+
+        assert (
+            await _count(
+                d["name"], "SELECT count(*) FROM pg_namespace WHERE nspname = :n", n=schema
+            )
+            == 1
+        )
+    finally:
+        await drop_pg_schema_if_exists(d["name"], schema, **creds)

--- a/cognee/tests/e2e/postgres/test_admin_helpers_concurrency.py
+++ b/cognee/tests/e2e/postgres/test_admin_helpers_concurrency.py
@@ -11,6 +11,7 @@ and skips if it is unreachable.
 """
 
 import asyncio
+import logging
 import os
 import uuid
 
@@ -24,6 +25,8 @@ from cognee.infrastructure.databases.postgres import (
     drop_pg_database_if_exists,
     drop_pg_schema_if_exists,
 )
+
+logger = logging.getLogger(__name__)
 
 CONCURRENCY = 6
 
@@ -51,7 +54,10 @@ async def _postgres_reachable() -> bool:
         async with engine.connect() as connection:
             await connection.execute(text("SELECT 1"))
         return True
-    except Exception:  # noqa: BLE001 - any connection failure means "skip"
+    except Exception:
+        # Any failure to connect means the suite skips, and the cause goes
+        # to the log with its traceback rather than being swallowed.
+        logger.debug("Postgres not reachable; skipping", exc_info=True)
         return False
     finally:
         await engine.dispose()

--- a/cognee/tests/unit/infrastructure/databases/test_dataset_database_provisioning_race.py
+++ b/cognee/tests/unit/infrastructure/databases/test_dataset_database_provisioning_race.py
@@ -1,0 +1,55 @@
+"""First-use provisioning of a dataset's databases must survive concurrent callers (SDK-603).
+
+A query on a brand-new dataset can enter the dataset context at the same moment
+the first ingestion (or another query) does. Every caller must end up with the
+one registry row, and none of them may fail.
+"""
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import delete, select
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.infrastructure.databases.utils.get_or_create_dataset_database import (
+    get_or_create_dataset_database,
+)
+from cognee.modules.data.methods import create_dataset
+from cognee.modules.data.models import Dataset
+from cognee.modules.users.methods import get_default_user
+from cognee.modules.users.models import DatasetDatabase
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_use_provisioning_yields_one_row_and_no_errors():
+    user = await get_default_user()
+    engine = get_relational_engine()
+
+    async with engine.get_async_session() as session:
+        dataset = await create_dataset(f"sdk603_race_{uuid4().hex[:8]}", user, session)
+        await session.commit()
+        dataset_id = dataset.id
+
+    try:
+        rows = await asyncio.gather(
+            *(get_or_create_dataset_database(dataset_id, user) for _ in range(4))
+        )
+
+        assert {row.dataset_id for row in rows} == {dataset_id}
+        assert {row.graph_database_name for row in rows} == {rows[0].graph_database_name}
+
+        async with engine.get_async_session() as session:
+            stored = (
+                await session.scalars(
+                    select(DatasetDatabase).where(DatasetDatabase.dataset_id == dataset_id)
+                )
+            ).all()
+        assert len(stored) == 1
+    finally:
+        async with engine.get_async_session() as session:
+            await session.execute(
+                delete(DatasetDatabase).where(DatasetDatabase.dataset_id == dataset_id)
+            )
+            await session.execute(delete(Dataset).where(Dataset.id == dataset_id))
+            await session.commit()


### PR DESCRIPTION
## Description
Fixes [SDK-603](https://linear.app/cognee/issue/SDK-603/concurrent-first-use-provisioning-of-a-datasets-databases-crashes-the), reported by a cloud user: querying a brand-new dataset while it is still being built fails with an error.

### What happened
Every operation on a dataset enters the dataset context, and the context provisions the dataset's databases on first use (`get_or_create_dataset_database`). That was a check-then-create with nothing serializing it: read the registry row, find none, create the physical graph and vector databases, insert the row. Two callers doing this for the same fresh dataset both passed the check, and the second insert violated the primary key. The `IntegrityError` was re-raised, so that caller's operation died (HTTP 500 through the API).

Ingestion pipelines run under the per-dataset lock, but search/recall never take it and have no "does this dataset have data yet" check in front of the context, so the race is reachable through the public API as a recall during the first `add`/`remember` of a dataset, or as two concurrent recalls on a never-built dataset. The window is milliseconds on Ladybug/LanceDB (an `asyncio.gather` hits it every time) and one to several seconds on Neo4j (online wait) and pgvector (`CREATE DATABASE`). On pgvector database-per-dataset and the Postgres graph demo the loser could fail one level down as well, because `create_pg_database_if_not_exists` was check-then-`CREATE DATABASE` and Postgres has no `IF NOT EXISTS` for databases.

In code since #869 (June 2025); no test covered concurrent provisioning.

### The fix
- **Registry row** (`get_or_create_dataset_database.py`): losing the insert is no longer an error. The row the winner committed is read back and returned. Every name the handlers produce is derived from the dataset id, so the databases both callers created are the same ones. A conflict with no row behind it (an owner row gone) still raises the original error.
- **Postgres create helpers** (`postgres/admin.py`): both `create_pg_database_if_not_exists` and `create_pg_schema_if_not_exists` serialize creators on an advisory lock keyed by the target database, session-level for `CREATE DATABASE` (cannot run in a transaction) and transaction-level for the schema DDL. The check and the create are atomic across every process in the cluster, and Postgres releases the locks if a connection drops. `CREATE SCHEMA/EXTENSION IF NOT EXISTS` needed it too: Postgres documents that two transactions that both pass the check collide on the catalog's unique index.

No behaviour changes for sequential callers: the same rows, names and return values as before.

### Tests
- `cognee/tests/unit/infrastructure/databases/test_dataset_database_provisioning_race.py`: races four provisioning calls on a fresh dataset on the default stack and asserts one row, no errors. Added to the community unit-test job.
- `cognee/tests/e2e/postgres/test_admin_helpers_concurrency.py`: races six callers of each helper against a live Postgres (skips if unreachable) and asserts one create, no errors. Added to the Postgres job in `graph_db_tests.yml`.

Both failed before the change with the exact reported errors (`UNIQUE constraint failed: dataset_database.dataset_id`; `duplicate key value violates unique constraint "pg_database_datname_index"`) and pass after, the Postgres one three runs in a row locally. The existing shared-schema Postgres suite and the context-manager unit tests pass; the CI-equivalent `ty check` and pre-commit pass.

### Out of scope
Whether a read-only operation such as search should provision a dataset's databases at all is a separate design question; this PR keeps that behaviour and only makes it safe.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
