### PR TITLE
fix(examples): Run the typed extraction demo against a dataset so recall can find what it stores (RES-42)

### DIFF
--- a/examples/demos/custom_pipelines/custom_pipeline_single_object_example.py
+++ b/examples/demos/custom_pipelines/custom_pipeline_single_object_example.py
@@ -1,9 +1,10 @@
 """
 Custom pipeline example: LLM-powered entity extraction on DataPoint objects.
 
-Demonstrates the deferred-call pipeline pattern (TaskSpec / BoundTask)
-with typed DataPoint models, field annotations, LLM structured output,
-and per-source freshness tracking via source_content_hash.
+Demonstrates a custom Task pipeline with typed DataPoint models, field
+annotations, LLM structured output, and per-source freshness tracking via
+source_content_hash — run against a named dataset so the nodes it stores are
+attributed to that dataset and searchable with recall().
 
 Usage:
     uv run python examples/demos/custom_pipelines/custom_pipeline_single_object_example.py
@@ -17,11 +18,15 @@ from typing import Annotated
 
 from pydantic import BaseModel, Field
 
+import cognee
 from cognee.infrastructure.engine import DataPoint, Dedup, Embeddable
+from cognee.infrastructure.files.utils.open_data_file import open_data_file
 from cognee.infrastructure.llm import LLMGateway
-from cognee.modules.pipelines.operations.run_pipeline import run_pipeline
-from cognee.modules.pipelines.tasks.task import task
+from cognee.modules.data.models import Data
+from cognee.modules.pipelines import Task
 from cognee.tasks.storage import add_data_points
+
+DATASET_NAME = "science_claims"
 
 # -- Data models --
 
@@ -42,8 +47,14 @@ class Person(DataPoint):
     claims: list[ScientificClaim] | None = None
 
 
-class AnalysisResult(BaseModel):
-    """LLM output model for structured extraction."""
+class AnalysisResult(DataPoint):
+    """LLM output model for structured extraction.
+
+    A DataPoint rather than a plain BaseModel so the pipeline's provenance
+    stamping walks into it and reaches the nested Person and ScientificClaim
+    objects; a plain BaseModel would stop the walk and leave their
+    source_content_hash empty. It is never stored — only its contents are.
+    """
 
     people: list[Person] = Field(default_factory=list)
     claims: list[ScientificClaim] = Field(default_factory=list)
@@ -52,11 +63,15 @@ class AnalysisResult(BaseModel):
 # -- Pipeline tasks --
 
 
-@task
-async def extract_entities(text: str) -> AnalysisResult:
-    """Use LLM to extract people and claims from text."""
+async def extract_entities(data_items: list[Data]) -> AnalysisResult:
+    """Read the ingested document(s) and use LLM to extract people and claims."""
+    text_parts = []
+    for data_item in data_items:
+        async with open_data_file(data_item.raw_data_location, mode="r", encoding="utf-8") as file:
+            text_parts.append(file.read())
+
     result = await LLMGateway.acreate_structured_output(
-        text_input=text,
+        text_input="\n".join(text_parts),
         system_prompt=(
             "Extract all people and scientific claims from the text. "
             "For each person, provide their name and role. "
@@ -67,7 +82,6 @@ async def extract_entities(text: str) -> AnalysisResult:
     return result
 
 
-@task
 async def link_claims_to_people(analysis: AnalysisResult) -> list[Person]:
     """Associate claims with the people who made them, using LLM."""
 
@@ -102,9 +116,8 @@ async def link_claims_to_people(analysis: AnalysisResult) -> list[Person]:
     return analysis.people
 
 
-@task
 async def store_and_summarize(people: list[Person]) -> str:
-    """Store DataPoints in graph + vector DBs, then return a summary."""
+    """Store DataPoints in graph + vector DBs, then print and return a summary."""
 
     # add_data_points persists nodes and edges to graph DB,
     # and indexes embeddable fields in vector DB
@@ -121,14 +134,16 @@ async def store_and_summarize(people: list[Person]) -> str:
                 lines.append(f"  - {claim.text} [confidence: {claim.confidence}]")
         else:
             lines.append("  (no claims linked)")
-    return "\n".join(lines)
+
+    summary = "\n".join(lines)
+    print(summary)
+    return summary
 
 
 # -- Run --
 
 
 async def main():
-    import cognee
     from cognee.infrastructure.databases.relational.create_db_and_tables import (
         create_db_and_tables,
     )
@@ -145,24 +160,29 @@ async def main():
         "Niels Bohr proposed the atomic model with quantized electron orbits in 1913."
     )
 
-    # Run the custom pipeline
-    results = await run_pipeline(
-        [
-            extract_entities(),
-            link_claims_to_people(),
-            store_and_summarize(),
+    # Ingest the text into a dataset first. This creates the dataset, stores the
+    # text as a Data record with a content hash, and is what makes the graph the
+    # custom pipeline builds below both attributable and searchable.
+    await cognee.add(sample_text, dataset_name=DATASET_NAME)
+
+    # Run the custom pipeline over the dataset's ingested documents. With no
+    # `data` argument the first task receives the dataset's Data records.
+    await cognee.run_custom_pipeline(
+        tasks=[
+            Task(extract_entities),
+            Task(link_claims_to_people),
+            Task(store_and_summarize),
         ],
-        data=sample_text,
+        dataset=DATASET_NAME,
         pipeline_name="entity_extraction",
     )
-
-    print(results[0] if results else "No output")
 
     # Recall from the graph
     print("\n--- Recall: 'Who worked on gravity?' ---")
     answer = await cognee.recall(
         "Who worked on gravity?",
         query_type=cognee.SearchType.GRAPH_COMPLETION,
+        datasets=[DATASET_NAME],
     )
     print(f"  {answer}")
 

--- a/examples/demos/custom_pipelines/custom_pipeline_single_object_example.py
+++ b/examples/demos/custom_pipelines/custom_pipeline_single_object_example.py
@@ -1,5 +1,5 @@
 """
