### PR TITLE
feat(update): Return one result shape with the fallback reason (SDK-587)

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -380,6 +380,19 @@ jobs:
           EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
         run: uv run python ./cognee/tests/test_dlt_mixed_input_e2e.py
 
+      - name: Run DLT Update Test
+        env:
+          ENV: 'dev'
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_ARGS: ${{ secrets.LLM_ARGS }}
+          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
+          EMBEDDING_DIMENSIONS: 300
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+        run: uv run python ./cognee/tests/test_dlt_update_e2e.py
+
   run-code-graph-e2e-test:
     name: Code Graph E2E Test (enola ingest -> typed graph -> CODE search)
     runs-on: ubuntu-22.04

--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -274,9 +274,13 @@ async def add(
     # not None) deletes dlt rows no longer present in the source; it is
     # deferred until after the fresh rows are committed to avoid a data-loss
     # window on a mid-ingest failure.
+    # The dataset's stored name, not the caller's argument: a DLT manifest's
+    # identity is seeded from (dataset name, source name), and update()'s
+    # rebuild re-adds by dataset_id alone. Passing None there would mint a
+    # second manifest for the same source.
     data, orphan_cleanup = await resolve_dlt_sources(
         data,
-        dataset_name=dataset_name,
+        dataset_name=authorized_dataset.name,
         user=user,
         dataset_id=authorized_dataset.id,
         **kwargs,

--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -26,6 +26,9 @@ from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
 from cognee.tasks.ingestion import ingest_data, resolve_data_directories
 from cognee.tasks.ingestion.data_item import DataItem
+from cognee.tasks.ingestion.refuse_changed_existing_documents import (
+    refuse_changed_existing_documents,
+)
 from cognee.tasks.ingestion.resolve_dlt_sources import resolve_dlt_sources
 from cognee.tasks.ingestion.utils import materialize_stream_for_background
 
@@ -61,6 +64,12 @@ async def add(
         - **LLM_API_KEY**: Must be set in environment variables for content processing
         - **Database Setup**: Relational and vector databases must be configured
         - **User Authentication**: Uses default user if none provided (created automatically)
+
+    add() creates documents; it never updates one. A file that already exists in
+    the dataset (the same path, or the same filename for an upload) with different
+    content raises ``DocumentUpdateRequiredError``: replace the stored version with
+    ``update(data_id=..., data=..., dataset_id=...)`` so the document keeps its id
+    and its graph is replaced in place. Re-adding identical content is a no-op.
 
     Supported Input Types:
         - **Text strings**: Direct text content (str) - any string not starting with "/" or "file://"
@@ -285,6 +294,11 @@ async def add(
         dataset_id=authorized_dataset.id,
         **kwargs,
     )
+
+    # A file the dataset already holds with other content is an update in
+    # disguise: refuse the whole request now, before the pipeline writes the
+    # items ahead of it one by one, and point at update().
+    await refuse_changed_existing_documents(data, user, authorized_dataset)
 
     # Background runs must not depend on caller/request-scoped stream lifetimes.
     # Materialize stream-like inputs into owned in-memory buffers up front.

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -8,6 +8,7 @@ from pydantic import WithJsonSchema
 from cognee import __version__ as cognee_version
 from cognee.api.DTO import ErrorResponse
 from cognee.api.upload_fields import OptionalUploadFile, drop_blank_uploads
+from cognee.api.v1.exceptions import DocumentUpdateRequiredError
 from cognee.modules.pipelines.models import PipelineRunErrored
 from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunInfo
 from cognee.modules.users.methods import get_authenticated_user
@@ -146,7 +147,10 @@ def get_add_router() -> APIRouter:
         ## Error Codes
         - **400 Bad Request**: Neither datasetId nor datasetName provided, or neither
           data nor raw_data provided
-        - **409 Conflict**: Error during add operation
+        - **409 Conflict**: A file in the request already exists in the dataset with
+          different content. This endpoint never updates a document; send the new
+          version to `PATCH /api/v1/update?data_id=...&dataset_id=...` so the document
+          keeps its id. Re-adding identical content is a no-op, not an error.
         - **403 Forbidden**: User doesn't have permission to add to dataset
 
         ## Notes
@@ -223,6 +227,16 @@ def get_add_router() -> APIRouter:
                     ).model_dump(),
                 )
             return add_run
+        except DocumentUpdateRequiredError as error:
+            # An existing file with new content is an update, which has its own
+            # endpoint; say so with the endpoint rather than failing as a 500.
+            return JSONResponse(
+                status_code=status.HTTP_409_CONFLICT,
+                content=ErrorResponse(
+                    error="Document already exists; use the update endpoint",
+                    detail=error.api_message,
+                ).model_dump(),
+            )
         except Exception as error:
             logger.exception("Add failed")
             return JSONResponse(

--- a/cognee/api/v1/datasets/datasets.py
+++ b/cognee/api/v1/datasets/datasets.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from cognee.api.v1.datasets.dto import DataDTO
 from cognee.context_global_variables import set_database_global_context_variables
+from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.locks import dataset_lock
 from cognee.modules.data.exceptions.exceptions import UnauthorizedDataAccessError
 from cognee.modules.data.methods import (
@@ -290,8 +291,14 @@ class datasets:
                             deleted_elements = DeletedGraphElements.from_source_ref_removal(
                                 provenance_result
                             )
-                        else:
+                        elif hasattr(await get_graph_engine(), "get_document_subgraph"):
                             deleted_elements = await legacy_delete(data, "soft")
+                        else:
+                            # An unmarked graph on an adapter without the legacy
+                            # subgraph API (the Postgres demo) holds no legacy
+                            # data: it is a document that was never cognified,
+                            # so there is nothing in the graph to delete.
+                            deleted_elements = DeletedGraphElements()
 
                     await _invalidate_sessions_for_deleted_data_nonfatal(
                         dataset.id, deleted_elements, user.id

--- a/cognee/api/v1/exceptions/__init__.py
+++ b/cognee/api/v1/exceptions/__init__.py
@@ -10,5 +10,6 @@ from .exceptions import (
     DatasetNotFoundError,
     DataNotFoundError,
     DocumentSubgraphNotFoundError,
+    DocumentUpdateRequiredError,
     UpdateTargetNotFoundError,
 )

--- a/cognee/api/v1/exceptions/exceptions.py
+++ b/cognee/api/v1/exceptions/exceptions.py
@@ -67,6 +67,59 @@ class UpdateTargetNotFoundError(CogneeValidationError):
         super().__init__(message, name, status_code)
 
 
+class DocumentUpdateRequiredError(CogneeValidationError):
+    """add() was given a file that already exists in the dataset with other content.
+
+    add() creates documents and leaves existing ones alone: a file that
+    matches a stored document by origin (the same path, or the same filename
+    for an upload) but carries different content is an update, and updates
+    go through update() so the document keeps its id and its graph is
+    replaced in place instead of a second copy being minted. Identical
+    content is not an error: re-adding it is a no-op.
+
+    ``conflicts`` lists every offending file as ``{"name", "data_id"}`` and
+    ``api_message`` says the same thing for HTTP callers, pointing at
+    ``PATCH /api/v1/update``.
+    """
+
+    def __init__(
+        self,
+        conflicts: list[dict],
+        dataset_id,
+        name: str = "DocumentUpdateRequiredError",
+        status_code: int = status.HTTP_409_CONFLICT,
+    ):
+        self.conflicts = conflicts
+        self.dataset_id = dataset_id
+        super().__init__(self._describe(sdk=True), name, status_code)
+
+    @property
+    def api_message(self) -> str:
+        """The same refusal for HTTP callers, pointing at the update endpoint."""
+        return self._describe(sdk=False)
+
+    def _describe(self, sdk: bool) -> str:
+        listed = ", ".join(f"'{c['name']}' (data_id {c['data_id']})" for c in self.conflicts)
+        # With one offending file the pointer is the exact call to make.
+        data_id = self.conflicts[0]["data_id"] if len(self.conflicts) == 1 else "<data_id>"
+        verb = "exists" if len(self.conflicts) == 1 else "exist"
+        if sdk:
+            return (
+                f"add() does not update documents. {listed} already {verb} in dataset "
+                f"{self.dataset_id} with different content. To replace the stored version, call "
+                f"cognee.update(data_id={data_id}, data=<new content>, dataset_id={self.dataset_id})"
+                f"{'' if len(self.conflicts) == 1 else ' for each document'}; identical content "
+                "can be re-added and is a no-op."
+            )
+        return (
+            f"POST /api/v1/add does not update documents. {listed} already {verb} in "
+            f"dataset {self.dataset_id} with different content. Send the new version to "
+            f"PATCH /api/v1/update?data_id={data_id}&dataset_id={self.dataset_id} (multipart "
+            "field 'data'), or cognee.update(...) from the SDK; identical content can be "
+            "re-added and is a no-op."
+        )
+
+
 class DocumentSubgraphNotFoundError(CogneeValidationError):
     def __init__(
         self,

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -3,7 +3,7 @@
 import io
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from uuid import UUID
 
 import aiohttp
@@ -11,9 +11,6 @@ import aiohttp
 from cognee.modules.ingestion.data_types.TextData import create_text_data
 from cognee.modules.search.types import ContextFormat
 from cognee.shared.logging_utils import get_logger
-
-if TYPE_CHECKING:
-    from cognee.api.v1.update.result import UpdateResult
 
 logger = get_logger("serve.cloud_client")
 
@@ -30,16 +27,16 @@ def _text_upload_filename(text: str) -> str:
     return create_text_data(text).get_metadata()["name"]
 
 
-def _failed_update_result(body: str) -> "UpdateResult | None":
-    """Parse a 500 body as an UpdateResult when it is one with status "failed"."""
+def _failed_update_result(body: str) -> dict | None:
+    """Parse a 500 body as an update result when it is one with status "failed"."""
     from cognee.api.v1.update.result import UpdateResult
 
     try:
         payload = json.loads(body)
     except ValueError:
         return None
-    if isinstance(payload, dict) and payload.get("status") == "failed" and "mode" in payload:
-        return UpdateResult.model_validate(payload)
+    if isinstance(payload, dict) and payload.get("status") == "failed" and "data_id" in payload:
+        return UpdateResult.model_validate(payload).model_dump()
     return None
 
 
@@ -356,7 +353,7 @@ class CloudClient:
         dataset_id: UUID,
         node_set: list | None = None,
         chunk_level_diff: bool = True,
-    ) -> "UpdateResult":
+    ) -> dict:
         """PATCH /api/v1/update — replace one document in place on the remote.
 
         Mirrors the route: ``data_id``, ``dataset_id`` and ``chunk_level_diff``
@@ -413,7 +410,9 @@ class CloudClient:
                 if failed is not None:
                     return failed
                 raise RuntimeError(f"Remote update failed ({resp.status}): {body}")
-            return UpdateResult.model_validate(await resp.json())
+            # Through the schema so the dict matches the local result exactly:
+            # UUIDs as UUID objects, the fallback reason as its enum member.
+            return UpdateResult.model_validate(await resp.json()).model_dump()
 
     async def list_data(self, dataset_id: UUID) -> list:
         """GET /api/v1/datasets/{dataset_id}/data — the documents in a dataset."""

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -1,8 +1,9 @@
 """Remote HTTP client that proxies V2 operations to a Cognee Cloud instance."""
 
 import io
+import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 import aiohttp
@@ -10,6 +11,9 @@ import aiohttp
 from cognee.modules.ingestion.data_types.TextData import create_text_data
 from cognee.modules.search.types import ContextFormat
 from cognee.shared.logging_utils import get_logger
+
+if TYPE_CHECKING:
+    from cognee.api.v1.update.result import UpdateResult
 
 logger = get_logger("serve.cloud_client")
 
@@ -24,6 +28,19 @@ def _text_upload_filename(text: str) -> str:
     (FileContentHashingError 409s).
     """
     return create_text_data(text).get_metadata()["name"]
+
+
+def _failed_update_result(body: str) -> "UpdateResult | None":
+    """Parse a 500 body as an UpdateResult when it is one with status "failed"."""
+    from cognee.api.v1.update.result import UpdateResult
+
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        return None
+    if isinstance(payload, dict) and payload.get("status") == "failed" and "mode" in payload:
+        return UpdateResult.model_validate(payload)
+    return None
 
 
 class CloudClient:
@@ -339,7 +356,7 @@ class CloudClient:
         dataset_id: UUID,
         node_set: list | None = None,
         chunk_level_diff: bool = True,
-    ) -> dict:
+    ) -> "UpdateResult":
         """PATCH /api/v1/update — replace one document in place on the remote.
 
         Mirrors the route: ``data_id``, ``dataset_id`` and ``chunk_level_diff``
@@ -382,13 +399,21 @@ class CloudClient:
             "dataset_id": str(dataset_id),
             "chunk_level_diff": "true" if chunk_level_diff else "false",
         }
+        from cognee.api.v1.update.result import UpdateResult
+
         async with session.patch(
             f"{self.service_url}/api/v1/update", params=params, data=form
         ) as resp:
             if resp.status >= 400:
                 body = await resp.text()
+                # A failed rebuild travels with a 500 but is still a result, in
+                # the same shape the local path returns, so the caller can read
+                # the error and retry. Anything else is a remote error.
+                failed = _failed_update_result(body)
+                if failed is not None:
+                    return failed
                 raise RuntimeError(f"Remote update failed ({resp.status}): {body}")
-            return await resp.json()
+            return UpdateResult.model_validate(await resp.json())
 
     async def list_data(self, dataset_id: UUID) -> list:
         """GET /api/v1/datasets/{dataset_id}/data — the documents in a dataset."""

--- a/cognee/api/v1/update/__init__.py
+++ b/cognee/api/v1/update/__init__.py
@@ -1,2 +1,2 @@
-from .result import ChunkChanges, UpdateResult
+from .result import UpdateResult
 from .update import update

--- a/cognee/api/v1/update/__init__.py
+++ b/cognee/api/v1/update/__init__.py
@@ -1,1 +1,2 @@
+from .result import ChunkChanges, UpdateResult
 from .update import update

--- a/cognee/api/v1/update/incremental.py
+++ b/cognee/api/v1/update/incremental.py
@@ -127,7 +127,7 @@ class RefusalReason(str, Enum):
     Every refusal used to surface as one free-text message and one log line, so
     a permanent misconfiguration (an incompatible chunker, an unsupported
     backend) looked exactly like a first ingestion. The reason is logged as a
-    structured field and returned in ``UpdateResult.fallback_reason`` so they
+    structured field and returned in ``UpdateResult.fallback`` so they
     are separable. The first three come from ``update()`` before this engine
     is consulted; the rest are this engine's own refusals.
     """
@@ -469,11 +469,11 @@ def _changed_staged_metadata(data, old_data: Data, staged: StagedContent) -> lis
     ]
 
 
-def _unchanged_result(reindexed: int) -> dict:
+def _unchanged_result(reindexed: int, kept: int) -> dict:
     """The no-op result, shaped like the incremental one.
 
-    ``update()`` turns both into the same ``UpdateResult.chunks``, so a no-op
-    reports every counter (as zero) rather than omitting them.
+    ``update()`` turns both into the same ``UpdateResult.chunks``. Unchanged
+    content keeps every stored chunk, so ``kept`` is the stored count, not zero.
     """
     return {
         "status": "unchanged",
@@ -481,8 +481,9 @@ def _unchanged_result(reindexed: int) -> dict:
         "deleted_chunks": 0,
         "added_chunks": 0,
         "reused_chunks": 0,
-        "kept_chunks": 0,
+        "kept_chunks": kept,
         "reindexed_chunks": reindexed,
+        "total_chunks": kept,
     }
 
 
@@ -509,7 +510,7 @@ async def _repair_unchanged(
         "incremental update: content unchanged, repaired %s",
         ", ".join(bundle.get("repairs") or ["nothing"]),
     )
