### PR TITLE
fix(search): Require write for Cypher search types (SDK-547)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -390,6 +390,10 @@ ACCEPT_LOCAL_FILE_PATH=True
 # reachable by untrusted callers; cognee's own data/system/cache/logs/repos roots stay allowed.
 # COGNEE_ALLOWED_LOCAL_FILE_ROOTS=/srv/projects:/home/me/docs
 ALLOW_HTTP_REQUESTS=True
+# CYPHER and NATURAL_LANGUAGE search hand a Cypher statement to the graph engine, so they
+# require write permission on every dataset they target; a read-only share is not enough.
+# Even with that gate, raw Cypher on Neo4j and Ladybug can reach files, other databases and
+# the network, so set this to False on deployments with untrusted users.
 ALLOW_CYPHER_QUERY=True
 RAISE_INCREMENTAL_LOADING_ERRORS=True
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,8 +260,8 @@ Available search types (from `cognee/modules/search/types/SearchType.py`), passe
 - **CHUNKS** - Vector similarity search over chunks
 - **CHUNKS_LEXICAL** - Lexical (keyword) search over chunks
 - **SUMMARIES** - Search pre-computed document summaries
-- **CYPHER** - Direct Cypher query execution (requires `ALLOW_CYPHER_QUERY=True`)
-- **NATURAL_LANGUAGE** - Natural language to structured query
+- **CYPHER** - Direct Cypher query execution (requires `ALLOW_CYPHER_QUERY=True` and write permission on every targeted dataset)
+- **NATURAL_LANGUAGE** - Natural language to Cypher query, executed against the graph (same gate and write requirement as CYPHER)
 - **TEMPORAL** - Time-aware graph search
 - **FEELING_LUCKY** - Automatic search type selection
 - **CODING_RULES** - Code-specific search rules
@@ -702,7 +702,7 @@ Several security environment variables in `.env`:
 - `ACCEPT_LOCAL_FILE_PATH` - Allow local file paths (default: True)
 - `COGNEE_ALLOWED_LOCAL_FILE_ROOTS` - Optional `os.pathsep`-separated allowlist of directories local paths may be read from. Unset (default) means any local path is accepted, so a local repo or document tree can be ingested from anywhere; a path-looking string that does not exist is still ingested as text. When set, paths outside the listed roots are rejected (or ingested as text on the non-strict `add()` path); cognee's own data/system/cache/logs/repos roots are always allowed. Set it for servers reachable by untrusted callers.
 - `ALLOW_HTTP_REQUESTS` - Allow HTTP requests from Cognee (default: True)
-- `ALLOW_CYPHER_QUERY` - Allow raw Cypher queries (default: True)
+- `ALLOW_CYPHER_QUERY` - Allow raw Cypher queries (default: True). CYPHER and NATURAL_LANGUAGE search also require write permission on every dataset they target (`SearchType.required_permissions`), and FEELING_LUCKY never routes to them. Set to False on multi-tenant deployments with untrusted users: raw Cypher on Neo4j and Ladybug can reach files, other databases, and the network.
 - `ENABLE_BACKEND_ACCESS_CONTROL` - Multi-tenant isolation (default: True). When `true`, API auth is required and per-user/dataset DB isolation is enabled. When `false`, single-user mode: shared DBs and auth off unless overridden.
 - `REQUIRE_AUTHENTICATION` - Explicit auth override. Unset (default): follows `ENABLE_BACKEND_ACCESS_CONTROL`. `false` is ignored when `ENABLE_BACKEND_ACCESS_CONTROL=true`. For a single-user deployment with auth off, set `ENABLE_BACKEND_ACCESS_CONTROL=false` (and optionally `REQUIRE_AUTHENTICATION=false`).
 