-Custom pipeline example: LLM-powered entity extraction on DataPoint objects.
+Custom pipeline example: LLM-powered entity extraction into typed DataPoints.
 
 Demonstrates a custom Task pipeline with typed DataPoint models, field
 annotations, LLM structured output, and per-source freshness tracking via
@@ -28,7 +28,7 @@ from cognee.tasks.storage import add_data_points
 
 DATASET_NAME = "science_claims"
 
-# -- Data models --
+# -- Graph models: what gets stored --
 
 
 class ScientificClaim(DataPoint):
@@ -47,56 +47,78 @@ class Person(DataPoint):
     claims: list[ScientificClaim] | None = None
 
 
-class AnalysisResult(DataPoint):
-    """LLM output model for structured extraction.
+# -- LLM output models: what the model is asked to produce --
+#
+# Kept separate from the DataPoints on purpose. A DataPoint carries id, metadata,
+# versioning and provenance fields, and a structured-output call would hand every
+# one of them to the LLM to fill in. Extract into plain schemas, then build the
+# DataPoints from them so ids, metadata and provenance come from cognee.
 
-    A DataPoint rather than a plain BaseModel so the pipeline's provenance
-    stamping walks into it and reaches the nested Person and ScientificClaim
-    objects; a plain BaseModel would stop the walk and leave their
-    source_content_hash empty. It is never stored — only its contents are.
-    """
 
-    people: list[Person] = Field(default_factory=list)
-    claims: list[ScientificClaim] = Field(default_factory=list)
+class ExtractedPerson(BaseModel):
+    name: str
+    role: str = ""
+
+
+class ExtractedClaim(BaseModel):
+    text: str
+    subject: str = ""
+    confidence: float = 1.0
+
+
+class ExtractionResult(BaseModel):
+    people: list[ExtractedPerson] = Field(default_factory=list)
+    claims: list[ExtractedClaim] = Field(default_factory=list)
+
+
+class ClaimAssignment(BaseModel):
+    person_name: str
+    claim_texts: list[str]
+
+
+class Assignments(BaseModel):
+    assignments: list[ClaimAssignment]
 
 
 # -- Pipeline tasks --
 
 
