### PR TITLE
fix: Point the API reference playground at a reachable base URL (RES-44)

### DIFF
--- a/tools/check_spec_extras.py
+++ b/tools/check_spec_extras.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import re
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
@@ -86,6 +87,19 @@ def check_servers(servers: list) -> list[str]:
             problems.append(f"servers entry has no absolute http(s) url: {url!r}")
         if not entry.get("description"):
             problems.append(f"servers entry {url!r} has no description")
+
+        # A templated url like https://{tenant}.aws.cognee.ai only renders as an
+        # editable field if every placeholder has a matching `variables` entry with
+        # a default. Without one the playground sends the literal braces.
+        placeholders = set(re.findall(r"\{([^{}]+)\}", url))
+        variables = entry.get("variables") or {}
+        for name in sorted(placeholders - variables.keys()):
+            problems.append(f"servers entry {url!r} has no variables entry for {{{name}}}")
+        for name in sorted(placeholders & variables.keys()):
+            if not (variables[name] or {}).get("default"):
+                problems.append(f"servers entry {url!r} variable {{{name}}} has no default")
+        for name in sorted(variables.keys() - placeholders):
+            problems.append(f"servers entry {url!r} declares unused variable {{{name}}}")
     return problems
 
 

--- a/tools/spec_extras.json
+++ b/tools/spec_extras.json
@@ -2,12 +2,18 @@
   "_comment": "Docs-facing extras applied by tools/sync_release_docs.py:enhance_spec(). FastAPI does not emit any of this; Mintlify reads all of it from the published spec. tag_descriptions and request_examples are maintained automatically by the spec extras sync workflow (tools/fix_spec_extras.py) - edit them here, not in the Python source. request_examples is keyed by \"METHOD /path\" rather than FastAPI's operationId: the operationId embeds the handler function name, so renaming a handler silently orphaned its example.",
   "servers": [
     {
-      "url": "https://api.cognee.ai",
-      "description": "Production server (full functionality)"
+      "url": "https://{tenant}.aws.cognee.ai",
+      "description": "Cognee Cloud: your tenant pod, named in the platform.cognee.ai dashboard",
+      "variables": {
+        "tenant": {
+          "default": "your-tenant",
+          "description": "Your tenant name, shown in the Cognee Cloud dashboard"
+        }
+      }
     },
     {
       "url": "http://localhost:8000",
-      "description": "Local development server (requires local setup)"
+      "description": "Self-hosted: a locally running cognee server"
     }
   ],
   "tag_descriptions": {


### PR DESCRIPTION
Closes RES-44.

## The problem

`https://api.cognee.ai` has been `servers[0]` since the spec was first added (Aug 2025, `8d2e6580`). **It does not work.** DNS resolves it to a Modal deployment that no longer serves the domain, so the request dies in the TLS handshake:

```
$ curl https://api.cognee.ai/health
curl: (35) LibreSSL/3.3.6: error:1404B438:SSL routines:ST_CONNECT:tlsv1 alert internal error
```

Mintlify renders `servers[0]` as the playground base URL **and** in every generated curl sample across all 104 endpoint pages. So a reader who copies a snippet gets a TLS failure, not a clean 404 — harder to diagnose, and it looks like their own network or certs.

## Why not `api.aws.cognee.ai`

That host is live (`/health` 200, `/docs` 200) and the Cloud UI links to it, but it is the **management API**, a different surface:

```
live paths: 33   documented paths: 104   shared: 4
live surface: tenants 9, integrations 9, users 4, billing 3, api-keys 3, permissions 3, survey 2
```

No `/api/v1/add`, `/cognify`, `/search` or `/remember`. Pointing the playground there trades a TLS error for a 404 on ~100 of 104 endpoints. `cognee.serve()` confirms the split: it takes an instance `url` and a separate `management_url`.

## The fix

The documented endpoints live on the per-tenant pod. `*.aws.cognee.ai` is a real wildcard — valid TLS, clean 404 for unknown names — and `your-tenant.aws.cognee.ai` is the placeholder the Cloud UI itself shows (`AgentConnectionSection.tsx:37`).

Since the working host is per-tenant, this uses an **OpenAPI server variable** rather than a fixed URL, so Mintlify renders `{tenant}` as an editable field:

```json
{
  "url": "https://{tenant}.aws.cognee.ai",
  "description": "Cognee Cloud: your tenant pod, named in the platform.cognee.ai dashboard",
  "variables": { "tenant": { "default": "your-tenant", "description": "..." } }
}
```

`check_servers` is extended so a templated URL cannot ship broken: every `{name}` needs a `variables` entry with a default, and an unused variable is flagged. Verified against all three broken shapes plus the current config.

## Verification

- Spec regenerates with the new `servers` block; `check_spec_extras.py` → `0 issue(s)`; ruff clean.
- Reachability checked directly: `api.cognee.ai` TLS error; `api.aws.cognee.ai` 200 but wrong surface; `test.aws.cognee.ai` → clean 404, so the wildcard serves.

## Needs a look before merge

**Server-variable rendering is unverified.** OpenAPI 3.1 server variables are standard and Mintlify documents support, but I could not confirm how the editable field renders without a docs preview. If it does not render, the fallback is a plain `https://your-tenant.aws.cognee.ai` string.

## Not included

- `cognee/api/v1/serve/serve.py:36` — the `serve()` docstring uses `https://my-instance.cognee.ai`, another non-existent host, which flows into the Python API reference.
- A liveness check in `check_servers`. It would have caught this a year ago, but makes CI depend on prod uptime.
- The prose placeholder fix, which is [topoteretes/cognee-docs](https://github.com/topoteretes/cognee-docs) — see RES-45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)