### PR TITLE
SDK-620 ci(mcp): Publish cognee-mcp to PyPI via Trusted Publishing

### DIFF
--- a/.github/workflows/release_mcp.yml
+++ b/.github/workflows/release_mcp.yml
@@ -1,0 +1,119 @@
+name: release_mcp.yml
+# Publish cognee-mcp to PyPI.
+#
+# cognee-mcp versions independently of the cognee library (0.5.x vs 1.5.x), so
+# it gets its own workflow and its own tag namespace (cognee-mcp-v*) instead of
+# riding release.yml — which builds from the repo root and therefore only ever
+# publishes `cognee`. Until this file existed every MCP release was done by
+# hand, which is how the package sat at 0.5.5 for seven weeks while ~40 commits
+# (the whole FastMCP 3 migration) went unpublished.
+#
+# Same supply-chain posture as release.yml: PyPI Trusted Publishing over OIDC
+# (no API token), PEP 740 attestations on the uploaded files, and a SLSA build
+# provenance attestation hosted by GitHub. One-time PyPI setup is described in
+# docs/supply_chain_provenance.md — the `cognee-mcp` project needs its own
+# trusted publisher entry; the one registered for `cognee` does not cover it.
+on:
+  workflow_dispatch:
+
+# Minimal default permissions (OSSF Scorecard: Token-Permissions). The one job
+# opts in to exactly what it needs.
+permissions:
+  contents: read
+
+jobs:
+  release-mcp-pypi:
+    name: Release cognee-mcp to PyPI from ${{ github.ref_name }}
+    # Both side effects of this job — the PyPI upload and the tag — are
+    # permanent, so it only runs from main.
+    if: ${{ github.ref_name == 'main' }}
+    permissions:
+      contents: write       # push the cognee-mcp-v* tag
+      id-token: write       # OIDC: Trusted Publishing + signing attestations
+      attestations: write   # Persist the SLSA build provenance attestation
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cognee-mcp
+
+    steps:
+      - name: Check out ${{ github.ref_name }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
+
+      - name: Install Python
+        # Pinned below 3.14 on purpose: cognee[docs] -> unstructured -> spacy
+        # has no cp314 wheel, and cognee-mcp declares requires-python <3.14.
+        # 3.12 matches the runtime in cognee-mcp/Dockerfile.
+        run: uv python install 3.12
+
+      - name: Resolve version and tag
+        id: meta
+        run: |
+          VERSION="$(uv version --short)"
+          TAG="cognee-mcp-v${VERSION}"
+          echo "Releasing cognee-mcp ${VERSION} as ${TAG}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse to republish an existing version
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          # PyPI versions are immutable: a second upload of the same version is
+          # rejected, and a yanked version can never be reused. Fail here, with
+          # a message that says what to do, rather than at the upload step.
+          if curl -fsS "https://pypi.org/pypi/cognee-mcp/${VERSION}/json" >/dev/null 2>&1; then
+            echo "::error::cognee-mcp ${VERSION} is already on PyPI. Bump the version in cognee-mcp/pyproject.toml (and re-lock) before releasing."
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists on origin."
+            exit 1
+          fi
+          echo "${VERSION} is unpublished and ${TAG} is free."
+
+      - name: Verify the lockfile matches pyproject.toml
+        # Cheap consistency gate before building: a stale lock here means the
+        # pin someone meant to ship is not the one that would be resolved.
+        run: uv lock --check
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Validate distribution metadata
+        # twine >= 7 is required to accept Metadata-Version 2.5, which uv emits.
+        run: uvx --from "twine>=7" twine check dist/*
+
+      # `with:` paths on actions are workspace-relative — the job-level
+      # working-directory only applies to `run:` steps.
+      - name: Attest build provenance for distributions
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2.4.0
+        with:
+          subject-path: "cognee-mcp/dist/*"
+
+      - name: Publish cognee-mcp ${{ steps.meta.outputs.version }} to PyPI
+        # Trusted Publishing (OIDC) — no API token. The action generates and
+        # uploads PEP 740 digital attestations by default.
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2 (twine 7.0.0: accepts Metadata-Version 2.5)
+        with:
+          packages-dir: cognee-mcp/dist/
+
+      - name: Tag the released commit
+        # After the upload, not before: a tag that points at an unpublished
+        # version is a lie, whereas a published version with no tag is a
+        # one-line fix by hand.
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          git config user.name "Cognee Team"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "${TAG}"
+          git push origin "${TAG}"
+          echo "Tagged ${TAG} at $(git rev-parse --short HEAD)"

--- a/docs/supply_chain_provenance.md
+++ b/docs/supply_chain_provenance.md
@@ -39,6 +39,27 @@ on PyPI **once**:
 
 3. Save both.
 
+`cognee-mcp` is a **separate PyPI project** with its own release workflow
+(`.github/workflows/release_mcp.yml`), and PyPI scopes trusted publishers per
+project — the two entries above do not cover it. Register a third publisher
+for it, once:
+
+4. Go to <https://pypi.org/manage/project/cognee-mcp/settings/publishing/>.
+5. Under **Add a new pending publisher** → **GitHub**, add:
+
+   | Field | MCP release publisher |
+   | --- | --- |
+   | Owner | `topoteretes` |
+   | Repository | `cognee` |
+   | Workflow name | `release_mcp.yml` |
+   | Environment | *(leave blank)* |
+
+6. Save. Then release by running `release_mcp.yml` from `main` in the Actions
+   tab: it reads the version from `cognee-mcp/pyproject.toml`, refuses to run
+   if that version is already on PyPI, publishes over OIDC, and tags the commit
+   `cognee-mcp-v<version>` (its own namespace, since cognee-mcp versions
+   independently of the library).
+
 > The **Environment** value must match the `environment:` declared on the
 > publishing job. The workflows do not set one, so leave this blank — if you
 > later add a GitHub Actions environment, set the same name on both sides or the


### PR DESCRIPTION
## Description

Linear: [SDK-620](https://linear.app/cognee/issue/SDK-620)

`cognee-mcp` 0.5.6 is merged to `main` (#4994 / #5010) but **cannot be published, because nothing publishes it.** Both publish steps in the repo — `release.yml:142` and `dev_canary_release.yml:101` — run `uv build` from the repo root, so they only ever release the `cognee` library. `release.yml` touches `cognee-mcp` solely to re-lock it afterwards.

Every MCP release to date has been done by hand. That is the actual root cause of the package sitting at 0.5.5 (2026-07-21) for seven weeks while ~40 commits went unpublished — and the 0.5.5 on PyPI doesn't even declare `fastmcp`, so `uvx cognee-mcp` today installs a server that can't import its own framework.

### What this adds

`.github/workflows/release_mcp.yml` — `workflow_dispatch`, runs from `main` only. Same supply-chain posture as the `cognee` job: Trusted Publishing over OIDC (no API token), PEP 740 attestations, SLSA build provenance. Every action SHA-pinned per SDK-569.

Design choices worth a look:

- **Own tag namespace, `cognee-mcp-v<version>`.** `cognee-mcp` versions independently of the library (0.5.6 vs 1.5.4), so it doesn't ride `release.yml`.
- **Fails before the upload, not at it.** PyPI versions are immutable. The job refuses to run if the version is already on PyPI or the tag exists, with a message saying to bump `pyproject.toml`. Verified the negative case locally: it correctly trips on 0.5.5.
- **Tags after publishing, not before.** A tag pointing at an unpublished version is a lie; a published version missing its tag is a one-line manual fix.
- **Python pinned to 3.12.** `cognee[docs]` → `spacy` has no cp314 wheel and the package declares `<3.14`; 3.12 matches `cognee-mcp/Dockerfile`.
- **`twine>=7` for the metadata check.** uv emits `Metadata-Version: 2.5`, which older twine rejects — same reason `release.yml` pins its publish action.

`docs/supply_chain_provenance.md` gains the third publisher registration, since PyPI scopes trusted publishers **per project** and the `cognee` entries do not cover `cognee-mcp`.

## Two steps this cannot do — a project owner must

1. **Register the trusted publisher** at https://pypi.org/manage/project/cognee-mcp/settings/publishing/ — owner `topoteretes`, repo `cognee`, workflow `release_mcp.yml`, environment blank. Without this the OIDC publish step fails auth.
2. **Run `release_mcp.yml` from `main`** in the Actions tab.

## Verified locally on the real 0.5.6 tree

- `uv build` → `cognee_mcp-0.5.6.tar.gz` + `.whl`; `twine check` **PASSED** on both
- Wheel metadata: `Requires-Python: <3.14,>=3.10`, `fastmcp<4.0.0,>=3.4.0`, `mcp<2.0.0,>=1.24.0`; `strip_vectors` / `codingagents` correctly absent
- `uv lock --check` clean; Python 3.12 resolves
- Guard: 0.5.6 unpublished + tag free → proceeds; 0.5.5 → blocked
- YAML parses; every `run:` block passes `bash -n`; all `uses:` SHA-pinned