-    return _unchanged_result(len(shifted))
+    return _unchanged_result(len(shifted), bundle["stored_count"])
 
 
 async def incremental_update(
@@ -646,7 +647,7 @@ async def _run_incremental_update(
     # A no-op with nothing to repair is the only path that writes nothing, and
     # so the only one that records no run.
     if bundle.get("status") == "unchanged" and not bundle.get("repairs"):
-        return {**_unchanged_result(0), "pipeline_run_id": None}
+        return {**_unchanged_result(0, bundle["stored_count"]), "pipeline_run_id": None}
 
     pipeline_id = generate_pipeline_id(user.id, dataset.id, RUN_PIPELINE_NAME)
     pipeline_run = await log_pipeline_run_start(
@@ -764,6 +765,7 @@ async def _stage_and_plan(
             "repairs": repairs,
             "data_item": old_data,
             "shifted_chunks": shifted,
+            "stored_count": len(stored_chunks),
         }
 
     # Compatibility is a planning question, so answer it before planning. Every
@@ -963,4 +965,5 @@ async def _write_and_publish(
         "reused_chunks": len(reused_chunks),
         "kept_chunks": kept_count,
         "reindexed_chunks": len(shifted_chunks),
+        "total_chunks": kept_count + added_chunks,
     }

--- a/cognee/api/v1/update/incremental.py
+++ b/cognee/api/v1/update/incremental.py
@@ -138,7 +138,9 @@ class RefusalReason(str, Enum):
     PER_CALL_DB_CONFIG = "per_call_db_config"  # vector_db_config / graph_db_config
     UNSUPPORTED_BACKEND = "unsupported_backend"
     UNSUPPORTED_CHUNKER = "unsupported_chunker"
-    UNSUPPORTED_METADATA = "unsupported_metadata"  # node_set, label, external metadata, rename
+    UNSUPPORTED_METADATA = (
+        "unsupported_metadata"  # node_set, label, external metadata, content type
+    )
     NO_BASELINE = "no_baseline"
     CHUNKS_NOT_TILING = "chunks_not_tiling"
     UNREADABLE_TEXT = "unreadable_text"
@@ -451,8 +453,15 @@ async def _stage_new_content(data, preferred_loaders) -> StagedContent:
     )
 
 
-def _changed_staged_metadata(data, old_data: Data, staged: StagedContent) -> list[str]:
-    """Return metadata changes that need document-wide full-update handling."""
+def _changed_staged_metadata(old_data: Data, staged: StagedContent) -> list[str]:
+    """Return metadata changes that need document-wide full-update handling.
+
+    The replacement's filename is not one of them: ``data_id`` names the
+    document, so a file sent under another name is still that document, and
+    the publish step writes the new name onto the row. What does need the full
+    path is a change of content type — extension, mime type or loader — since
+    those pick the document class and the chunker that built the baseline.
+    """
     fields = [
         "extension",
         "mime_type",
@@ -460,11 +469,6 @@ def _changed_staged_metadata(data, old_data: Data, staged: StagedContent) -> lis
         "original_mime_type",
         "loader_engine",
     ]
-    # Direct text gets an internal content-derived filename, so its name is
-    # expected to change with its text. User-named uploads and streams are not.
-    source_data = data.data if isinstance(data, DataItem) else data
-    if hasattr(source_data, "filename") or hasattr(source_data, "name"):
-        fields.append("name")
     return [
         field for field in fields if getattr(old_data, field, None) != getattr(staged, field, None)
     ]
@@ -751,7 +755,7 @@ async def _stage_and_plan(
     new_text = await _read_processed_text(staged.raw_data_location)
     content_unchanged = staged.content_hash == old_data.content_hash and new_text == old_text
 
-    changed_metadata = _changed_staged_metadata(data, old_data, staged)
+    changed_metadata = _changed_staged_metadata(old_data, staged)
     if changed_metadata:
         raise IncrementalUpdateNotPossible(
             f"replacement metadata changed ({', '.join(changed_metadata)})",

--- a/cognee/api/v1/update/incremental.py
+++ b/cognee/api/v1/update/incremental.py
@@ -127,12 +127,17 @@ class RefusalReason(str, Enum):
     Every refusal used to surface as one free-text message and one log line, so
     a permanent misconfiguration (an incompatible chunker, an unsupported
     backend) looked exactly like a first ingestion. The reason is logged as a
-    structured field so they are separable.
+    structured field and returned in ``UpdateResult.fallback_reason`` so they
+    are separable. The first three come from ``update()`` before this engine
+    is consulted; the rest are this engine's own refusals.
     """
 
+    DISABLED = "disabled"  # the caller passed chunk_level_diff=False
+    CUSTOM_EXTRACTION_CONFIG = "custom_extraction_config"  # graph_model / custom_prompt
+    PER_CALL_DB_CONFIG = "per_call_db_config"  # vector_db_config / graph_db_config
     UNSUPPORTED_BACKEND = "unsupported_backend"
     UNSUPPORTED_CHUNKER = "unsupported_chunker"
-    UNSUPPORTED_METADATA = "unsupported_metadata"
+    UNSUPPORTED_METADATA = "unsupported_metadata"  # node_set, label, external metadata, rename
     NO_BASELINE = "no_baseline"
     CHUNKS_NOT_TILING = "chunks_not_tiling"
     UNREADABLE_TEXT = "unreadable_text"
@@ -467,9 +472,8 @@ def _changed_staged_metadata(data, old_data: Data, staged: StagedContent) -> lis
 def _unchanged_result(reindexed: int) -> dict:
     """The no-op result, shaped like the incremental one.
 
-    The router returns this dict verbatim as the HTTP body, and both the SDK
-    docstring and the route documentation advertise the same keys for either
-    status — so a client reading kept_chunks must not get a KeyError on a no-op.
+    ``update()`` turns both into the same ``UpdateResult.chunks``, so a no-op
+    reports every counter (as zero) rather than omitting them.
     """
     return {
         "status": "unchanged",
@@ -642,7 +646,7 @@ async def _run_incremental_update(
     # A no-op with nothing to repair is the only path that writes nothing, and
     # so the only one that records no run.
     if bundle.get("status") == "unchanged" and not bundle.get("repairs"):
-        return _unchanged_result(0)
+        return {**_unchanged_result(0), "pipeline_run_id": None}
 
     pipeline_id = generate_pipeline_id(user.id, dataset.id, RUN_PIPELINE_NAME)
     pipeline_run = await log_pipeline_run_start(
@@ -687,7 +691,7 @@ async def _run_incremental_update(
         user.id,
         additional_properties={"dataset_id": str(dataset.id), "data_id": str(data_id), **result},
     )
-    return result
+    return {**result, "pipeline_run_id": pipeline_run.pipeline_run_id}
 
 
 async def _stage_and_plan(

--- a/cognee/api/v1/update/incremental.py
+++ b/cognee/api/v1/update/incremental.py
@@ -67,6 +67,7 @@ from cognee.modules.chunking.chunk_policy import (
 from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
 from cognee.modules.chunking.TextChunker import TextChunker
 from cognee.modules.cognify.config import get_cognify_config
+from cognee.modules.cognify.routing import CognifyRoute, cognify_route_for
 from cognee.modules.data.exceptions.exceptions import UnauthorizedDataAccessError
 from cognee.modules.data.methods import (
     StagedContent,
@@ -572,6 +573,18 @@ async def incremental_update(
     if old_data is None or not old_data.raw_data_location:
         raise IncrementalUpdateNotPossible(
             "no stored processed text for this data item", RefusalReason.NO_BASELINE
+        )
+    # Code files and DLT source manifests are built by their own cognify
+    # routes, which write typed nodes and never a document chunk, so there is
+    # nothing to diff: the full rebuild re-runs that route over the new
+    # content. Say so, instead of reporting the missing chunks as "not
+    # cognified yet".
+    route = cognify_route_for(old_data)
+    if route is not CognifyRoute.STANDARD:
+        raise IncrementalUpdateNotPossible(
+            f"document is on the {route.value} cognify route, which keeps no chunks to "
+            "diff; the whole document is rebuilt",
+            RefusalReason.NO_BASELINE,
         )
 
     # Same per-dataset lock as pipeline runs and delete_data: serialize against

--- a/cognee/api/v1/update/result.py
+++ b/cognee/api/v1/update/result.py
@@ -18,9 +18,10 @@ from cognee.api.v1.update.incremental import RefusalReason
 class ChunkChanges(BaseModel):
     """What the chunk-level path did to the document's chunks.
 
-    ``regions`` is the number of disjoint edited spans the diff found; the
-    counts are work done, so ``added`` can exceed the net change when a re-cut
-    chunk with unchanged content is re-extracted in place.
+    ``regions`` is the number of disjoint edited spans the diff found and
+    ``total`` the chunk count after the update, so "kept 29 of 30" reads off
+    directly. The counts are work done: ``added`` can exceed the net change
+    when a re-cut chunk with unchanged content is re-extracted in place.
     """
 
     regions: int = 0
@@ -29,19 +30,34 @@ class ChunkChanges(BaseModel):
     reused: int = 0
     kept: int = 0
     reindexed: int = 0
+    total: int = 0
+
+
+class Fallback(BaseModel):
+    """Why the full rebuild ran instead of the chunk-level update."""
+
+    reason: RefusalReason
+    detail: str
+
+
+class UpdateError(BaseModel):
+    """Why the rebuild's cognify run failed."""
+
+    error_class: str | None = None
+    message: str | None = None
 
 
 class UpdateResult(BaseModel):
     """Per-document outcome of ``update()``.
 
     ``status`` says what happened to the document; ``mode`` says how. A
-    ``full_rebuild`` carries ``fallback_reason`` whenever the chunk-level path
-    was requested and could not run (or was switched off by the caller), so an
-    update that took far longer than usual explains itself. ``chunks`` is set
-    only for the incremental mode: a rebuild re-extracts the whole document
-    and has no diff to report.
+    ``full_rebuild`` always carries ``fallback``, naming why the chunk-level
+    path did not run (or that the caller switched it off), so an update that
+    took far longer than usual explains itself; ``duration_seconds`` makes the
+    "longer" visible. ``chunks`` is set only for the incremental mode: a
+    rebuild re-extracts the whole document and has no diff to report.
 
-    A ``failed`` status names the error so the caller can retry this one
+    A ``failed`` status carries ``error`` so the caller can retry this one
     document; the document keeps its ``data_id`` on every path.
     """
 
@@ -49,9 +65,8 @@ class UpdateResult(BaseModel):
     dataset_id: UUID
     status: Literal["updated", "unchanged", "failed"]
     mode: Literal["incremental", "full_rebuild"]
+    duration_seconds: float
     chunks: ChunkChanges | None = None
-    fallback_reason: RefusalReason | None = None
-    fallback_detail: str | None = None
+    fallback: Fallback | None = None
     pipeline_run_id: UUID | None = None
-    error_class: str | None = None
-    error_message: str | None = None
+    error: UpdateError | None = None

--- a/cognee/api/v1/update/result.py
+++ b/cognee/api/v1/update/result.py
@@ -1,0 +1,57 @@
+"""The result of ``update()``: one shape for every path.
+
+``update()`` used to answer in two incompatible shapes — a summary dict from the
+chunk-level path and a pipeline-run mapping from the full rebuild — so a caller
+could not tell from the value alone whether the document was refreshed cheaply,
+rebuilt from scratch, or left as it was, and the reason for a rebuild lived only
+in the server log. This model answers those questions in the value itself.
+"""
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from cognee.api.v1.update.incremental import RefusalReason
+
+
+class ChunkChanges(BaseModel):
+    """What the chunk-level path did to the document's chunks.
+
+    ``regions`` is the number of disjoint edited spans the diff found; the
+    counts are work done, so ``added`` can exceed the net change when a re-cut
+    chunk with unchanged content is re-extracted in place.
+    """
+
+    regions: int = 0
+    deleted: int = 0
+    added: int = 0
+    reused: int = 0
+    kept: int = 0
+    reindexed: int = 0
+
+
+class UpdateResult(BaseModel):
+    """Per-document outcome of ``update()``.
+
+    ``status`` says what happened to the document; ``mode`` says how. A
+    ``full_rebuild`` carries ``fallback_reason`` whenever the chunk-level path
+    was requested and could not run (or was switched off by the caller), so an
+    update that took far longer than usual explains itself. ``chunks`` is set
+    only for the incremental mode: a rebuild re-extracts the whole document
+    and has no diff to report.
+
+    A ``failed`` status names the error so the caller can retry this one
+    document; the document keeps its ``data_id`` on every path.
+    """
+
+    data_id: UUID
+    dataset_id: UUID
+    status: Literal["updated", "unchanged", "failed"]
+    mode: Literal["incremental", "full_rebuild"]
+    chunks: ChunkChanges | None = None
+    fallback_reason: RefusalReason | None = None
+    fallback_detail: str | None = None
+    pipeline_run_id: UUID | None = None
+    error_class: str | None = None
+    error_message: str | None = None

--- a/cognee/api/v1/update/result.py
+++ b/cognee/api/v1/update/result.py
@@ -4,7 +4,12 @@
 chunk-level path and a pipeline-run mapping from the full rebuild — so a caller
 could not tell from the value alone whether the document was refreshed cheaply,
 rebuilt from scratch, or left as it was, and the reason for a rebuild lived only
-in the server log. This model answers those questions in the value itself.
+in the server log.
+
+The result is a dict on every path, and a superset of the chunk-level summary
+that shipped before: the same keys with the same values, plus the fields below.
+This model is its schema — the HTTP route validates and documents the body
+with it, and the remote client normalizes what it receives through it.
 """
 
 from typing import Literal
@@ -13,24 +18,6 @@ from uuid import UUID
 from pydantic import BaseModel
 
 from cognee.api.v1.update.incremental import RefusalReason
-
-
-class ChunkChanges(BaseModel):
-    """What the chunk-level path did to the document's chunks.
-
-    ``regions`` is the number of disjoint edited spans the diff found and
-    ``total`` the chunk count after the update, so "kept 29 of 30" reads off
-    directly. The counts are work done: ``added`` can exceed the net change
-    when a re-cut chunk with unchanged content is re-extracted in place.
-    """
-
-    regions: int = 0
-    deleted: int = 0
-    added: int = 0
-    reused: int = 0
-    kept: int = 0
-    reindexed: int = 0
-    total: int = 0
 
 
 class Fallback(BaseModel):
@@ -50,23 +37,32 @@ class UpdateError(BaseModel):
 class UpdateResult(BaseModel):
     """Per-document outcome of ``update()``.
 
-    ``status`` says what happened to the document; ``mode`` says how. A
-    ``full_rebuild`` always carries ``fallback``, naming why the chunk-level
-    path did not run (or that the caller switched it off), so an update that
-    took far longer than usual explains itself; ``duration_seconds`` makes the
-    "longer" visible. ``chunks`` is set only for the incremental mode: a
-    rebuild re-extracts the whole document and has no diff to report.
+    ``status`` says what happened: the chunk-level path replaced chunks
+    (``incremental``) or found nothing to change (``unchanged``), the whole
+    document was rebuilt (``full_rebuild``), or the rebuild's cognify run
+    errored (``failed``, with ``error`` naming the cause so the call can be
+    retried). A rebuild always carries ``fallback``, naming why the chunk-level
+    path did not run or that the caller switched it off, and
+    ``duration_seconds`` makes a slow update visible next to its reason.
 
-    A ``failed`` status carries ``error`` so the caller can retry this one
-    document; the document keeps its ``data_id`` on every path.
+    The chunk counters are work done by the chunk-level path — ``added`` can
+    exceed the net change when a re-cut chunk with unchanged content is
+    re-extracted in place — and ``total_chunks`` is the count after the
+    update. They are ``None`` on a rebuild, which has no diff. The document
+    keeps its ``data_id`` on every path.
     """
 
+    status: Literal["incremental", "unchanged", "full_rebuild", "failed"]
+    regions: int | None = None
+    deleted_chunks: int | None = None
+    added_chunks: int | None = None
+    reused_chunks: int | None = None
+    kept_chunks: int | None = None
+    reindexed_chunks: int | None = None
+    total_chunks: int | None = None
     data_id: UUID
     dataset_id: UUID
-    status: Literal["updated", "unchanged", "failed"]
-    mode: Literal["incremental", "full_rebuild"]
     duration_seconds: float
-    chunks: ChunkChanges | None = None
-    fallback: Fallback | None = None
     pipeline_run_id: UUID | None = None
+    fallback: Fallback | None = None
     error: UpdateError | None = None

--- a/cognee/api/v1/update/routers/get_update_router.py
+++ b/cognee/api/v1/update/routers/get_update_router.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, Form, Query, status
 from fastapi import UploadFile as UF
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from pydantic import WithJsonSchema
 
@@ -94,20 +95,23 @@ def get_update_router() -> APIRouter:
                  by the edit instead of re-ingesting the whole document.
 
         ## Response
-        One shape on every path, an `UpdateResult`:
-        - **status**: `"updated"`, `"unchanged"` (the chunk-level path found no content
-          change) or `"failed"` (the rebuild's cognify run errored; `error` says why, and
-          the call can be retried).
-        - **mode**: `"incremental"` or `"full_rebuild"`.
+        One body on every path (`UpdateResult`), a superset of the chunk-level summary
+        returned before:
+        - **status**: `"incremental"` (chunks replaced), `"unchanged"` (no content change),
+          `"full_rebuild"` (delete + re-add + cognify ran) or `"failed"` (the rebuild's
+          cognify run errored; `error` says why, and the call can be retried).
+        - **regions**, **deleted_chunks**, **added_chunks**, **reused_chunks**,
+          **kept_chunks**, **reindexed_chunks**, **total_chunks**: the chunk-level
+          counters; `null` on a rebuild, which has no diff.
+        - **data_id**, **dataset_id**: the document, the handle to retry with.
         - **duration_seconds**: wall-clock time of the update.
-        - **chunks**: the chunk-level counters (`regions`, `deleted`, `added`, `reused`,
-          `kept`, `reindexed`, `total`); `null` on a full rebuild, which has no diff.
-        - **fallback**: set on every full rebuild; its `reason` names why the chunk-level
-          path did not run (`disabled`, `unsupported_metadata`, `custom_extraction_config`,
+        - **pipeline_run_id**: the run to inspect; `null` for a no-op.
+        - **fallback**: set on every rebuild; its `reason` names why the chunk-level path
+          did not run (`disabled`, `unsupported_metadata`, `custom_extraction_config`,
           `per_call_db_config`, `unsupported_backend`, `unsupported_chunker`,
           `no_baseline`, `chunks_not_tiling`, `unreadable_text`) and `detail` says it in
           a sentence.
-        - **pipeline_run_id**: the run to inspect; `null` for a no-op.
+        - **error**: `error_class` and `message` when `status` is `"failed"`.
 
         ## Error Codes
         - **422 Unprocessable Entity**: data_id or dataset_id missing or not a valid UUID
@@ -144,12 +148,12 @@ def get_update_router() -> APIRouter:
                 chunk_level_diff=chunk_level_diff,
             )
 
-            if result.status == "failed":
+            if result["status"] == "failed":
                 # Same body as a success, so the client can read the error and
                 # retry this document; the status code still says it failed.
                 return JSONResponse(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    content=result.model_dump(mode="json"),
+                    content=jsonable_encoder(result),
                 )
             return result
 

--- a/cognee/api/v1/update/routers/get_update_router.py
+++ b/cognee/api/v1/update/routers/get_update_router.py
@@ -96,15 +96,17 @@ def get_update_router() -> APIRouter:
         ## Response
         One shape on every path, an `UpdateResult`:
         - **status**: `"updated"`, `"unchanged"` (the chunk-level path found no content
-          change) or `"failed"` (the rebuild's cognify run errored; `error_class` and
-          `error_message` say why, and the call can be retried).
+          change) or `"failed"` (the rebuild's cognify run errored; `error` says why, and
+          the call can be retried).
         - **mode**: `"incremental"` or `"full_rebuild"`.
+        - **duration_seconds**: wall-clock time of the update.
         - **chunks**: the chunk-level counters (`regions`, `deleted`, `added`, `reused`,
-          `kept`, `reindexed`); `null` on a full rebuild, which has no diff.
-        - **fallback_reason** / **fallback_detail**: set on every full rebuild, naming why
-          the chunk-level path did not run (`disabled`, `unsupported_metadata`,
-          `custom_extraction_config`, `per_call_db_config`, `unsupported_backend`,
-          `unsupported_chunker`, `no_baseline`, `chunks_not_tiling`, `unreadable_text`).
+          `kept`, `reindexed`, `total`); `null` on a full rebuild, which has no diff.
+        - **fallback**: set on every full rebuild; its `reason` names why the chunk-level
+          path did not run (`disabled`, `unsupported_metadata`, `custom_extraction_config`,
+          `per_call_db_config`, `unsupported_backend`, `unsupported_chunker`,
+          `no_baseline`, `chunks_not_tiling`, `unreadable_text`) and `detail` says it in
+          a sentence.
         - **pipeline_run_id**: the run to inspect; `null` for a no-op.
 
         ## Error Codes

--- a/cognee/api/v1/update/routers/get_update_router.py
+++ b/cognee/api/v1/update/routers/get_update_router.py
@@ -1,18 +1,15 @@
-from typing import Annotated, Literal
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, Form, Query, status
 from fastapi import UploadFile as UF
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, WithJsonSchema
+from pydantic import WithJsonSchema
 
 from cognee import __version__ as cognee_version
 from cognee.api.DTO import ErrorResponse
+from cognee.api.v1.update.result import UpdateResult
 from cognee.exceptions import CogneeApiError
-from cognee.modules.pipelines.models.PipelineRunInfo import (
-    PipelineRunErrored,
-    PipelineRunInfo,
-)
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
@@ -25,26 +22,22 @@ UploadFile = Annotated[UF, WithJsonSchema({"type": "string", "format": "binary"}
 logger = get_logger()
 
 
-class IncrementalUpdateResponse(BaseModel):
-    status: Literal["incremental", "unchanged"]
-    regions: int
-    deleted_chunks: int
-    added_chunks: int
-    reused_chunks: int
-    kept_chunks: int
-    reindexed_chunks: int
-
-
 def get_update_router() -> APIRouter:
     router = APIRouter()
 
     @router.patch(
         "",
-        response_model=IncrementalUpdateResponse | dict[UUID, PipelineRunInfo],
+        response_model=UpdateResult,
         responses={
             403: {"model": ErrorResponse},
             422: {"model": ErrorResponse},
-            500: {"model": ErrorResponse},
+            500: {
+                "model": UpdateResult | ErrorResponse,
+                "description": (
+                    "The rebuild's cognify run errored (an UpdateResult with status "
+                    '"failed", naming the error) or an unexpected error occurred.'
+                ),
+            },
         },
     )
     async def update(
@@ -101,17 +94,25 @@ def get_update_router() -> APIRouter:
                  by the edit instead of re-ingesting the whole document.
 
         ## Response
-        With chunk_level_diff, a summary of the incremental operation (same keys for
-        either status):
-        `{"status": "incremental" | "unchanged", "regions": n, "deleted_chunks": n,
-        "added_chunks": n, "reused_chunks": n, "kept_chunks": n, "reindexed_chunks": n}`.
-        When the full flow runs (chunk_level_diff disabled, or its preconditions not met),
-        pipeline run information for the delete + re-add + cognify operation.
+        One shape on every path, an `UpdateResult`:
+        - **status**: `"updated"`, `"unchanged"` (the chunk-level path found no content
+          change) or `"failed"` (the rebuild's cognify run errored; `error_class` and
+          `error_message` say why, and the call can be retried).
+        - **mode**: `"incremental"` or `"full_rebuild"`.
+        - **chunks**: the chunk-level counters (`regions`, `deleted`, `added`, `reused`,
+          `kept`, `reindexed`); `null` on a full rebuild, which has no diff.
+        - **fallback_reason** / **fallback_detail**: set on every full rebuild, naming why
+          the chunk-level path did not run (`disabled`, `unsupported_metadata`,
+          `custom_extraction_config`, `per_call_db_config`, `unsupported_backend`,
+          `unsupported_chunker`, `no_baseline`, `chunks_not_tiling`, `unreadable_text`).
+        - **pipeline_run_id**: the run to inspect; `null` for a no-op.
 
         ## Error Codes
         - **422 Unprocessable Entity**: data_id or dataset_id missing or not a valid UUID
         - **403 Forbidden**: User lacks write permission on the dataset
-        - **500 Internal Server Error**: Pipeline run errored or an unexpected error occurred during the update
+        - **404 Not Found**: data_id resolves to no document in the dataset
+        - **500 Internal Server Error**: the rebuild's cognify run errored (body is the
+          `UpdateResult` with status `"failed"`) or an unexpected error occurred
 
         ## Notes
         - Chunk-level updates keep unaffected chunks, their entities, and their summaries
@@ -132,7 +133,7 @@ def get_update_router() -> APIRouter:
         from cognee.api.v1.update import update as cognee_update
 
         try:
-            update_run = await cognee_update(
+            result = await cognee_update(
                 data_id=data_id,
                 data=data,
                 dataset_id=dataset_id,
@@ -141,27 +142,14 @@ def get_update_router() -> APIRouter:
                 chunk_level_diff=chunk_level_diff,
             )
 
-            # Chunk-level path returns its own summary dict, no pipeline runs.
-            if isinstance(update_run, dict) and "status" in update_run:
-                return update_run
-
-            # If any cognify run errored return JSONResponse with proper error status code
-            if any(isinstance(v, PipelineRunErrored) for v in update_run.values()):
-                first_err = next(
-                    (v for v in update_run.values() if isinstance(v, PipelineRunErrored)), None
-                )
-                detail = getattr(first_err, "error", None) if first_err else None
-                if not detail:
-                    detail = str(first_err) if first_err else "Pipeline run errored"
-
+            if result.status == "failed":
+                # Same body as a success, so the client can read the error and
+                # retry this document; the status code still says it failed.
                 return JSONResponse(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    content=ErrorResponse(
-                        error="Pipeline run errored",
-                        detail=detail,
-                    ).model_dump(),
+                    content=result.model_dump(mode="json"),
                 )
-            return update_run
+            return result
 
         except CogneeApiError:
             # Typed API errors (e.g. UpdateTargetNotFoundError -> 404) carry

--- a/cognee/api/v1/update/routers/get_update_router.py
+++ b/cognee/api/v1/update/routers/get_update_router.py
@@ -72,7 +72,7 @@ def get_update_router() -> APIRouter:
             default=True,
             description=(
                 "Diff the new content against the stored text and re-ingest only the "
-                "affected chunks. Falls back to the full delete + re-add + cognify flow "
+                "affected chunks. Falls back to the full rebuild (memory dropped, row refreshed) "
                 "when chunk-level preconditions are not met."
             ),
         ),
@@ -98,7 +98,7 @@ def get_update_router() -> APIRouter:
         One body on every path (`UpdateResult`), a superset of the chunk-level summary
         returned before:
         - **status**: `"incremental"` (chunks replaced), `"unchanged"` (no content change),
-          `"full_rebuild"` (delete + re-add + cognify ran) or `"failed"` (the rebuild's
+          `"full_rebuild"` (memory dropped and rebuilt from the new content) or `"failed"` (the rebuild's
           cognify run errored; `error` says why, and the call can be retried).
         - **regions**, **deleted_chunks**, **added_chunks**, **reused_chunks**,
           **kept_chunks**, **reindexed_chunks**, **total_chunks**: the chunk-level

--- a/cognee/api/v1/update/update.py
+++ b/cognee/api/v1/update/update.py
@@ -1,3 +1,4 @@
+from time import perf_counter
 from typing import Any, BinaryIO
 from uuid import UUID
 
@@ -12,7 +13,7 @@ from cognee.api.v1.update.incremental import (
     incremental_update,
     recorded_chunk_budget,
 )
-from cognee.api.v1.update.result import ChunkChanges, UpdateResult
+from cognee.api.v1.update.result import ChunkChanges, Fallback, UpdateError, UpdateResult
 from cognee.modules.chunking.chunk_policy import DEFAULT_CHUNK_POLICY, ChunkPolicy
 from cognee.modules.chunking.TextChunker import TextChunker
 from cognee.modules.pipelines.models.PipelineRunInfo import get_errored_run_info
@@ -139,12 +140,13 @@ async def update(
     Returns:
         UpdateResult, the same shape on every path:
             - ``status``: "updated", "unchanged" (chunk-level path found no content
-              change) or "failed" (the rebuild's cognify run errored; ``error_class``
-              and ``error_message`` say why, and the call can be retried).
+              change) or "failed" (the rebuild's cognify run errored; ``error`` says
+              why, and the call can be retried).
             - ``mode``: "incremental" or "full_rebuild".
+            - ``duration_seconds``: wall-clock time of the update.
             - ``chunks``: the chunk-level counters (regions, deleted, added, reused,
-              kept, reindexed); None on a full rebuild, which has no diff.
-            - ``fallback_reason`` / ``fallback_detail``: set on every full rebuild,
+              kept, reindexed, total); None on a full rebuild, which has no diff.
+            - ``fallback``: set on every full rebuild, its ``reason`` and ``detail``
               naming why the chunk-level path did not run — the caller switched it
               off, an unsupported parameter, or one of the engine's refusals.
             - ``pipeline_run_id``: the run to inspect; None for a no-op.
@@ -184,6 +186,7 @@ async def update(
             chunk_level_diff=chunk_level_diff,
         )
 
+    started = perf_counter()
     if not user:
         user = await get_default_user()
 
@@ -282,6 +285,7 @@ async def update(
                 dataset_id=dataset_id,
                 status="unchanged" if summary["status"] == "unchanged" else "updated",
                 mode="incremental",
+                duration_seconds=round(perf_counter() - started, 3),
                 chunks=ChunkChanges(
                     regions=summary["regions"],
                     deleted=summary["deleted_chunks"],
@@ -289,6 +293,7 @@ async def update(
                     reused=summary["reused_chunks"],
                     kept=summary["kept_chunks"],
                     reindexed=summary["reindexed_chunks"],
+                    total=summary["total_chunks"],
                 ),
                 pipeline_run_id=summary["pipeline_run_id"],
             )
@@ -344,11 +349,12 @@ async def update(
         dataset_id=dataset_id,
         status="failed" if errored else "updated",
         mode="full_rebuild",
-        fallback_reason=fallback[0],
-        fallback_detail=fallback[1],
+        duration_seconds=round(perf_counter() - started, 3),
+        fallback=Fallback(reason=fallback[0], detail=fallback[1]),
         pipeline_run_id=run.pipeline_run_id,
-        error_class=errored.error_class if errored else None,
-        error_message=errored.error_message if errored else None,
+        error=UpdateError(error_class=errored.error_class, message=errored.error_message)
+        if errored
+        else None,
     )
 
 

--- a/cognee/api/v1/update/update.py
+++ b/cognee/api/v1/update/update.py
@@ -104,7 +104,8 @@ async def update(
 
     Args:
         data_id: UUID of existing data to update (current or pre-fork)
-        data: The latest version of the data. Can be:
+        data: The latest version of the data. ``data_id`` names the document, so the
+            replacement may carry any filename; the new name lands on the row. Can be:
             - Single text string: "Your text content here"
             - DLT resource or source: replaces a DLT source manifest under the same
               source name (the whole source is re-ingested and re-cognified)

--- a/cognee/api/v1/update/update.py
+++ b/cognee/api/v1/update/update.py
@@ -106,6 +106,8 @@ async def update(
         data_id: UUID of existing data to update (current or pre-fork)
         data: The latest version of the data. Can be:
             - Single text string: "Your text content here"
+            - DLT resource or source: replaces a DLT source manifest under the same
+              source name (the whole source is re-ingested and re-cognified)
             - Absolute file path: "/path/to/document.pdf"
             - File URL: "file:///absolute/path/to/document.pdf" or "file://relative/path.txt"
             - S3 path: "s3://my-bucket/documents/file.pdf"
@@ -128,7 +130,8 @@ async def update(
                  processed text and replace only the chunks the edit touched — unaffected
                  chunks keep their nodes, entities, and summaries. Falls back to the full
                  delete + pinned re-add + cognify flow when chunk-level preconditions are
-                 not met (first ingestion, non-text content, unverified graph adapter).
+                 not met (first ingestion, non-text content, unverified graph adapter,
+                 a code file or a DLT source manifest — those routes keep no chunks).
                  Permission errors always propagate and never trigger the fallback.
         chunker: Chunking strategy. Must match the one that built the document's stored
                  chunks — a mismatch is refused (and falls back) rather than surfacing
@@ -195,6 +198,7 @@ async def update(
     from cognee.modules.data.models import Data
     from cognee.modules.ingestion.exceptions import IngestionError
     from cognee.tasks.ingestion.data_item import DataItem
+    from cognee.tasks.ingestion.resolve_dlt_sources import check_dlt_replacement, is_dlt_input
 
     if isinstance(data, list):
         if len(data) != 1:
@@ -297,6 +301,17 @@ async def update(
                 ),
                 pipeline_run_id=summary["pipeline_run_id"],
             )
+
+    # The rebuild deletes first and re-adds second, so anything that would
+    # make the re-add refuse the replacement must be found now, while the
+    # document still exists. A dlt source is the one input whose identity is
+    # decided by the resolver rather than by the pinned id.
+    replacement = data.data if isinstance(data, DataItem) else data
+    if is_dlt_input(replacement):
+        from cognee.modules.data.methods import get_authorized_dataset
+
+        dataset = await get_authorized_dataset(user, dataset_id, "write")
+        await check_dlt_replacement(replacement, pinned_id, dataset.name, user)
 
     await datasets.delete_data(
         dataset_id=dataset_id,

--- a/cognee/api/v1/update/update.py
+++ b/cognee/api/v1/update/update.py
@@ -8,12 +8,14 @@ from cognee.api.v1.cognify import cognify
 from cognee.api.v1.datasets import datasets
 from cognee.api.v1.update.incremental import (
     IncrementalUpdateNotPossible,
+    RefusalReason,
     incremental_update,
     recorded_chunk_budget,
 )
+from cognee.api.v1.update.result import ChunkChanges, UpdateResult
 from cognee.modules.chunking.chunk_policy import DEFAULT_CHUNK_POLICY, ChunkPolicy
 from cognee.modules.chunking.TextChunker import TextChunker
-from cognee.modules.pipelines.models import PipelineRunInfo
+from cognee.modules.pipelines.models.PipelineRunInfo import get_errored_run_info
 from cognee.modules.users.methods import get_default_user
 from cognee.modules.users.models import User
 from cognee.shared.data_models import KnowledgeGraph
@@ -69,7 +71,7 @@ async def update(
     custom_prompt: str | None = None,
     chunker: type = TextChunker,
     policy: ChunkPolicy = DEFAULT_CHUNK_POLICY,
-) -> dict[str, PipelineRunInfo] | list[PipelineRunInfo] | dict:
+) -> UpdateResult:
     """
     Update existing data in Cognee.
 
@@ -135,14 +137,17 @@ async def update(
                  Chunk-level path only; not exposed on the HTTP route.
 
     Returns:
-        With chunk_level_diff, a summary dict with the same keys for either status:
-            {"status": "incremental" | "unchanged", "regions": n, "deleted_chunks": n,
-             "added_chunks": n, "reused_chunks": n, "kept_chunks": n, "reindexed_chunks": n}
-        Otherwise PipelineRunInfo: Information about the ingestion pipeline execution including:
-            - Pipeline run ID for tracking
-            - Dataset ID where data was stored
-            - Processing status and any errors
-            - Execution timestamps and metadata
+        UpdateResult, the same shape on every path:
+            - ``status``: "updated", "unchanged" (chunk-level path found no content
+              change) or "failed" (the rebuild's cognify run errored; ``error_class``
+              and ``error_message`` say why, and the call can be retried).
+            - ``mode``: "incremental" or "full_rebuild".
+            - ``chunks``: the chunk-level counters (regions, deleted, added, reused,
+              kept, reindexed); None on a full rebuild, which has no diff.
+            - ``fallback_reason`` / ``fallback_detail``: set on every full rebuild,
+              naming why the chunk-level path did not run — the caller switched it
+              off, an unsupported parameter, or one of the engine's refusals.
+            - ``pipeline_run_id``: the run to inspect; None for a no-op.
     """
     # Route to the remote instance when connected via serve(). This must come
     # before any local work: the paths below resolve the LOCAL default user and
@@ -218,41 +223,20 @@ async def update(
             preserved_legacy_id = old_row.legacy_id
             preserved_owner_id = old_row.owner_id
 
-    data_item_changes_metadata = isinstance(data, DataItem) and (
-        data.label is not None or data.external_metadata is not None
+    # Why the chunk-level path is not taken, if it is not. Every full rebuild
+    # names its cause in the result, so an update that took far longer than
+    # usual explains itself instead of leaving the reason in the server log.
+    fallback = _full_rebuild_reason(
+        chunk_level_diff,
+        data,
+        node_set,
+        graph_model,
+        custom_prompt,
+        vector_db_config,
+        graph_db_config,
     )
-    if chunk_level_diff and (node_set or data_item_changes_metadata):
-        # Warning, not info: the response carries no hint that the slower,
-        # costlier full rebuild ran instead of the chunk-level update.
-        logger.warning(
-            "Chunk-level incremental update does not reconcile document metadata or "
-            "node_set; running full update"
-        )
-        chunk_level_diff = False
-
-    if chunk_level_diff and (graph_model is not KnowledgeGraph or custom_prompt is not None):
-        # The baseline does not persist the model/prompt that produced its
-        # graph. Applying a new configuration only to fresh chunks would mix
-        # extraction schemas or rules inside one document.
-        logger.warning(
-            "Chunk-level incremental update supports only the default graph model and prompt; "
-            "running full update"
-        )
-        chunk_level_diff = False
-
-    if chunk_level_diff and (vector_db_config is not None or graph_db_config is not None):
-        # The chunk-level incremental engine resolves its stores through the
-        # dataset-context routing system, not per-call config dicts — running
-        # it with these params would silently read and write the DEFAULT
-        # stores. The full ingestion flow honors them, so it runs instead.
-        logger.warning(
-            "Chunk-level incremental update is not supported with per-call "
-            "vector_db_config/graph_db_config forwarding; running full "
-            "ingestion instead. To get incremental updates, configure your "
-            "stores through environment settings and the dataset-context "
-            "database routing system instead of per-call config dicts."
-        )
-        chunk_level_diff = False
+    if fallback is not None:
+        logger.warning("%s; running full update", fallback[1])
 
     # The fallback re-cognifies the whole document. It keeps the chunk budget
     # the stored chunks record so the document's granularity survives the
@@ -260,7 +244,7 @@ async def update(
     # cannot take) means the current default.
     fallback_chunk_size = None
 
-    if chunk_level_diff:
+    if fallback is None:
         # Chunk-level incremental path: diff the new text against the stored
         # processed text, replace only the affected chunks — the Data row is
         # updated in place, so the id trivially survives. Falls through to
@@ -268,7 +252,7 @@ async def update(
         # non-text content, stored chunks unavailable). Permission errors
         # propagate — they must never trigger the fallback.
         try:
-            return await incremental_update(
+            summary = await incremental_update(
                 data_id=pinned_id,
                 data=data,
                 dataset_id=dataset_id,
@@ -284,16 +268,30 @@ async def update(
             # The reason is a structured field, not just prose: an unsupported
             # chunker and a first ingestion produce the same sentence otherwise,
             # so a permanent misconfiguration is indistinguishable from a
-            # one-off in the logs. A warning, not info: the fallback re-extracts
-            # the whole document and the caller's response carries no hint of
-            # it (pipeline-run info instead of the incremental summary), so
-            # this line is the only place the downgrade and its cause show up.
+            # one-off in the logs.
             logger.warning(
                 "chunk-level update not possible (%s); running full update",
                 refusal,
                 extra={"refusal_reason": refusal.reason.value},
             )
+            fallback = (refusal.reason, str(refusal))
             fallback_chunk_size = await recorded_chunk_budget(pinned_id, dataset_id, user)
+        else:
+            return UpdateResult(
+                data_id=pinned_id,
+                dataset_id=dataset_id,
+                status="unchanged" if summary["status"] == "unchanged" else "updated",
+                mode="incremental",
+                chunks=ChunkChanges(
+                    regions=summary["regions"],
+                    deleted=summary["deleted_chunks"],
+                    added=summary["added_chunks"],
+                    reused=summary["reused_chunks"],
+                    kept=summary["kept_chunks"],
+                    reindexed=summary["reindexed_chunks"],
+                ),
+                pipeline_run_id=summary["pipeline_run_id"],
+            )
 
     await datasets.delete_data(
         dataset_id=dataset_id,
@@ -324,7 +322,7 @@ async def update(
 
     await _restore_row_lineage(pinned_id, preserved_legacy_id, preserved_owner_id)
 
-    cognify_run = await cognify(
+    cognify_runs = await cognify(
         datasets=[dataset_id],
         user=user,
         vector_db_config=vector_db_config,
@@ -334,9 +332,70 @@ async def update(
         graph_model=graph_model,
         custom_prompt=custom_prompt,
         chunk_size=fallback_chunk_size,
-        # update() returns the run info for the caller to inspect — an errored
-        # run is a valid return value here, not an exception.
+        # An errored run is reported as a failed result, not raised: the
+        # caller gets the document id and the error to retry this one update.
         raise_on_error=False,
     )
 
-    return cognify_run
+    errored = get_errored_run_info(cognify_runs)
+    run = errored or next(iter(cognify_runs.values()))
+    return UpdateResult(
+        data_id=pinned_id,
+        dataset_id=dataset_id,
+        status="failed" if errored else "updated",
+        mode="full_rebuild",
+        fallback_reason=fallback[0],
+        fallback_detail=fallback[1],
+        pipeline_run_id=run.pipeline_run_id,
+        error_class=errored.error_class if errored else None,
+        error_message=errored.error_message if errored else None,
+    )
+
+
+def _full_rebuild_reason(
+    chunk_level_diff: bool,
+    data,
+    node_set,
+    graph_model,
+    custom_prompt,
+    vector_db_config,
+    graph_db_config,
+) -> tuple[RefusalReason, str] | None:
+    """Decide, before the engine is consulted, whether the full rebuild must run.
+
+    Returns the reason and a sentence for the caller, or None when the
+    chunk-level path may be attempted. Each cause is a limitation of the
+    chunk-level engine: it reconciles chunks, not document metadata; the
+    baseline does not persist the model or prompt that produced its graph, so
+    a different one applied to fresh chunks only would mix extraction schemas
+    inside one document; and it resolves its stores through the dataset
+    context, not per-call config dicts, so running it with those would read
+    and write the default stores while the caller's stores never see the edit.
+    """
+    from cognee.tasks.ingestion.data_item import DataItem
+
+    if not chunk_level_diff:
+        return RefusalReason.DISABLED, "chunk_level_diff=False was requested"
+
+    data_item_changes_metadata = isinstance(data, DataItem) and (
+        data.label is not None or data.external_metadata is not None
+    )
+    if node_set or data_item_changes_metadata:
+        return (
+            RefusalReason.UNSUPPORTED_METADATA,
+            "chunk-level update does not reconcile node_set or document metadata",
+        )
+    if graph_model is not KnowledgeGraph or custom_prompt is not None:
+        return (
+            RefusalReason.CUSTOM_EXTRACTION_CONFIG,
+            "chunk-level update supports only the default graph model and prompt",
+        )
+    if vector_db_config is not None or graph_db_config is not None:
+        return (
+            RefusalReason.PER_CALL_DB_CONFIG,
+            (
+                "chunk-level update does not take per-call vector_db_config/graph_db_config; "
+                "configure stores through environment settings and the dataset-context routing"
+            ),
+        )
+    return None

--- a/cognee/api/v1/update/update.py
+++ b/cognee/api/v1/update/update.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from cognee.api.v1.add import add
 from cognee.api.v1.cognify import cognify
-from cognee.api.v1.datasets import datasets
+from cognee.api.v1.forget import forget
 from cognee.api.v1.update.incremental import (
     IncrementalUpdateNotPossible,
     RefusalReason,
@@ -23,37 +23,6 @@ from cognee.shared.data_models import KnowledgeGraph
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("update")
-
-
-async def _restore_row_lineage(
-    data_id: UUID, legacy_id: UUID | None, owner_id: UUID | None
-) -> None:
-    """Carry the replaced row's identity onto the one re-ingestion just minted.
-
-    The full fallback deletes the row and re-adds it, and ``add()`` builds a
-    fresh ``Data`` with ``owner_id=user.id``. Both values must survive that:
-
-    - ``legacy_id`` so a fork document's pre-fork id keeps resolving;
-    - ``owner_id`` so a collaborator updating a document does not silently
-      become its owner. Update is authorized by the dataset ACL, which says
-      nothing about who owns the row.
-    """
-    if legacy_id is None and owner_id is None:
-        return
-
-    from cognee.infrastructure.databases.relational import get_relational_engine
-    from cognee.modules.data.models import Data
-
-    db_engine = get_relational_engine()
-    async with db_engine.get_async_session() as session:
-        row = await session.get(Data, data_id)
-        if row is None:
-            return
-        if legacy_id is not None and row.legacy_id is None:
-            row.legacy_id = legacy_id
-        if owner_id is not None:
-            row.owner_id = owner_id
-        await session.commit()
 
 
 async def update(
@@ -79,8 +48,10 @@ async def update(
     The document keeps its ``data_id`` across updates — on EVERY path. The
     incoming id is resolved first (exact, or the recorded pre-fork
     ``legacy_id``), the chunk-level incremental path operates on the resolved
-    row in place, and the full-rebuild fallback re-ingests pinned to the same
-    id — so externally held id mappings never break, incremental or not.
+    row in place, and the full rebuild drops the document's memory and
+    refreshes the same row with a pinned re-add — the row is never deleted, so
+    externally held id mappings never break and a failed rebuild leaves a
+    document to re-cognify rather than a document that is gone.
     Exactly one document is replaced per call — lists of more than one item
     are rejected. An id that resolves to no document raises
     ``UpdateTargetNotFoundError`` (404) — update() never creates documents;
@@ -130,7 +101,8 @@ async def update(
         chunk_level_diff: When True (default), diff the new content against the stored
                  processed text and replace only the chunks the edit touched — unaffected
                  chunks keep their nodes, entities, and summaries. Falls back to the full
-                 delete + pinned re-add + cognify flow when chunk-level preconditions are
+                 rebuild (memory dropped, row refreshed by a pinned re-add, cognify) when
+                 chunk-level preconditions are
                  not met (first ingestion, non-text content, unverified graph adapter,
                  a code file or a DLT source manifest — those routes keep no chunks).
                  Permission errors always propagate and never trigger the fallback.
@@ -145,7 +117,8 @@ async def update(
         One dict on every path (schema: ``UpdateResult``), a superset of the
         chunk-level summary returned before:
             - ``status``: "incremental" (chunks replaced), "unchanged" (no content
-              change), "full_rebuild" (delete + re-add + cognify ran) or "failed"
+              change), "full_rebuild" (memory dropped and rebuilt from the new
+              content) or "failed"
               (the rebuild's cognify run errored; ``error`` says why, and the call
               can be retried).
             - ``regions``, ``deleted_chunks``, ``added_chunks``, ``reused_chunks``,
@@ -198,9 +171,7 @@ async def update(
     if not user:
         user = await get_default_user()
 
-    from cognee.infrastructure.databases.relational import get_relational_engine
-    from cognee.modules.data.methods import resolve_data_id
-    from cognee.modules.data.models import Data
+    from cognee.modules.data.methods import reset_data_pipeline_status, resolve_data_id
     from cognee.modules.ingestion.exceptions import IngestionError
     from cognee.tasks.ingestion.data_item import DataItem
     from cognee.tasks.ingestion.resolve_dlt_sources import check_dlt_replacement, is_dlt_input
@@ -226,15 +197,6 @@ async def update(
         raise UpdateTargetNotFoundError(data_id=data_id, dataset_id=dataset_id)
     pinned_id = resolved_id
 
-    preserved_legacy_id = None
-    preserved_owner_id = None
-    db_engine = get_relational_engine()
-    async with db_engine.get_async_session() as session:
-        old_row = await session.get(Data, resolved_id)
-        if old_row is not None:
-            preserved_legacy_id = old_row.legacy_id
-            preserved_owner_id = old_row.owner_id
-
     # Why the chunk-level path is not taken, if it is not. Every full rebuild
     # names its cause in the result, so an update that took far longer than
     # usual explains itself instead of leaving the reason in the server log.
@@ -249,12 +211,6 @@ async def update(
     )
     if fallback is not None:
         logger.warning("%s; running full update", fallback[1])
-
-    # The fallback re-cognifies the whole document. It keeps the chunk budget
-    # the stored chunks record so the document's granularity survives the
-    # rebuild; None (no baseline, or a recorded budget the current provider
-    # cannot take) means the current default.
-    fallback_chunk_size = None
 
     if fallback is None:
         # Chunk-level incremental path: diff the new text against the stored
@@ -287,7 +243,6 @@ async def update(
                 extra={"refusal_reason": refusal.reason.value},
             )
             fallback = (refusal.reason, str(refusal))
-            fallback_chunk_size = await recorded_chunk_budget(pinned_id, dataset_id, user)
         else:
             return UpdateResult(
                 status=summary["status"],
@@ -304,10 +259,16 @@ async def update(
                 pipeline_run_id=summary["pipeline_run_id"],
             ).model_dump()
 
-    # The rebuild deletes first and re-adds second, so anything that would
-    # make the re-add refuse the replacement must be found now, while the
-    # document still exists. A dlt source is the one input whose identity is
-    # decided by the resolver rather than by the pinned id.
+    # The rebuild re-cognifies the whole document. It keeps the chunk budget
+    # the stored chunks record so the document's granularity survives the
+    # rebuild, whichever way the rebuild was decided; None (no baseline, or a
+    # recorded budget the current provider cannot take) means the current
+    # default.
+    fallback_chunk_size = await recorded_chunk_budget(pinned_id, dataset_id, user)
+
+    # A dlt source's identity is decided by the resolver, not by the pinned
+    # id, so a replacement the re-add would refuse is refused now, before the
+    # document's memory is dropped.
     replacement = data.data if isinstance(data, DataItem) else data
     if is_dlt_input(replacement):
         from cognee.modules.data.methods import get_authorized_dataset
@@ -315,15 +276,18 @@ async def update(
         dataset = await get_authorized_dataset(user, dataset_id, "write")
         await check_dlt_replacement(replacement, pinned_id, dataset.name, user)
 
-    await datasets.delete_data(
-        dataset_id=dataset_id,
-        data_id=pinned_id,
-        user=user,
-    )
+    # The rebuild never deletes the document. Its memory (graph nodes, edges,
+    # vectors) is dropped while the row and its stored files stay; the pinned
+    # re-add then refreshes the row in place with the new content, name and
+    # metadata, and cognify rebuilds the graph. A re-add that fails leaves a
+    # document with no graph that the next cognify() rebuilds from its stored
+    # content, not a document that is gone. The row keeps its id, owner and
+    # pre-fork legacy id by construction.
+    await forget(data_id=pinned_id, dataset_id=dataset_id, memory_only=True, user=user)
+    # forget() clears the cognify stamp; the add stamp must go too, or the
+    # pinned re-add is skipped as already added and the row is never refreshed.
+    await reset_data_pipeline_status(pinned_id, dataset_id)
 
-    # Fallback keeps the id too: re-ingest pinned to the resolved id instead
-    # of minting a fresh one (the fallback-churn defect the reconciliation
-    # review identified — callers must never lose their handle to a fallback).
     if isinstance(data, DataItem):
         data.data_id = pinned_id
         pinned_item = data
@@ -341,8 +305,6 @@ async def update(
         incremental_loading=incremental_loading,
         data_cache=data_cache,
     )
-
-    await _restore_row_lineage(pinned_id, preserved_legacy_id, preserved_owner_id)
 
     cognify_runs = await cognify(
         datasets=[dataset_id],

--- a/cognee/api/v1/update/update.py
+++ b/cognee/api/v1/update/update.py
@@ -13,7 +13,7 @@ from cognee.api.v1.update.incremental import (
     incremental_update,
     recorded_chunk_budget,
 )
-from cognee.api.v1.update.result import ChunkChanges, Fallback, UpdateError, UpdateResult
+from cognee.api.v1.update.result import Fallback, UpdateError, UpdateResult
 from cognee.modules.chunking.chunk_policy import DEFAULT_CHUNK_POLICY, ChunkPolicy
 from cognee.modules.chunking.TextChunker import TextChunker
 from cognee.modules.pipelines.models.PipelineRunInfo import get_errored_run_info
@@ -72,7 +72,7 @@ async def update(
     custom_prompt: str | None = None,
     chunker: type = TextChunker,
     policy: ChunkPolicy = DEFAULT_CHUNK_POLICY,
-) -> UpdateResult:
+) -> dict:
     """
     Update existing data in Cognee.
 
@@ -141,18 +141,22 @@ async def update(
                  Chunk-level path only; not exposed on the HTTP route.
 
     Returns:
-        UpdateResult, the same shape on every path:
-            - ``status``: "updated", "unchanged" (chunk-level path found no content
-              change) or "failed" (the rebuild's cognify run errored; ``error`` says
-              why, and the call can be retried).
-            - ``mode``: "incremental" or "full_rebuild".
+        One dict on every path (schema: ``UpdateResult``), a superset of the
+        chunk-level summary returned before:
+            - ``status``: "incremental" (chunks replaced), "unchanged" (no content
+              change), "full_rebuild" (delete + re-add + cognify ran) or "failed"
+              (the rebuild's cognify run errored; ``error`` says why, and the call
+              can be retried).
+            - ``regions``, ``deleted_chunks``, ``added_chunks``, ``reused_chunks``,
+              ``kept_chunks``, ``reindexed_chunks``, ``total_chunks``: the chunk-level
+              counters; None on a rebuild, which has no diff.
+            - ``data_id``, ``dataset_id``: the document, the handle to retry with.
             - ``duration_seconds``: wall-clock time of the update.
-            - ``chunks``: the chunk-level counters (regions, deleted, added, reused,
-              kept, reindexed, total); None on a full rebuild, which has no diff.
-            - ``fallback``: set on every full rebuild, its ``reason`` and ``detail``
-              naming why the chunk-level path did not run — the caller switched it
-              off, an unsupported parameter, or one of the engine's refusals.
             - ``pipeline_run_id``: the run to inspect; None for a no-op.
+            - ``fallback``: set on every rebuild, its ``reason`` and ``detail`` naming
+              why the chunk-level path did not run — the caller switched it off, an
+              unsupported parameter, or one of the engine's refusals.
+            - ``error``: ``error_class`` and ``message`` when ``status`` is "failed".
     """
     # Route to the remote instance when connected via serve(). This must come
     # before any local work: the paths below resolve the LOCAL default user and
@@ -285,22 +289,19 @@ async def update(
             fallback_chunk_size = await recorded_chunk_budget(pinned_id, dataset_id, user)
         else:
             return UpdateResult(
+                status=summary["status"],
+                regions=summary["regions"],
+                deleted_chunks=summary["deleted_chunks"],
+                added_chunks=summary["added_chunks"],
+                reused_chunks=summary["reused_chunks"],
+                kept_chunks=summary["kept_chunks"],
+                reindexed_chunks=summary["reindexed_chunks"],
+                total_chunks=summary["total_chunks"],
                 data_id=pinned_id,
                 dataset_id=dataset_id,
-                status="unchanged" if summary["status"] == "unchanged" else "updated",
-                mode="incremental",
                 duration_seconds=round(perf_counter() - started, 3),
-                chunks=ChunkChanges(
-                    regions=summary["regions"],
-                    deleted=summary["deleted_chunks"],
-                    added=summary["added_chunks"],
-                    reused=summary["reused_chunks"],
-                    kept=summary["kept_chunks"],
-                    reindexed=summary["reindexed_chunks"],
-                    total=summary["total_chunks"],
-                ),
                 pipeline_run_id=summary["pipeline_run_id"],
-            )
+            ).model_dump()
 
     # The rebuild deletes first and re-adds second, so anything that would
     # make the re-add refuse the replacement must be found now, while the
@@ -360,17 +361,16 @@ async def update(
     errored = get_errored_run_info(cognify_runs)
     run = errored or next(iter(cognify_runs.values()))
     return UpdateResult(
+        status="failed" if errored else "full_rebuild",
         data_id=pinned_id,
         dataset_id=dataset_id,
-        status="failed" if errored else "updated",
-        mode="full_rebuild",
         duration_seconds=round(perf_counter() - started, 3),
-        fallback=Fallback(reason=fallback[0], detail=fallback[1]),
         pipeline_run_id=run.pipeline_run_id,
+        fallback=Fallback(reason=fallback[0], detail=fallback[1]),
         error=UpdateError(error_class=errored.error_class, message=errored.error_message)
         if errored
         else None,
-    )
+    ).model_dump()
 
 
 def _full_rebuild_reason(

--- a/cognee/modules/data/methods/__init__.py
+++ b/cognee/modules/data/methods/__init__.py
@@ -23,6 +23,7 @@ from .publish_updated_data import (
     mark_data_processed,
     merged_external_metadata,
     publish_updated_data,
+    reset_data_pipeline_status,
 )
 
 # Delete

--- a/cognee/modules/data/methods/publish_updated_data.py
+++ b/cognee/modules/data/methods/publish_updated_data.py
@@ -13,6 +13,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 from sqlalchemy import select
+from sqlalchemy.orm.attributes import flag_modified
 
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.data.models import Data
@@ -130,6 +131,26 @@ async def mark_data_processed(data_id: UUID, dataset_id: UUID) -> None:
             return
         status_for_pipeline = data_point.pipeline_status.setdefault(COGNIFY_PIPELINE_NAME, {})
         status_for_pipeline[str(dataset_id)] = _completed_status()
+        await session.merge(data_point)
+        await session.commit()
+
+
+async def reset_data_pipeline_status(data_id: UUID, dataset_id: UUID) -> None:
+    """Forget every pipeline's completion stamp for this document in this dataset.
+
+    A pinned re-add then ingests the document again instead of skipping it as
+    already added, and cognify processes it instead of skipping it as done.
+    """
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        data_point = (
+            await session.execute(select(Data).filter(Data.id == data_id))
+        ).scalar_one_or_none()
+        if data_point is None or not data_point.pipeline_status:
+            return
+        for pipeline_status in data_point.pipeline_status.values():
+            pipeline_status.pop(str(dataset_id), None)
+        flag_modified(data_point, "pipeline_status")
         await session.merge(data_point)
         await session.commit()
 

--- a/cognee/tasks/ingestion/refuse_changed_existing_documents.py
+++ b/cognee/tasks/ingestion/refuse_changed_existing_documents.py
@@ -1,0 +1,135 @@
+"""Refuse an add() of a file the dataset already holds with other content.
+
+add() creates documents and leaves existing ones alone. A file that matches a
+stored document by origin but not by content is an update, and updates go
+through update() so the document keeps its id and its graph is replaced in
+place instead of a second copy being minted. Identical content is not an
+error: ingestion deduplicates it by content hash and the re-add is a no-op.
+
+This runs once, over the whole request, before the add pipeline starts: the
+pipeline processes items one at a time, so a check inside it would refuse the
+offending file only after the files before it were written.
+
+Origin is the source path for a local file (``Data.original_data_location``)
+and the filename for an upload, whose stored location carries a content hash
+and so cannot be matched. Raw text is named by its content hash: a changed
+text never matches and is a new document by construction. Pinned items (DLT
+manifests, code-repo manifests, update()'s own re-add) name their document
+and are exempt. The lookup shares the dedup scope, (dataset, owner, tenant),
+so another user's same-named file is never a conflict.
+
+Not covered: s3:// objects and repository URLs, whose bytes are not local.
+"""
+
+import os
+from pathlib import Path, PureWindowsPath
+from typing import Any
+
+from sqlalchemy import or_, select
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.infrastructure.files.utils.get_file_metadata import get_file_metadata
+from cognee.infrastructure.files.utils.local_path_safety import resolve_local_path
+from cognee.modules.data.models.Data import Data
+from cognee.modules.users.models import User
+from cognee.tasks.ingestion.data_item import DataItem
+
+
+def _local_file(item: Any) -> Path | None:
+    """The existing local file ``item`` names, or None for anything else."""
+    if not isinstance(item, (str, Path)):
+        return None
+    try:
+        path = resolve_local_path(item, must_exist=True)
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    return path if path.is_file() else None
+
+
+def _local_files(item: Any) -> list[Path]:
+    """``item`` as local files: itself, or every file under it when it is a directory."""
+    if isinstance(item, (str, Path)):
+        try:
+            path = resolve_local_path(item, must_exist=True)
+        except (FileNotFoundError, OSError, ValueError):
+            return []
+        if path.is_dir():
+            return sorted(p for p in path.rglob("*") if p.is_file())
+    single = _local_file(item)
+    return [single] if single else []
+
+
+async def _origins(data: Any) -> tuple[dict[str, str], dict[tuple[str, str], str]]:
+    """Origin keys of the unpinned inputs, each mapped to its content hash."""
+    items = data if isinstance(data, list) else [data]
+    by_location: dict[str, str] = {}
+    by_name: dict[tuple[str, str], str] = {}
+    for item in items:
+        if isinstance(item, DataItem):
+            if item.data_id is not None:
+                continue
+            item = item.data
+        for path in _local_files(item):
+            with open(path, "rb") as file:
+                metadata = await get_file_metadata(file, name=path.name)
+            by_location[path.as_uri()] = metadata["content_hash"]
+        stream = getattr(item, "file", None)
+        filename = getattr(item, "filename", None)
+        if stream is not None and filename:
+            # An upload is stored under its user-visible filename: the stem is
+            # the row's name (ingestion derives it the same way), the extension
+            # comes from the content type guessed with the filename as a hint.
+            metadata = await get_file_metadata(stream, name=str(filename))
+            stream.seek(0)
+            stem = PureWindowsPath(str(filename)).stem
+            by_name[(stem, metadata["extension"])] = metadata["content_hash"]
+    return by_location, by_name
+
+
+async def refuse_changed_existing_documents(data: Any, user: User, dataset) -> None:
+    """Raise ``DocumentUpdateRequiredError`` for every input that is an update in disguise."""
+    by_location, by_name = await _origins(data)
+    if not by_location and not by_name:
+        return
+
+    tenant_filter = Data.tenant_id == user.tenant_id if user.tenant_id else Data.tenant_id.is_(None)
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        rows = (
+            await session.execute(
+                select(
+                    Data.id,
+                    Data.name,
+                    Data.extension,
+                    Data.original_data_location,
+                    Data.content_hash,
+                ).filter(
+                    Data.dataset_id == dataset.id,
+                    Data.owner_id == user.id,
+                    tenant_filter,
+                    or_(
+                        Data.original_data_location.in_(list(by_location)),
+                        Data.name.in_([name for name, _ in by_name]),
+                    ),
+                )
+            )
+        ).fetchall()
+
+    conflicts: list[dict] = []
+    for data_id, name, extension, original_location, stored_hash in rows:
+        if original_location in by_location:
+            if by_location[original_location] != str(stored_hash):
+                conflicts.append(
+                    {"name": os.path.basename(str(original_location)), "data_id": data_id}
+                )
+        elif (name, extension) in by_name and by_name[(name, extension)] != str(stored_hash):
+            conflicts.append(
+                {"name": f"{name}.{extension}" if extension else name, "data_id": data_id}
+            )
+    if conflicts:
+        from cognee.api.v1.exceptions import DocumentUpdateRequiredError
+
+        raise DocumentUpdateRequiredError(conflicts, dataset.id)
+
+
+__all__ = ["refuse_changed_existing_documents"]

--- a/cognee/tasks/ingestion/resolve_dlt_sources.py
+++ b/cognee/tasks/ingestion/resolve_dlt_sources.py
@@ -41,6 +41,57 @@ logger = get_logger("resolve_dlt_sources")
 # free text, not categorical data, and would produce useless one-off nodes.
 
 
+def dlt_manifest_identifier(dataset_name: str, source_name: str) -> str:
+    """The identity a DLT source's manifest is seeded from: (dataset, source name)."""
+    return f"dlt_source:{dataset_name}:{source_name}"
+
+
+def is_dlt_input(item: Any) -> bool:
+    """Whether ``item`` is a dlt resource, source, or source factory."""
+    try:
+        from dlt.extract import DltResource, SourceFactory
+        from dlt.extract.source import DltSource
+    except ImportError:
+        return False
+    return isinstance(item, (DltResource, DltSource, SourceFactory))
+
+
+async def check_dlt_replacement(
+    dlt_item: Any, pinned_id: UUID, dataset_name: str, user: User
+) -> None:
+    """Refuse a dlt source that cannot replace the document ``pinned_id``.
+
+    update()'s full rebuild deletes the document and re-adds the replacement
+    pinned to its id, so this runs BEFORE that delete: a replacement that
+    would not resolve to the same manifest must be refused while the
+    document still exists. A document-tagged source yields one document per
+    row and has no single identity; a relational source under another name
+    resolves to a different manifest, and rebuilding it under the old id
+    would leave the next plain add() of that source minting a second one.
+    """
+    from cognee.exceptions import CogneeValidationError
+
+    if document_source_tag(dlt_item):
+        raise CogneeValidationError(
+            message=(
+                "A document-tagged DLT source yields one document per row, so it cannot "
+                "replace a single document; update() cannot take it. Re-add the source."
+            ),
+            name="DltDocumentSourceNotUpdatable",
+        )
+    source_name = getattr(dlt_item, "name", None) or dataset_name
+    manifest_id = await get_unique_data_id(dlt_manifest_identifier(dataset_name, source_name), user)
+    if manifest_id != pinned_id:
+        raise CogneeValidationError(
+            message=(
+                f"DLT source {source_name!r} resolves to manifest {manifest_id}, not the "
+                f"document {pinned_id} being updated. update() replaces a DLT source under "
+                "the same source name."
+            ),
+            name="DltSourceIdentityMismatch",
+        )
+
+
 async def resolve_dlt_sources(
     data: Any,
     dataset_name: str,
@@ -108,8 +159,19 @@ async def resolve_dlt_sources(
 
     dlt_items = []
     non_dlt_items = []
+    # update()'s full rebuild re-adds the replacement wrapped in a DataItem
+    # pinned to the manifest's id. Unwrap it here so the source is ingested
+    # like a bare one, and remember the pin to check it against the manifest
+    # identity the source resolves to.
+    pinned_ids: dict[int, UUID] = {}
 
     for item in data_list:
+        if isinstance(item, DataItem) and isinstance(
+            item.data, (DltResource, DltSource, SourceFactory)
+        ):
+            if item.data_id is not None:
+                pinned_ids[id(item.data)] = item.data_id
+            item = item.data
         if isinstance(item, (DltResource, DltSource, SourceFactory)):
             dlt_items.append(item)
         else:
@@ -118,6 +180,13 @@ async def resolve_dlt_sources(
     if not dlt_items:
         # Nothing to expand — return original data unchanged
         return data, None
+
+    # A pinned item must resolve to the manifest it is pinned to; update()
+    # checks this before deleting the document, and it is re-checked here so
+    # a pinned wrapper from any caller is held to the same rule.
+    for dlt_item in dlt_items:
+        if id(dlt_item) in pinned_ids:
+            await check_dlt_replacement(dlt_item, pinned_ids[id(dlt_item)], dataset_name, user)
 
     # A dlt source may opt into the document path (each row → a text document
     # that goes through normal cognify) by declaring a document-source tag;
@@ -402,7 +471,7 @@ async def _build_source_manifest_item(
     # add(..., incremental_loading=False, data_cache=False). Renaming a source (or dataset)
     # changes this identity and is remove + add — a one-time full rebuild,
     # by design.
-    data_id = await get_unique_data_id(f"dlt_source:{dataset_name}:{source_name}", user)
+    data_id = await get_unique_data_id(dlt_manifest_identifier(dataset_name, source_name), user)
 
     return DataItem(
         data=manifest_text,

--- a/cognee/tests/e2e/incremental_update/test_add_existing_document.py
+++ b/cognee/tests/e2e/incremental_update/test_add_existing_document.py
@@ -60,13 +60,23 @@ def add_env():
         except (ImportError, AttributeError):
             pass
 
+    import re
+
     from cognee.infrastructure.llm.LLMGateway import LLMGateway
-    from cognee.shared.data_models import KnowledgeGraph, SummarizedContent
+    from cognee.shared.data_models import KnowledgeGraph, Node, SummarizedContent
+
+    marker = re.compile(r"ENT[A-Z0-9]+")
 
     @staticmethod
     async def _mock_acreate(text_input, system_prompt, response_model, **kwargs):
+        # Documents produce entities; the same deterministic extraction the
+        # other suites in this directory use, so the graph is never empty.
         if isinstance(response_model, type) and issubclass(response_model, KnowledgeGraph):
-            return KnowledgeGraph(nodes=[], edges=[])
+            names = sorted(set(marker.findall(str(text_input))))
+            return KnowledgeGraph(
+                nodes=[Node(id=n, name=n, type="Marker", description=f"marker {n}") for n in names],
+                edges=[],
+            )
         if isinstance(response_model, type) and issubclass(response_model, SummarizedContent):
             return SummarizedContent(summary="Mock summary.", description="")
         return response_model() if isinstance(response_model, type) else "mock"
@@ -97,10 +107,10 @@ async def test_re_adding_a_changed_file_is_refused_and_update_is_the_way(add_env
     from cognee.modules.users.methods import get_default_user
 
     report = add_env / "report.txt"
-    report.write_text("Quarterly report, version one.\n")
+    report.write_text("Quarterly report ENTREPORT, version one.\n")
     await cognee.add(str(report), dataset_name="existing")
     await cognee.add(
-        _upload(b"Meeting notes, version one.\n", "notes.txt"), dataset_name="existing"
+        _upload(b"Meeting notes ENTNOTES, version one.\n", "notes.txt"), dataset_name="existing"
     )
     user = await get_default_user()
     dataset = next(d for d in await get_datasets(user.id) if d.name == "existing")
@@ -110,12 +120,12 @@ async def test_re_adding_a_changed_file_is_refused_and_update_is_the_way(add_env
     # Identical content re-added: a no-op, still two rows.
     await cognee.add(str(report), dataset_name="existing")
     await cognee.add(
-        _upload(b"Meeting notes, version one.\n", "notes.txt"), dataset_name="existing"
+        _upload(b"Meeting notes ENTNOTES, version one.\n", "notes.txt"), dataset_name="existing"
     )
     assert len(await get_dataset_data(dataset.id)) == 2
 
     # The same path with new content: refused, naming the document to update.
-    report.write_text("Quarterly report, version two.\n")
+    report.write_text("Quarterly report ENTREPORT ENTV2, version two.\n")
     with pytest.raises(DocumentUpdateRequiredError) as refused:
         await cognee.add(str(report), dataset_name="existing")
     assert refused.value.status_code == 409
@@ -126,13 +136,14 @@ async def test_re_adding_a_changed_file_is_refused_and_update_is_the_way(add_env
     # The same upload name with new content: refused too.
     with pytest.raises(DocumentUpdateRequiredError) as refused:
         await cognee.add(
-            _upload(b"Meeting notes, version two.\n", "notes.txt"), dataset_name="existing"
+            _upload(b"Meeting notes ENTNOTES ENTV2, version two.\n", "notes.txt"),
+            dataset_name="existing",
         )
     assert refused.value.conflicts[0]["data_id"] == rows["notes"].id
 
     # A batch with one changed file is refused whole, before anything is written.
     fresh = add_env / "fresh.txt"
-    fresh.write_text("A brand new document.\n")
+    fresh.write_text("A brand new document ENTFRESH.\n")
     with pytest.raises(DocumentUpdateRequiredError):
         await cognee.add([str(fresh), str(report)], dataset_name="existing")
     assert len(await get_dataset_data(dataset.id)) == 2, "a refused add must write nothing"
@@ -147,11 +158,11 @@ async def test_re_adding_a_changed_file_is_refused_and_update_is_the_way(add_env
     # A directory re-added after one of its files changed is refused whole too.
     folder = add_env / "folder"
     folder.mkdir(exist_ok=True)
-    (folder / "a.txt").write_text("Folder file A.\n")
-    (folder / "b.txt").write_text("Folder file B.\n")
+    (folder / "a.txt").write_text("Folder file A ENTA.\n")
+    (folder / "b.txt").write_text("Folder file B ENTB.\n")
     await cognee.add(str(folder), dataset_name="existing")
     assert len(await get_dataset_data(dataset.id)) == 4
-    (folder / "b.txt").write_text("Folder file B, edited.\n")
+    (folder / "b.txt").write_text("Folder file B ENTB ENTEDIT, edited.\n")
     with pytest.raises(DocumentUpdateRequiredError) as refused:
         await cognee.add(str(folder), dataset_name="existing")
     assert [c["name"] for c in refused.value.conflicts] == ["b.txt"]

--- a/cognee/tests/e2e/incremental_update/test_add_existing_document.py
+++ b/cognee/tests/e2e/incremental_update/test_add_existing_document.py
@@ -1,0 +1,163 @@
+"""add() refuses a file it already holds with other content and points at update().
+
+Runs on the default local stack in a scratch root with the mocked LLM and
+embeddings (same fixture shape as test_incremental_update). The rule under
+test is the resolution step of ingestion, so the scenarios are about which
+call is accepted, which is refused, and that a refusal writes nothing.
+"""
+
+import io
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cognee.tests.e2e.incremental_update.backend_env import (
+    incremental_test_backend_env,
+    reset_backend_state,
+)
+
+
+@pytest.fixture(scope="module")
+def add_env():
+    import os
+
+    root = Path(tempfile.mkdtemp(prefix="cognee_add_existing_"))
+    import cognee
+
+    os.environ.update(
+        **incremental_test_backend_env(),
+        CACHE_BACKEND="sqlite",
+        MOCK_EMBEDDING="true",
+        TELEMETRY_DISABLED="1",
+        DATA_ROOT_DIRECTORY=str(root / "data"),
+        SYSTEM_ROOT_DIRECTORY=str(root / "system"),
+        ENABLE_BACKEND_ACCESS_CONTROL=os.environ.get("INCR_TEST_ACL", "true"),
+    )
+    import importlib
+
+    for module_name, factory_name in [
+        ("cognee.base_config", "get_base_config"),
+        ("cognee.infrastructure.databases.relational.config", "get_relational_config"),
+        (
+            "cognee.infrastructure.databases.relational.get_relational_engine",
+            "get_relational_engine",
+        ),
+        ("cognee.infrastructure.databases.graph.config", "get_graph_config"),
+        ("cognee.infrastructure.databases.vector.config", "get_vectordb_config"),
+        ("cognee.infrastructure.databases.cache.config", "get_cache_config"),
+        ("cognee.infrastructure.databases.cache.get_cache_engine", "create_cache_engine"),
+        ("cognee.infrastructure.databases.vector.embeddings.config", "get_embedding_config"),
+        (
+            "cognee.infrastructure.databases.vector.embeddings.get_embedding_engine",
+            "create_embedding_engine",
+        ),
+        ("cognee.infrastructure.llm.config", "get_llm_config"),
+    ]:
+        try:
+            getattr(importlib.import_module(module_name), factory_name).cache_clear()
+        except (ImportError, AttributeError):
+            pass
+
+    from cognee.infrastructure.llm.LLMGateway import LLMGateway
+    from cognee.shared.data_models import KnowledgeGraph, SummarizedContent
+
+    @staticmethod
+    async def _mock_acreate(text_input, system_prompt, response_model, **kwargs):
+        if isinstance(response_model, type) and issubclass(response_model, KnowledgeGraph):
+            return KnowledgeGraph(nodes=[], edges=[])
+        if isinstance(response_model, type) and issubclass(response_model, SummarizedContent):
+            return SummarizedContent(summary="Mock summary.", description="")
+        return response_model() if isinstance(response_model, type) else "mock"
+
+    original = LLMGateway.acreate_structured_output
+    LLMGateway.acreate_structured_output = _mock_acreate
+    yield root
+    LLMGateway.acreate_structured_output = original
+    shutil.rmtree(root, ignore_errors=True)
+
+
+def _upload(content: bytes, filename: str):
+    from starlette.datastructures import UploadFile
+
+    spooled = tempfile.SpooledTemporaryFile()  # noqa: SIM115 - handed to UploadFile, which owns it
+    spooled.write(content)
+    spooled.seek(0)
+    return UploadFile(file=spooled, filename=filename)
+
+
+@pytest.mark.asyncio
+async def test_re_adding_a_changed_file_is_refused_and_update_is_the_way(add_env):
+    await reset_backend_state()
+    import cognee
+    from cognee.api.v1.exceptions import DocumentUpdateRequiredError
+    from cognee.modules.data.methods import get_datasets
+    from cognee.modules.data.methods.get_dataset_data import get_dataset_data
+    from cognee.modules.users.methods import get_default_user
+
+    report = add_env / "report.txt"
+    report.write_text("Quarterly report, version one.\n")
+    await cognee.add(str(report), dataset_name="existing")
+    await cognee.add(
+        _upload(b"Meeting notes, version one.\n", "notes.txt"), dataset_name="existing"
+    )
+    user = await get_default_user()
+    dataset = next(d for d in await get_datasets(user.id) if d.name == "existing")
+    rows = {row.name: row for row in await get_dataset_data(dataset.id)}
+    assert set(rows) == {"report", "notes"}
+
+    # Identical content re-added: a no-op, still two rows.
+    await cognee.add(str(report), dataset_name="existing")
+    await cognee.add(
+        _upload(b"Meeting notes, version one.\n", "notes.txt"), dataset_name="existing"
+    )
+    assert len(await get_dataset_data(dataset.id)) == 2
+
+    # The same path with new content: refused, naming the document to update.
+    report.write_text("Quarterly report, version two.\n")
+    with pytest.raises(DocumentUpdateRequiredError) as refused:
+        await cognee.add(str(report), dataset_name="existing")
+    assert refused.value.status_code == 409
+    assert refused.value.conflicts == [{"name": "report.txt", "data_id": rows["report"].id}]
+    assert "cognee.update(" in refused.value.message
+    assert "PATCH /api/v1/update" in refused.value.api_message
+
+    # The same upload name with new content: refused too.
+    with pytest.raises(DocumentUpdateRequiredError) as refused:
+        await cognee.add(
+            _upload(b"Meeting notes, version two.\n", "notes.txt"), dataset_name="existing"
+        )
+    assert refused.value.conflicts[0]["data_id"] == rows["notes"].id
+
+    # A batch with one changed file is refused whole, before anything is written.
+    fresh = add_env / "fresh.txt"
+    fresh.write_text("A brand new document.\n")
+    with pytest.raises(DocumentUpdateRequiredError):
+        await cognee.add([str(fresh), str(report)], dataset_name="existing")
+    assert len(await get_dataset_data(dataset.id)) == 2, "a refused add must write nothing"
+
+    # The way to do it: update() keeps the id and takes the new content.
+    result = await cognee.update(rows["report"].id, str(report), dataset.id, user=user)
+    assert result["data_id"] == rows["report"].id
+    assert result["status"] in ("incremental", "full_rebuild"), result
+    after = {row.name: row for row in await get_dataset_data(dataset.id)}
+    assert after["report"].id == rows["report"].id and len(after) == 2
+
+    # A directory re-added after one of its files changed is refused whole too.
+    folder = add_env / "folder"
+    folder.mkdir(exist_ok=True)
+    (folder / "a.txt").write_text("Folder file A.\n")
+    (folder / "b.txt").write_text("Folder file B.\n")
+    await cognee.add(str(folder), dataset_name="existing")
+    assert len(await get_dataset_data(dataset.id)) == 4
+    (folder / "b.txt").write_text("Folder file B, edited.\n")
+    with pytest.raises(DocumentUpdateRequiredError) as refused:
+        await cognee.add(str(folder), dataset_name="existing")
+    assert [c["name"] for c in refused.value.conflicts] == ["b.txt"]
+    assert len(await get_dataset_data(dataset.id)) == 4
+
+    # Same name in a different dataset is a different document, not a conflict.
+    await cognee.add(str(report), dataset_name="another")
+    # And another user's dataset is out of scope by construction (dedup scope),
+    # which the query shares with identify_many.

--- a/cognee/tests/e2e/incremental_update/test_chunk_budget_persistence.py
+++ b/cognee/tests/e2e/incremental_update/test_chunk_budget_persistence.py
@@ -162,7 +162,7 @@ async def _scenario():
         text_v2 = text_v1[:start] + replacement + text_v1[end:]
 
         result = await cognee.update(data_id, text_v2, dataset.id, user=user)
-        assert isinstance(result, dict) and result.get("status") == "incremental", result
+        assert (result.mode, result.status) == ("incremental", "updated"), result
     finally:
         incremental_module.get_max_chunk_tokens = original_budget
 

--- a/cognee/tests/e2e/incremental_update/test_chunk_budget_persistence.py
+++ b/cognee/tests/e2e/incremental_update/test_chunk_budget_persistence.py
@@ -162,7 +162,7 @@ async def _scenario():
         text_v2 = text_v1[:start] + replacement + text_v1[end:]
 
         result = await cognee.update(data_id, text_v2, dataset.id, user=user)
-        assert (result.mode, result.status) == ("incremental", "updated"), result
+        assert isinstance(result, dict) and result.get("status") == "incremental", result
     finally:
         incremental_module.get_max_chunk_tokens = original_budget
 

--- a/cognee/tests/e2e/incremental_update/test_chunk_ownership_semantics.py
+++ b/cognee/tests/e2e/incremental_update/test_chunk_ownership_semantics.py
@@ -295,7 +295,7 @@ async def test_entity_orphaned_by_update_is_deleted(ownership_env):
     result = await cognee.update(
         data_id, "Hole met Rabbit.\n\nRabbit met Alice.\n\nNothing remains.", dataset.id, user=user
     )
-    assert result["status"] == "incremental", result
+    assert (result.mode, result.status) == ("incremental", "updated"), result
 
     after = await _view(user, dataset)
     assert "queen" not in after.entities, (
@@ -325,7 +325,7 @@ async def test_fact_survives_loss_of_its_first_producer(ownership_env):
     result = await cognee.update(
         data_id, "Alice met Queen.\n\nAlice met Queen again today.", dataset.id, user=user
     )
-    assert result["status"] == "incremental", result
+    assert (result.mode, result.status) == ("incremental", "updated"), result
     stated_twice = await _view(user, dataset)
     assert len(stated_twice.supporting("alice", "queen")) == 2, "both paragraphs state the fact"
     ownership_before = stated_twice.describe_edge("alice", "queen")
@@ -333,7 +333,7 @@ async def test_fact_survives_loss_of_its_first_producer(ownership_env):
     result = await cognee.update(
         data_id, "Nothing here.\n\nAlice met Queen again today.", dataset.id, user=user
     )
-    assert result["status"] == "incremental", result
+    assert (result.mode, result.status) == ("incremental", "updated"), result
     after = await _view(user, dataset)
     assert after.supporting("alice", "queen"), "a live chunk still states the fact"
     assert ("alice", "queen") in after.precedes, (

--- a/cognee/tests/e2e/incremental_update/test_chunk_ownership_semantics.py
+++ b/cognee/tests/e2e/incremental_update/test_chunk_ownership_semantics.py
@@ -295,7 +295,7 @@ async def test_entity_orphaned_by_update_is_deleted(ownership_env):
     result = await cognee.update(
         data_id, "Hole met Rabbit.\n\nRabbit met Alice.\n\nNothing remains.", dataset.id, user=user
     )
-    assert (result.mode, result.status) == ("incremental", "updated"), result
+    assert result["status"] == "incremental", result
 
     after = await _view(user, dataset)
     assert "queen" not in after.entities, (
@@ -325,7 +325,7 @@ async def test_fact_survives_loss_of_its_first_producer(ownership_env):
     result = await cognee.update(
         data_id, "Alice met Queen.\n\nAlice met Queen again today.", dataset.id, user=user
     )
-    assert (result.mode, result.status) == ("incremental", "updated"), result
+    assert result["status"] == "incremental", result
     stated_twice = await _view(user, dataset)
     assert len(stated_twice.supporting("alice", "queen")) == 2, "both paragraphs state the fact"
     ownership_before = stated_twice.describe_edge("alice", "queen")
@@ -333,7 +333,7 @@ async def test_fact_survives_loss_of_its_first_producer(ownership_env):
     result = await cognee.update(
         data_id, "Nothing here.\n\nAlice met Queen again today.", dataset.id, user=user
     )
-    assert (result.mode, result.status) == ("incremental", "updated"), result
+    assert result["status"] == "incremental", result
     after = await _view(user, dataset)
     assert after.supporting("alice", "queen"), "a live chunk still states the fact"
     assert ("alice", "queen") in after.precedes, (

--- a/cognee/tests/e2e/incremental_update/test_incremental_update.py
+++ b/cognee/tests/e2e/incremental_update/test_incremental_update.py
@@ -194,11 +194,9 @@ async def test_incremental_update_full_flow(incremental_env):
     text_v2 = text_v1[:edit_start] + insertion + " CHANGED " + text_v1[mid_next:]
 
     result = await update_like_an_api_request(data_id, text_v2, dataset.id, user=user)
-    assert (result.mode, result.status) == ("incremental", "updated"), (
-        f"chunk-level path did not run: {result}"
-    )
-    assert result.chunks.deleted == 2
-    assert result.chunks.kept == len(old_nodes) - 2
+    assert result["status"] == "incremental", f"chunk-level path did not run: {result}"
+    assert result["deleted_chunks"] == 2
+    assert result["kept_chunks"] == len(old_nodes) - 2
     assert await _stored_text(user, data_id) == text_v2
 
     new_nodes = await _doc_chunk_nodes(data_id, text_v2)
@@ -228,9 +226,9 @@ async def test_incremental_update_full_flow(incremental_env):
         + "MULTI TAIL LINE\n"
     )
     result_multi = await update_like_an_api_request(data_id, text_multi, dataset.id, user=user)
-    assert (result_multi.mode, result_multi.status) == ("incremental", "updated")
-    assert result_multi.chunks.regions == 3, f"expected three regions: {result_multi}"
-    assert result_multi.chunks.kept >= total_before - 6, (
+    assert result_multi["status"] == "incremental"
+    assert result_multi["regions"] == 3, f"expected three regions: {result_multi}"
+    assert result_multi["kept_chunks"] >= total_before - 6, (
         f"disjoint edits must keep the untouched middle: {result_multi}"
     )
     assert await _stored_text(user, data_id) == text_multi
@@ -289,7 +287,8 @@ async def test_incremental_update_full_flow(incremental_env):
     # Retry with the same content: stored chunks no longer tile the stored
     # text (old + new region chunks coexist), so the full update takes over.
     retry = await update_like_an_api_request(data_id, text_v5, dataset.id, user=user)
-    assert retry.mode == "full_rebuild", "retry after crash must fall back to the full update"
+    assert retry["status"] == "full_rebuild", "retry after crash must fall back to the full update"
+    assert retry["fallback"]["reason"] == "chunks_not_tiling", retry["fallback"]
     # The full update is pinned to the existing row too, so callers keep the
     # same handle even when incremental preconditions fail.
     healed_data = (await get_dataset_data(dataset.id))[0]
@@ -320,7 +319,7 @@ async def test_incremental_update_full_flow(incremental_env):
         f"{healed_data.name}.{healed_data.original_extension}",
     )
     result6 = await update_like_an_api_request(data_id, [upload], dataset.id, user=user)
-    assert (result6.mode, result6.status) == ("incremental", "updated"), (
+    assert result6["status"] == "incremental", (
         f"single-UploadFile update must run chunk-level: {result6}"
     )
     healed_text = await _stored_text(user, data_id)

--- a/cognee/tests/e2e/incremental_update/test_incremental_update.py
+++ b/cognee/tests/e2e/incremental_update/test_incremental_update.py
@@ -312,18 +312,17 @@ async def test_incremental_update_full_flow(incremental_env):
         return UploadFile(file=spooled, filename=filename)
 
     text_v6 = healed_text.replace("Paragraph 3", "Paragraph 3 ENTV6", 1)
-    # Keep the existing user-visible metadata. A rename intentionally takes
-    # the full path; this case exercises safe same-name staging instead.
-    upload = _upload(
-        text_v6.encode("utf-8"),
-        f"{healed_data.name}.{healed_data.original_extension}",
-    )
+    # The upload carries another filename: data_id names the document, so the
+    # replacement still updates it chunk-level, and the new name lands on the row.
+    upload = _upload(text_v6.encode("utf-8"), "renamed_by_the_client.txt")
     result6 = await update_like_an_api_request(data_id, [upload], dataset.id, user=user)
     assert result6["status"] == "incremental", (
         f"single-UploadFile update must run chunk-level: {result6}"
     )
     healed_text = await _stored_text(user, data_id)
     assert healed_text == text_v6, "UploadFile content must land as the stored text"
+    renamed_row = next(row for row in await get_dataset_data(dataset.id) if row.id == data_id)
+    assert renamed_row.name == "renamed_by_the_client", "the replacement's name lands on the row"
 
     # --- Permissions: non-permitted user is rejected, nothing changes -------- #
     from uuid import uuid4

--- a/cognee/tests/e2e/incremental_update/test_incremental_update.py
+++ b/cognee/tests/e2e/incremental_update/test_incremental_update.py
@@ -194,9 +194,11 @@ async def test_incremental_update_full_flow(incremental_env):
     text_v2 = text_v1[:edit_start] + insertion + " CHANGED " + text_v1[mid_next:]
 
     result = await update_like_an_api_request(data_id, text_v2, dataset.id, user=user)
-    assert result["status"] == "incremental", f"chunk-level path did not run: {result}"
-    assert result["deleted_chunks"] == 2
-    assert result["kept_chunks"] == len(old_nodes) - 2
+    assert (result.mode, result.status) == ("incremental", "updated"), (
+        f"chunk-level path did not run: {result}"
+    )
+    assert result.chunks.deleted == 2
+    assert result.chunks.kept == len(old_nodes) - 2
     assert await _stored_text(user, data_id) == text_v2
 
     new_nodes = await _doc_chunk_nodes(data_id, text_v2)
@@ -226,9 +228,9 @@ async def test_incremental_update_full_flow(incremental_env):
         + "MULTI TAIL LINE\n"
     )
     result_multi = await update_like_an_api_request(data_id, text_multi, dataset.id, user=user)
-    assert result_multi["status"] == "incremental"
-    assert result_multi["regions"] == 3, f"expected three regions: {result_multi}"
-    assert result_multi["kept_chunks"] >= total_before - 6, (
+    assert (result_multi.mode, result_multi.status) == ("incremental", "updated")
+    assert result_multi.chunks.regions == 3, f"expected three regions: {result_multi}"
+    assert result_multi.chunks.kept >= total_before - 6, (
         f"disjoint edits must keep the untouched middle: {result_multi}"
     )
     assert await _stored_text(user, data_id) == text_multi
@@ -287,9 +289,7 @@ async def test_incremental_update_full_flow(incremental_env):
     # Retry with the same content: stored chunks no longer tile the stored
     # text (old + new region chunks coexist), so the full update takes over.
     retry = await update_like_an_api_request(data_id, text_v5, dataset.id, user=user)
-    assert not (isinstance(retry, dict) and retry.get("status") == "incremental"), (
-        "retry after crash must fall back to the full update"
-    )
+    assert retry.mode == "full_rebuild", "retry after crash must fall back to the full update"
     # The full update is pinned to the existing row too, so callers keep the
     # same handle even when incremental preconditions fail.
     healed_data = (await get_dataset_data(dataset.id))[0]
@@ -320,7 +320,7 @@ async def test_incremental_update_full_flow(incremental_env):
         f"{healed_data.name}.{healed_data.original_extension}",
     )
     result6 = await update_like_an_api_request(data_id, [upload], dataset.id, user=user)
-    assert isinstance(result6, dict) and result6.get("status") == "incremental", (
+    assert (result6.mode, result6.status) == ("incremental", "updated"), (
         f"single-UploadFile update must run chunk-level: {result6}"
     )
     healed_text = await _stored_text(user, data_id)

--- a/cognee/tests/e2e/incremental_update/test_legacy_chunk_id_compat.py
+++ b/cognee/tests/e2e/incremental_update/test_legacy_chunk_id_compat.py
@@ -191,7 +191,7 @@ async def _scenario():
     insert_at = sum(len(p) for p in paragraphs[:3])
     text_v2 = text_v1[:insert_at] + _para("x", "ENTX") + text_v1[insert_at:]
     result = await cognee.update(data_id, text_v2, dataset.id, user=user)
-    assert (result.mode, result.status) == ("incremental", "updated"), result
+    assert isinstance(result, dict) and result.get("status") == "incremental", result
 
     data_id = (await get_dataset_data(dataset.id))[0].id
     stored = await _read_processed_text((await get_data(user.id, data_id)).raw_data_location)

--- a/cognee/tests/e2e/incremental_update/test_legacy_chunk_id_compat.py
+++ b/cognee/tests/e2e/incremental_update/test_legacy_chunk_id_compat.py
@@ -191,7 +191,7 @@ async def _scenario():
     insert_at = sum(len(p) for p in paragraphs[:3])
     text_v2 = text_v1[:insert_at] + _para("x", "ENTX") + text_v1[insert_at:]
     result = await cognee.update(data_id, text_v2, dataset.id, user=user)
-    assert isinstance(result, dict) and result.get("status") == "incremental", result
+    assert (result.mode, result.status) == ("incremental", "updated"), result
 
     data_id = (await get_dataset_data(dataset.id))[0].id
     stored = await _read_processed_text((await get_data(user.id, data_id)).raw_data_location)

--- a/cognee/tests/e2e/incremental_update/test_staged_publish.py
+++ b/cognee/tests/e2e/incremental_update/test_staged_publish.py
@@ -206,7 +206,7 @@ async def _scenario():
     # ── 3. a genuine incremental edit over the healed baseline ────────────── #
     text_v3 = text_v2.replace("ENTC", "ENTC3", 1)
     result = await cognee.update(data_id, text_v3, dataset.id, user=user)
-    assert (result.mode, result.status) == ("incremental", "updated"), result
+    assert isinstance(result, dict) and result.get("status") == "incremental"
     assert await _stored_text(user, data_id, dataset.id) == text_v3
     runs = await _run_records(dataset.id)
     assert any(any("COMPLETED" in status for status in statuses) for statuses in runs.values()), (
@@ -216,9 +216,9 @@ async def _scenario():
 
     # Unchanged re-submission: zero new run records.
     unchanged = await cognee.update(data_id, text_v3, dataset.id, user=user)
-    assert (unchanged.mode, unchanged.status) == ("incremental", "unchanged"), unchanged
-    assert unchanged.pipeline_run_id is None, "a no-op records no run"
-    assert unchanged.chunks.kept == unchanged.chunks.total == result.chunks.total, (
+    assert unchanged["status"] == "unchanged", unchanged
+    assert unchanged["pipeline_run_id"] is None, "a no-op records no run"
+    assert unchanged["kept_chunks"] == unchanged["total_chunks"] == result["total_chunks"], (
         "unchanged content keeps every chunk"
     )
     assert len(await _run_records(dataset.id)) == baseline_count, (

--- a/cognee/tests/e2e/incremental_update/test_staged_publish.py
+++ b/cognee/tests/e2e/incremental_update/test_staged_publish.py
@@ -218,6 +218,9 @@ async def _scenario():
     unchanged = await cognee.update(data_id, text_v3, dataset.id, user=user)
     assert (unchanged.mode, unchanged.status) == ("incremental", "unchanged"), unchanged
     assert unchanged.pipeline_run_id is None, "a no-op records no run"
+    assert unchanged.chunks.kept == unchanged.chunks.total == result.chunks.total, (
+        "unchanged content keeps every chunk"
+    )
     assert len(await _run_records(dataset.id)) == baseline_count, (
         "an unchanged update must leave no run-record noise"
     )

--- a/cognee/tests/e2e/incremental_update/test_staged_publish.py
+++ b/cognee/tests/e2e/incremental_update/test_staged_publish.py
@@ -206,7 +206,7 @@ async def _scenario():
     # ── 3. a genuine incremental edit over the healed baseline ────────────── #
     text_v3 = text_v2.replace("ENTC", "ENTC3", 1)
     result = await cognee.update(data_id, text_v3, dataset.id, user=user)
-    assert isinstance(result, dict) and result.get("status") == "incremental"
+    assert (result.mode, result.status) == ("incremental", "updated"), result
     assert await _stored_text(user, data_id, dataset.id) == text_v3
     runs = await _run_records(dataset.id)
     assert any(any("COMPLETED" in status for status in statuses) for statuses in runs.values()), (
@@ -216,7 +216,8 @@ async def _scenario():
 
     # Unchanged re-submission: zero new run records.
     unchanged = await cognee.update(data_id, text_v3, dataset.id, user=user)
-    assert isinstance(unchanged, dict) and unchanged.get("status") == "unchanged"
+    assert (unchanged.mode, unchanged.status) == ("incremental", "unchanged"), unchanged
+    assert unchanged.pipeline_run_id is None, "a no-op records no run"
     assert len(await _run_records(dataset.id)) == baseline_count, (
         "an unchanged update must leave no run-record noise"
     )

--- a/cognee/tests/e2e/incremental_update/test_update_fallback_durability.py
+++ b/cognee/tests/e2e/incremental_update/test_update_fallback_durability.py
@@ -1,0 +1,154 @@
+"""The full rebuild never loses the document.
+
+The rebuild used to delete the row and re-add it pinned to the same id, so a
+re-add that failed left no document at all. Now the document's memory is
+dropped while the row and its stored files stay, and the pinned re-add
+refreshes the row in place. A re-add that fails leaves a document with no
+graph that the next cognify() rebuilds from its stored content.
+
+Default local stack in a scratch root, mocked LLM and embeddings.
+"""
+
+import re
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cognee.tests.e2e.incremental_update.backend_env import (
+    incremental_test_backend_env,
+    reset_backend_state,
+)
+
+MARKER = re.compile(r"ENT[A-Z0-9]+")
+
+
+@pytest.fixture(scope="module")
+def durability_env():
+    import os
+
+    root = Path(tempfile.mkdtemp(prefix="cognee_update_durability_"))
+    import cognee
+
+    os.environ.update(
+        **incremental_test_backend_env(),
+        CACHE_BACKEND="sqlite",
+        MOCK_EMBEDDING="true",
+        TELEMETRY_DISABLED="1",
+        DATA_ROOT_DIRECTORY=str(root / "data"),
+        SYSTEM_ROOT_DIRECTORY=str(root / "system"),
+        ENABLE_BACKEND_ACCESS_CONTROL=os.environ.get("INCR_TEST_ACL", "true"),
+    )
+    import importlib
+
+    for module_name, factory_name in [
+        ("cognee.base_config", "get_base_config"),
+        ("cognee.infrastructure.databases.relational.config", "get_relational_config"),
+        (
+            "cognee.infrastructure.databases.relational.get_relational_engine",
+            "get_relational_engine",
+        ),
+        ("cognee.infrastructure.databases.graph.config", "get_graph_config"),
+        ("cognee.infrastructure.databases.vector.config", "get_vectordb_config"),
+        ("cognee.infrastructure.databases.cache.config", "get_cache_config"),
+        ("cognee.infrastructure.databases.cache.get_cache_engine", "create_cache_engine"),
+        ("cognee.infrastructure.databases.vector.embeddings.config", "get_embedding_config"),
+        (
+            "cognee.infrastructure.databases.vector.embeddings.get_embedding_engine",
+            "create_embedding_engine",
+        ),
+        ("cognee.infrastructure.llm.config", "get_llm_config"),
+    ]:
+        try:
+            getattr(importlib.import_module(module_name), factory_name).cache_clear()
+        except (ImportError, AttributeError):
+            pass
+
+    from cognee.infrastructure.llm.LLMGateway import LLMGateway
+    from cognee.shared.data_models import KnowledgeGraph, Node, SummarizedContent
+
+    @staticmethod
+    async def _mock_acreate(text_input, system_prompt, response_model, **kwargs):
+        if isinstance(response_model, type) and issubclass(response_model, KnowledgeGraph):
+            names = sorted(set(MARKER.findall(str(text_input))))
+            return KnowledgeGraph(
+                nodes=[Node(id=n, name=n, type="Marker", description=f"marker {n}") for n in names],
+                edges=[],
+            )
+        if isinstance(response_model, type) and issubclass(response_model, SummarizedContent):
+            return SummarizedContent(summary="Mock summary.", description="")
+        return response_model() if isinstance(response_model, type) else "mock"
+
+    original = LLMGateway.acreate_structured_output
+    LLMGateway.acreate_structured_output = _mock_acreate
+    yield root
+    LLMGateway.acreate_structured_output = original
+    shutil.rmtree(root, ignore_errors=True)
+
+
+async def _entity_names(dataset_id, user_id):
+    from cognee.context_global_variables import set_database_global_context_variables
+    from cognee.infrastructure.databases.graph import get_graph_engine
+
+    async with set_database_global_context_variables(dataset_id, user_id):
+        nodes, _ = await (await get_graph_engine()).get_graph_data()
+    return {
+        str(props.get("name", "")).lower() for _, props in nodes if props.get("type") == "Entity"
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_failed_rebuild_keeps_the_document_and_the_next_cognify_restores_it(
+    durability_env, monkeypatch
+):
+    await reset_backend_state()
+    import sys
+
+    import cognee
+    import cognee.api.v1.update.update  # bind the real submodule
+
+    # The package re-exports the update() function under the module's name, so a
+    # dotted import yields the function; take the module for patching.
+    update_module = sys.modules["cognee.api.v1.update.update"]
+    from cognee.modules.data.methods import get_datasets
+    from cognee.modules.data.methods.get_dataset_data import get_dataset_data
+    from cognee.modules.users.methods import get_default_user
+
+    report = durability_env / "report.txt"
+    report.write_text("Report ENTALPHA, version one.\n")
+    await cognee.add(str(report), dataset_name="durable")
+    user = await get_default_user()
+    dataset = next(d for d in await get_datasets(user.id) if d.name == "durable")
+    await cognee.cognify(datasets=[dataset.id])
+    (row,) = await get_dataset_data(dataset.id)
+    assert "entalpha" in await _entity_names(dataset.id, user.id)
+
+    # The re-add blows up mid-rebuild.
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("simulated failure inside the re-add")
+
+    monkeypatch.setattr(update_module, "add", _boom)
+    report.write_text("Report ENTBETA, version two.\n")
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        await cognee.update(row.id, str(report), dataset.id, user=user, chunk_level_diff=False)
+    monkeypatch.undo()
+
+    # The document is still there under its id, with its stored content, and
+    # its memory is gone rather than half-replaced.
+    (survivor,) = await get_dataset_data(dataset.id)
+    assert survivor.id == row.id
+    assert survivor.content_hash == row.content_hash, "a failed rebuild leaves the old content"
+    assert not await _entity_names(dataset.id, user.id)
+
+    # cognify() rebuilds the old content from the row; nothing was lost.
+    await cognee.cognify(datasets=[dataset.id])
+    assert "entalpha" in await _entity_names(dataset.id, user.id)
+
+    # And the update itself works once the cause is gone: same id, new content.
+    result = await cognee.update(row.id, str(report), dataset.id, user=user, chunk_level_diff=False)
+    assert result["status"] == "full_rebuild" and result["data_id"] == row.id
+    (updated,) = await get_dataset_data(dataset.id)
+    assert updated.id == row.id and updated.content_hash != row.content_hash
+    names = await _entity_names(dataset.id, user.id)
+    assert "entbeta" in names and "entalpha" not in names

--- a/cognee/tests/test_dlt_update_e2e.py
+++ b/cognee/tests/test_dlt_update_e2e.py
@@ -16,7 +16,6 @@ import json
 import dlt
 
 import cognee
-from cognee.api.v1.update import UpdateResult
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.modules.data.methods import get_datasets
 from cognee.modules.data.methods.get_dataset_data import get_dataset_data
@@ -71,10 +70,10 @@ async def main():
     result = await cognee.update(
         manifest.id, dlt.resource(ROWS_V2, name="people", primary_key="id"), dataset.id, user=user
     )
-    assert isinstance(result, UpdateResult), result
-    assert (result.status, result.mode) == ("updated", "full_rebuild"), result
-    assert result.fallback.reason.value == "no_baseline", result.fallback
-    assert "dlt_source cognify route" in result.fallback.detail, result.fallback
+    assert result["status"] == "full_rebuild", result
+    assert result["fallback"]["reason"] == "no_baseline", result["fallback"]
+    assert "dlt_source cognify route" in result["fallback"]["detail"], result["fallback"]
+    assert result["data_id"] == manifest.id and result["regions"] is None, result
 
     rows = await get_dataset_data(dataset.id)
     assert len(rows) == 1 and rows[0].id == manifest.id, (

--- a/cognee/tests/test_dlt_update_e2e.py
+++ b/cognee/tests/test_dlt_update_e2e.py
@@ -1,0 +1,111 @@
+"""E2E: update() replaces a DLT source manifest through the full rebuild.
+
+A DLT manifest is built by the DLT cognify route, which writes row nodes and
+never a document chunk, so the chunk-level path refuses and update() falls
+back to delete + pinned re-add + cognify. The re-add carries the replacement
+resource wrapped in a DataItem pinned to the manifest's id; the resolver must
+unwrap it and the DLT route must re-emit the new rows under the same manifest.
+
+Runs on the default local stack; the DLT route makes no LLM calls, but the
+rows are embedded, so an embedding configuration (or MOCK_EMBEDDING) is needed.
+"""
+
+import asyncio
+import json
+
+import dlt
+
+import cognee
+from cognee.api.v1.update import UpdateResult
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.modules.data.methods import get_datasets
+from cognee.modules.data.methods.get_dataset_data import get_dataset_data
+from cognee.modules.users.methods import get_default_user
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
+DATASET_NAME = "dlt_update_e2e"
+ROWS_V1 = [{"id": 1, "name": "Ada Lovelace"}, {"id": 2, "name": "Alan Turing"}]
+ROWS_V2 = [
+    {"id": 1, "name": "Ada Lovelace"},
+    {"id": 2, "name": "Alan M. Turing"},
+    {"id": 3, "name": "Grace Hopper"},
+]
+
+
+def _system_metadata(row) -> dict:
+    metadata = getattr(row, "system_metadata", None)
+    if isinstance(metadata, str):
+        metadata = json.loads(metadata)
+    return metadata or {}
+
+
+async def _row_names(dataset_id, user):
+    from cognee.context_global_variables import set_database_global_context_variables
+
+    async with set_database_global_context_variables(dataset_id, user.id):
+        nodes, _ = await (await get_graph_engine()).get_graph_data()
+    return sorted(
+        str(props.get("name"))
+        for _, props in nodes
+        if props.get("type") == "DltRow" or str(props.get("table_name", "")) == "people"
+    )
+
+
+async def main():
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    await cognee.add(dlt.resource(ROWS_V1, name="people", primary_key="id"), DATASET_NAME)
+    user = await get_default_user()
+    dataset = next(d for d in await get_datasets(user.id) if d.name == DATASET_NAME)
+    await cognee.cognify(datasets=[dataset.id])
+
+    (manifest,) = await get_dataset_data(dataset.id)
+    assert _system_metadata(manifest).get("source") == "dlt_source", _system_metadata(manifest)
+    assert _system_metadata(manifest).get("row_count") == len(ROWS_V1)
+    names_v1 = await _row_names(dataset.id, user)
+    assert names_v1, "the DLT route emitted no row nodes"
+
+    result = await cognee.update(
+        manifest.id, dlt.resource(ROWS_V2, name="people", primary_key="id"), dataset.id, user=user
+    )
+    assert isinstance(result, UpdateResult), result
+    assert (result.status, result.mode) == ("updated", "full_rebuild"), result
+    assert result.fallback.reason.value == "no_baseline", result.fallback
+    assert "dlt_source cognify route" in result.fallback.detail, result.fallback
+
+    rows = await get_dataset_data(dataset.id)
+    assert len(rows) == 1 and rows[0].id == manifest.id, (
+        f"the manifest must survive the update under its id: {[r.id for r in rows]}"
+    )
+    assert _system_metadata(rows[0]).get("row_count") == len(ROWS_V2), _system_metadata(rows[0])
+
+    names_v2 = await _row_names(dataset.id, user)
+    assert names_v2 != names_v1, "the graph must reflect the replacement rows"
+
+    # A replacement under another source name is a different manifest: refused
+    # before the rebuild deletes anything, so the document survives.
+    from cognee.exceptions import CogneeValidationError
+
+    try:
+        await cognee.update(
+            manifest.id,
+            dlt.resource(ROWS_V2, name="staff", primary_key="id"),
+            dataset.id,
+            user=user,
+        )
+    except CogneeValidationError as error:
+        assert error.name == "DltSourceIdentityMismatch", error
+    else:
+        raise AssertionError("a renamed dlt source must be refused")
+    survivors = await get_dataset_data(dataset.id)
+    assert [row.id for row in survivors] == [manifest.id], (
+        "the refusal must not delete the manifest"
+    )
+    logger.info("DLT update e2e passed: %d -> %d rows", len(ROWS_V1), len(ROWS_V2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cognee/tests/test_dlt_update_e2e.py
+++ b/cognee/tests/test_dlt_update_e2e.py
@@ -2,7 +2,7 @@
 
 A DLT manifest is built by the DLT cognify route, which writes row nodes and
 never a document chunk, so the chunk-level path refuses and update() falls
-back to delete + pinned re-add + cognify. The re-add carries the replacement
+back to the full rebuild: memory dropped, pinned re-add, cognify. The re-add carries the replacement
 resource wrapped in a DataItem pinned to the manifest's id; the resolver must
 unwrap it and the DLT route must re-emit the new rows under the same manifest.
 

--- a/cognee/tests/test_incremental_update_stress.py
+++ b/cognee/tests/test_incremental_update_stress.py
@@ -452,9 +452,8 @@ async def _verify(
 
     # -- Update summary agrees with the observed id-diff -------------------- #
     if summary is not None:
-        assert summary.mode == "incremental", f"{label}: the chunk-level path did not run"
-        assert summary.status == ("unchanged" if not expect_run else "updated"), (
-            f"{label}: unexpected status {summary.status}"
+        assert summary["status"] == ("unchanged" if not expect_run else "incremental"), (
+            f"{label}: unexpected status {summary['status']}"
         )
         if expect_run:
             # The summary counts WORK (chunks extracted / chunks deleted); the
@@ -466,13 +465,13 @@ async def _verify(
             # wasted spend, not wrongness — correctness is pinned by the
             # structure/ownership/vector asserts. Here we pin only that the
             # graph never changes MORE than the summary accounts for.
-            assert len(added_ids) <= summary.chunks.added, (
+            assert len(added_ids) <= summary["added_chunks"], (
                 f"{label}: graph gained {len(added_ids)} chunks but the "
-                f"summary reports only {summary.chunks.added} added"
+                f"summary reports only {summary['added_chunks']} added"
             )
-            assert len(dead_ids) <= summary.chunks.deleted, (
+            assert len(dead_ids) <= summary["deleted_chunks"], (
                 f"{label}: graph lost {len(dead_ids)} chunks but the "
-                f"summary reports only {summary.chunks.deleted} deleted"
+                f"summary reports only {summary['deleted_chunks']} deleted"
             )
         else:
             assert all_chunk_ids == prev_chunk_ids, f"{label}: unchanged must not touch chunks"

--- a/cognee/tests/test_incremental_update_stress.py
+++ b/cognee/tests/test_incremental_update_stress.py
@@ -452,8 +452,9 @@ async def _verify(
 
     # -- Update summary agrees with the observed id-diff -------------------- #
     if summary is not None:
-        assert summary["status"] == ("unchanged" if not expect_run else "incremental"), (
-            f"{label}: unexpected status {summary['status']}"
+        assert summary.mode == "incremental", f"{label}: the chunk-level path did not run"
+        assert summary.status == ("unchanged" if not expect_run else "updated"), (
+            f"{label}: unexpected status {summary.status}"
         )
         if expect_run:
             # The summary counts WORK (chunks extracted / chunks deleted); the
@@ -465,13 +466,13 @@ async def _verify(
             # wasted spend, not wrongness — correctness is pinned by the
             # structure/ownership/vector asserts. Here we pin only that the
             # graph never changes MORE than the summary accounts for.
-            assert len(added_ids) <= summary["added_chunks"], (
+            assert len(added_ids) <= summary.chunks.added, (
                 f"{label}: graph gained {len(added_ids)} chunks but the "
-                f"summary reports only {summary['added_chunks']} added"
+                f"summary reports only {summary.chunks.added} added"
             )
-            assert len(dead_ids) <= summary["deleted_chunks"], (
+            assert len(dead_ids) <= summary.chunks.deleted, (
                 f"{label}: graph lost {len(dead_ids)} chunks but the "
-                f"summary reports only {summary['deleted_chunks']} deleted"
+                f"summary reports only {summary.chunks.deleted} deleted"
             )
         else:
             assert all_chunk_ids == prev_chunk_ids, f"{label}: unchanged must not touch chunks"

--- a/cognee/tests/unit/api/test_api_error_responses.py
+++ b/cognee/tests/unit/api/test_api_error_responses.py
@@ -470,20 +470,16 @@ class TestUpdateEndpoint:
         error from the same fields it would read counters from, and retries."""
         import cognee.api.v1.update as update_pkg
         from cognee.api.v1.update import UpdateResult
-        from cognee.api.v1.update.result import Fallback, UpdateError
 
         failed = UpdateResult(
+            status="failed",
             data_id=uuid4(),
             dataset_id=MOCK_DATASET_ID,
-            status="failed",
-            mode="full_rebuild",
             duration_seconds=2.5,
-            fallback=Fallback(
-                reason="no_baseline", detail="no stored processed text for this data item"
-            ),
             pipeline_run_id=MOCK_PIPELINE_RUN_ID,
-            error=UpdateError(error_class="RuntimeError", message="update failed"),
-        )
+            fallback={"reason": "no_baseline", "detail": "no stored processed text"},
+            error={"error_class": "RuntimeError", "message": "update failed"},
+        ).model_dump()
         update_pkg.update = AsyncMock(return_value=failed)
 
         resp = client.patch(
@@ -493,22 +489,20 @@ class TestUpdateEndpoint:
             data={"node_set": ""},
         )
         assert resp.status_code == 500
-        assert resp.json() == failed.model_dump(mode="json")
+        assert resp.json() == UpdateResult.model_validate(failed).model_dump(mode="json")
 
     def test_update_full_rebuild_returns_200(self, client):
         import cognee.api.v1.update as update_pkg
         from cognee.api.v1.update import UpdateResult
-        from cognee.api.v1.update.result import Fallback
 
         rebuilt = UpdateResult(
+            status="full_rebuild",
             data_id=uuid4(),
             dataset_id=MOCK_DATASET_ID,
-            status="updated",
-            mode="full_rebuild",
             duration_seconds=4.0,
-            fallback=Fallback(reason="disabled", detail="chunk_level_diff=False was requested"),
             pipeline_run_id=MOCK_PIPELINE_RUN_ID,
-        )
+            fallback={"reason": "disabled", "detail": "chunk_level_diff=False was requested"},
+        ).model_dump()
         update_pkg.update = AsyncMock(return_value=rebuilt)
 
         resp = client.patch(
@@ -518,31 +512,34 @@ class TestUpdateEndpoint:
             data={"node_set": ""},
         )
         assert resp.status_code == 200
-        assert resp.json() == rebuilt.model_dump(mode="json")
-        assert resp.json()["chunks"] is None
+        body = resp.json()
+        assert body == UpdateResult.model_validate(rebuilt).model_dump(mode="json")
+        assert body["kept_chunks"] is None and body["fallback"]["reason"] == "disabled"
 
-    @pytest.mark.parametrize("incremental_status", ["updated", "unchanged"])
+    @pytest.mark.parametrize("incremental_status", ["incremental", "unchanged"])
     def test_update_incremental_result_returns_200(self, client, incremental_status):
+        """The old summary keys travel unchanged, the new ones beside them."""
         import cognee.api.v1.update as update_pkg
-        from cognee.api.v1.update import ChunkChanges, UpdateResult
+        from cognee.api.v1.update import UpdateResult
 
-        changed = incremental_status == "updated"
+        changed = incremental_status == "incremental"
+        summary = {
+            "status": incremental_status,
+            "regions": int(changed),
+            "deleted_chunks": int(changed),
+            "added_chunks": int(changed),
+            "reused_chunks": 0,
+            "kept_chunks": 2,
+            "reindexed_chunks": 1,
+        }
         result = UpdateResult(
+            **summary,
+            total_chunks=2 + int(changed),
             data_id=uuid4(),
             dataset_id=MOCK_DATASET_ID,
-            status=incremental_status,
-            mode="incremental",
             duration_seconds=0.4,
-            chunks=ChunkChanges(
-                regions=int(changed),
-                deleted=int(changed),
-                added=int(changed),
-                kept=2,
-                reindexed=1,
-                total=2 + int(changed),
-            ),
             pipeline_run_id=MOCK_PIPELINE_RUN_ID if changed else None,
-        )
+        ).model_dump()
         update_pkg.update = AsyncMock(return_value=result)
 
         resp = client.patch(
@@ -553,7 +550,9 @@ class TestUpdateEndpoint:
         )
 
         assert resp.status_code == 200
-        assert resp.json() == result.model_dump(mode="json")
+        body = resp.json()
+        assert {key: body[key] for key in summary} == summary
+        assert body == UpdateResult.model_validate(result).model_dump(mode="json")
         assert update_pkg.update.await_args.kwargs["node_set"] is None
 
     def test_update_internal_error_returns_500(self, client):

--- a/cognee/tests/unit/api/test_api_error_responses.py
+++ b/cognee/tests/unit/api/test_api_error_responses.py
@@ -465,10 +465,24 @@ class TestUpdateEndpoint:
         assert resp.status_code == 422
         update.assert_not_awaited()
 
-    def test_update_pipeline_errored_returns_500(self, client):
+    def test_update_failed_result_returns_500_with_the_result_body(self, client):
+        """A failed rebuild keeps the one result shape: the client reads the
+        error from the same fields it would read counters from, and retries."""
         import cognee.api.v1.update as update_pkg
+        from cognee.api.v1.update import UpdateResult
 
-        update_pkg.update = AsyncMock(return_value={"run": _make_errored(error="update failed")})
+        failed = UpdateResult(
+            data_id=uuid4(),
+            dataset_id=MOCK_DATASET_ID,
+            status="failed",
+            mode="full_rebuild",
+            fallback_reason="no_baseline",
+            fallback_detail="no stored processed text for this data item",
+            pipeline_run_id=MOCK_PIPELINE_RUN_ID,
+            error_class="RuntimeError",
+            error_message="update failed",
+        )
+        update_pkg.update = AsyncMock(return_value=failed)
 
         resp = client.patch(
             "/update",
@@ -477,14 +491,22 @@ class TestUpdateEndpoint:
             data={"node_set": ""},
         )
         assert resp.status_code == 500
-        body = resp.json()
-        assert body["error"] == "Pipeline run errored"
+        assert resp.json() == failed.model_dump(mode="json")
 
-    def test_update_success_returns_200(self, client):
+    def test_update_full_rebuild_returns_200(self, client):
         import cognee.api.v1.update as update_pkg
+        from cognee.api.v1.update import UpdateResult
 
-        completed = _make_completed()
-        update_pkg.update = AsyncMock(return_value={str(MOCK_DATASET_ID): completed})
+        rebuilt = UpdateResult(
+            data_id=uuid4(),
+            dataset_id=MOCK_DATASET_ID,
+            status="updated",
+            mode="full_rebuild",
+            fallback_reason="disabled",
+            fallback_detail="chunk_level_diff=False was requested",
+            pipeline_run_id=MOCK_PIPELINE_RUN_ID,
+        )
+        update_pkg.update = AsyncMock(return_value=rebuilt)
 
         resp = client.patch(
             "/update",
@@ -493,21 +515,26 @@ class TestUpdateEndpoint:
             data={"node_set": ""},
         )
         assert resp.status_code == 200
+        assert resp.json() == rebuilt.model_dump(mode="json")
+        assert resp.json()["chunks"] is None
 
-    @pytest.mark.parametrize("incremental_status", ["incremental", "unchanged"])
-    def test_update_incremental_summary_returns_200(self, client, incremental_status):
+    @pytest.mark.parametrize("incremental_status", ["updated", "unchanged"])
+    def test_update_incremental_result_returns_200(self, client, incremental_status):
         import cognee.api.v1.update as update_pkg
+        from cognee.api.v1.update import ChunkChanges, UpdateResult
 
-        summary = {
-            "status": incremental_status,
-            "regions": 1 if incremental_status == "incremental" else 0,
-            "deleted_chunks": 1 if incremental_status == "incremental" else 0,
-            "added_chunks": 1 if incremental_status == "incremental" else 0,
-            "reused_chunks": 0,
-            "kept_chunks": 2,
-            "reindexed_chunks": 1,
-        }
-        update_pkg.update = AsyncMock(return_value=summary)
+        changed = incremental_status == "updated"
+        result = UpdateResult(
+            data_id=uuid4(),
+            dataset_id=MOCK_DATASET_ID,
+            status=incremental_status,
+            mode="incremental",
+            chunks=ChunkChanges(
+                regions=int(changed), deleted=int(changed), added=int(changed), kept=2, reindexed=1
+            ),
+            pipeline_run_id=MOCK_PIPELINE_RUN_ID if changed else None,
+        )
+        update_pkg.update = AsyncMock(return_value=result)
 
         resp = client.patch(
             "/update",
@@ -517,7 +544,7 @@ class TestUpdateEndpoint:
         )
 
         assert resp.status_code == 200
-        assert resp.json() == summary
+        assert resp.json() == result.model_dump(mode="json")
         assert update_pkg.update.await_args.kwargs["node_set"] is None
 
     def test_update_internal_error_returns_500(self, client):

--- a/cognee/tests/unit/api/test_api_error_responses.py
+++ b/cognee/tests/unit/api/test_api_error_responses.py
@@ -470,17 +470,19 @@ class TestUpdateEndpoint:
         error from the same fields it would read counters from, and retries."""
         import cognee.api.v1.update as update_pkg
         from cognee.api.v1.update import UpdateResult
+        from cognee.api.v1.update.result import Fallback, UpdateError
 
         failed = UpdateResult(
             data_id=uuid4(),
             dataset_id=MOCK_DATASET_ID,
             status="failed",
             mode="full_rebuild",
-            fallback_reason="no_baseline",
-            fallback_detail="no stored processed text for this data item",
+            duration_seconds=2.5,
+            fallback=Fallback(
+                reason="no_baseline", detail="no stored processed text for this data item"
+            ),
             pipeline_run_id=MOCK_PIPELINE_RUN_ID,
-            error_class="RuntimeError",
-            error_message="update failed",
+            error=UpdateError(error_class="RuntimeError", message="update failed"),
         )
         update_pkg.update = AsyncMock(return_value=failed)
 
@@ -496,14 +498,15 @@ class TestUpdateEndpoint:
     def test_update_full_rebuild_returns_200(self, client):
         import cognee.api.v1.update as update_pkg
         from cognee.api.v1.update import UpdateResult
+        from cognee.api.v1.update.result import Fallback
 
         rebuilt = UpdateResult(
             data_id=uuid4(),
             dataset_id=MOCK_DATASET_ID,
             status="updated",
             mode="full_rebuild",
-            fallback_reason="disabled",
-            fallback_detail="chunk_level_diff=False was requested",
+            duration_seconds=4.0,
+            fallback=Fallback(reason="disabled", detail="chunk_level_diff=False was requested"),
             pipeline_run_id=MOCK_PIPELINE_RUN_ID,
         )
         update_pkg.update = AsyncMock(return_value=rebuilt)
@@ -529,8 +532,14 @@ class TestUpdateEndpoint:
             dataset_id=MOCK_DATASET_ID,
             status=incremental_status,
             mode="incremental",
+            duration_seconds=0.4,
             chunks=ChunkChanges(
-                regions=int(changed), deleted=int(changed), added=int(changed), kept=2, reindexed=1
+                regions=int(changed),
+                deleted=int(changed),
+                added=int(changed),
+                kept=2,
+                reindexed=1,
+                total=2 + int(changed),
             ),
             pipeline_run_id=MOCK_PIPELINE_RUN_ID if changed else None,
         )

--- a/cognee/tests/unit/api/test_api_error_responses.py
+++ b/cognee/tests/unit/api/test_api_error_responses.py
@@ -445,6 +445,33 @@ class TestMemifyEndpoint:
         assert resp.json()["error"] == "Internal server error"
 
 
+class TestAddExistingDocument:
+    def test_add_of_a_changed_existing_file_returns_409_with_the_update_endpoint(self, client):
+        import cognee.api.v1.add as add_pkg
+        from cognee.api.v1.exceptions import DocumentUpdateRequiredError
+
+        data_id = uuid4()
+        add_pkg.add = AsyncMock(
+            side_effect=DocumentUpdateRequiredError(
+                [{"name": "report.txt", "data_id": data_id}], MOCK_DATASET_ID
+            )
+        )
+
+        resp = client.post(
+            "/add",
+            files={"data": ("report.txt", b"version two", "text/plain")},
+            data={"datasetName": "test_dataset"},
+        )
+
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["error"] == "Document already exists; use the update endpoint"
+        assert (
+            f"PATCH /api/v1/update?data_id={data_id}&dataset_id={MOCK_DATASET_ID}" in body["detail"]
+        )
+        assert "report.txt" in body["detail"]
+
+
 # ---------------------------------------------------------------------------
 # Update endpoint
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/api/test_incremental_refusals.py
+++ b/cognee/tests/unit/api/test_incremental_refusals.py
@@ -54,50 +54,43 @@ def test_refusal_defaults_to_no_baseline():
     assert IncrementalUpdateNotPossible("nope").reason is RefusalReason.NO_BASELINE
 
 
+def _stored_row(**overrides):
+    row = SimpleNamespace(
+        name="old.txt",
+        extension="txt",
+        mime_type="text/plain",
+        original_extension="txt",
+        original_mime_type="text/plain",
+        loader_engine="text_loader",
+    )
+    for key, value in overrides.items():
+        setattr(row, key, value)
+    return row
+
+
+def test_a_replacement_under_another_name_is_not_a_metadata_change():
+    """data_id names the document; the file it is updated with may carry any
+    name. The publish step writes the new name onto the row."""
+    old = _stored_row()
+    staged = _stored_row(name="new.txt")
+
+    assert _changed_staged_metadata(old, staged) == []
+
+
 def test_direct_text_ignores_its_content_derived_internal_name():
-    old = SimpleNamespace(
-        name="text_old.txt",
-        extension="txt",
-        mime_type="text/plain",
-        original_extension="txt",
-        original_mime_type="text/plain",
-        loader_engine="text_loader",
-    )
-    staged = SimpleNamespace(**vars(old))
-    staged.name = "text_new.txt"
+    old = _stored_row(name="text_old.txt")
+    staged = _stored_row(name="text_new.txt")
 
-    assert _changed_staged_metadata("new text", old, staged) == []
+    assert _changed_staged_metadata(old, staged) == []
 
 
-def test_user_named_upload_requires_full_update_when_renamed():
-    old = SimpleNamespace(
-        name="old.txt",
-        extension="txt",
-        mime_type="text/plain",
-        original_extension="txt",
-        original_mime_type="text/plain",
-        loader_engine="text_loader",
-    )
-    staged = SimpleNamespace(**vars(old))
-    staged.name = "new.txt"
+def test_a_content_type_change_requires_the_full_update():
+    """A .txt replaced by a .md picks another document class and chunker, so the
+    stored chunks are no baseline for it."""
+    old = _stored_row()
+    staged = _stored_row(name="old.md", extension="md", original_extension="md")
 
-    assert _changed_staged_metadata(SimpleNamespace(filename="new.txt"), old, staged) == ["name"]
-
-
-def test_wrapped_user_named_upload_requires_full_update_when_renamed():
-    old = SimpleNamespace(
-        name="old.txt",
-        extension="txt",
-        mime_type="text/plain",
-        original_extension="txt",
-        original_mime_type="text/plain",
-        loader_engine="text_loader",
-    )
-    staged = SimpleNamespace(**vars(old))
-    staged.name = "new.txt"
-
-    wrapped_upload = DataItem(data=SimpleNamespace(filename="new.txt"))
-    assert _changed_staged_metadata(wrapped_upload, old, staged) == ["name"]
+    assert _changed_staged_metadata(old, staged) == ["extension", "original_extension"]
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/api/test_incremental_refusals.py
+++ b/cognee/tests/unit/api/test_incremental_refusals.py
@@ -265,7 +265,16 @@ async def test_unmarked_graph_refuses_before_incremental_work(monkeypatch):
     monkeypatch.setattr(
         incremental,
         "get_data",
-        AsyncMock(return_value=SimpleNamespace(id=data_id, raw_data_location="old.txt")),
+        AsyncMock(
+            return_value=SimpleNamespace(
+                id=data_id,
+                raw_data_location="old.txt",
+                system_metadata=None,
+                extension="txt",
+                mime_type="text/plain",
+                name="doc",
+            )
+        ),
     )
     monkeypatch.setattr(incremental, "dataset_lock", lambda _dataset_id: _Context())
     monkeypatch.setattr(
@@ -513,7 +522,15 @@ async def test_a_dataset_collaborator_may_update_a_row_they_do_not_own(monkeypat
     )
     # The row belongs to the dataset owner, not the caller.
     get_data = AsyncMock(
-        return_value=SimpleNamespace(id=data_id, owner_id=owner_id, raw_data_location="old.txt")
+        return_value=SimpleNamespace(
+            id=data_id,
+            owner_id=owner_id,
+            raw_data_location="old.txt",
+            system_metadata=None,
+            extension="txt",
+            mime_type="text/plain",
+            name="doc",
+        )
     )
     monkeypatch.setattr(incremental, "get_data", get_data)
     monkeypatch.setattr(incremental, "dataset_lock", lambda _dataset_id: _Context())
@@ -666,3 +683,61 @@ async def test_undecodable_stored_text_is_a_refusal_not_a_crash(tmp_path):
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("system_metadata", "route"),
+    [({"source": "code"}, "code"), ({"source": "dlt_source"}, "dlt_source")],
+)
+async def test_chunkless_routes_refuse_before_reading_the_graph(
+    monkeypatch, system_metadata, route
+):
+    """Code files and DLT manifests are built by routes that keep no chunks.
+    The refusal must name the route, not report the document as uncognified,
+    and must come before the stored chunks are read."""
+    from cognee.api.v1.update import incremental
+
+    data_id, dataset_id = uuid4(), uuid4()
+
+    async def _authorize(_user, _dataset_id, _permission):
+        return SimpleNamespace(id=dataset_id, owner_id=uuid4())
+
+    monkeypatch.setattr(incremental, "get_authorized_dataset", _authorize)
+    monkeypatch.setattr(
+        incremental, "get_dataset_data", AsyncMock(return_value=[SimpleNamespace(id=data_id)])
+    )
+    monkeypatch.setattr(
+        incremental,
+        "get_data",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                id=data_id,
+                raw_data_location="old.txt",
+                system_metadata=system_metadata,
+                extension="py" if route == "code" else "json",
+                mime_type="text/plain",
+                name="doc",
+            )
+        ),
+    )
+
+    class _Adapter:
+        supports_incremental_chunk_updates = True
+
+    monkeypatch.setattr(incremental, "get_graph_engine", AsyncMock(return_value=_Adapter()))
+    stored_chunks = AsyncMock()
+    monkeypatch.setattr(incremental, "_get_stored_chunks", stored_chunks)
+    run_incremental = AsyncMock()
+    monkeypatch.setattr(incremental, "_run_incremental_update", run_incremental)
+
+    with pytest.raises(IncrementalUpdateNotPossible) as raised:
+        await incremental_update(
+            data_id, "replacement", dataset_id, user=SimpleNamespace(id=uuid4())
+        )
+
+    assert raised.value.reason is RefusalReason.NO_BASELINE
+    assert f"{route} cognify route" in str(raised.value)
+    assert "rebuilt" in str(raised.value)
+    stored_chunks.assert_not_awaited()
+    run_incremental.assert_not_awaited()

--- a/cognee/tests/unit/api/test_update_config_routing.py
+++ b/cognee/tests/unit/api/test_update_config_routing.py
@@ -17,11 +17,38 @@ from uuid import uuid4
 import pytest
 
 import cognee.api.v1.update.update  # bind the real submodule
+from cognee.api.v1.update.incremental import RefusalReason
+from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunCompleted
 
 update_module = sys.modules["cognee.api.v1.update.update"]
 data_methods_module = sys.modules["cognee.modules.data.methods"]
 
 pytestmark = pytest.mark.asyncio
+
+FULL_RUN_ID = uuid4()
+
+
+def _full_result(dataset_id):
+    """What cognify() hands back for the rebuild: one completed run per dataset."""
+    return {
+        dataset_id: PipelineRunCompleted(
+            pipeline_run_id=FULL_RUN_ID, dataset_id=dataset_id, dataset_name="ds"
+        )
+    }
+
+
+def _engine_summary(status="incremental"):
+    """The chunk-level engine's raw summary, as incremental_update() returns it."""
+    return {
+        "status": status,
+        "regions": 1,
+        "deleted_chunks": 1,
+        "added_chunks": 2,
+        "reused_chunks": 0,
+        "kept_chunks": 5,
+        "reindexed_chunks": 0,
+        "pipeline_run_id": uuid4(),
+    }
 
 
 def _relational_engine_stub(row):
@@ -56,7 +83,7 @@ def _patches(data_id, incremental, full_result, row=None):
 async def test_custom_configs_skip_the_incremental_path():
     data_id, dataset_id = uuid4(), uuid4()
     incremental = AsyncMock()
-    full_result = {"run": "full"}
+    full_result = _full_result(dataset_id)
 
     for config_kwargs in (
         {"vector_db_config": {"vector_db_provider": "custom"}},
@@ -77,13 +104,16 @@ async def test_custom_configs_skip_the_incremental_path():
                 **config_kwargs,
             )
         incremental.assert_not_called()
-        assert result == full_result, "custom-config updates must return the full-flow result"
+        assert result.mode == "full_rebuild", "custom-config updates must run the full flow"
+        assert result.status == "updated"
+        assert result.fallback_reason is RefusalReason.PER_CALL_DB_CONFIG
+        assert result.pipeline_run_id == FULL_RUN_ID
 
 
 async def test_node_set_change_skips_the_incremental_path():
     data_id, dataset_id = uuid4(), uuid4()
     incremental = AsyncMock()
-    full_result = {"run": "full"}
+    full_result = _full_result(dataset_id)
 
     p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, full_result)
     with p1, p2, p3, p4, p5, p6:
@@ -96,7 +126,8 @@ async def test_node_set_change_skips_the_incremental_path():
         )
 
     incremental.assert_not_called()
-    assert result == full_result
+    assert result.mode == "full_rebuild"
+    assert result.fallback_reason is RefusalReason.UNSUPPORTED_METADATA
 
 
 @pytest.mark.parametrize(
@@ -109,7 +140,7 @@ async def test_node_set_change_skips_the_incremental_path():
 async def test_custom_extraction_config_skips_the_incremental_path(config_kwargs):
     data_id, dataset_id = uuid4(), uuid4()
     incremental = AsyncMock()
-    full_result = {"run": "full"}
+    full_result = _full_result(dataset_id)
 
     p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, full_result)
     with p1, p2, p3, p4, p5, p6:
@@ -122,7 +153,8 @@ async def test_custom_extraction_config_skips_the_incremental_path(config_kwargs
         )
 
     incremental.assert_not_called()
-    assert result == full_result
+    assert result.mode == "full_rebuild"
+    assert result.fallback_reason is RefusalReason.CUSTOM_EXTRACTION_CONFIG
 
 
 async def test_multi_item_input_is_rejected_not_multiplied():
@@ -139,7 +171,7 @@ async def test_multi_item_input_is_rejected_not_multiplied():
     data_id, dataset_id = uuid4(), uuid4()
     incremental = AsyncMock()
 
-    p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, {"run": "full"})
+    p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, _full_result(dataset_id))
     with p1, p2, p3, p4, p5, p6, pytest.raises(IngestionError):
         await update_module.update(
             data_id=data_id,
@@ -154,9 +186,9 @@ async def test_multi_item_input_is_rejected_not_multiplied():
 async def test_single_item_list_is_unwrapped():
     """The permissive shape the HTTP router sends is accepted, not refused."""
     data_id, dataset_id = uuid4(), uuid4()
-    incremental = AsyncMock(return_value={"status": "incremental"})
+    incremental = AsyncMock(return_value=_engine_summary())
 
-    p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, {"run": "full"})
+    p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, _full_result(dataset_id))
     with p1, p2, p3, p4, p5, p6:
         await update_module.update(
             data_id=data_id,
@@ -180,7 +212,7 @@ async def test_the_full_fallback_keeps_the_original_row_owner():
     row = SimpleNamespace(id=data_id, legacy_id=None, owner_id=original_owner)
     collaborator = SimpleNamespace(id=uuid4())
 
-    p1, p2, p3, p4, p5, p6 = _patches(data_id, AsyncMock(), {"run": "full"}, row=row)
+    p1, p2, p3, p4, p5, p6 = _patches(data_id, AsyncMock(), _full_result(dataset_id), row=row)
     with p1, p2, p3, p4, p5, p6:
         await update_module.update(
             data_id=data_id,
@@ -195,9 +227,10 @@ async def test_the_full_fallback_keeps_the_original_row_owner():
 
 async def test_no_configs_take_the_incremental_path():
     data_id, dataset_id = uuid4(), uuid4()
-    incremental = AsyncMock(return_value={"status": "incremental"})
+    summary = _engine_summary()
+    incremental = AsyncMock(return_value=summary)
 
-    p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, {"run": "full"})
+    p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, _full_result(dataset_id))
     with p1, p2, p3, p4, p5, p6:
         result = await update_module.update(
             data_id=data_id,
@@ -206,4 +239,8 @@ async def test_no_configs_take_the_incremental_path():
             user=SimpleNamespace(id=uuid4()),
         )
     incremental.assert_awaited_once()
-    assert result == {"status": "incremental"}
+    assert (result.mode, result.status) == ("incremental", "updated")
+    assert result.fallback_reason is None
+    assert (result.chunks.regions, result.chunks.deleted, result.chunks.added) == (1, 1, 2)
+    assert (result.chunks.kept, result.chunks.reindexed) == (5, 0)
+    assert result.pipeline_run_id == summary["pipeline_run_id"]

--- a/cognee/tests/unit/api/test_update_config_routing.py
+++ b/cognee/tests/unit/api/test_update_config_routing.py
@@ -47,6 +47,7 @@ def _engine_summary(status="incremental"):
         "reused_chunks": 0,
         "kept_chunks": 5,
         "reindexed_chunks": 0,
+        "total_chunks": 7,
         "pipeline_run_id": uuid4(),
     }
 
@@ -106,7 +107,7 @@ async def test_custom_configs_skip_the_incremental_path():
         incremental.assert_not_called()
         assert result.mode == "full_rebuild", "custom-config updates must run the full flow"
         assert result.status == "updated"
-        assert result.fallback_reason is RefusalReason.PER_CALL_DB_CONFIG
+        assert result.fallback.reason is RefusalReason.PER_CALL_DB_CONFIG
         assert result.pipeline_run_id == FULL_RUN_ID
 
 
@@ -127,7 +128,7 @@ async def test_node_set_change_skips_the_incremental_path():
 
     incremental.assert_not_called()
     assert result.mode == "full_rebuild"
-    assert result.fallback_reason is RefusalReason.UNSUPPORTED_METADATA
+    assert result.fallback.reason is RefusalReason.UNSUPPORTED_METADATA
 
 
 @pytest.mark.parametrize(
@@ -154,7 +155,7 @@ async def test_custom_extraction_config_skips_the_incremental_path(config_kwargs
 
     incremental.assert_not_called()
     assert result.mode == "full_rebuild"
-    assert result.fallback_reason is RefusalReason.CUSTOM_EXTRACTION_CONFIG
+    assert result.fallback.reason is RefusalReason.CUSTOM_EXTRACTION_CONFIG
 
 
 async def test_multi_item_input_is_rejected_not_multiplied():
@@ -240,7 +241,7 @@ async def test_no_configs_take_the_incremental_path():
         )
     incremental.assert_awaited_once()
     assert (result.mode, result.status) == ("incremental", "updated")
-    assert result.fallback_reason is None
+    assert result.fallback is None
     assert (result.chunks.regions, result.chunks.deleted, result.chunks.added) == (1, 1, 2)
-    assert (result.chunks.kept, result.chunks.reindexed) == (5, 0)
+    assert (result.chunks.kept, result.chunks.reindexed, result.chunks.total) == (5, 0, 7)
     assert result.pipeline_run_id == summary["pipeline_run_id"]

--- a/cognee/tests/unit/api/test_update_config_routing.py
+++ b/cognee/tests/unit/api/test_update_config_routing.py
@@ -75,9 +75,11 @@ def _patches(data_id, incremental, full_result, row=None):
             MagicMock(return_value=_relational_engine_stub(row)),
         ),
         patch.object(update_module, "incremental_update", incremental),
-        patch.object(update_module, "datasets", SimpleNamespace(delete_data=AsyncMock())),
+        patch.object(update_module, "forget", AsyncMock()),
+        patch.object(data_methods_module, "reset_data_pipeline_status", AsyncMock()),
         patch.object(update_module, "add", AsyncMock()),
         patch.object(update_module, "cognify", AsyncMock(return_value=full_result)),
+        patch.object(update_module, "recorded_chunk_budget", AsyncMock(return_value=None)),
     )
 
 
@@ -95,8 +97,8 @@ async def test_custom_configs_skip_the_incremental_path():
         },
     ):
         incremental.reset_mock()
-        p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, full_result)
-        with p1, p2, p3, p4, p5, p6:
+        p1, p2, p3, p4, p5, p6, p7, p8 = _patches(data_id, incremental, full_result)
+        with p1, p2, p3, p4, p5, p6, p7, p8:
             result = await update_module.update(
                 data_id=data_id,
                 data="new content",
@@ -115,8 +117,8 @@ async def test_node_set_change_skips_the_incremental_path():
     incremental = AsyncMock()
     full_result = _full_result(dataset_id)
 
-    p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, full_result)
-    with p1, p2, p3, p4, p5, p6:
+    p1, p2, p3, p4, p5, p6, p7, p8 = _patches(data_id, incremental, full_result)
+    with p1, p2, p3, p4, p5, p6, p7, p8:
         result = await update_module.update(
             data_id=data_id,
             data="new content",
@@ -142,8 +144,8 @@ async def test_custom_extraction_config_skips_the_incremental_path(config_kwargs
     incremental = AsyncMock()
     full_result = _full_result(dataset_id)
 
-    p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, full_result)
-    with p1, p2, p3, p4, p5, p6:
+    p1, p2, p3, p4, p5, p6, p7, p8 = _patches(data_id, incremental, full_result)
+    with p1, p2, p3, p4, p5, p6, p7, p8:
         result = await update_module.update(
             data_id=data_id,
             data="new content",
@@ -171,8 +173,8 @@ async def test_multi_item_input_is_rejected_not_multiplied():
     data_id, dataset_id = uuid4(), uuid4()
     incremental = AsyncMock()
 
-    p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, _full_result(dataset_id))
-    with p1, p2, p3, p4, p5, p6, pytest.raises(IngestionError):
+    p1, p2, p3, p4, p5, p6, p7, p8 = _patches(data_id, incremental, _full_result(dataset_id))
+    with p1, p2, p3, p4, p5, p6, p7, p8, pytest.raises(IngestionError):
         await update_module.update(
             data_id=data_id,
             data=["first document", "second document"],
@@ -188,8 +190,8 @@ async def test_single_item_list_is_unwrapped():
     data_id, dataset_id = uuid4(), uuid4()
     incremental = AsyncMock(return_value=_engine_summary())
 
-    p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, _full_result(dataset_id))
-    with p1, p2, p3, p4, p5, p6:
+    p1, p2, p3, p4, p5, p6, p7, p8 = _patches(data_id, incremental, _full_result(dataset_id))
+    with p1, p2, p3, p4, p5, p6, p7, p8:
         await update_module.update(
             data_id=data_id,
             data=["only document"],
@@ -203,17 +205,19 @@ async def test_single_item_list_is_unwrapped():
 async def test_the_full_fallback_keeps_the_original_row_owner():
     """Re-ingestion must not hand the document to whoever updated it.
 
-    The fallback deletes the row and calls add(), which mints a fresh Data
-    with owner_id=user.id. A collaborator authorized by the dataset ACL would
-    otherwise take ownership of a document they merely edited — a permission
-    change nobody asked for, and one the incremental branch never makes.
+    The rebuild never deletes the row: it drops the document's memory and
+    refreshes the same row with a pinned add(), so a collaborator authorized
+    by the dataset ACL keeps editing a document that stays owned by whoever
+    ingested it — the incremental branch and the rebuild agree on this.
     """
     data_id, dataset_id, original_owner = uuid4(), uuid4(), uuid4()
     row = SimpleNamespace(id=data_id, legacy_id=None, owner_id=original_owner)
     collaborator = SimpleNamespace(id=uuid4())
 
-    p1, p2, p3, p4, p5, p6 = _patches(data_id, AsyncMock(), _full_result(dataset_id), row=row)
-    with p1, p2, p3, p4, p5, p6:
+    p1, p2, p3, p4, p5, p6, p7, p8 = _patches(
+        data_id, AsyncMock(), _full_result(dataset_id), row=row
+    )
+    with p1, p2, p3, p4, p5, p6, p7, p8:
         await update_module.update(
             data_id=data_id,
             data="new content",
@@ -230,8 +234,8 @@ async def test_no_configs_take_the_incremental_path():
     summary = _engine_summary()
     incremental = AsyncMock(return_value=summary)
 
-    p1, p2, p3, p4, p5, p6 = _patches(data_id, incremental, _full_result(dataset_id))
-    with p1, p2, p3, p4, p5, p6:
+    p1, p2, p3, p4, p5, p6, p7, p8 = _patches(data_id, incremental, _full_result(dataset_id))
+    with p1, p2, p3, p4, p5, p6, p7, p8:
         result = await update_module.update(
             data_id=data_id,
             data="new content",

--- a/cognee/tests/unit/api/test_update_config_routing.py
+++ b/cognee/tests/unit/api/test_update_config_routing.py
@@ -105,10 +105,9 @@ async def test_custom_configs_skip_the_incremental_path():
                 **config_kwargs,
             )
         incremental.assert_not_called()
-        assert result.mode == "full_rebuild", "custom-config updates must run the full flow"
-        assert result.status == "updated"
-        assert result.fallback.reason is RefusalReason.PER_CALL_DB_CONFIG
-        assert result.pipeline_run_id == FULL_RUN_ID
+        assert result["status"] == "full_rebuild", "custom-config updates must run the full flow"
+        assert result["fallback"]["reason"] is RefusalReason.PER_CALL_DB_CONFIG
+        assert result["pipeline_run_id"] == FULL_RUN_ID
 
 
 async def test_node_set_change_skips_the_incremental_path():
@@ -127,8 +126,8 @@ async def test_node_set_change_skips_the_incremental_path():
         )
 
     incremental.assert_not_called()
-    assert result.mode == "full_rebuild"
-    assert result.fallback.reason is RefusalReason.UNSUPPORTED_METADATA
+    assert result["status"] == "full_rebuild"
+    assert result["fallback"]["reason"] is RefusalReason.UNSUPPORTED_METADATA
 
 
 @pytest.mark.parametrize(
@@ -154,8 +153,8 @@ async def test_custom_extraction_config_skips_the_incremental_path(config_kwargs
         )
 
     incremental.assert_not_called()
-    assert result.mode == "full_rebuild"
-    assert result.fallback.reason is RefusalReason.CUSTOM_EXTRACTION_CONFIG
+    assert result["status"] == "full_rebuild"
+    assert result["fallback"]["reason"] is RefusalReason.CUSTOM_EXTRACTION_CONFIG
 
 
 async def test_multi_item_input_is_rejected_not_multiplied():
@@ -240,8 +239,8 @@ async def test_no_configs_take_the_incremental_path():
             user=SimpleNamespace(id=uuid4()),
         )
     incremental.assert_awaited_once()
-    assert (result.mode, result.status) == ("incremental", "updated")
-    assert result.fallback is None
-    assert (result.chunks.regions, result.chunks.deleted, result.chunks.added) == (1, 1, 2)
-    assert (result.chunks.kept, result.chunks.reindexed, result.chunks.total) == (5, 0, 7)
-    assert result.pipeline_run_id == summary["pipeline_run_id"]
+    assert result["status"] == "incremental"
+    assert result["fallback"] is None
+    assert (result["regions"], result["deleted_chunks"], result["added_chunks"]) == (1, 1, 2)
+    assert (result["kept_chunks"], result["reindexed_chunks"], result["total_chunks"]) == (5, 0, 7)
+    assert result["pipeline_run_id"] == summary["pipeline_run_id"]

--- a/cognee/tests/unit/api/v1/test_update_remote_routing.py
+++ b/cognee/tests/unit/api/v1/test_update_remote_routing.py
@@ -6,6 +6,7 @@ the remote dataset id, failing with "Dataset not found" while the remote
 document stayed untouched."""
 
 import importlib
+import json
 from contextlib import asynccontextmanager
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -14,6 +15,7 @@ import pytest
 
 from cognee.api.v1.serve import state as state_mod
 from cognee.api.v1.serve.cloud_client import CloudClient
+from cognee.api.v1.update import UpdateResult
 
 # ``cognee.api.v1.update`` re-exports the update() *function* under the same
 # name as its module, so a plain ``from ... import update`` yields the
@@ -96,10 +98,28 @@ async def test_update_remote_is_silent_when_only_routable_parameters_are_given(
 # ----- CloudClient.update wire format -----
 
 
+def _result_payload(**overrides):
+    """A PATCH /update body as the server sends it."""
+    payload = {
+        "data_id": str(uuid4()),
+        "dataset_id": str(uuid4()),
+        "status": "updated",
+        "mode": "incremental",
+        "chunks": {"regions": 1, "deleted": 1, "added": 1, "reused": 0, "kept": 3, "reindexed": 0},
+        "fallback_reason": None,
+        "fallback_detail": None,
+        "pipeline_run_id": str(uuid4()),
+        "error_class": None,
+        "error_message": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
 class _FakeResponse:
     def __init__(self, status=200, payload=None, text=""):
         self.status = status
-        self._payload = payload or {}
+        self._payload = payload if payload is not None else _result_payload()
         self._text = text
 
     async def json(self):
@@ -134,7 +154,8 @@ def _field_names(form):
 
 @pytest.mark.asyncio
 async def test_cloud_client_update_matches_the_route_contract(monkeypatch):
-    client, captured = _client_with_fake_patch(monkeypatch, _FakeResponse(payload={"ok": 1}))
+    payload = _result_payload()
+    client, captured = _client_with_fake_patch(monkeypatch, _FakeResponse(payload=payload))
     data_id, dataset_id = uuid4(), uuid4()
 
     result = await client.update(
@@ -145,7 +166,8 @@ async def test_cloud_client_update_matches_the_route_contract(monkeypatch):
         chunk_level_diff=False,
     )
 
-    assert result == {"ok": 1}
+    assert result == UpdateResult.model_validate(payload)
+    assert (result.mode, result.status, result.chunks.kept) == ("incremental", "updated", 3)
     assert captured["url"] == "http://remote.invalid/api/v1/update"
     assert captured["params"] == {
         "data_id": str(data_id),
@@ -182,3 +204,26 @@ async def test_cloud_client_update_surfaces_remote_errors(monkeypatch):
 
     with pytest.raises(RuntimeError, match=r"Remote update failed \(404\)"):
         await client.update(data_id=uuid4(), data="new text", dataset_id=uuid4())
+
+
+@pytest.mark.asyncio
+async def test_cloud_client_update_returns_a_failed_result_instead_of_raising(monkeypatch):
+    """The route answers a failed rebuild with 500 and the result body; the
+    client hands that result back so the caller can read the error and retry."""
+    failed = _result_payload(
+        status="failed",
+        mode="full_rebuild",
+        chunks=None,
+        fallback_reason="disabled",
+        fallback_detail="chunk_level_diff=False was requested",
+        error_class="RuntimeError",
+        error_message="cognify failed",
+    )
+    client, _ = _client_with_fake_patch(
+        monkeypatch, _FakeResponse(status=500, text=json.dumps(failed))
+    )
+
+    result = await client.update(data_id=uuid4(), data="new text", dataset_id=uuid4())
+
+    assert result == UpdateResult.model_validate(failed)
+    assert (result.status, result.error_message) == ("failed", "cognify failed")

--- a/cognee/tests/unit/api/v1/test_update_remote_routing.py
+++ b/cognee/tests/unit/api/v1/test_update_remote_routing.py
@@ -9,7 +9,7 @@ import importlib
 import json
 from contextlib import asynccontextmanager
 from unittest.mock import MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -101,22 +101,19 @@ async def test_update_remote_is_silent_when_only_routable_parameters_are_given(
 def _result_payload(**overrides):
     """A PATCH /update body as the server sends it."""
     payload = {
+        "status": "incremental",
+        "regions": 1,
+        "deleted_chunks": 1,
+        "added_chunks": 1,
+        "reused_chunks": 0,
+        "kept_chunks": 3,
+        "reindexed_chunks": 0,
+        "total_chunks": 4,
         "data_id": str(uuid4()),
         "dataset_id": str(uuid4()),
-        "status": "updated",
-        "mode": "incremental",
         "duration_seconds": 0.8,
-        "chunks": {
-            "regions": 1,
-            "deleted": 1,
-            "added": 1,
-            "reused": 0,
-            "kept": 3,
-            "reindexed": 0,
-            "total": 4,
-        },
-        "fallback": None,
         "pipeline_run_id": str(uuid4()),
+        "fallback": None,
         "error": None,
     }
     payload.update(overrides)
@@ -173,8 +170,9 @@ async def test_cloud_client_update_matches_the_route_contract(monkeypatch):
         chunk_level_diff=False,
     )
 
-    assert result == UpdateResult.model_validate(payload)
-    assert (result.mode, result.status, result.chunks.kept) == ("incremental", "updated", 3)
+    assert result == UpdateResult.model_validate(payload).model_dump()
+    assert (result["status"], result["kept_chunks"]) == ("incremental", 3)
+    assert result["data_id"] == UUID(payload["data_id"]), "remote ids are UUIDs, as locally"
     assert captured["url"] == "http://remote.invalid/api/v1/update"
     assert captured["params"] == {
         "data_id": str(data_id),
@@ -219,8 +217,17 @@ async def test_cloud_client_update_returns_a_failed_result_instead_of_raising(mo
     client hands that result back so the caller can read the error and retry."""
     failed = _result_payload(
         status="failed",
-        mode="full_rebuild",
-        chunks=None,
+        **dict.fromkeys(
+            (
+                "regions",
+                "deleted_chunks",
+                "added_chunks",
+                "reused_chunks",
+                "kept_chunks",
+                "reindexed_chunks",
+                "total_chunks",
+            ),
+        ),
         fallback={"reason": "disabled", "detail": "chunk_level_diff=False was requested"},
         error={"error_class": "RuntimeError", "message": "cognify failed"},
     )
@@ -230,5 +237,5 @@ async def test_cloud_client_update_returns_a_failed_result_instead_of_raising(mo
 
     result = await client.update(data_id=uuid4(), data="new text", dataset_id=uuid4())
 
-    assert result == UpdateResult.model_validate(failed)
-    assert (result.status, result.error.message) == ("failed", "cognify failed")
+    assert result == UpdateResult.model_validate(failed).model_dump()
+    assert (result["status"], result["error"]["message"]) == ("failed", "cognify failed")

--- a/cognee/tests/unit/api/v1/test_update_remote_routing.py
+++ b/cognee/tests/unit/api/v1/test_update_remote_routing.py
@@ -105,12 +105,19 @@ def _result_payload(**overrides):
         "dataset_id": str(uuid4()),
         "status": "updated",
         "mode": "incremental",
-        "chunks": {"regions": 1, "deleted": 1, "added": 1, "reused": 0, "kept": 3, "reindexed": 0},
-        "fallback_reason": None,
-        "fallback_detail": None,
+        "duration_seconds": 0.8,
+        "chunks": {
+            "regions": 1,
+            "deleted": 1,
+            "added": 1,
+            "reused": 0,
+            "kept": 3,
+            "reindexed": 0,
+            "total": 4,
+        },
+        "fallback": None,
         "pipeline_run_id": str(uuid4()),
-        "error_class": None,
-        "error_message": None,
+        "error": None,
     }
     payload.update(overrides)
     return payload
@@ -214,10 +221,8 @@ async def test_cloud_client_update_returns_a_failed_result_instead_of_raising(mo
         status="failed",
         mode="full_rebuild",
         chunks=None,
-        fallback_reason="disabled",
-        fallback_detail="chunk_level_diff=False was requested",
-        error_class="RuntimeError",
-        error_message="cognify failed",
+        fallback={"reason": "disabled", "detail": "chunk_level_diff=False was requested"},
+        error={"error_class": "RuntimeError", "message": "cognify failed"},
     )
     client, _ = _client_with_fake_patch(
         monkeypatch, _FakeResponse(status=500, text=json.dumps(failed))
@@ -226,4 +231,4 @@ async def test_cloud_client_update_returns_a_failed_result_instead_of_raising(mo
     result = await client.update(data_id=uuid4(), data="new text", dataset_id=uuid4())
 
     assert result == UpdateResult.model_validate(failed)
-    assert (result.status, result.error_message) == ("failed", "cognify failed")
+    assert (result.status, result.error.message) == ("failed", "cognify failed")

--- a/cognee/tests/unit/api/v1/test_update_result.py
+++ b/cognee/tests/unit/api/v1/test_update_result.py
@@ -3,7 +3,7 @@
 The chunk-level engine and the full rebuild used to return different values
 (a summary dict versus a pipeline-run mapping), and the reason for a rebuild
 lived only in the server log. Every path now returns an ``UpdateResult`` with
-the same fields, and every rebuild carries its ``fallback_reason`` (SDK-587).
+the same fields, and every rebuild carries its ``fallback`` reason (SDK-587).
 """
 
 import sys
@@ -16,6 +16,7 @@ import pytest
 import cognee.api.v1.update.update  # bind the real submodule
 from cognee.api.v1.update import UpdateResult
 from cognee.api.v1.update.incremental import IncrementalUpdateNotPossible, RefusalReason
+from cognee.api.v1.update.result import Fallback
 from cognee.modules.pipelines.models.PipelineRunInfo import (
     PipelineRunCompleted,
     PipelineRunErrored,
@@ -109,8 +110,10 @@ async def test_engine_refusal_becomes_a_full_rebuild_with_its_reason():
 
     assert isinstance(result, UpdateResult)
     assert (result.status, result.mode) == ("updated", "full_rebuild")
-    assert result.fallback_reason is RefusalReason.NO_BASELINE
-    assert result.fallback_detail == "no stored processed text for this data item"
+    assert result.fallback.reason is RefusalReason.NO_BASELINE
+    assert result.fallback.detail == "no stored processed text for this data item"
+    assert result.error is None
+    assert result.duration_seconds >= 0
     assert result.chunks is None, "a rebuild has no chunk diff to report"
     assert result.pipeline_run_id == run.pipeline_run_id
     assert (result.data_id, result.dataset_id) == (data_id, dataset_id)
@@ -138,8 +141,8 @@ async def test_every_pre_check_downgrade_names_its_reason(kwargs, reason):
 
     incremental.assert_not_called()
     assert result.mode == "full_rebuild"
-    assert result.fallback_reason is reason
-    assert result.fallback_detail, "the reason comes with a sentence for the caller"
+    assert result.fallback.reason is reason
+    assert result.fallback.detail, "the reason comes with a sentence for the caller"
 
 
 async def test_incremental_result_carries_the_chunk_counters_and_no_reason():
@@ -153,6 +156,7 @@ async def test_incremental_result_carries_the_chunk_counters_and_no_reason():
         "reused_chunks": 1,
         "kept_chunks": 7,
         "reindexed_chunks": 2,
+        "total_chunks": 11,
         "pipeline_run_id": run_id,
     }
     stack = _Stack(data_id, dataset_id, AsyncMock(return_value=summary), _run(dataset_id))
@@ -167,8 +171,9 @@ async def test_incremental_result_carries_the_chunk_counters_and_no_reason():
         "reused": 1,
         "kept": 7,
         "reindexed": 2,
+        "total": 11,
     }
-    assert result.fallback_reason is None and result.fallback_detail is None
+    assert result.fallback is None
     assert result.pipeline_run_id == run_id
     stack.delete_data.assert_not_awaited()
     stack.cognify.assert_not_awaited()
@@ -182,8 +187,9 @@ async def test_unchanged_content_is_reported_as_unchanged():
         "deleted_chunks": 0,
         "added_chunks": 0,
         "reused_chunks": 0,
-        "kept_chunks": 0,
+        "kept_chunks": 9,
         "reindexed_chunks": 0,
+        "total_chunks": 9,
         "pipeline_run_id": None,
     }
     stack = _Stack(data_id, dataset_id, AsyncMock(return_value=summary), _run(dataset_id))
@@ -191,9 +197,11 @@ async def test_unchanged_content_is_reported_as_unchanged():
     result = await _update(stack, data_id, dataset_id)
 
     assert (result.status, result.mode) == ("unchanged", "incremental")
-    assert result.chunks.model_dump() == dict.fromkeys(
-        ("regions", "deleted", "added", "reused", "kept", "reindexed"), 0
-    )
+    assert result.chunks.model_dump() == {
+        **dict.fromkeys(("regions", "deleted", "added", "reused", "reindexed"), 0),
+        "kept": 9,
+        "total": 9,
+    }
     assert result.pipeline_run_id is None
 
 
@@ -205,8 +213,8 @@ async def test_errored_rebuild_is_a_failed_result_not_an_exception():
     result = await _update(stack, data_id, dataset_id, chunk_level_diff=False)
 
     assert (result.status, result.mode) == ("failed", "full_rebuild")
-    assert result.fallback_reason is RefusalReason.DISABLED
-    assert (result.error_class, result.error_message) == ("LLMRateLimitError", "rate limited")
+    assert result.fallback.reason is RefusalReason.DISABLED
+    assert (result.error.error_class, result.error.message) == ("LLMRateLimitError", "rate limited")
     assert result.pipeline_run_id == errored.pipeline_run_id
     assert (result.data_id, result.dataset_id) == (data_id, dataset_id), (
         "a failed result keeps the ids the caller needs to retry"
@@ -219,11 +227,17 @@ def test_result_serializes_to_plain_json():
         dataset_id=uuid4(),
         status="updated",
         mode="full_rebuild",
-        fallback_reason=RefusalReason.UNSUPPORTED_CHUNKER,
-        fallback_detail="document was chunked by x, not y",
+        duration_seconds=1.5,
+        fallback=Fallback(
+            reason=RefusalReason.UNSUPPORTED_CHUNKER, detail="document was chunked by x, not y"
+        ),
         pipeline_run_id=uuid4(),
     )
     body = result.model_dump(mode="json")
-    assert body["fallback_reason"] == "unsupported_chunker"
+    assert body["fallback"] == {
+        "reason": "unsupported_chunker",
+        "detail": "document was chunked by x, not y",
+    }
+    assert body["error"] is None
     assert body["chunks"] is None
     assert UpdateResult.model_validate(body) == result

--- a/cognee/tests/unit/api/v1/test_update_result.py
+++ b/cognee/tests/unit/api/v1/test_update_result.py
@@ -67,7 +67,8 @@ class _Stack:
     def __init__(self, data_id, dataset_id, incremental, cognify_run):
         row = SimpleNamespace(id=data_id, legacy_id=None, owner_id=uuid4())
         relational_module = sys.modules["cognee.infrastructure.databases.relational"]
-        self.delete_data = AsyncMock()
+        self.forget = AsyncMock()
+        self.reset_status = AsyncMock()
         self.add = AsyncMock()
         self.cognify = AsyncMock(return_value={dataset_id: cognify_run})
         self.recorded_budget = AsyncMock(return_value=None)
@@ -79,7 +80,8 @@ class _Stack:
                 MagicMock(return_value=_relational_engine_stub(row)),
             ),
             patch.object(update_module, "incremental_update", incremental),
-            patch.object(update_module, "datasets", SimpleNamespace(delete_data=self.delete_data)),
+            patch.object(update_module, "forget", self.forget),
+            patch.object(data_methods_module, "reset_data_pipeline_status", self.reset_status),
             patch.object(update_module, "add", self.add),
             patch.object(update_module, "cognify", self.cognify),
             patch.object(update_module, "recorded_chunk_budget", self.recorded_budget),
@@ -128,7 +130,8 @@ async def test_engine_refusal_becomes_a_full_rebuild_with_its_reason():
     assert result["pipeline_run_id"] == run.pipeline_run_id
     assert (result["data_id"], result["dataset_id"]) == (data_id, dataset_id)
     assert result["duration_seconds"] >= 0
-    stack.delete_data.assert_awaited_once()
+    stack.forget.assert_awaited_once()
+    stack.reset_status.assert_awaited_once()
     stack.add.assert_awaited_once()
 
 
@@ -182,7 +185,7 @@ async def test_incremental_result_keeps_the_old_summary_keys_and_adds_the_new_on
     assert result["fallback"] is None and result["error"] is None
     assert result["pipeline_run_id"] == run_id
     assert (result["data_id"], result["dataset_id"]) == (data_id, dataset_id)
-    stack.delete_data.assert_not_awaited()
+    stack.forget.assert_not_awaited()
     stack.cognify.assert_not_awaited()
 
 
@@ -267,5 +270,5 @@ async def test_dlt_replacement_under_another_name_is_refused_before_the_delete()
             chunk_level_diff=False,
         )
 
-    stack.delete_data.assert_not_awaited()
+    stack.forget.assert_not_awaited()
     stack.add.assert_not_awaited()

--- a/cognee/tests/unit/api/v1/test_update_result.py
+++ b/cognee/tests/unit/api/v1/test_update_result.py
@@ -1,0 +1,229 @@
+"""update() answers in one shape on every path, and a full rebuild says why.
+
+The chunk-level engine and the full rebuild used to return different values
+(a summary dict versus a pipeline-run mapping), and the reason for a rebuild
+lived only in the server log. Every path now returns an ``UpdateResult`` with
+the same fields, and every rebuild carries its ``fallback_reason`` (SDK-587).
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+import cognee.api.v1.update.update  # bind the real submodule
+from cognee.api.v1.update import UpdateResult
+from cognee.api.v1.update.incremental import IncrementalUpdateNotPossible, RefusalReason
+from cognee.modules.pipelines.models.PipelineRunInfo import (
+    PipelineRunCompleted,
+    PipelineRunErrored,
+)
+
+update_module = sys.modules["cognee.api.v1.update.update"]
+data_methods_module = sys.modules["cognee.modules.data.methods"]
+
+pytestmark = pytest.mark.asyncio
+
+
+def _relational_engine_stub(row):
+    session = MagicMock()
+    session.get = AsyncMock(return_value=row)
+    session.commit = AsyncMock()
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=session)
+    context.__aexit__ = AsyncMock(return_value=False)
+    engine = MagicMock()
+    engine.get_async_session = MagicMock(return_value=context)
+    return engine
+
+
+def _run(dataset_id, errored=False):
+    if errored:
+        return PipelineRunErrored(
+            pipeline_run_id=uuid4(),
+            dataset_id=dataset_id,
+            dataset_name="ds",
+            error_class="LLMRateLimitError",
+            error_message="rate limited",
+        )
+    return PipelineRunCompleted(pipeline_run_id=uuid4(), dataset_id=dataset_id, dataset_name="ds")
+
+
+class _Stack:
+    """update() with its collaborators stubbed; records what the rebuild called."""
+
+    def __init__(self, data_id, dataset_id, incremental, cognify_run):
+        row = SimpleNamespace(id=data_id, legacy_id=None, owner_id=uuid4())
+        relational_module = sys.modules["cognee.infrastructure.databases.relational"]
+        self.delete_data = AsyncMock()
+        self.add = AsyncMock()
+        self.cognify = AsyncMock(return_value={dataset_id: cognify_run})
+        self.recorded_budget = AsyncMock(return_value=None)
+        self.patches = (
+            patch.object(data_methods_module, "resolve_data_id", AsyncMock(return_value=data_id)),
+            patch.object(
+                relational_module,
+                "get_relational_engine",
+                MagicMock(return_value=_relational_engine_stub(row)),
+            ),
+            patch.object(update_module, "incremental_update", incremental),
+            patch.object(update_module, "datasets", SimpleNamespace(delete_data=self.delete_data)),
+            patch.object(update_module, "add", self.add),
+            patch.object(update_module, "cognify", self.cognify),
+            patch.object(update_module, "recorded_chunk_budget", self.recorded_budget),
+        )
+
+    def __enter__(self):
+        for p in self.patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in self.patches:
+            p.stop()
+        return False
+
+
+async def _update(stack, data_id, dataset_id, **kwargs):
+    with stack:
+        return await update_module.update(
+            data_id=data_id,
+            data="new content",
+            dataset_id=dataset_id,
+            user=SimpleNamespace(id=uuid4()),
+            **kwargs,
+        )
+
+
+async def test_engine_refusal_becomes_a_full_rebuild_with_its_reason():
+    data_id, dataset_id = uuid4(), uuid4()
+    refusal = IncrementalUpdateNotPossible(
+        "no stored processed text for this data item", RefusalReason.NO_BASELINE
+    )
+    run = _run(dataset_id)
+    stack = _Stack(data_id, dataset_id, AsyncMock(side_effect=refusal), run)
+
+    result = await _update(stack, data_id, dataset_id)
+
+    assert isinstance(result, UpdateResult)
+    assert (result.status, result.mode) == ("updated", "full_rebuild")
+    assert result.fallback_reason is RefusalReason.NO_BASELINE
+    assert result.fallback_detail == "no stored processed text for this data item"
+    assert result.chunks is None, "a rebuild has no chunk diff to report"
+    assert result.pipeline_run_id == run.pipeline_run_id
+    assert (result.data_id, result.dataset_id) == (data_id, dataset_id)
+    stack.delete_data.assert_awaited_once()
+    stack.add.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "reason"),
+    [
+        ({"chunk_level_diff": False}, RefusalReason.DISABLED),
+        ({"node_set": ["group"]}, RefusalReason.UNSUPPORTED_METADATA),
+        ({"custom_prompt": "be brief"}, RefusalReason.CUSTOM_EXTRACTION_CONFIG),
+        ({"graph_model": type("Custom", (), {})}, RefusalReason.CUSTOM_EXTRACTION_CONFIG),
+        ({"vector_db_config": {"vector_db_provider": "x"}}, RefusalReason.PER_CALL_DB_CONFIG),
+        ({"graph_db_config": {"graph_database_provider": "x"}}, RefusalReason.PER_CALL_DB_CONFIG),
+    ],
+)
+async def test_every_pre_check_downgrade_names_its_reason(kwargs, reason):
+    data_id, dataset_id = uuid4(), uuid4()
+    incremental = AsyncMock()
+    stack = _Stack(data_id, dataset_id, incremental, _run(dataset_id))
+
+    result = await _update(stack, data_id, dataset_id, **kwargs)
+
+    incremental.assert_not_called()
+    assert result.mode == "full_rebuild"
+    assert result.fallback_reason is reason
+    assert result.fallback_detail, "the reason comes with a sentence for the caller"
+
+
+async def test_incremental_result_carries_the_chunk_counters_and_no_reason():
+    data_id, dataset_id = uuid4(), uuid4()
+    run_id = uuid4()
+    summary = {
+        "status": "incremental",
+        "regions": 2,
+        "deleted_chunks": 3,
+        "added_chunks": 4,
+        "reused_chunks": 1,
+        "kept_chunks": 7,
+        "reindexed_chunks": 2,
+        "pipeline_run_id": run_id,
+    }
+    stack = _Stack(data_id, dataset_id, AsyncMock(return_value=summary), _run(dataset_id))
+
+    result = await _update(stack, data_id, dataset_id)
+
+    assert (result.status, result.mode) == ("updated", "incremental")
+    assert result.chunks.model_dump() == {
+        "regions": 2,
+        "deleted": 3,
+        "added": 4,
+        "reused": 1,
+        "kept": 7,
+        "reindexed": 2,
+    }
+    assert result.fallback_reason is None and result.fallback_detail is None
+    assert result.pipeline_run_id == run_id
+    stack.delete_data.assert_not_awaited()
+    stack.cognify.assert_not_awaited()
+
+
+async def test_unchanged_content_is_reported_as_unchanged():
+    data_id, dataset_id = uuid4(), uuid4()
+    summary = {
+        "status": "unchanged",
+        "regions": 0,
+        "deleted_chunks": 0,
+        "added_chunks": 0,
+        "reused_chunks": 0,
+        "kept_chunks": 0,
+        "reindexed_chunks": 0,
+        "pipeline_run_id": None,
+    }
+    stack = _Stack(data_id, dataset_id, AsyncMock(return_value=summary), _run(dataset_id))
+
+    result = await _update(stack, data_id, dataset_id)
+
+    assert (result.status, result.mode) == ("unchanged", "incremental")
+    assert result.chunks.model_dump() == dict.fromkeys(
+        ("regions", "deleted", "added", "reused", "kept", "reindexed"), 0
+    )
+    assert result.pipeline_run_id is None
+
+
+async def test_errored_rebuild_is_a_failed_result_not_an_exception():
+    data_id, dataset_id = uuid4(), uuid4()
+    errored = _run(dataset_id, errored=True)
+    stack = _Stack(data_id, dataset_id, AsyncMock(), errored)
+
+    result = await _update(stack, data_id, dataset_id, chunk_level_diff=False)
+
+    assert (result.status, result.mode) == ("failed", "full_rebuild")
+    assert result.fallback_reason is RefusalReason.DISABLED
+    assert (result.error_class, result.error_message) == ("LLMRateLimitError", "rate limited")
+    assert result.pipeline_run_id == errored.pipeline_run_id
+    assert (result.data_id, result.dataset_id) == (data_id, dataset_id), (
+        "a failed result keeps the ids the caller needs to retry"
+    )
+
+
+def test_result_serializes_to_plain_json():
+    result = UpdateResult(
+        data_id=uuid4(),
+        dataset_id=uuid4(),
+        status="updated",
+        mode="full_rebuild",
+        fallback_reason=RefusalReason.UNSUPPORTED_CHUNKER,
+        fallback_detail="document was chunked by x, not y",
+        pipeline_run_id=uuid4(),
+    )
+    body = result.model_dump(mode="json")
+    assert body["fallback_reason"] == "unsupported_chunker"
+    assert body["chunks"] is None
+    assert UpdateResult.model_validate(body) == result

--- a/cognee/tests/unit/api/v1/test_update_result.py
+++ b/cognee/tests/unit/api/v1/test_update_result.py
@@ -2,8 +2,8 @@
 
 The chunk-level engine and the full rebuild used to return different values
 (a summary dict versus a pipeline-run mapping), and the reason for a rebuild
-lived only in the server log. Every path now returns an ``UpdateResult`` with
-the same fields, and every rebuild carries its ``fallback`` reason (SDK-587).
+lived only in the server log. Every path now returns one dict, a superset of
+the old summary, and every rebuild carries its ``fallback`` reason (SDK-587).
 """
 
 import sys
@@ -16,7 +16,6 @@ import pytest
 import cognee.api.v1.update.update  # bind the real submodule
 from cognee.api.v1.update import UpdateResult
 from cognee.api.v1.update.incremental import IncrementalUpdateNotPossible, RefusalReason
-from cognee.api.v1.update.result import Fallback
 from cognee.modules.pipelines.models.PipelineRunInfo import (
     PipelineRunCompleted,
     PipelineRunErrored,
@@ -26,6 +25,16 @@ update_module = sys.modules["cognee.api.v1.update.update"]
 data_methods_module = sys.modules["cognee.modules.data.methods"]
 
 pytestmark = pytest.mark.asyncio
+
+COUNTER_KEYS = (
+    "regions",
+    "deleted_chunks",
+    "added_chunks",
+    "reused_chunks",
+    "kept_chunks",
+    "reindexed_chunks",
+    "total_chunks",
+)
 
 
 def _relational_engine_stub(row):
@@ -108,15 +117,17 @@ async def test_engine_refusal_becomes_a_full_rebuild_with_its_reason():
 
     result = await _update(stack, data_id, dataset_id)
 
-    assert isinstance(result, UpdateResult)
-    assert (result.status, result.mode) == ("updated", "full_rebuild")
-    assert result.fallback.reason is RefusalReason.NO_BASELINE
-    assert result.fallback.detail == "no stored processed text for this data item"
-    assert result.error is None
-    assert result.duration_seconds >= 0
-    assert result.chunks is None, "a rebuild has no chunk diff to report"
-    assert result.pipeline_run_id == run.pipeline_run_id
-    assert (result.data_id, result.dataset_id) == (data_id, dataset_id)
+    assert isinstance(result, dict)
+    assert result["status"] == "full_rebuild"
+    assert result["fallback"] == {
+        "reason": RefusalReason.NO_BASELINE,
+        "detail": "no stored processed text for this data item",
+    }
+    assert result["error"] is None
+    assert all(result[key] is None for key in COUNTER_KEYS), "a rebuild has no chunk diff"
+    assert result["pipeline_run_id"] == run.pipeline_run_id
+    assert (result["data_id"], result["dataset_id"]) == (data_id, dataset_id)
+    assert result["duration_seconds"] >= 0
     stack.delete_data.assert_awaited_once()
     stack.add.assert_awaited_once()
 
@@ -140,12 +151,15 @@ async def test_every_pre_check_downgrade_names_its_reason(kwargs, reason):
     result = await _update(stack, data_id, dataset_id, **kwargs)
 
     incremental.assert_not_called()
-    assert result.mode == "full_rebuild"
-    assert result.fallback.reason is reason
-    assert result.fallback.detail, "the reason comes with a sentence for the caller"
+    assert result["status"] == "full_rebuild"
+    assert result["fallback"]["reason"] is reason
+    assert result["fallback"]["detail"], "the reason comes with a sentence for the caller"
 
 
-async def test_incremental_result_carries_the_chunk_counters_and_no_reason():
+async def test_incremental_result_keeps_the_old_summary_keys_and_adds_the_new_ones():
+    """The chunk-level summary that shipped before is a strict subset: same
+    keys, same values, so a caller reading result["kept_chunks"] or comparing
+    result["status"] == "incremental" is unaffected."""
     data_id, dataset_id = uuid4(), uuid4()
     run_id = uuid4()
     summary = {
@@ -163,18 +177,11 @@ async def test_incremental_result_carries_the_chunk_counters_and_no_reason():
 
     result = await _update(stack, data_id, dataset_id)
 
-    assert (result.status, result.mode) == ("updated", "incremental")
-    assert result.chunks.model_dump() == {
-        "regions": 2,
-        "deleted": 3,
-        "added": 4,
-        "reused": 1,
-        "kept": 7,
-        "reindexed": 2,
-        "total": 11,
-    }
-    assert result.fallback is None
-    assert result.pipeline_run_id == run_id
+    old_summary = {key: value for key, value in summary.items() if key != "pipeline_run_id"}
+    assert {key: result[key] for key in old_summary} == old_summary
+    assert result["fallback"] is None and result["error"] is None
+    assert result["pipeline_run_id"] == run_id
+    assert (result["data_id"], result["dataset_id"]) == (data_id, dataset_id)
     stack.delete_data.assert_not_awaited()
     stack.cognify.assert_not_awaited()
 
@@ -196,13 +203,9 @@ async def test_unchanged_content_is_reported_as_unchanged():
 
     result = await _update(stack, data_id, dataset_id)
 
-    assert (result.status, result.mode) == ("unchanged", "incremental")
-    assert result.chunks.model_dump() == {
-        **dict.fromkeys(("regions", "deleted", "added", "reused", "reindexed"), 0),
-        "kept": 9,
-        "total": 9,
-    }
-    assert result.pipeline_run_id is None
+    assert result["status"] == "unchanged"
+    assert (result["kept_chunks"], result["total_chunks"]) == (9, 9)
+    assert result["pipeline_run_id"] is None
 
 
 async def test_errored_rebuild_is_a_failed_result_not_an_exception():
@@ -212,35 +215,28 @@ async def test_errored_rebuild_is_a_failed_result_not_an_exception():
 
     result = await _update(stack, data_id, dataset_id, chunk_level_diff=False)
 
-    assert (result.status, result.mode) == ("failed", "full_rebuild")
-    assert result.fallback.reason is RefusalReason.DISABLED
-    assert (result.error.error_class, result.error.message) == ("LLMRateLimitError", "rate limited")
-    assert result.pipeline_run_id == errored.pipeline_run_id
-    assert (result.data_id, result.dataset_id) == (data_id, dataset_id), (
+    assert result["status"] == "failed"
+    assert result["fallback"]["reason"] is RefusalReason.DISABLED
+    assert result["error"] == {"error_class": "LLMRateLimitError", "message": "rate limited"}
+    assert result["pipeline_run_id"] == errored.pipeline_run_id
+    assert (result["data_id"], result["dataset_id"]) == (data_id, dataset_id), (
         "a failed result keeps the ids the caller needs to retry"
     )
 
 
-def test_result_serializes_to_plain_json():
+def test_result_schema_round_trips_through_json():
     result = UpdateResult(
+        status="full_rebuild",
         data_id=uuid4(),
         dataset_id=uuid4(),
-        status="updated",
-        mode="full_rebuild",
         duration_seconds=1.5,
-        fallback=Fallback(
-            reason=RefusalReason.UNSUPPORTED_CHUNKER, detail="document was chunked by x, not y"
-        ),
         pipeline_run_id=uuid4(),
+        fallback={"reason": RefusalReason.UNSUPPORTED_CHUNKER, "detail": "chunked by x, not y"},
     )
     body = result.model_dump(mode="json")
-    assert body["fallback"] == {
-        "reason": "unsupported_chunker",
-        "detail": "document was chunked by x, not y",
-    }
-    assert body["error"] is None
-    assert body["chunks"] is None
-    assert UpdateResult.model_validate(body) == result
+    assert body["fallback"] == {"reason": "unsupported_chunker", "detail": "chunked by x, not y"}
+    assert body["kept_chunks"] is None and body["error"] is None
+    assert UpdateResult.model_validate(body).model_dump() == result.model_dump()
 
 
 async def test_dlt_replacement_under_another_name_is_refused_before_the_delete():

--- a/cognee/tests/unit/api/v1/test_update_result.py
+++ b/cognee/tests/unit/api/v1/test_update_result.py
@@ -241,3 +241,35 @@ def test_result_serializes_to_plain_json():
     assert body["error"] is None
     assert body["chunks"] is None
     assert UpdateResult.model_validate(body) == result
+
+
+async def test_dlt_replacement_under_another_name_is_refused_before_the_delete():
+    """The rebuild deletes first, so a replacement the re-add would refuse
+    must be refused while the manifest still exists."""
+    dlt = pytest.importorskip("dlt")
+    from cognee.exceptions import CogneeValidationError
+
+    resolve_module = sys.modules["cognee.tasks.ingestion.resolve_dlt_sources"]
+    data_id, dataset_id = uuid4(), uuid4()
+    stack = _Stack(data_id, dataset_id, AsyncMock(), _run(dataset_id))
+
+    with (
+        stack,
+        patch.object(
+            data_methods_module,
+            "get_authorized_dataset",
+            AsyncMock(return_value=SimpleNamespace(id=dataset_id, name="ds")),
+        ),
+        patch.object(resolve_module, "get_unique_data_id", AsyncMock(return_value=uuid4())),
+        pytest.raises(CogneeValidationError, match="same source name"),
+    ):
+        await update_module.update(
+            data_id=data_id,
+            data=dlt.resource([{"id": 1}], name="renamed", primary_key="id"),
+            dataset_id=dataset_id,
+            user=SimpleNamespace(id=uuid4()),
+            chunk_level_diff=False,
+        )
+
+    stack.delete_data.assert_not_awaited()
+    stack.add.assert_not_awaited()

--- a/cognee/tests/unit/exceptions/test_cognee_error_contract.py
+++ b/cognee/tests/unit/exceptions/test_cognee_error_contract.py
@@ -45,6 +45,7 @@ PACKAGE_ROOT = Path(cognee.__file__).parent
 # instantiate every subclass regardless of its signature. A raw KeyError here is
 # turned into an actionable failure (see ``_build_kwargs``).
 SAMPLE_ARGUMENTS = {
+    "conflicts": [{"name": "report.txt", "data_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}],
     "attribute": "sample_attribute",
     "candidates": [
         {

--- a/cognee/tests/unit/tasks/ingestion/test_dlt_stable_manifest_id.py
+++ b/cognee/tests/unit/tasks/ingestion/test_dlt_stable_manifest_id.py
@@ -168,3 +168,74 @@ async def test_csv_paths_pass_through_resolve_untouched():
 
     assert result == data
     assert cleanup is None
+
+
+@pytest.mark.asyncio
+async def test_update_pinned_dlt_source_is_unwrapped_and_resolved():
+    """update()'s full rebuild re-adds the replacement as a DataItem wrapping the
+    dlt resource, pinned to the manifest's id. resolve must ingest it like a
+    bare resource and hand back the manifest, not pass the wrapper through to
+    the loader (which cannot read a DltResource)."""
+    dlt = pytest.importorskip("dlt")
+
+    import sys
+
+    import cognee.tasks.ingestion.resolve_dlt_sources
+
+    resolve_module = sys.modules["cognee.tasks.ingestion.resolve_dlt_sources"]
+
+    @dlt.resource(name="people")
+    def people():
+        yield {"id": 1}
+
+    manifest_id = uuid4()
+    manifest = DataItem(
+        data="{}",
+        system_metadata={"source": "dlt_source", "source_name": "people"},
+        data_id=manifest_id,
+    )
+    ingest = AsyncMock(return_value=["row"])
+
+    with (
+        patch.object(resolve_module, "ingest_dlt_source", new=ingest),
+        patch.object(resolve_module, "get_unique_data_id", new=AsyncMock(return_value=manifest_id)),
+        patch.object(
+            resolve_module, "_build_source_manifest_item", new=AsyncMock(return_value=manifest)
+        ),
+    ):
+        result, _cleanup = await resolve_module.resolve_dlt_sources(
+            DataItem(data=people(), data_id=manifest_id), "ds", user=SimpleNamespace(id=uuid4())
+        )
+
+    ingest.assert_awaited_once()
+    assert result == [manifest]
+
+
+@pytest.mark.asyncio
+async def test_update_pinned_dlt_source_must_keep_its_source_name():
+    """A replacement resolving to another manifest identity is a different
+    document; rebuilding it under the old id is refused before any write."""
+    dlt = pytest.importorskip("dlt")
+
+    import sys
+
+    import cognee.tasks.ingestion.resolve_dlt_sources
+    from cognee.exceptions import CogneeValidationError
+
+    resolve_module = sys.modules["cognee.tasks.ingestion.resolve_dlt_sources"]
+
+    @dlt.resource(name="staff")
+    def staff():
+        yield {"id": 1}
+
+    ingest = AsyncMock(return_value=["row"])
+    with (
+        patch.object(resolve_module, "ingest_dlt_source", new=ingest),
+        patch.object(resolve_module, "get_unique_data_id", new=AsyncMock(return_value=uuid4())),
+        pytest.raises(CogneeValidationError, match="same source name"),
+    ):
+        await resolve_module.resolve_dlt_sources(
+            DataItem(data=staff(), data_id=uuid4()), "ds", user=SimpleNamespace(id=uuid4())
+        )
+
+    ingest.assert_not_awaited()


### PR DESCRIPTION
Part of [SDK-587](https://linear.app/cognee/issue/SDK-587/productionize-incremental-update-legible-results-identity-freshness) (phase 2, plus the `add()` refusal from phase 1). `update()` returns one result shape on every path, every full rebuild says why it ran, and a rebuild can no longer lose the document.

## Summary

| Before | After |
|---|---|
| Chunk-level path returned a summary dict; full rebuild returned cognify's `{dataset_id: PipelineRunInfo}` mapping | One dict on every path, validated by `UpdateResult`, identical for local calls, `PATCH /update` and `serve()` |
| Five downgrade conditions only logged a warning | `fallback.reason` from one nine-value enum, with a `detail` sentence |
| Rebuild = delete row → re-add pinned → cognify; a failed re-add left no document | Rebuild = `forget(memory_only=True)` → re-add refreshes the row in place → cognify; the row and its files survive any failure |
| A DLT manifest updated through `update()` was destroyed (415 on re-add after the delete) | DLT manifests rebuild under their id; a rename or wrong-source replacement is refused with a 422 before anything is touched |
| Every text update through `serve()` was a full rebuild (content-hash filename read as a metadata change) | Filename is irrelevant; `data_id` names the document |
| `add()` silently created a duplicate when a file was re-added with new content | `add()` raises `DocumentUpdateRequiredError` (409) pointing at the update endpoint / `cognee.update()` |

## The result shape

`UpdateResult` (`cognee/api/v1/update/result.py`) is a strict superset of the chunk-level summary that shipped in v1.5.4. The old keys keep their names and values, so `result["status"] == "incremental"` and `result["kept_chunks"]` keep working.

- `status`: `incremental` | `unchanged` (as before) | `full_rebuild` (delete + re-add + cognify ran) | `failed` (the rebuild's cognify run errored).
- `regions`, `deleted_chunks`, `added_chunks`, `reused_chunks`, `kept_chunks`, `reindexed_chunks`: as before. New `total_chunks` is the count after the update, so "kept 29 of 30" reads off directly. All counters are `null` on a rebuild, which has no diff.
- `data_id`, `dataset_id`: the handle to retry with.
- `duration_seconds`: wall-clock time of the call.
- `pipeline_run_id`: the run to inspect; `null` for a no-op.
- `fallback`: `{reason, detail}`, set on every rebuild.
- `error`: `{error_class, message}` on `failed`.

The route's `response_model` is `UpdateResult`. A failed rebuild keeps the 500 status but sends this body, so a client reads the error from the same fields it reads counters from. `CloudClient.update()` parses both the 200 and the 500 body through the same model.

**Compatibility.** The chunk-level summary is unchanged. What changes is the full-rebuild response, which was the cognify run mapping keyed by dataset id. That mapping carried no document id and no reason, so nothing could be built on it; callers that inspected it for `PipelineRunErrored` read `status == "failed"` and `error` instead.

### Fallback reasons

`RefusalReason` gains the three causes `update()` decided before consulting the engine: `disabled`, `custom_extraction_config`, `per_call_db_config`. With the existing `unsupported_backend`, `unsupported_chunker`, `unsupported_metadata`, `no_baseline`, `chunks_not_tiling`, `unreadable_text`, all nine are one enum, exposed in OpenAPI. Documents on the code and DLT cognify routes have no chunks to diff; their refusal now says so instead of "not cognified yet?":

```
document is on the code cognify route, which keeps no chunks to diff; the whole document is rebuilt
```

## The rebuild never deletes the document

The full rebuild used to delete the row and re-add it pinned to the same id. A re-add that failed left no document at all; that is what turned the DLT bug below into data loss, and the review bot flagged the sequence as a blocker. The rebuild now drops the document's memory with `forget(memory_only=True)` while the row and its stored files stay, clears the row's pipeline stamps, and lets the pinned re-add refresh the row in place (content, name, metadata) before cognify rebuilds the graph. The row keeps its id, owner and legacy id by construction, so the old lineage-restore step is gone. A re-add that fails leaves a document with no graph and its old content, which the next `cognify()` rebuilds. `test_update_fallback_durability.py` proves it: a re-add that raises mid-rebuild, the row survives with its content, `cognify()` restores the old graph, and the retried update lands the new content under the same id.

The recorded chunk budget is now looked up for every rebuild, not only after an engine refusal. A document cognified at 60 tokens keeps that granularity whichever pre-check downgraded it.

## Fixes this dragged in

- **DLT source manifests.** On dev the rebuild deleted the manifest, then the pinned re-add failed with `Data type not supported: DltResource (415)` because the resolver only recognised bare dlt objects; the dataset was left with zero rows. Now `resolve_dlt_sources` unwraps a `DataItem` carrying a dlt resource and holds the pinned id to the manifest identity it resolves to; `add()` passes the dataset's stored name to the resolver (the identity is seeded from `(dataset name, source name)`, and the rebuild re-adds by `dataset_id` alone, so `None` minted a second manifest); and `update()` checks the replacement **before** any delete. A document-tagged source or a source under another name is refused with a typed 422 while the manifest is untouched. Live result: manifest kept under its id, `row_count` 2 → 3, new row nodes in the graph.
- **Filename.** The chunk-level path refused a differently named file as a metadata change. `serve()` uploads a string as a file part named by its content hash, so every remote text update was a full rebuild. The name is no longer compared; the publish step writes the staged name onto the row, so a renamed replacement updates content and name in place. A change of content type (extension, mime type, loader) still takes the full path.
- **Postgres demo adapter.** Deleting or updating a document that was added but never cognified crashed, because the unmarked graph sent the delete down the legacy subgraph path and that adapter has no `get_document_subgraph`. An unmarked graph on such an adapter holds no legacy data, so the delete skips the graph there and removes the row as before.

## add() refuses an update in disguise

A file that already exists in the dataset with different content is an update, not a new document. `add()` raises `DocumentUpdateRequiredError` (409 on `POST /add`) naming every such file with its `data_id` and pointing at `cognee.update(data_id=..., data=..., dataset_id=...)`, or `PATCH /api/v1/update?data_id=...&dataset_id=...` in the API wording. The check runs once over the whole request before the pipeline starts, so a batch with one changed file is refused whole and nothing is written. Origin is the source path for a local file and the filename for an upload; raw text is named by its content hash and never matches; identical content is still a no-op; pinned items (DLT and code-repo manifests, `update()`'s own re-add) are exempt. Documented on `add()` and on the route.

```json
{
  "error": "Document already exists; use the update endpoint",
  "detail": "POST /api/v1/add does not update documents. 'report.txt' (data_id 72e06b81-212a-4f43-ba66-10f02eb12a48) already exists in dataset f3565164-44a1-5b35-a42f-ee98185f2b65 with different content. Send the new version to PATCH /api/v1/update?data_id=72e06b81-212a-4f43-ba66-10f02eb12a48&dataset_id=f3565164-44a1-5b35-a42f-ee98185f2b65 (multipart field 'data'), or cognee.update(...) from the SDK; identical content can be re-added and is a no-op."
}
```

## Sample output

Live runs on the default stack (Ladybug + LanceDB + SQLite, mocked LLM). The JSON is exactly the `PATCH /update` body.

**Incremental, one edited paragraph**

```json
{
  "status": "incremental",
  "regions": 1,
  "deleted_chunks": 1,
  "added_chunks": 1,
  "reused_chunks": 0,
  "kept_chunks": 29,
  "reindexed_chunks": 0,
  "total_chunks": 30,
  "data_id": "210636db-81b5-43ba-8058-4774960825b2",
  "dataset_id": "7b3b10c5-29f9-5d27-8e57-cb60356841d3",
  "duration_seconds": 0.677,
  "pipeline_run_id": "ce17df94-aacb-48e3-9582-ba5aadd803f3",
  "fallback": null,
  "error": null
}
```

**Unchanged, same content re-sent**: `status: "unchanged"`, every counter 0, `kept_chunks` and `total_chunks` 30, `pipeline_run_id: null`.

**Full rebuild, a pre-check downgrade (`node_set` passed)**

```json
{
  "status": "full_rebuild",
  "regions": null,
  "deleted_chunks": null,
  "added_chunks": null,
  "reused_chunks": null,
  "kept_chunks": null,
  "reindexed_chunks": null,
  "total_chunks": null,
  "data_id": "210636db-81b5-43ba-8058-4774960825b2",
  "dataset_id": "7b3b10c5-29f9-5d27-8e57-cb60356841d3",
  "duration_seconds": 0.735,
  "pipeline_run_id": "a29ac80c-5b54-4be8-a28f-d734287e6f48",
  "fallback": {
    "reason": "unsupported_metadata",
    "detail": "chunk-level update does not reconcile node_set or document metadata"
  },
  "error": null
}
```

**Failed**: same shape with `status: "failed"`, the rebuild's `pipeline_run_id`, `fallback` set, and `error: {"error_class": "...", "message": "..."}`; HTTP 500.

## Not in this PR

Batch aggregation of per-document results for `add()` (ticket point 7); rollback of a half-written incremental update ([SDK-434](https://linear.app/cognee/issue/SDK-434/update-endpoint-handle-failure), whose data-loss half this PR closes); phases 3 and 4.

## Verification

- **Unit**: `test_update_result.py` (every path and every pre-check reason, JSON round-trip, DLT pre-delete refusal), route tests for the 200/500 update bodies and the 409 add body, remote-client parsing, config routing, route-aware refusals, resolver unwrap and identity, exception contract. Full unit suite: 5,883 passed locally.
- **E2E**: the incremental suite (13 tests) on Ladybug + LanceDB and on Postgres graph + PGVector, including the new `test_add_existing_document.py` and `test_update_fallback_durability.py`; the stress test (10 iterations, exact structure at every step); new `cognee/tests/test_dlt_update_e2e.py`, wired into the DLT job in `e2e_tests.yml`.
- **Live**: a uvicorn server with `serve()` and raw HTTP clients: renamed upload and remote text string both update chunk-level, the 409 body above, code-route and DLT rebuilds.
- ruff, format, the strict exception set, pre-commit and `ty check` are clean.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

https://claude.ai/code/session_01EzVVTVg7nGagvcEoWZuoaq
