### PR TITLE
SDK-578 feat: Record pipeline run liveness

### DIFF
--- a/cognee/alembic/versions/b2d6f4a8c150_add_pipeline_runs_last_heartbeat_at.py
+++ b/cognee/alembic/versions/b2d6f4a8c150_add_pipeline_runs_last_heartbeat_at.py
@@ -1,0 +1,67 @@
+"""Add last_heartbeat_at to pipeline_runs so staleness stops being a guess
+
+Revision ID: b2d6f4a8c150
+Revises: a7c2e9f4b8d1
+Create Date: 2026-09-10
+
+PipelineRun gained a nullable ``last_heartbeat_at`` column
+(cognee/modules/pipelines/models/PipelineRun.py) recording when a run last
+showed a sign of life, so readers can tell a run that is still working from
+one whose process died instead of guessing from the row's age.
+
+Deliberately no backfill. Existing rows keep NULL, and readers fall back to
+``created_at`` for them, which is exactly today's behaviour — so this
+migration changes nothing on its own. Backfilling ``created_at`` into the
+column would be indistinguishable from a genuine tick and would claim
+evidence the run never produced.
+
+No index: the column is only ever read alongside a row already selected by
+the existing dataset_id/pipeline_name/created_at index, and this row is
+updated repeatedly while a run is in flight, where a second index would cost
+write throughput on the default SQLite backend for no read benefit.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b2d6f4a8c150"
+down_revision: str | None = "a7c2e9f4b8d1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+TABLE_NAME = "pipeline_runs"
+COLUMN_NAME = "last_heartbeat_at"
+
+
+def _has_column(inspector, table: str, name: str) -> bool:
+    return any(col["name"] == name for col in inspector.get_columns(table))
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    if TABLE_NAME not in insp.get_table_names():
+        return
+
+    if not _has_column(insp, TABLE_NAME, COLUMN_NAME):
+        op.add_column(
+            TABLE_NAME,
+            sa.Column(COLUMN_NAME, sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    if TABLE_NAME not in insp.get_table_names():
+        return
+
+    if _has_column(insp, TABLE_NAME, COLUMN_NAME):
+        # batch mode: SQLite cannot DROP COLUMN in place.
+        with op.batch_alter_table(TABLE_NAME) as batch_op:
+            batch_op.drop_column(COLUMN_NAME)

--- a/cognee/modules/pipelines/models/PipelineRun.py
+++ b/cognee/modules/pipelines/models/PipelineRun.py
@@ -59,6 +59,32 @@ class PipelineRun(Base):
     dataset_id = Column(UUID, index=True)
     run_info = Column(JSON)
 
+    # When this run last showed a sign of life. Written by
+    # log_pipeline_run_progress, which already UPDATEs the STARTED row in
+    # place, so recording it costs no extra write and no extra row.
+    #
+    # Its resolution is one item completion, throttled in run_tasks.py to ~20
+    # per run. So it advances for a multi-item run and does NOT advance while
+    # a run is inside a single long item: a one-item cognify stamps exactly
+    # once, when that item finishes, and nothing before it — the run's start
+    # is only created_at, since log_pipeline_run_start records no liveness.
+    # Treating a frozen value as proof of death is therefore wrong for that
+    # shape; bounding the gap inside one item needs an event source inside
+    # the task, which this column does not provide.
+    #
+    # Nullable with no backfill: rows written before this column existed stay
+    # NULL, and readers fall back to created_at for them. NULL therefore means
+    # "no evidence either way, judge by age", never "dead" — several paths
+    # legitimately hold a STARTED row without ever ticking (an update() run
+    # driven outside run_tasks, a dataset still queued behind others in a
+    # background multi-dataset run).
+    #
+    # Readers must normalize before comparing: SQLite drops the tzinfo on a
+    # DateTime(timezone=True) round trip and returns naive UTC, while Postgres
+    # returns it aware, so `value < datetime.now(timezone.utc)` raises on the
+    # default backend. recovery.py does this for created_at already.
+    last_heartbeat_at = Column(DateTime(timezone=True))
+
     # Operation-record columns (SDK-399). All nullable: rows written before
     # this change stay NULL — no backfill. Non-pipeline operations (search,
     # recall, forget, remember, delete, prune) write exactly one row with

--- a/cognee/modules/pipelines/operations/log_pipeline_run_progress.py
+++ b/cognee/modules/pipelines/operations/log_pipeline_run_progress.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from uuid import UUID
 
 from sqlalchemy import select
@@ -29,6 +30,14 @@ async def log_pipeline_run_progress(
     same row from different sessions) — last write wins, no locking. That's
     fine for a display-only "how far along are we" signal; it only risks a
     slightly stale snapshot between ticks, never a growing table.
+
+    The same UPDATE stamps ``last_heartbeat_at``. A tick only happens because
+    the run did something, so the timestamp means "was alive at least this
+    recently" — which is what separates a working run from a dead one, and
+    what the row's age cannot say. Riding the existing write is the point:
+    liveness costs no extra write, no extra row, and no timer. What it buys
+    is bounded by how often the caller ticks; see the column's comment on
+    PipelineRun for the shapes it does not cover.
     """
     db_engine = get_relational_engine()
 