-async def extract_entities(data_items: list[Data]) -> AnalysisResult:
-    """Read the ingested document(s) and use LLM to extract people and claims."""
+async def extract_entities(data_items: list[Data]) -> list[Person | ScientificClaim]:
+    """Read the ingested document(s) and extract people and claims as DataPoints."""
     text_parts = []
     for data_item in data_items:
         async with open_data_file(data_item.raw_data_location, mode="r", encoding="utf-8") as file:
             text_parts.append(file.read())
 
-    result = await LLMGateway.acreate_structured_output(
+    extraction = await LLMGateway.acreate_structured_output(
         text_input="\n".join(text_parts),
         system_prompt=(
             "Extract all people and scientific claims from the text. "
             "For each person, provide their name and role. "
             "For each claim, provide the claim text, subject, and confidence (0-1)."
         ),
-        response_model=AnalysisResult,
+        response_model=ExtractionResult,
     )
-    return result
+
+    people = [Person(name=p.name, role=p.role) for p in extraction.people]
+    claims = [
+        ScientificClaim(text=c.text, subject=c.subject, confidence=c.confidence)
+        for c in extraction.claims
+    ]
+
+    # Returned as one list of DataPoints so the pipeline stamps provenance —
+    # including the source document's content hash — on every node before the
+    # next task wires them together.
+    return [*people, *claims]
 
 
-async def link_claims_to_people(analysis: AnalysisResult) -> list[Person]:
+async def link_claims_to_people(nodes: list[Person | ScientificClaim]) -> list[Person]:
     """Associate claims with the people who made them, using LLM."""
-
-    class ClaimAssignment(BaseModel):
-        person_name: str
-        claim_texts: list[str]
-
-    class Assignments(BaseModel):
-        assignments: list[ClaimAssignment]
+    people = [node for node in nodes if isinstance(node, Person)]
+    claims = [node for node in nodes if isinstance(node, ScientificClaim)]
 
     assignments = await LLMGateway.acreate_structured_output(
-        text_input=(
-            f"People: {[p.name for p in analysis.people]}\n"
-            f"Claims: {[c.text for c in analysis.claims]}"
-        ),
+        text_input=(f"People: {[p.name for p in people]}\nClaims: {[c.text for c in claims]}"),
         system_prompt=(
             "Assign each claim to the person who made it or is most associated with it. "
             "Return a list of assignments, each with a person_name and their claim_texts."
@@ -105,15 +127,15 @@ async def link_claims_to_people(analysis: AnalysisResult) -> list[Person]:
     )
 
     # Build lookup and attach claims to people
-    claim_lookup = {c.text: c for c in analysis.claims}
+    claim_lookup = {c.text: c for c in claims}
     for assignment in assignments.assignments:
-        for person in analysis.people:
+        for person in people:
             if person.name.lower() == assignment.person_name.lower():
                 person.claims = [
                     claim_lookup[t] for t in assignment.claim_texts if t in claim_lookup
                 ]
 
-    return analysis.people
+    return people
 
 
 async def store_and_summarize(people: list[Person]) -> str:


### PR DESCRIPTION
## Description

`examples/demos/custom_pipelines/custom_pipeline_single_object_example.py` stores its `Person` / `ScientificClaim` nodes but its closing `recall()` never finds them. Running the script on a clean instance ends with:

```text
--- Recall: 'Who worked on gravity?' ---
  [ResponseMarkerEntry(source='system', status='memory_warming_up', text='Memory is still warming up: no knowledge graph data exists yet for the requested datasets.', datapoint_count=0, threshold=1)]
--- Forget everything ---
  {'datasets_removed': 0, 'status': 'success'}
```

Two independent problems:

1. **No dataset.** The script uses the deferred-call `run_pipeline` (`cognee.modules.pipelines.operations.run_pipeline`) with a raw string and no dataset. That entry point never resolves a dataset, never enters a dataset database context, and never logs a pipeline run. With backend access control on by default, `add_data_points` writes into the default database instead of a dataset database, `recall()`'s readiness probe finds no permitted datasets and short-circuits, and the per-dataset search would not see the nodes anyway. `source_content_hash` is always `N/A`, because a raw string carries no content hash.

2. **DataPoints used as LLM response models.** `Person` and `ScientificClaim` were passed straight to `acreate_structured_output`, so the LLM was asked to fill in every `DataPoint` field: `id`, `metadata`, `version`, the `source_*` provenance fields. The ids in the stored graph were LLM-invented (`c1a1d1f3-0001-0000-0000-000000000101`), and on current `dev`, where `MetaData` has a `transparent` key, the LLM sets `metadata.transparent = true` and every node is unwrapped as a container and dropped:

```text
Person is marked transparent but carries data in 'name'; a transparent node is never stored, so that value is dropped. ...
Dataset 'science_claims' has 1 data item(s) but the knowledge graph is empty. Please run cognify to process the data before searching.
```

Fix, in the demo only:

- Ingest the text with `cognee.add(..., dataset_name="science_claims")` first, then run the tasks with `cognee.run_custom_pipeline(..., dataset="science_claims")`. The pipeline runs in the dataset's context, logs a run, and the first task receives the dataset's `Data` records and reads the text from them.
- Separate the LLM output schemas (`ExtractedPerson`, `ExtractedClaim`, `ExtractionResult`, `ClaimAssignment`, `Assignments`, all plain `BaseModel`) from the graph models. The first task builds `Person` / `ScientificClaim` DataPoints from the extraction, so ids come from the `Dedup` identity fields and metadata and provenance come from cognee.
- The first task returns the people and claims as one list of DataPoints. Provenance stamping in `run_tasks_base` only walks DataPoints and lists, so this is what carries the source document's content hash onto every node before the second task links them.
- Scope the recall with `datasets=["science_claims"]` and have the store task print its own summary, since `run_custom_pipeline` returns run info rather than task output.

Library gap surfaced by this and left out of scope here: the deferred `run_pipeline` accepts `dataset=` but only stores the string on the `PipelineContext`. Its own docstring example (`dataset="main"`) produces an unrecallable graph under default access control.

The cognee-docs page for this demo (topoteretes/cognee-docs#1610) describes the old script and will be re-synced once this lands on `dev`.

## Acceptance Criteria

- No `transparent` warnings, a real `source_hash` for every person, `recall()` returns a graph answer, and the final `forget()` reports one dataset removed.
- Output of the fixed script on a clean local instance built from this branch:

```text
Albert Einstein (Physicist) [source_hash: f9bf9de04a56]
  - Albert Einstein published the theory of general relativity in 1915. [confidence: 1.0]
  - General relativity describes gravity as spacetime curvature. [confidence: 1.0]
Marie Curie (Physicist and chemist) [source_hash: f9bf9de04a56]
  - Marie Curie discovered polonium and radium. [confidence: 1.0]
  - Marie Curie won Nobel Prizes in both physics and chemistry. [confidence: 1.0]
Niels Bohr (Physicist) [source_hash: f9bf9de04a56]
  - Niels Bohr proposed the atomic model with quantized electron orbits in 1913. [confidence: 1.0]

--- Recall: 'Who worked on gravity?' ---
  [ResponseGraphEntry(kind='graph_completion', search_type='GRAPH_COMPLETION', text='Albert Einstein — he developed general relativity, which describes gravity as spacetime curvature.', dataset_name='science_claims', ...)]

--- Forget everything ---
  {'datasets_removed': 1, 'status': 'success'}
```

- `ruff check` and `ruff format --check` pass on the file.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
Run output is quoted above; no UI involved.

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
