### PR TITLE
fix: Serve the API with more than one worker (SDK-606)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -827,6 +827,11 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # Server bind/port inside the container (entrypoint defaults shown).
 #HTTP_PORT=8000
 #BIND_ADDRESS=0.0.0.0
+# Number of gunicorn workers. Each worker is a separate process with its own
+# event loop, so more than one keeps a slow or fatal request from taking the
+# whole API down with it. Memory scales with the count -- lower it on
+# memory-constrained deployments. Defaults to 4, or 1 when DEBUG=true.
+#API_WORKERS=4
 
 # -- MCP server (cognee/cognee-mcp image) -------------------------------------
 # Transport the MCP container serves. The Docker image reads TRANSPORT_MODE;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,9 +11,21 @@ echo "Environment: $ENV"
 DEBUG_PORT=${DEBUG_PORT:-5678}
 HTTP_PORT=${HTTP_PORT:-8000}
 BIND_ADDRESS=${BIND_ADDRESS:-"0.0.0.0"}
+# One gunicorn worker means one event loop for the whole API: a single slow
+# request stalls every other request, and a worker that dies takes every
+# in-flight connection with it. Serve with several so one bad request degrades
+# only itself. Debugging is the exception -- breakpoints spread across forked
+# workers are not useful -- so DEBUG=true defaults to one. Override either
+# default with API_WORKERS; memory scales with the count.
+if [ "$DEBUG" = "true" ]; then
+    API_WORKERS=${API_WORKERS:-1}
+else
+    API_WORKERS=${API_WORKERS:-4}
+fi
 echo "Debug port: $DEBUG_PORT"
 echo "HTTP port: $HTTP_PORT"
 echo "Bind address: $BIND_ADDRESS"
+echo "API workers: $API_WORKERS"
 
 # Run migrations through cognee's own migration system rather than raw
 # alembic: it knows a fresh database from an existing one (fresh -> create
@@ -53,10 +65,10 @@ sleep 2
 if [ "$ENV" = "dev" ] || [ "$ENV" = "local" ]; then
     if [ "$DEBUG" = "true" ]; then
         echo "Waiting for the debugger to attach..."
-        exec debugpy --wait-for-client --listen $BIND_ADDRESS:$DEBUG_PORT -m gunicorn -w 1 -k uvicorn.workers.UvicornWorker -t 30000 --bind=$BIND_ADDRESS:$HTTP_PORT --log-level debug --reload --access-logfile - --error-logfile - cognee.api.client:app
+        exec debugpy --wait-for-client --listen $BIND_ADDRESS:$DEBUG_PORT -m gunicorn -w $API_WORKERS -k uvicorn.workers.UvicornWorker -t 30000 --bind=$BIND_ADDRESS:$HTTP_PORT --log-level debug --reload --access-logfile - --error-logfile - cognee.api.client:app
     else
-        exec gunicorn -w 1 -k uvicorn.workers.UvicornWorker -t 30000 --bind=$BIND_ADDRESS:$HTTP_PORT --log-level debug --reload --access-logfile - --error-logfile - cognee.api.client:app
+        exec gunicorn -w $API_WORKERS -k uvicorn.workers.UvicornWorker -t 30000 --bind=$BIND_ADDRESS:$HTTP_PORT --log-level debug --reload --access-logfile - --error-logfile - cognee.api.client:app
     fi
 else
-    exec gunicorn -w 1 -k uvicorn.workers.UvicornWorker -t 30000 --bind=$BIND_ADDRESS:$HTTP_PORT --log-level error --access-logfile - --error-logfile - cognee.api.client:app
+    exec gunicorn -w $API_WORKERS -k uvicorn.workers.UvicornWorker -t 30000 --bind=$BIND_ADDRESS:$HTTP_PORT --log-level error --access-logfile - --error-logfile - cognee.api.client:app
 fi


### PR DESCRIPTION
## Description

`entrypoint.sh` hardcoded `-w 1` on all three gunicorn invocations, so the entire API ran on a single event loop. That is not a slow-endpoint problem — it is a blast-radius problem, and it has two shapes, both observed on a 10 GB deployment (cognee 1.5.1, Aurora PG 16.9):

**One slow request stalls every other request.** Several handlers do synchronous CPU work inside `async def`. While one such request was in flight, `GET /v1/datasets` — a single indexed lookup returning 181 bytes — went from **0.39 s idle to 8.9 s**.

**A worker that dies takes every in-flight connection with it.** The kernel OOM-killed the worker at ~22 GB RSS:

```
oom-kill:constraint=CONSTRAINT_MEMCG
Killed process 90498 (gunicorn) anon-rss:22,979,412 kB
[gunicorn] Worker (pid:28) was sent SIGKILL! Perhaps out of memory?
memory.events: oom_kill 27
```

One of those kills terminated an unrelated request that had been running for 112 minutes and had nothing to do with the endpoint that caused the OOM.

Neither is fixed by making any single endpoint faster, which is why this is worth landing ahead of the endpoint fixes it accompanies.

## Changes

- `API_WORKERS`, defaulting to **4**, honoured by all three gunicorn invocations.
- `DEBUG=true` defaults to **1** instead. Breakpoints spread across forked workers are not useful, and that path exists to be stepped through. Still overridable.
- Documented in `.env.template` next to `HTTP_PORT` / `BIND_ADDRESS`.

`API_WORKERS=1` reproduces today's behaviour exactly, for deployments sized around one process.

## Deliberately not here

- Fixing the endpoints that block the loop or exhaust memory — SDK-607, SDK-608, SDK-609, and the `/visualize` full-graph load.
- Moving synchronous encode work off the event loop with `run_in_threadpool`. Worth doing; it changes every handler and belongs on its own.
- Auto-sizing from CPU count. Per-deployment memory headroom varies too much to derive safely.

## Reviewer note

**Memory scales with the worker count.** Deployments with tight per-pod limits should set `API_WORKERS` explicitly rather than inherit 4 — that is the cloud-side port, CLO-766, which also re-checks DB pool sizing (pools are per-process, so N workers multiply connections against the Aurora cap).

Fixes SDK-606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqYNHtL3zqaXmaLfcNpVCv