@@ -53,6 +62,7 @@ async def log_pipeline_run_progress(
             run_info = dict(pipeline_run.run_info or {})
             run_info["progress"] = progress
             pipeline_run.run_info = run_info
+            pipeline_run.last_heartbeat_at = datetime.now(timezone.utc)
             session.add(pipeline_run)
         else:
             # No STARTED row found. In today's only caller (run_tasks.py) this
@@ -104,6 +114,7 @@ async def log_pipeline_run_progress(
                 status=PipelineRunStatus.DATASET_PROCESSING_STARTED,
                 dataset_id=dataset_id,
                 run_info={"data": None, "progress": progress},
+                last_heartbeat_at=datetime.now(timezone.utc),
             )
             session.add(pipeline_run)
 

--- a/cognee/tests/unit/modules/pipelines/test_pipeline_run_progress.py
+++ b/cognee/tests/unit/modules/pipelines/test_pipeline_run_progress.py
@@ -17,6 +17,7 @@ Covered here:
   the same way it already does for the other PipelineRunInfo subclasses.
 """
 
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
@@ -314,3 +315,112 @@ def test_queue_round_trips_pipeline_run_progress():
         assert received.current_stage == "extract_graph_from_data"
     finally:
         queues_module.remove_queue(pipeline_run_id)
+
+
+def _as_utc(value):
+    """SQLite drops the tzinfo on a DateTime(timezone=True) round trip, so a
+    value read back from the default backend is naive UTC. Postgres returns it
+    aware. Readers of last_heartbeat_at have to normalize either way; these
+    tests do the same so they assert the instant, not the backend."""
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+async def _stored_heartbeat(pipeline_run_id):
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        row = (
+            await session.execute(
+                select(PipelineRun)
+                .filter(PipelineRun.pipeline_run_id == pipeline_run_id)
+                .filter(PipelineRun.status == PipelineRunStatus.DATASET_PROCESSING_STARTED)
+            )
+        ).scalar_one()
+        return row.last_heartbeat_at
+
+
+@pytest.mark.asyncio
+async def test_progress_write_stamps_a_real_utc_instant():
+    """A tick only happens because the run did something, so the same UPDATE
+    records when that was. Asserting the value lands inside a window taken
+    around the call catches the two ways this silently breaks: a stamp that
+    never advances, and a stamp taken off the local clock instead of UTC
+    (the latter only where local time is not UTC, so CI cannot see it)."""
+    await create_db_and_tables()
+
+    dataset_id = uuid4()
+    pipeline_id = uuid4()
+
+    pipeline_run = await log_pipeline_run_start(pipeline_id, "cognify_pipeline", dataset_id, None)
+    pipeline_run_id = pipeline_run.pipeline_run_id
+
+    # Starting is not evidence of progress: a run that dies immediately must
+    # not look alive, so log_pipeline_run_start records no liveness of its own.
+    assert await _stored_heartbeat(pipeline_run_id) is None
+
+    before = datetime.now(timezone.utc)
+    await log_pipeline_run_progress(
+        pipeline_run_id=pipeline_run_id,
+        pipeline_id=pipeline_id,
+        pipeline_name="cognify_pipeline",
+        dataset_id=dataset_id,
+        completed_items=1,
+        total_items=2,
+    )
+    after = datetime.now(timezone.utc)
+
+    first = _as_utc(await _stored_heartbeat(pipeline_run_id))
+    assert before <= first <= after
+
+
+@pytest.mark.asyncio
+async def test_each_progress_write_advances_the_stamp():
+    """The column answers "how recently was this alive", so a value written
+    once and then left alone is the failure mode worth pinning: a stamp that
+    is merely non-NULL says nothing."""
+    await create_db_and_tables()
+
+    dataset_id = uuid4()
+    pipeline_id = uuid4()
+
+    pipeline_run = await log_pipeline_run_start(pipeline_id, "cognify_pipeline", dataset_id, None)
+    pipeline_run_id = pipeline_run.pipeline_run_id
+
+    stamps = []
+    for tick in (1, 2, 3):
+        await log_pipeline_run_progress(
+            pipeline_run_id=pipeline_run_id,
+            pipeline_id=pipeline_id,
+            pipeline_name="cognify_pipeline",
+            dataset_id=dataset_id,
+            completed_items=tick,
+            total_items=3,
+        )
+        stamps.append(_as_utc(await _stored_heartbeat(pipeline_run_id)))
+
+    assert stamps[0] < stamps[1] < stamps[2]
+
+
+@pytest.mark.asyncio
+async def test_the_insert_fallback_stamps_the_row_it_creates():
+    """The fallback INSERT runs when a tick finds no row for the run at all.
+    A tick still drove it, so the row it writes carries the same evidence an
+    UPDATE would have; leaving it NULL would claim the run never ticked."""
+    await create_db_and_tables()
+
+    dataset_id = uuid4()
+    pipeline_id = uuid4()
+    pipeline_run_id = uuid4()  # no log_pipeline_run_start: no row exists yet
+
+    before = datetime.now(timezone.utc)
+    await log_pipeline_run_progress(
+        pipeline_run_id=pipeline_run_id,
+        pipeline_id=pipeline_id,
+        pipeline_name="cognify_pipeline",
+        dataset_id=dataset_id,
+        completed_items=1,
+        total_items=1,
+    )
+    after = datetime.now(timezone.utc)
+
+    stamped = _as_utc(await _stored_heartbeat(pipeline_run_id))
+    assert before <= stamped <= after

--- a/cognee/tests/unit/test_add_pipeline_runs_last_heartbeat_at_migration.py
+++ b/cognee/tests/unit/test_add_pipeline_runs_last_heartbeat_at_migration.py
@@ -1,0 +1,105 @@
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "b2d6f4a8c150_add_pipeline_runs_last_heartbeat_at.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "pipeline_runs_last_heartbeat_at_migration", _MIGRATION_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+migration = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(migration)
+
+
+def _engine_with_pipeline_runs(*, with_heartbeat: bool = False) -> sa.Engine:
+    """A real in-memory SQLite DB holding the pre-migration pipeline_runs shape."""
+    engine = sa.create_engine("sqlite://")
+    meta = sa.MetaData()
+    columns = [
+        sa.Column("id", sa.String, primary_key=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("status", sa.String, nullable=True),
+        sa.Column("pipeline_run_id", sa.String, nullable=True),
+    ]
+    if with_heartbeat:
+        columns.append(sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True))
+    sa.Table("pipeline_runs", meta, *columns)
+    meta.create_all(engine)
+    return engine
+
+
+def _run(engine: sa.Engine, fn) -> None:
+    with engine.begin() as conn:
+        ctx = MigrationContext.configure(conn)
+        with Operations.context(ctx):
+            fn()
+
+
+def _columns(engine: sa.Engine) -> set[str]:
+    return {col["name"] for col in sa.inspect(engine).get_columns("pipeline_runs")}
+
+
+def test_upgrade_adds_the_nullable_column_and_leaves_existing_rows_null():
+    """No backfill by design: an existing row has produced no evidence of
+    liveness, and stamping created_at into the column would fake one."""
+    engine = _engine_with_pipeline_runs()
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO pipeline_runs (id, created_at, status) "
+                "VALUES ('r1', '2026-01-01 00:00:00', 'DATASET_PROCESSING_STARTED')"
+            )
+        )
+
+    _run(engine, migration.upgrade)
+
+    assert "last_heartbeat_at" in _columns(engine)
+    with engine.begin() as conn:
+        row = conn.execute(sa.text("SELECT last_heartbeat_at FROM pipeline_runs")).fetchone()
+    assert row is not None and row[0] is None
+
+
+def test_upgrade_is_idempotent_against_a_real_database():
+    """Running upgrade() twice must not fail on 'column already exists'."""
+    engine = _engine_with_pipeline_runs()
+
+    for _ in range(2):
+        _run(engine, migration.upgrade)
+
+    assert "last_heartbeat_at" in _columns(engine)
+
+
+def test_upgrade_is_a_noop_when_create_all_already_added_the_column():
+    """A fresh database is built by create_all() from the current models and
+    then stamped at head, so the column is already there when the chain runs."""
+    engine = _engine_with_pipeline_runs(with_heartbeat=True)
+
+    _run(engine, migration.upgrade)
+
+    assert "last_heartbeat_at" in _columns(engine)
+
+
+def test_downgrade_removes_the_column():
+    engine = _engine_with_pipeline_runs()
+    _run(engine, migration.upgrade)
+
+    _run(engine, migration.downgrade)
+
+    assert "last_heartbeat_at" not in _columns(engine)
+
+
+def test_upgrade_and_downgrade_are_noops_without_the_table():
+    engine = sa.create_engine("sqlite://")
+
+    _run(engine, migration.upgrade)
+    _run(engine, migration.downgrade)
+
+    assert "pipeline_runs" not in sa.inspect(engine).get_table_names()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

Right now nothing can tell a pipeline run that is still working from one whose process
died. Both look the same in `pipeline_runs`: a `DATASET_PROCESSING_STARTED` row with no
terminal row after it. So everything that needs to know falls back to the row's age, and
picks a different number for it. Startup recovery waits an hour before rolling a run back;
the dataset status endpoints call it abandoned after half that. Neither number measures
anything about the run, so a long cognify gets rolled back while it is running, and a run
that died a minute after a restart sits as "processing" until the next boot.

The signal we need is already being produced and thrown away. `log_pipeline_run_progress`
updates the run's STARTED row in place every time items complete, recording how far along
the run is but never when that was true. This adds a nullable `last_heartbeat_at` and
stamps it on that same UPDATE, so a reader can ask "when was this last alive" instead of
"how old is this row". No extra write, no extra row, no background timer.

Nothing reads the column in this PR. Recovery still decides from `created_at`, and the
read-time consumer lands separately. That split is on purpose: recovery is the destructive
reader, and a wrong verdict there runs `cognify_rollback_handler`, which deletes graph
nodes, edges and their embeddings while the live worker is still writing. I would rather
the value be visible in status for a release before anything acts on it.

Two things worth being upfront about.

First, the column is nullable with no backfill, and NULL means "no evidence either way,
judge by age", never "dead". Several paths legitimately hold a STARTED row without ever
ticking: an `update()` run driven outside `run_tasks`, or a dataset still sitting in the
queue behind others in a background multi-dataset run. Backfilling `created_at` would have
been easy and wrong, since it fabricates a tick the run never produced.

Second, the resolution is one item completion, throttled to about twenty per run. That
means it advances for a multi-item run and does not advance while a run is inside a single
long item. A one-document cognify stamps once, when that document finishes. I had a second
mechanism in here to cover that case and removed it: `PipelineRunYield` turns out to be
emitted once per terminal result of the last task rather than per stage, and with the
default `chunks_per_batch` of 2000 a whole document is one batch, so it fired exactly once
at the very end and bought nothing. Closing that gap needs an event source inside the task
itself, which is a separate decision and not attempted here. The limitation is written into
the column comment rather than left for someone to discover.

Related prior art, so reviewers have it: #4326 and #4441 proposed a fuller version of this
(heartbeat plus host and PID ownership) and were closed on the grounds that liveness is
mostly a local-LLM concern. This is deliberately much smaller: no new writer, no new
mechanism, no ownership, no reaper. It puts a timestamp on a write that already happens.

## Acceptance Criteria

* A run doing work records when it last did so, on the row a reader already selects.
* Rows written before this migration behave exactly as they do today, with no backfill.
* Write volume against `pipeline_runs` is unchanged: same number of writes, same number of
  rows, one more column in the SET.
* No behaviour change on its own, since nothing reads the column yet.

Proof:

* `test_progress_write_stamps_a_real_utc_instant` asserts the stored value lands inside a
  window taken around the call, so a frozen stamp or one taken off the local clock fails.
* `test_each_progress_write_advances_the_stamp` pins that repeated ticks move it forward.
  A value that is merely non-NULL says nothing.
* `test_the_insert_fallback_stamps_the_row_it_creates` covers the branch that inserts a row
  when none exists.
* The same tests assert `log_pipeline_run_start` leaves the column NULL: starting is not
  evidence of progress.
* All four are mutation checked. Freezing the stamp reddens all three; deleting only the
  UPDATE stamp reddens two; deleting only the INSERT stamp reddens exactly one. That last
  one is the point, it shows the fallback branch has real coverage and not incidental
  coverage.
* Migration tests follow the existing per-migration convention: idempotent upgrade, the
  create_all case where the column is already present, downgrade, and a no-op against a
  database with no `pipeline_runs` table.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

    $ pytest cognee/tests/unit/modules/pipelines/ \
        cognee/tests/unit/test_add_pipeline_runs_last_heartbeat_at_migration.py \
        cognee/tests/unit/test_frozen_schema_seal.py \
        cognee/tests/e2e/migrations/test_migration_model_lockstep.py

    97 passed, 98 warnings in 15.95s

Frozen schema seal and the migration/model lockstep guard are in that run. `alembic heads`
reports a single head, `b2d6f4a8c150`, on parent `a7c2e9f4b8d1`.

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.