### PR TITLE
fix(improve): persist only new agent trace steps

### DIFF
--- a/cognee/api/v1/improve/improve.py
+++ b/cognee/api/v1/improve/improve.py
@@ -545,7 +545,8 @@ async def _persist_session_traces(
             dataset=dataset,
             node_set_name="agent_trace_feedbacks",
             raw_trace_content=False,
-            last_n_steps=None,  # persist all stored steps on demand
+            last_n_steps=None,
+            incremental=True,
             run_in_background=run_in_background,
         )
         logger.info(

--- a/cognee/infrastructure/session/agent_trace_persist_watermark.py
+++ b/cognee/infrastructure/session/agent_trace_persist_watermark.py
@@ -1,0 +1,73 @@
+"""Per-session watermark for persisting agent traces into the knowledge graph.
+
+The extractor reads the number of successfully persisted trace steps and emits
+only the append-only suffix above that count. The cognify task advances the
+watermark after graph ingestion succeeds, leaving failed windows pending for a
+later ``improve()`` retry.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+
+AGENT_TRACE_PERSIST_STATE_ID = "agent_trace_persist_watermark"
+AGENT_TRACE_PERSIST_STATE_KIND = "agent_trace_persist_watermark_state"
+
+
+@dataclass(frozen=True, slots=True)
+class AgentTracePersistWindow:
+    """One not-yet-persisted slice of a session's agent trace."""
+
+    user_id: str
+    session_id: str
+    text: str
+    persisted_trace_count: int
+
+
+def _extract_state_row(raw_entries: list) -> dict | None:
+    for raw in raw_entries or []:
+        if not isinstance(raw, dict):
+            continue
+        if raw.get("id") == AGENT_TRACE_PERSIST_STATE_ID:
+            return raw
+        if raw.get("kind") == AGENT_TRACE_PERSIST_STATE_KIND:
+            return raw
+    return None
+
+
+async def get_persisted_trace_count(session_manager, user_id: str, session_id: str) -> int:
+    """Read the trace watermark; missing or malformed state starts at zero."""
+    raw_entries = await session_manager.get_session_context_entries(
+        user_id=user_id, session_id=session_id
+    )
+    row = _extract_state_row(raw_entries)
+    if row is None:
+        return 0
+    try:
+        return max(0, int(row.get("persisted_trace_count") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+async def save_persisted_trace_count(
+    session_manager, user_id: str, session_id: str, persisted_trace_count: int
+) -> None:
+    """Store the trace watermark as an internal, non-rendered context row."""
+    payload = {
+        "id": AGENT_TRACE_PERSIST_STATE_ID,
+        "kind": AGENT_TRACE_PERSIST_STATE_KIND,
+        "persisted_trace_count": max(0, int(persisted_trace_count)),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    updated = await session_manager.update_session_context_entry(
+        user_id=user_id,
+        session_id=session_id,
+        entry_id=AGENT_TRACE_PERSIST_STATE_ID,
+        merge=payload,
+    )
+    if not updated:
+        await session_manager.create_session_context_entry(
+            user_id=user_id,
+            session_id=session_id,
+            entry_dump=payload,
+        )

--- a/cognee/memify_pipelines/persist_agent_trace_feedbacks_in_knowledge_graph.py
+++ b/cognee/memify_pipelines/persist_agent_trace_feedbacks_in_knowledge_graph.py
@@ -22,6 +22,7 @@ async def persist_agent_trace_feedbacks_in_knowledge_graph_pipeline(
     raw_trace_content: bool = False,
     last_n_steps: int | None = None,
     run_in_background: bool = False,
+    incremental: bool = True,
 ):
     """
     Persist agent trace content into the knowledge graph via memify pipeline.
@@ -41,6 +42,7 @@ async def persist_agent_trace_feedbacks_in_knowledge_graph_pipeline(
         last_n_steps: Optional number of most recent trace steps to persist per
             session. When None, all stored steps are persisted.
         run_in_background: If True, runs memify asynchronously and returns immediately.
+        incremental: Persist only trace steps above the last successful watermark.
     """
     await set_session_user_context_variable(user)
     dataset_to_write = await get_authorized_existing_datasets(
@@ -64,6 +66,7 @@ async def persist_agent_trace_feedbacks_in_knowledge_graph_pipeline(
             session_ids=session_ids,
             raw_trace_content=raw_trace_content,
             last_n_steps=last_n_steps,
+            incremental=incremental,
         )
     ]
     enrichment_tasks = [
@@ -92,6 +95,7 @@ async def persist_agent_trace_feedbacks_in_knowledge_graph_pipeline(
             "node_set_name": node_set_name,
             "raw_trace_content": raw_trace_content,
             "last_n_steps": last_n_steps,
+            "incremental": incremental,
         },
     )
     return result

--- a/cognee/tasks/memify/cognify_agent_trace_feedback.py
+++ b/cognee/tasks/memify/cognify_agent_trace_feedback.py
@@ -54,8 +54,12 @@ async def cognify_agent_trace_feedback(
             )
 
         for item in items:
-            window = item if isinstance(item, AgentTracePersistWindow) else None
-            trace_content = window.text if window is not None else item
+            if isinstance(item, AgentTracePersistWindow):
+                window = item
+                trace_content = item.text
+            else:
+                window = None
+                trace_content = item
 
             if not trace_content.strip():
                 if window is None:

--- a/cognee/tasks/memify/cognify_agent_trace_feedback.py
+++ b/cognee/tasks/memify/cognify_agent_trace_feedback.py
@@ -2,6 +2,11 @@ from uuid import UUID
 
 import cognee
 from cognee.exceptions import CogneeSystemError, CogneeValidationError
+from cognee.infrastructure.session.agent_trace_persist_watermark import (
+    AgentTracePersistWindow,
+    save_persisted_trace_count,
+)
+from cognee.infrastructure.session.get_session_manager import get_session_manager
 from cognee.modules.pipelines.models.PipelineRunInfo import get_errored_run_info
 from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
@@ -10,7 +15,7 @@ logger = get_logger("cognify_agent_trace_feedback")
 
 
 async def cognify_agent_trace_feedback(
-    data: str,
+    data: str | AgentTracePersistWindow | list[str | AgentTracePersistWindow],
     dataset_id: UUID | str | None = None,
     node_set_name: str = "agent_trace_feedbacks",
     user: User | None = None,
@@ -19,9 +24,9 @@ async def cognify_agent_trace_feedback(
     Process and cognify agent trace session text into the knowledge graph.
 
     Args:
-        data: Agent trace text for a single session. Depending on the extractor
-            configuration, this may contain either session feedback summaries or
-            raw method return values.
+        data: Agent trace text or incremental trace window(s). Depending on the
+            extractor configuration, content may contain either session feedback
+            summaries or raw method return values.
         dataset_id: Dataset identifier to write to.
         node_set_name: Node-set name used when adding the trace text.
         user: User the add/cognify calls run as. Without it they fall back to
@@ -41,28 +46,63 @@ async def cognify_agent_trace_feedback(
                 log=False,
             )
 
-        logger.info("Processing agent trace content for cognification")
-
-        await cognee.add(data, dataset_id=dataset_id, node_set=[node_set_name], user=user)
-        logger.debug(
-            "Agent trace content added to cognee with node_set: %s",
-            node_set_name,
-        )
-        # raise_on_error=False: one trace session's failed build must not kill
-        # the whole memify run — log the cause and let the remaining sessions
-        # proceed (the pre-loud-cognify behavior, now with the error visible).
-        cognify_result = await cognee.cognify(
-            datasets=[dataset_id], user=user, raise_on_error=False
-        )
-        errored_run = get_errored_run_info(cognify_result)
-        if errored_run is not None:
-            logger.error(
-                "Cognify failed for agent trace content (%s: %s); continuing with the run",
-                errored_run.error_class,
-                errored_run.error_message,
+        items = data if isinstance(data, list) else [data]
+        if not all(isinstance(item, (str, AgentTracePersistWindow)) for item in items):
+            raise CogneeValidationError(
+                message="Agent trace content must be text or a persistence window",
+                log=False,
             )
-            return
-        logger.info("Agent trace content successfully cognified")
+
+        for item in items:
+            window = item if isinstance(item, AgentTracePersistWindow) else None
+            trace_content = window.text if window is not None else item
+
+            if not trace_content.strip():
+                if window is None:
+                    raise CogneeValidationError(
+                        message="Agent trace content cannot be empty",
+                        log=False,
+                    )
+                await save_persisted_trace_count(
+                    get_session_manager(),
+                    user_id=window.user_id,
+                    session_id=window.session_id,
+                    persisted_trace_count=window.persisted_trace_count,
+                )
+                continue
+
+            logger.info("Processing agent trace content for cognification")
+            await cognee.add(
+                trace_content,
+                dataset_id=dataset_id,
+                node_set=[node_set_name],
+                user=user,
+            )
+            logger.debug(
+                "Agent trace content added to cognee with node_set: %s",
+                node_set_name,
+            )
+            # Keep a failed window pending so a later improve() can retry it.
+            cognify_result = await cognee.cognify(
+                datasets=[dataset_id], user=user, raise_on_error=False
+            )
+            errored_run = get_errored_run_info(cognify_result)
+            if errored_run is not None:
+                logger.error(
+                    "Cognify failed for agent trace content (%s: %s); continuing with the run",
+                    errored_run.error_class,
+                    errored_run.error_message,
+                )
+                continue
+            logger.info("Agent trace content successfully cognified")
+
+            if window is not None:
+                await save_persisted_trace_count(
+                    get_session_manager(),
+                    user_id=window.user_id,
+                    session_id=window.session_id,
+                    persisted_trace_count=window.persisted_trace_count,
+                )
 
     except CogneeValidationError:
         raise

--- a/cognee/tasks/memify/extract_agent_trace_feedbacks.py
+++ b/cognee/tasks/memify/extract_agent_trace_feedbacks.py
@@ -2,6 +2,10 @@ import json
 
 from cognee.context_global_variables import session_user
 from cognee.exceptions import CogneeSystemError
+from cognee.infrastructure.session.agent_trace_persist_watermark import (
+    AgentTracePersistWindow,
+    get_persisted_trace_count,
+)
 from cognee.infrastructure.session.get_session_manager import get_session_manager
 from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
@@ -29,6 +33,7 @@ async def extract_agent_trace_feedbacks(
     session_ids: list[str] | None = None,
     raw_trace_content: bool = False,
     last_n_steps: int | None = None,
+    incremental: bool = False,
 ):
     """
     Extract step-level agent trace content for the current user.
@@ -44,9 +49,12 @@ async def extract_agent_trace_feedbacks(
             of ``session_feedback`` summaries.
         last_n_steps: Optional number of most recent trace steps to extract per
             session. When None, all stored steps are used.
+        incremental: When True, extract only steps above the successful-persist watermark
+            and yield ``AgentTracePersistWindow`` values for acknowledgement.
 
     Yields:
-        String containing the session ID and all non-empty extracted entries.
+        A string for legacy extraction, or an ``AgentTracePersistWindow`` when
+        incremental extraction is enabled.
 
     Raises:
         CogneeSystemError: If SessionManager is unavailable or extraction fails.
@@ -83,17 +91,51 @@ async def extract_agent_trace_feedbacks(
                     content_label = (
                         "method_return_value" if raw_trace_content else "session_feedback"
                     )
+                    persisted_trace_count = 0
+                    total_trace_count = 0
+                    steps_to_fetch = last_n_steps
+                    if incremental:
+                        total_trace_count = await session_manager.get_agent_trace_count(
+                            user_id=user_id,
+                            session_id=session_id,
+                        )
+                        persisted_trace_count = await get_persisted_trace_count(
+                            session_manager, user_id, session_id
+                        )
+                        if persisted_trace_count > total_trace_count:
+                            logger.warning(
+                                "Session %s has %d trace steps but watermark is %d; "
+                                "treating watermark as stale and persisting from the start",
+                                session_id,
+                                total_trace_count,
+                                persisted_trace_count,
+                            )
+                            persisted_trace_count = 0
+
+                        pending_trace_count = total_trace_count - persisted_trace_count
+                        if pending_trace_count == 0:
+                            logger.info(
+                                "Session %s trace already persisted up to step %d, nothing new",
+                                session_id,
+                                persisted_trace_count,
+                            )
+                            continue
+                        steps_to_fetch = (
+                            pending_trace_count
+                            if last_n_steps is None
+                            else min(last_n_steps, pending_trace_count)
+                        )
                     if not raw_trace_content:
                         trace_values = await session_manager.get_agent_trace_feedback(
                             user_id=user_id,
                             session_id=session_id,
-                            last_n=last_n_steps,
+                            last_n=steps_to_fetch,
                         )
                     else:
                         trace_session = await session_manager.get_agent_trace_session(
                             user_id=user_id,
                             session_id=session_id,
-                            last_n=last_n_steps,
+                            last_n=steps_to_fetch,
                         )
                         trace_values = [entry.method_return_value for entry in trace_session]
 
@@ -109,7 +151,20 @@ async def extract_agent_trace_feedbacks(
                             len(normalized_trace_values),
                             content_label,
                         )
-                        yield f"Session ID: {session_id}\n\n" + "\n".join(normalized_trace_values)
+                    text = (
+                        f"Session ID: {session_id}\n\n" + "\n".join(normalized_trace_values)
+                        if normalized_trace_values
+                        else ""
+                    )
+                    if incremental:
+                        yield AgentTracePersistWindow(
+                            user_id=user_id,
+                            session_id=session_id,
+                            text=text,
+                            persisted_trace_count=total_trace_count,
+                        )
+                    elif text:
+                        yield text
                 except Exception as error:
                     logger.warning(
                         "Failed to extract agent trace %s for session %s: %s",

--- a/cognee/tests/unit/memify_pipelines/test_persist_agent_trace_feedbacks_pipeline.py
+++ b/cognee/tests/unit/memify_pipelines/test_persist_agent_trace_feedbacks_pipeline.py
@@ -59,6 +59,7 @@ async def test_persist_agent_trace_feedbacks_pipeline_wires_memify_tasks():
     assert extraction_task.default_params["kwargs"]["session_ids"] == ["s1", "s2"]
     assert extraction_task.default_params["kwargs"]["raw_trace_content"] is True
     assert extraction_task.default_params["kwargs"]["last_n_steps"] == 3
+    assert extraction_task.default_params["kwargs"]["incremental"] is True
     assert enrichment_task.default_params["kwargs"]["dataset_id"] == "dataset-1"
     assert enrichment_task.default_params["kwargs"]["node_set_name"] == "custom_feedbacks"
     assert enrichment_task.default_params["kwargs"]["user"] == user

--- a/cognee/tests/unit/tasks/memify/test_agent_trace_persist_watermark.py
+++ b/cognee/tests/unit/tasks/memify/test_agent_trace_persist_watermark.py
@@ -1,0 +1,205 @@
+"""Watermark-based incremental agent-trace persistence tests."""
+
+import sys
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+import cognee
+from cognee.context_global_variables import session_user
+from cognee.exceptions import CogneeSystemError
+from cognee.infrastructure.session.agent_trace_persist_watermark import (
+    AgentTracePersistWindow,
+    get_persisted_trace_count,
+    save_persisted_trace_count,
+)
+from cognee.tasks.memify.cognify_agent_trace_feedback import cognify_agent_trace_feedback
+from cognee.tasks.memify.extract_agent_trace_feedbacks import extract_agent_trace_feedbacks
+
+SESSION = "trace_watermark_test_session"
+
+
+class FakeSessionManager:
+    is_available = True
+
+    def __init__(self):
+        self.traces: dict[tuple[str, str], list[str]] = {}
+        self.context: dict[tuple[str, str], list[dict]] = {}
+
+    def add_trace(self, user_id: str, session_id: str, feedback: str):
+        self.traces.setdefault((user_id, session_id), []).append(feedback)
+
+    async def get_agent_trace_count(self, *, user_id, session_id=None):
+        return len(self.traces.get((user_id, session_id), []))
+
+    async def get_agent_trace_feedback(self, *, user_id, session_id=None, last_n=None):
+        traces = self.traces.get((user_id, session_id), [])
+        return list(traces if last_n is None else traces[-last_n:])
+
+    async def get_session_context_entries(self, *, user_id, session_id=None):
+        return list(self.context.get((user_id, session_id), []))
+
+    async def update_session_context_entry(self, *, user_id, entry_id, merge, session_id=None):
+        for row in self.context.get((user_id, session_id), []):
+            if row.get("id") == entry_id:
+                row.update(merge)
+                return True
+        return False
+
+    async def create_session_context_entry(self, *, user_id, entry_dump, session_id=None):
+        self.context.setdefault((user_id, session_id), []).append(dict(entry_dump))
+        return True
+
+
+@pytest.fixture
+def user():
+    fake_user = SimpleNamespace(id=uuid.uuid4())
+    token = session_user.set(fake_user)
+    yield fake_user
+    session_user.reset(token)
+
+
+@pytest.fixture
+def manager(monkeypatch):
+    extract_module = sys.modules["cognee.tasks.memify.extract_agent_trace_feedbacks"]
+    cognify_module = sys.modules["cognee.tasks.memify.cognify_agent_trace_feedback"]
+    fake = FakeSessionManager()
+    monkeypatch.setattr(extract_module, "get_session_manager", lambda: fake)
+    monkeypatch.setattr(cognify_module, "get_session_manager", lambda: fake)
+    return fake
+
+
+async def _extract_windows() -> list[AgentTracePersistWindow]:
+    return [
+        window
+        async for window in extract_agent_trace_feedbacks(
+            [{}], session_ids=[SESSION], incremental=True
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_incremental_trace_persistence_processes_each_step_once(user, manager, monkeypatch):
+    user_id = str(user.id)
+    persisted_texts: list[str] = []
+
+    async def fake_add(text, *args, **kwargs):
+        persisted_texts.append(text)
+
+    async def fake_cognify(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(cognee, "add", fake_add)
+    monkeypatch.setattr(cognee, "cognify", fake_cognify)
+
+    manager.add_trace(user_id, SESSION, "step-1")
+    manager.add_trace(user_id, SESSION, "step-2")
+    first_windows = await _extract_windows()
+    assert len(first_windows) == 1
+    await cognify_agent_trace_feedback(first_windows[0], dataset_id=uuid.uuid4(), user=user)
+
+    assert "step-1" in persisted_texts[0]
+    assert "step-2" in persisted_texts[0]
+    assert await get_persisted_trace_count(manager, user_id, SESSION) == 2
+    assert await _extract_windows() == []
+
+    manager.add_trace(user_id, SESSION, "step-3")
+    next_windows = await _extract_windows()
+    assert len(next_windows) == 1
+    assert "step-1" not in next_windows[0].text
+    assert "step-2" not in next_windows[0].text
+    assert "step-3" in next_windows[0].text
+    await cognify_agent_trace_feedback(next_windows[0], dataset_id=uuid.uuid4(), user=user)
+
+    combined = "".join(persisted_texts)
+    assert combined.count("step-1") == 1
+    assert combined.count("step-2") == 1
+    assert combined.count("step-3") == 1
+    assert await get_persisted_trace_count(manager, user_id, SESSION) == 3
+
+
+@pytest.mark.asyncio
+async def test_failed_trace_persistence_keeps_window_pending(user, manager, monkeypatch):
+    user_id = str(user.id)
+    manager.add_trace(user_id, SESSION, "retry-me")
+    window = (await _extract_windows())[0]
+
+    async def fake_add(*args, **kwargs):
+        return None
+
+    async def failing_cognify(*args, **kwargs):
+        raise RuntimeError("temporary LLM failure")
+
+    monkeypatch.setattr(cognee, "add", fake_add)
+    monkeypatch.setattr(cognee, "cognify", failing_cognify)
+
+    with pytest.raises(CogneeSystemError):
+        await cognify_agent_trace_feedback(window, dataset_id=uuid.uuid4(), user=user)
+
+    assert await get_persisted_trace_count(manager, user_id, SESSION) == 0
+    retry_windows = await _extract_windows()
+    assert len(retry_windows) == 1
+    assert "retry-me" in retry_windows[0].text
+
+
+@pytest.mark.asyncio
+async def test_errored_cognify_result_keeps_trace_window_pending(user, manager, monkeypatch):
+    from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunErrored
+
+    user_id = str(user.id)
+    manager.add_trace(user_id, SESSION, "retry-errored-run")
+    window = (await _extract_windows())[0]
+
+    async def fake_add(*args, **kwargs):
+        return None
+
+    async def errored_cognify(*args, **kwargs):
+        return {
+            "dataset": PipelineRunErrored(
+                pipeline_run_id=uuid.uuid4(),
+                dataset_id=uuid.uuid4(),
+                dataset_name="dataset",
+                error_class="RuntimeError",
+                error_message="temporary failure",
+            )
+        }
+
+    monkeypatch.setattr(cognee, "add", fake_add)
+    monkeypatch.setattr(cognee, "cognify", errored_cognify)
+
+    await cognify_agent_trace_feedback(window, dataset_id=uuid.uuid4(), user=user)
+
+    assert await get_persisted_trace_count(manager, user_id, SESSION) == 0
+    assert len(await _extract_windows()) == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_feedback_advances_watermark_without_cognify(user, manager, monkeypatch):
+    user_id = str(user.id)
+    manager.add_trace(user_id, SESSION, "   ")
+    window = (await _extract_windows())[0]
+
+    async def unexpected_call(*args, **kwargs):
+        raise AssertionError("empty feedback must not trigger graph ingestion")
+
+    monkeypatch.setattr(cognee, "add", unexpected_call)
+    monkeypatch.setattr(cognee, "cognify", unexpected_call)
+
+    await cognify_agent_trace_feedback(window, dataset_id=uuid.uuid4(), user=user)
+
+    assert await get_persisted_trace_count(manager, user_id, SESSION) == 1
+    assert await _extract_windows() == []
+
+
+@pytest.mark.asyncio
+async def test_stale_trace_watermark_restarts_from_current_history(user, manager):
+    user_id = str(user.id)
+    manager.add_trace(user_id, SESSION, "rebuilt-step")
+    await save_persisted_trace_count(manager, user_id, SESSION, 10)
+
+    windows = await _extract_windows()
+
+    assert len(windows) == 1
+    assert "rebuilt-step" in windows[0].text
+    assert windows[0].persisted_trace_count == 1


### PR DESCRIPTION
## Description

Fixes #4996.

Agent trace persistence now tracks a per-session count watermark and extracts only the append-only suffix that has not been persisted yet. The watermark advances after `add` and `cognify` succeed; exceptions and errored pipeline results leave the window pending for retry. Trace steps with no persistable feedback advance without invoking graph ingestion.

The existing non-incremental extractor mode remains available for direct task callers, while the persistence pipeline and `improve()` use incremental windows by default.

## Acceptance Criteria

- The first persistence run processes all existing trace steps.
- A repeated run with no new trace steps performs no graph ingestion.
- Later runs process only newly appended trace steps.
- Failed graph ingestion does not advance the watermark.
- A cleared and rebuilt session recovers from a stale count watermark.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

CLI test results:

```text
30 passed, 12 warnings in 8.44s
61 passed, 12 warnings in 11.08s
All Ruff checks passed
```

## Tests

```text
python -m pytest cognee/tests/unit/tasks/memify/test_agent_trace_persist_watermark.py cognee/tests/unit/modules/memify_tasks/test_extract_agent_trace_feedbacks.py cognee/tests/unit/modules/memify_tasks/test_cognify_agent_trace_feedback.py cognee/tests/unit/memify_pipelines/test_persist_agent_trace_feedbacks_pipeline.py cognee/tests/unit/api/v1/improve/test_improve_agent_context.py -q
python -m pytest cognee/tests/unit/modules/agent_memory/test_agent_memory.py -q
python -m ruff check <changed Python files>
```

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and affected existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.