--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -184,10 +184,21 @@ async def authorized_search(
     Verifies access for provided datasets or uses all datasets user has read access for and performs search per dataset.
     Not to be used outside of active access control mode.
     """
-    # Find datasets user has read access for (if datasets are provided only return them. Provided user has read access)
-    search_datasets = await get_authorized_existing_datasets(
-        datasets=dataset_ids, permission_type="read", user=user
-    )
+    # Every search type needs read on its datasets; the Cypher-executing types also
+    # need write (SearchType.required_permissions). Explicit datasets the user lacks
+    # a required permission on raise PermissionDeniedError inside
+    # get_authorized_existing_datasets. With no explicit datasets, only the datasets
+    # granted every required permission are searched.
+    search_datasets: list[Dataset] | None = None
+    for permission_type in query_type.required_permissions:
+        permitted_datasets = await get_authorized_existing_datasets(
+            datasets=dataset_ids, permission_type=permission_type, user=user
+        )
+        if search_datasets is None:
+            search_datasets = permitted_datasets
+            continue
+        permitted_ids = {dataset.id for dataset in permitted_datasets}
+        search_datasets = [dataset for dataset in search_datasets if dataset.id in permitted_ids]
 
     # Searches all provided datasets and handles setting up of appropriate database context based on permissions
     search_results = await search_in_datasets_context(

--- a/cognee/modules/search/operations/select_search_type.py
+++ b/cognee/modules/search/operations/select_search_type.py
@@ -21,10 +21,14 @@ async def select_search_type(
         The best search type given by the LLM.
     """
     default_search_type = SearchType.RAG_COMPLETION
-    # Search types that cannot answer a free-form natural-language query on
-    # their own: CODE runs one exact graph operation driven by a structured
-    # code_query, which FEELING_LUCKY has no way to construct.
-    excluded_search_types = {SearchType.CODE}
+    # Search types FEELING_LUCKY must never route to. CODE runs one exact graph
+    # operation driven by a structured code_query, which FEELING_LUCKY has no way
+    # to construct. The Cypher-executing types need write permission on every
+    # dataset searched (SearchType.required_permissions), and the datasets were
+    # resolved with read only before this selector runs.
+    excluded_search_types = {SearchType.CODE} | {
+        search_type for search_type in SearchType if "write" in search_type.required_permissions
+    }
     system_prompt = read_query_prompt(system_prompt_path)
 
     try:
@@ -38,8 +42,8 @@ async def select_search_type(
             selected_search_type = SearchType(response.upper())
             if selected_search_type in excluded_search_types:
                 logger.info(
-                    f"LLM selected {selected_search_type.value}, which requires structured "
-                    f"arguments; falling back to {default_search_type.value}."
+                    f"LLM selected {selected_search_type.value}, which FEELING_LUCKY cannot "
+                    f"route to; falling back to {default_search_type.value}."
                 )
                 return default_search_type
             logger.info(f"Selected lucky search type: {response.upper()}")

--- a/cognee/modules/search/types/SearchType.py
+++ b/cognee/modules/search/types/SearchType.py
@@ -22,3 +22,20 @@ class SearchType(str, Enum):
     CODE = "CODE"
     GRAPH_REPORT = "GRAPH_REPORT"
     SKILLS = "SKILLS"
+
+    @property
+    def required_permissions(self) -> tuple[str, ...]:
+        """Dataset permissions a caller must hold on every dataset this search type touches.
+
+        Every type needs ``read``. The types that execute Cypher, whether the caller
+        wrote it (CYPHER) or an LLM wrote it from the question (NATURAL_LANGUAGE), also
+        need ``write``: nothing restricts the statement to reads, so a read-only share
+        must not be enough to run one. ``authorized_search`` enforces this and the
+        FEELING_LUCKY selector refuses to route to these types.
+        """
+        if self in _CYPHER_EXECUTING_SEARCH_TYPES:
+            return ("read", "write")
+        return ("read",)
+
+
+_CYPHER_EXECUTING_SEARCH_TYPES = frozenset({SearchType.CYPHER, SearchType.NATURAL_LANGUAGE})

--- a/cognee/tests/unit/modules/search/test_search.py
+++ b/cognee/tests/unit/modules/search/test_search.py
@@ -435,3 +435,134 @@ def test_prompt_preview_fields_follow_the_requested_format_not_session_state(sea
         search_type=SearchType.GRAPH_COMPLETION,
     )
     assert search_mod._prompt_preview_fields(filled)["user_prompt_result"] == "The question is: `q`"
+
+
+# ---------------------------------------------------------------------------
+# Per-search-type permissions: CYPHER and NATURAL_LANGUAGE need write, not just read
+# ---------------------------------------------------------------------------
+
+
+def test_required_permissions_by_search_type():
+    cypher_types = {SearchType.CYPHER, SearchType.NATURAL_LANGUAGE}
+    for search_type in SearchType:
+        expected = ("read", "write") if search_type in cypher_types else ("read",)
+        assert search_type.required_permissions == expected, search_type
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query_type", [SearchType.CYPHER, SearchType.NATURAL_LANGUAGE])
+async def test_cypher_types_deny_read_only_datasets(monkeypatch, search_mod, query_type):
+    """A read-only share is not enough to run Cypher against a dataset."""
+    from cognee.modules.users.exceptions import PermissionDeniedError
+
+    user = _make_user()
+    ds = _make_dataset(name="shared-read-only")
+    requested = []
+
+    async def dummy_get_authorized_existing_datasets(*, datasets, permission_type, user):
+        requested.append(permission_type)
+        if permission_type == "read":
+            return [ds]
+        raise PermissionDeniedError(f"missing {permission_type}")
+
+    async def dummy_search_in_datasets_context(**_kwargs):
+        raise AssertionError("search must not run without write permission")
+
+    monkeypatch.setattr(
+        search_mod, "get_authorized_existing_datasets", dummy_get_authorized_existing_datasets
+    )
+    monkeypatch.setattr(search_mod, "search_in_datasets_context", dummy_search_in_datasets_context)
+
+    with pytest.raises(PermissionDeniedError):
+        await search_mod.authorized_search(
+            query_type=query_type,
+            query_text="MATCH (n) DETACH DELETE n",
+            user=user,
+            dataset_ids=[ds.id],
+        )
+
+    assert requested == ["read", "write"]
+
+
+@pytest.mark.asyncio
+async def test_cypher_runs_with_write_permission(monkeypatch, search_mod):
+    user = _make_user()
+    ds = _make_dataset(name="shared-writable")
+    seen = {}
+
+    async def dummy_get_authorized_existing_datasets(*, datasets, permission_type, user):
+        return [ds]
+
+    async def dummy_search_in_datasets_context(**kwargs):
+        seen["datasets"] = kwargs["search_datasets"]
+        return []
+
+    monkeypatch.setattr(
+        search_mod, "get_authorized_existing_datasets", dummy_get_authorized_existing_datasets
+    )
+    monkeypatch.setattr(search_mod, "search_in_datasets_context", dummy_search_in_datasets_context)
+
+    out = await search_mod.authorized_search(
+        query_type=SearchType.CYPHER,
+        query_text="MATCH (n) RETURN n LIMIT 1",
+        user=user,
+        dataset_ids=[ds.id],
+    )
+
+    assert out == []
+    assert seen["datasets"] == [ds]
+
+
+@pytest.mark.asyncio
+async def test_cypher_without_explicit_datasets_targets_only_writable_ones(monkeypatch, search_mod):
+    user = _make_user()
+    readable = _make_dataset(name="read-only")
+    writable = _make_dataset(name="writable")
+    seen = {}
+
+    async def dummy_get_authorized_existing_datasets(*, datasets, permission_type, user):
+        assert datasets is None
+        return [readable, writable] if permission_type == "read" else [writable]
+
+    async def dummy_search_in_datasets_context(**kwargs):
+        seen["datasets"] = kwargs["search_datasets"]
+        return []
+
+    monkeypatch.setattr(
+        search_mod, "get_authorized_existing_datasets", dummy_get_authorized_existing_datasets
+    )
+    monkeypatch.setattr(search_mod, "search_in_datasets_context", dummy_search_in_datasets_context)
+
+    await search_mod.authorized_search(
+        query_type=SearchType.NATURAL_LANGUAGE,
+        query_text="remove every node",
+        user=user,
+        dataset_ids=None,
+    )
+
+    assert seen["datasets"] == [writable]
+
+
+@pytest.mark.asyncio
+async def test_read_only_search_types_never_ask_for_write(monkeypatch, search_mod):
+    user = _make_user()
+    ds = _make_dataset(name="ds1")
+    requested = []
+
+    async def dummy_get_authorized_existing_datasets(*, datasets, permission_type, user):
+        requested.append(permission_type)
+        return [ds]
+
+    async def dummy_search_in_datasets_context(**_kwargs):
+        return []
+
+    monkeypatch.setattr(
+        search_mod, "get_authorized_existing_datasets", dummy_get_authorized_existing_datasets
+    )
+    monkeypatch.setattr(search_mod, "search_in_datasets_context", dummy_search_in_datasets_context)
+
+    await search_mod.authorized_search(
+        query_type=SearchType.GRAPH_COMPLETION, query_text="q", user=user, dataset_ids=[ds.id]
+    )
+
+    assert requested == ["read"]

--- a/cognee/tests/unit/modules/search/test_select_search_type.py
+++ b/cognee/tests/unit/modules/search/test_select_search_type.py
@@ -1,0 +1,42 @@
+"""FEELING_LUCKY must never route to a search type the caller may lack permission for."""
+
+import importlib
+
+import pytest
+
+from cognee.modules.search.types import SearchType
+
+# The package re-exports the function under the module's name, so import the module itself.
+selector = importlib.import_module("cognee.modules.search.operations.select_search_type")
+
+
+@pytest.fixture(autouse=True)
+def _no_prompt_file(monkeypatch):
+    monkeypatch.setattr(selector, "read_query_prompt", lambda *_args, **_kwargs: "prompt")
+
+
+def _llm_answering(answer: str):
+    async def fake_acreate_structured_output(**_kwargs):
+        return answer
+
+    return fake_acreate_structured_output
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("llm_choice", ["CYPHER", "NATURAL_LANGUAGE", "CODE"])
+async def test_unroutable_choices_fall_back_to_default(monkeypatch, llm_choice):
+    """Cypher-executing types need write permission; the datasets were resolved with read."""
+    monkeypatch.setattr(
+        selector.LLMGateway, "acreate_structured_output", _llm_answering(llm_choice)
+    )
+
+    assert await selector.select_search_type("remove every node") is SearchType.RAG_COMPLETION
+
+
+@pytest.mark.asyncio
+async def test_read_only_choice_is_kept(monkeypatch):
+    monkeypatch.setattr(
+        selector.LLMGateway, "acreate_structured_output", _llm_answering("GRAPH_COMPLETION")
+    )
+
+    assert await selector.select_search_type("who founded cognee") is SearchType.GRAPH_COMPLETION


### PR DESCRIPTION
## Description
[SDK-547](https://linear.app/cognee/issue/SDK-547/require-write-permission-for-cypher-and-natural_language-search). Search resolves its target datasets with read permission for every search type. CYPHER then hands the caller's statement to the graph engine and NATURAL_LANGUAGE hands it an LLM-written one, and nothing restricts either to reads. A user who was shared a dataset read-only could run `MATCH (n) DETACH DELETE n` with `query_type=CYPHER` through `search()`, `recall()`, `/search` or `/recall` and delete the owner's graph.

The permission requirement now lives on the search type itself. `SearchType.required_permissions` returns `("read",)` for every type and `("read", "write")` for CYPHER and NATURAL_LANGUAGE. `authorized_search` resolves the datasets once per required permission:

- an explicit dataset the user lacks write on raises `PermissionDeniedError` (the same path that already handles missing read);
- with no explicit datasets, only datasets granted every required permission are searched;
- every other type still asks for read only, so nothing changes for them.

Two automatic paths were checked. FEELING_LUCKY picks its real type after the datasets were resolved with read, so its selector now refuses CYPHER and NATURAL_LANGUAGE the same way it already refuses CODE and falls back to RAG_COMPLETION. The `recall()` router still routes raw Cypher syntax to CYPHER; for a read-only user that request now ends in `PermissionDeniedError` instead of executing, which is the intended outcome. The selector prompt still lists the excluded types, matching how CODE was already handled; the exclusion is enforced in code.

This closes the read-only-share case only. Raw Cypher on Neo4j and Ladybug can reach files, other databases and the network, so `ALLOW_CYPHER_QUERY=false` remains the only complete gate for untrusted users. `.env.template` and `CLAUDE.md` now say that. Changing that default is a separate decision, per the ticket.

## Acceptance Criteria
- A user with only read on a shared dataset gets `PermissionDeniedError` for `query_type=CYPHER` and `NATURAL_LANGUAGE` against it; the search never runs.
- The same user with write permission can run CYPHER against that dataset.
- With no explicit datasets, CYPHER and NATURAL_LANGUAGE target only datasets the user has write on.
- FEELING_LUCKY never resolves to CYPHER or NATURAL_LANGUAGE.
- Read-only search types never request write.
- `ALLOW_CYPHER_QUERY=false` still disables both types regardless of permission (unchanged code, covered by existing tests).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
```
$ uv run pytest cognee/tests/unit/modules/search/ -q
109 passed in 0.30s            # 9 new: 5 permission tests, 4 selector tests
$ uv run pytest cognee/tests/unit/api cognee/tests/unit/modules/users cognee/tests/unit/modules/search -q
855 passed, 1 skipped in 34.08s
$ uv run ruff check <changed files>
All checks passed!
$ uv run ruff check <changed files> --select BLE001,S110,S112,G201,TRY201,TRY002 --ignore-noqa
All checks passed!
$ uv run ruff format --check cognee/modules/search cognee/tests/unit/modules/search CLAUDE.md
36 files already formatted
$ uv run ty check .
Found 27 diagnostics      # identical count on untouched dev
$ pre-commit run --files <changed files>
all hooks Passed
```

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

Release note: a dataset shared read-only can no longer be queried with CYPHER or NATURAL_LANGUAGE; the share needs write permission.
