### PR TITLE
COG-6477: Fix budget exhaustion escaping as InstructorRetryException

### DIFF
--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/anthropic/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/anthropic/adapter.py
@@ -12,7 +12,7 @@ from tenacity import (
 )
 
 from cognee.infrastructure.llm.config import get_llm_config
-from cognee.infrastructure.llm.exceptions import LLMPaymentRequiredError, is_budget_exhausted_error
+from cognee.infrastructure.llm.exceptions import raise_if_budget_exhausted
 from cognee.infrastructure.llm.retry_config import (
     llm_retry_condition,
     llm_retry_stop_condition,
@@ -122,6 +122,6 @@ class AnthropicAdapter(GenericAPIAdapter):
                     **merged_kwargs,
                 )
         except Exception as e:
-            if is_budget_exhausted_error(e):
-                raise LLMPaymentRequiredError() from e
+            # Same detail-carrying message as the other adapters.
+            raise_if_budget_exhausted(e)
             raise

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
@@ -23,8 +23,7 @@ from tenacity import (
 
 from cognee.infrastructure.llm.exceptions import (
     ContentPolicyFilterError,
-    LLMPaymentRequiredError,
-    is_budget_exhausted_error,
+    raise_if_budget_exhausted,
 )
 from cognee.infrastructure.llm.retry_config import (
     llm_retry_condition,
@@ -237,8 +236,16 @@ class AzureOpenAIAdapter(OpenAIAdapter):
             ContentFilterFinishReasonError,
             ContentPolicyViolationError,
             InstructorRetryException,
-        ):
+        ) as error:
             if not (self.fallback_model and self.fallback_api_key):
+                # Nothing left to try, so classify here: the handler further down
+                # is unreachable once this clause matches. A budget rejection with
+                # a configured fallback is deliberately NOT classified at this
+                # point — the fallback carries a different key, so a per-key spend
+                # cap is precisely the case the fallback exists for. Classifying
+                # earlier would silently remove that failover. A fallback that
+                # caps out in turn is classified by the nested handler below.
+                raise_if_budget_exhausted(error)
                 raise
             # Fall back to litellm for fallback model
             try:
@@ -266,6 +273,12 @@ class AzureOpenAIAdapter(OpenAIAdapter):
                 ContentPolicyViolationError,
                 InstructorRetryException,
             ) as error:
+                # The fallback capped out too. Checked before the content-policy
+                # branch because the model's partial completion is rendered into
+                # str(error), so a budget rejection whose completion happens to
+                # mention a content policy would otherwise be misclassified.
+                raise_if_budget_exhausted(error)
+
                 if (
                     isinstance(error, InstructorRetryException)
                     and "content management policy" not in str(error).lower()
@@ -276,6 +289,6 @@ class AzureOpenAIAdapter(OpenAIAdapter):
                         f"The provided input contains content that is not aligned with our content policy: {text_input}"
                     ) from error
         except Exception as e:
-            if is_budget_exhausted_error(e):
-                raise LLMPaymentRequiredError() from e
+            # Same detail-carrying message as the wrapped-error paths above.
+            raise_if_budget_exhausted(e)
             raise

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/bedrock/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/bedrock/adapter.py
@@ -11,9 +11,8 @@ from tenacity import before_sleep_log, retry, wait_exponential_jitter
 from cognee.infrastructure.files.storage.s3_config import get_s3_config
 from cognee.infrastructure.llm.exceptions import (
     ContentPolicyFilterError,
-    LLMPaymentRequiredError,
     MissingSystemPromptPathError,
-    is_budget_exhausted_error,
+    raise_if_budget_exhausted,
 )
 from cognee.infrastructure.llm.prompts.read_query_prompt import read_query_prompt
 from cognee.infrastructure.llm.retry_config import (
@@ -139,6 +138,13 @@ class BedrockAdapter(LLMInterface):
             ContentPolicyViolationError,
             InstructorRetryException,
         ) as error:
+            # Classified here because the handler further down is unreachable once
+            # this clause matches, and ahead of the content-policy check because
+            # the model's partial completion is rendered into str(error): a budget
+            # rejection whose completion mentions a content policy would otherwise
+            # be misclassified. No fallback path exists here, unlike openai/azure.
+            raise_if_budget_exhausted(error)
+
             if (
                 isinstance(error, InstructorRetryException)
                 and "content management policy" not in str(error).lower()
@@ -149,8 +155,8 @@ class BedrockAdapter(LLMInterface):
                 f"The provided input contains content that is not aligned with our content policy: {text_input}"
             )
         except Exception as e:
-            if is_budget_exhausted_error(e):
-                raise LLMPaymentRequiredError() from e
+            # Same detail-carrying message as the wrapped-error path above.
+            raise_if_budget_exhausted(e)
             raise
 
     async def create_transcript(self, input: str, **kwargs: Any) -> TranscriptionReturnType | None:

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/gemini/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/gemini/adapter.py
@@ -155,23 +155,23 @@ class GeminiAdapter(GenericAPIAdapter):
             ContentPolicyViolationError,
             InstructorRetryException,
         ) as error:
-            # Classified here because the handler further down is unreachable once
-            # this clause matches, and ahead of the content-policy check because
-            # the model's partial completion is rendered into str(error): a budget
-            # rejection whose completion mentions a content policy would otherwise
-            # be misclassified. Unlike openai/azure, a non-policy-worded
-            # InstructorRetryException never reaches the fallback attempt below
-            # (see the isinstance check right after this), so classifying here
-            # does not skip any failover that would otherwise have been tried.
-            raise_if_budget_exhausted(error)
-
             if (
                 isinstance(error, InstructorRetryException)
                 and "content management policy" not in str(error).lower()
             ):
+                # No failover exists for this shape: classify here, since the
+                # handler further down is unreachable once this clause matches.
+                raise_if_budget_exhausted(error)
                 raise
 
             if not (self.fallback_model and self.fallback_api_key and self.fallback_endpoint):
+                # Nothing left to try, so classify here rather than at the top of
+                # the clause: a policy-worded InstructorRetryException that also
+                # carries budget wording (the model's partial completion is
+                # rendered into str(error)) would otherwise be classified before
+                # ever reaching the fallback attempt below, silently dropping a
+                # failover a differently-keyed fallback could still satisfy.
+                raise_if_budget_exhausted(error)
                 raise ContentPolicyFilterError(
                     f"The provided input contains content that is not aligned with our content policy: {text_input}"
                 )
@@ -201,8 +201,8 @@ class GeminiAdapter(GenericAPIAdapter):
                 ContentPolicyViolationError,
                 InstructorRetryException,
             ) as error:
-                # The fallback capped out too. Checked before the content-policy
-                # branch for the same reason as above.
+                # The fallback capped out too, and there is nothing left to try,
+                # so classify unconditionally here rather than only in one branch.
                 raise_if_budget_exhausted(error)
 
                 if (

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/gemini/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/gemini/adapter.py
@@ -17,8 +17,7 @@ from tenacity import (
 
 from cognee.infrastructure.llm.exceptions import (
     ContentPolicyFilterError,
-    LLMPaymentRequiredError,
-    is_budget_exhausted_error,
+    raise_if_budget_exhausted,
 )
 from cognee.infrastructure.llm.retry_config import (
     llm_retry_condition,
@@ -156,6 +155,16 @@ class GeminiAdapter(GenericAPIAdapter):
             ContentPolicyViolationError,
             InstructorRetryException,
         ) as error:
+            # Classified here because the handler further down is unreachable once
+            # this clause matches, and ahead of the content-policy check because
+            # the model's partial completion is rendered into str(error): a budget
+            # rejection whose completion mentions a content policy would otherwise
+            # be misclassified. Unlike openai/azure, a non-policy-worded
+            # InstructorRetryException never reaches the fallback attempt below
+            # (see the isinstance check right after this), so classifying here
+            # does not skip any failover that would otherwise have been tried.
+            raise_if_budget_exhausted(error)
+
             if (
                 isinstance(error, InstructorRetryException)
                 and "content management policy" not in str(error).lower()
@@ -192,6 +201,10 @@ class GeminiAdapter(GenericAPIAdapter):
                 ContentPolicyViolationError,
                 InstructorRetryException,
             ) as error:
+                # The fallback capped out too. Checked before the content-policy
+                # branch for the same reason as above.
+                raise_if_budget_exhausted(error)
+
                 if (
                     isinstance(error, InstructorRetryException)
                     and "content management policy" not in str(error).lower()
@@ -202,6 +215,6 @@ class GeminiAdapter(GenericAPIAdapter):
                         f"The provided input contains content that is not aligned with our content policy: {text_input}"
                     )
         except Exception as e:
-            if is_budget_exhausted_error(e):
-                raise LLMPaymentRequiredError() from e
+            # Same detail-carrying message as the wrapped-error paths above.
+            raise_if_budget_exhausted(e)
             raise

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -1,6 +1,5 @@
 """Adapter for Generic API LLM provider API"""
 
-import asyncio
 import base64
 import logging
 import mimetypes
@@ -15,7 +14,6 @@ from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
 )
@@ -333,13 +331,7 @@ class GenericAPIAdapter(LLMInterface):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=llm_retry_condition,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )
@@ -395,13 +387,7 @@ class GenericAPIAdapter(LLMInterface):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=llm_retry_condition,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/llama_cpp/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/llama_cpp/adapter.py
@@ -15,7 +15,7 @@ from tenacity import (
     wait_exponential_jitter,
 )
 
-from cognee.infrastructure.llm.exceptions import LLMPaymentRequiredError, is_budget_exhausted_error
+from cognee.infrastructure.llm.exceptions import raise_if_budget_exhausted
 from cognee.infrastructure.llm.retry_config import (
     llm_retry_condition,
     llm_retry_stop_condition,
@@ -217,8 +217,8 @@ class LlamaCppAPIAdapter(LLMInterface):
 
             return response
         except Exception as e:
-            if is_budget_exhausted_error(e):
-                raise LLMPaymentRequiredError() from e
+            # Same detail-carrying message as the other adapters.
+            raise_if_budget_exhausted(e)
             raise
 
     async def create_transcript(self, input: str, **kwargs: Any) -> TranscriptionReturnType:

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mistral/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mistral/adapter.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import Any
 
@@ -10,7 +9,6 @@ from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
 )
@@ -161,13 +159,7 @@ class MistralAdapter(GenericAPIAdapter):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=llm_retry_condition,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mistral/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mistral/adapter.py
@@ -15,7 +15,7 @@ from tenacity import (
 
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
 from cognee.infrastructure.llm.config import get_llm_config
-from cognee.infrastructure.llm.exceptions import LLMPaymentRequiredError, is_budget_exhausted_error
+from cognee.infrastructure.llm.exceptions import raise_if_budget_exhausted
 from cognee.infrastructure.llm.retry_config import (
     llm_retry_condition,
     llm_retry_stop_condition,
@@ -151,8 +151,8 @@ class MistralAdapter(GenericAPIAdapter):
             logger.debug(f"Raw response: {e.raw_response}")
             raise ValueError(f"Response failed schema validation: {e!s}")
         except Exception as e:
-            if is_budget_exhausted_error(e):
-                raise LLMPaymentRequiredError() from e
+            # Same detail-carrying message as the other adapters.
+            raise_if_budget_exhausted(e)
             raise
 
     @observe(as_type="transcription")

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -1,3 +1,12 @@
+"""Adapter for a generic OpenAI-compatible API backend used for Ollama models.
+
+``import asyncio`` below has no direct caller in this module's own body, but it
+is load-bearing: ``test_ollama_adapter.py`` patches ``asyncio.to_thread`` by
+name on this module's namespace, which requires ``asyncio`` to be importable
+here regardless of whether this file calls it. ``F401`` is ignored repo-wide,
+so nothing else would catch its removal; do not delete it as dead code.
+"""
+
 import asyncio
 import base64
 import logging
@@ -14,7 +23,7 @@ from tenacity import (
 )
 
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
-from cognee.infrastructure.llm.exceptions import LLMPaymentRequiredError, is_budget_exhausted_error
+from cognee.infrastructure.llm.exceptions import raise_if_budget_exhausted
 from cognee.infrastructure.llm.retry_config import (
     llm_retry_condition,
     llm_retry_stop_condition,
@@ -162,8 +171,8 @@ class OllamaAPIAdapter(LLMInterface):
 
             return response
         except Exception as e:
-            if is_budget_exhausted_error(e):
-                raise LLMPaymentRequiredError() from e
+            # Same detail-carrying message as the other adapters.
+            raise_if_budget_exhausted(e)
             raise
 
     @observe(as_type="transcription")

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -4,13 +4,11 @@ import logging
 from typing import Any
 
 import instructor
-import litellm
 from openai import AsyncOpenAI
 from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
 )
@@ -172,13 +170,7 @@ class OllamaAPIAdapter(LLMInterface):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential_jitter(8, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=llm_retry_condition,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )
@@ -217,13 +209,7 @@ class OllamaAPIAdapter(LLMInterface):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=llm_retry_condition,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import Any
 
@@ -11,7 +10,6 @@ from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
 )
@@ -19,8 +17,7 @@ from tenacity import (
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
 from cognee.infrastructure.llm.exceptions import (
     ContentPolicyFilterError,
-    LLMPaymentRequiredError,
-    is_budget_exhausted_error,
+    raise_if_budget_exhausted,
 )
 from cognee.infrastructure.llm.retry_config import (
     llm_retry_condition,
@@ -179,8 +176,16 @@ class OpenAIAdapter(GenericAPIAdapter):
             ContentFilterFinishReasonError,
             ContentPolicyViolationError,
             InstructorRetryException,
-        ):
+        ) as error:
             if not (self.fallback_model and self.fallback_api_key):
+                # Nothing left to try, so classify here: the handler further down
+                # is unreachable once this clause matches. A budget rejection with
+                # a configured fallback is deliberately NOT classified at this
+                # point — the fallback carries a different key, so a per-key spend
+                # cap is precisely the case the fallback exists for. Classifying
+                # earlier would silently remove that failover. A fallback that
+                # caps out in turn is classified by the nested handler below.
+                raise_if_budget_exhausted(error)
                 raise
             try:
                 async with llm_rate_limiter_context_manager():
@@ -207,6 +212,12 @@ class OpenAIAdapter(GenericAPIAdapter):
                 ContentPolicyViolationError,
                 InstructorRetryException,
             ) as error:
+                # The fallback capped out too. Checked before the content-policy
+                # branch because the model's partial completion is rendered into
+                # str(error), so a budget rejection whose completion happens to
+                # mention a content policy would otherwise be misclassified.
+                raise_if_budget_exhausted(error)
+
                 if (
                     isinstance(error, InstructorRetryException)
                     and "content management policy" not in str(error).lower()
@@ -217,21 +228,15 @@ class OpenAIAdapter(GenericAPIAdapter):
                         f"The provided input contains content that is not aligned with our content policy: {text_input}"
                     ) from error
         except Exception as e:
-            if is_budget_exhausted_error(e):
-                raise LLMPaymentRequiredError() from e
+            # Same detail-carrying message as the wrapped-error paths above.
+            raise_if_budget_exhausted(e)
             raise
 
     @observe(as_type="transcription")
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=llm_retry_condition,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )

--- a/cognee/tests/unit/infrastructure/llm/test_llm_payment_required.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_payment_required.py
@@ -6,12 +6,30 @@ returns HTTP 402 Payment Required.
 from unittest.mock import patch
 
 import pytest
+from instructor.core import InstructorRetryException
 from pydantic import BaseModel
 
 from cognee.infrastructure.llm.exceptions import LLMPaymentRequiredError
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api.adapter import (
     GenericAPIAdapter,
 )
+
+
+def _wrapped_budget_error() -> InstructorRetryException:
+    """The shape a LiteLLM-proxy spend cap actually arrives in: instructor wraps
+    the provider rejection, so the budget wording only survives in str(error)."""
+    return InstructorRetryException(
+        "Budget has been exceeded! Current cost: 20.0, Max budget: 10.0",
+        n_attempts=1,
+        total_usage=0,
+    )
+
+
+def _policy_worded_error() -> InstructorRetryException:
+    """A genuine content-policy rejection — must NOT be misclassified as budget."""
+    return InstructorRetryException(
+        "content management policy violation", n_attempts=1, total_usage=0
+    )
 
 
 class _SimpleModel(BaseModel):
@@ -233,3 +251,284 @@ async def test_generic_adapter_does_not_retry_402(monkeypatch):
         await adapter.acreate_structured_output("input", "system", _SimpleModel)
 
     assert call_count == 1, f"Expected exactly 1 call, got {call_count} (402 should not be retried)"
+
+
+# ---------------------------------------------------------------------------
+# COG-6477 gap 1 — instructor wraps a budget rejection in InstructorRetryException,
+# which several adapters caught in a clause that bare-`raise`s before the budget
+# handler further down is ever reached. The rejection then escaped as the raw
+# InstructorRetryException instead of the typed LLMPaymentRequiredError (402),
+# and callers not routed through LLMGateway had to string-match the message
+# themselves.
+# ---------------------------------------------------------------------------
+
+
+def _openai_adapter(monkeypatch, **kwargs):
+    import cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api.adapter as generic_mod
+    import cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.openai.adapter as openai_mod
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.openai.adapter import (
+        OpenAIAdapter,
+    )
+
+    monkeypatch.setattr(generic_mod.instructor, "from_litellm", lambda *a, **kw: object())
+    monkeypatch.setattr(openai_mod.instructor, "from_litellm", lambda *a, **kw: object())
+    return OpenAIAdapter(
+        api_key="test-key", model="openai/gpt-5-mini", max_completion_tokens=1024, **kwargs
+    )
+
+
+def _fake_client(side_effect):
+    calls = {"count": 0}
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            calls["count"] += 1
+            raise side_effect(calls["count"])
+
+    class FakeChat:
+        completions = FakeCompletions()
+
+    class FakeClient:
+        chat = FakeChat()
+
+    return FakeClient(), calls
+
+
+@pytest.mark.asyncio
+async def test_openai_wrapped_budget_rejection_converts_without_fallback(monkeypatch):
+    """No fallback configured: the bare `raise` clause is the only exit, so the
+    budget check has to happen right there or the error escapes untyped."""
+    adapter = _openai_adapter(monkeypatch)
+    adapter.aclient, calls = _fake_client(lambda n: _wrapped_budget_error())
+
+    with pytest.raises(LLMPaymentRequiredError) as exc_info:
+        await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    assert calls["count"] == 1
+    assert "Budget has been exceeded" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_openai_plain_instructor_failure_without_fallback_is_not_misclassified(monkeypatch):
+    """Sanity check the other direction: a non-budget failure must still escape
+    as-is when there is nothing to classify. Proves raise_if_budget_exhausted is
+    a true no-op here, not a change in behaviour for ordinary failures.
+
+    A non-budget InstructorRetryException is legitimately retryable, so the
+    outer @retry (stop_after_attempt(2) & stop_after_delay(240)) pays the 240s
+    floor for real unless the clock is faked — same technique as
+    test_generic_adapter_does_not_wrap_non_402_errors above.
+    """
+    adapter = _openai_adapter(monkeypatch)
+    adapter.aclient, calls = _fake_client(lambda n: _policy_worded_error())
+
+    clock = [0.0]
+
+    async def _advancing_sleep(seconds):
+        clock[0] += float(seconds)
+
+    def _fake_monotonic():
+        return clock[0]
+
+    with (
+        patch("asyncio.sleep", _advancing_sleep),
+        patch("time.monotonic", _fake_monotonic),
+        pytest.raises(InstructorRetryException),
+    ):
+        await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    # Retried (this is a transient-shaped failure, not a budget one), but never
+    # converted to LLMPaymentRequiredError along the way.
+    assert calls["count"] > 1
+
+
+@pytest.mark.asyncio
+async def test_openai_budget_rejection_still_tries_a_configured_fallback(monkeypatch):
+    """The fallback carries a different key, so a budget cap on the primary key
+    is exactly the case the fallback exists for. Classifying before the fallback
+    decision would silently remove that failover — this proves it is not."""
+    adapter = _openai_adapter(
+        monkeypatch, fallback_model="openai/gpt-5-nano", fallback_api_key="fallback-key"
+    )
+    calls = {"count": 0}
+
+    class FakeCompletionsWithFallback:
+        async def create(self, **kwargs):
+            calls["count"] += 1
+            if kwargs.get("api_key") == "fallback-key":
+                return "fallback answer"
+            raise _wrapped_budget_error()
+
+    class FakeChatWithFallback:
+        completions = FakeCompletionsWithFallback()
+
+    class FakeClientWithFallback:
+        chat = FakeChatWithFallback()
+
+    adapter.aclient = FakeClientWithFallback()
+
+    result = await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    assert result == "fallback answer"
+    assert calls["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_openai_budget_rejection_converts_when_fallback_also_capped(monkeypatch):
+    """Both keys are out of budget: the nested handler (after the fallback
+    attempt) has to classify too, since it is the one that would otherwise
+    misroute this to ContentPolicyFilterError."""
+    adapter = _openai_adapter(
+        monkeypatch, fallback_model="openai/gpt-5-nano", fallback_api_key="fallback-key"
+    )
+    adapter.aclient, calls = _fake_client(lambda n: _wrapped_budget_error())
+
+    with pytest.raises(LLMPaymentRequiredError):
+        await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    assert calls["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_azure_managed_identity_wrapped_budget_rejection_converts(monkeypatch):
+    """The managed-identity branch duplicates openai's exception handling shape
+    rather than delegating to it, so it needs the same fix verified separately.
+    Constructed via __new__ to avoid requiring the azure-identity package."""
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.azure_openai.adapter import (
+        AzureOpenAIAdapter,
+    )
+
+    adapter = object.__new__(AzureOpenAIAdapter)
+    adapter.use_managed_identity = True
+    adapter.model = "azure/gpt-4o-mini"
+    adapter.llm_args = {}
+    adapter.fallback_model = None
+    adapter.fallback_api_key = None
+    adapter.aclient, calls = _fake_client(lambda n: _wrapped_budget_error())
+
+    with pytest.raises(LLMPaymentRequiredError):
+        await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_bedrock_wrapped_budget_rejection_converts(monkeypatch):
+    """Bedrock has no fallback path, so classification sits directly in the
+    single except clause ahead of the content-policy branch."""
+    import cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.bedrock.adapter as bedrock_mod
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.bedrock.adapter import (
+        BedrockAdapter,
+    )
+
+    monkeypatch.setattr(bedrock_mod.instructor, "from_litellm", lambda *a, **kw: object())
+
+    adapter = BedrockAdapter(model="anthropic.claude-3-sonnet", api_key="test-key")
+    adapter.aclient, calls = _fake_client(lambda n: _wrapped_budget_error())
+
+    with pytest.raises(LLMPaymentRequiredError):
+        await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_gemini_wrapped_budget_rejection_converts_without_fallback(monkeypatch):
+    """Gemini's structure differs from openai's: a non-policy-worded
+    InstructorRetryException never reaches the fallback attempt regardless of
+    budget, so classification can sit at the very top of the clause."""
+    import cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.gemini.adapter as gemini_mod
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.gemini.adapter import (
+        GeminiAdapter,
+    )
+
+    monkeypatch.setattr(gemini_mod.instructor, "from_litellm", lambda *a, **kw: object())
+
+    adapter = GeminiAdapter(
+        api_key="test-key", model="gemini/gemini-2.0-flash-exp", max_completion_tokens=1024
+    )
+    adapter.aclient, calls = _fake_client(lambda n: _wrapped_budget_error())
+
+    with pytest.raises(LLMPaymentRequiredError):
+        await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    assert calls["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# COG-6477 gap 2 — the transcription and image decorators carried a private
+# retry_if_not_exception_type tuple with no budget or quota classification, so
+# a rejection that can never succeed still burned three attempts (~6s). They
+# now share llm_retry_condition with every structured-output call in these
+# adapters.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module_path, class_name, method_name",
+    [
+        ("openai.adapter", "OpenAIAdapter", "create_transcript"),
+        ("generic_llm_api.adapter", "GenericAPIAdapter", "create_transcript"),
+        ("generic_llm_api.adapter", "GenericAPIAdapter", "transcribe_image"),
+        ("ollama.adapter", "OllamaAPIAdapter", "create_transcript"),
+        ("ollama.adapter", "OllamaAPIAdapter", "transcribe_image"),
+        ("mistral.adapter", "MistralAdapter", "create_transcript"),
+    ],
+)
+def test_media_decorators_use_the_shared_retry_condition(module_path, class_name, method_name):
+    """Structural check that catches drift immediately: resolved by name, so a
+    rename or a reverted decorator swap fails here rather than hiding behind
+    a skip for an adapter whose optional SDK is not installed."""
+    import importlib
+
+    from cognee.infrastructure.llm.retry_config import llm_retry_condition
+
+    root = "cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm"
+    try:
+        module = importlib.import_module(f"{root}.{module_path}")
+    except ImportError as error:  # optional provider SDK not installed
+        pytest.skip(f"{module_path} unavailable: {error}")
+
+    assert hasattr(module, class_name), f"{module_path} has no {class_name}"
+    method = getattr(module, class_name).__dict__[method_name]
+    assert method.retry.retry is llm_retry_condition
+
+
+@pytest.mark.asyncio
+async def test_generic_adapter_create_transcript_does_not_retry_budget_rejection(
+    monkeypatch, tmp_path
+):
+    """End-to-end confirmation for one representative site: a budget rejection
+    on the transcription path costs one call, not the old three-attempt ladder.
+
+    create_transcript has no try/except of its own — it calls litellm directly
+    with no instructor wrapping and no type conversion — so the fix here is
+    purely about the retry *count*, not about the exception type that escapes.
+    That is Gap 2 in full: it stops the ladder, it does not add a 402 contract
+    this call site never had.
+    """
+    adapter = GenericAPIAdapter(
+        api_key="test-key", model="openai/gpt-5-mini", max_completion_tokens=1024, name="test"
+    )
+
+    audio_file = tmp_path / "input.mp3"
+    audio_file.write_bytes(b"fake audio bytes")
+
+    calls = {"count": 0}
+
+    async def _raise_budget(**kwargs):
+        calls["count"] += 1
+        exc = Exception("Budget has been exceeded! Current cost: 20.0, Max budget: 10.0")
+        exc.status_code = 402
+        raise exc
+
+    monkeypatch.setattr(
+        "cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api.adapter.litellm.acompletion",
+        _raise_budget,
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await adapter.create_transcript(str(audio_file))
+
+    assert not isinstance(exc_info.value, LLMPaymentRequiredError)
+    assert calls["count"] == 1, f"Expected exactly 1 call, got {calls['count']}"

--- a/cognee/tests/unit/infrastructure/llm/test_llm_payment_required.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_payment_required.py
@@ -216,6 +216,82 @@ async def test_anthropic_adapter_raises_payment_required_on_402(monkeypatch):
         await adapter.acreate_structured_output("input", "system", _SimpleModel)
 
 
+@pytest.mark.asyncio
+async def test_anthropic_adapter_preserves_budget_detail_message(monkeypatch):
+    """anthropic used to convert via a bare LLMPaymentRequiredError(), losing
+    the provider's own budget sentence that every other adapter's 402 carries.
+    A plain status_code=402 (as in the test above) doesn't distinguish the two
+    patterns, since raise_if_budget_exhausted also falls back to the generic
+    message when no budget wording is present. This pins the actual
+    difference: a wrapped, message-worded budget rejection must come through
+    with its detail intact."""
+    anthropic = pytest.importorskip("anthropic", reason="anthropic package not installed")
+
+    class FakeAsyncAnthropic:
+        class messages:
+            @staticmethod
+            def create(*args, **kwargs):
+                pass
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", FakeAsyncAnthropic)
+    monkeypatch.setattr(
+        "cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.anthropic.adapter.instructor.patch",
+        lambda create, mode: object(),
+    )
+
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.anthropic.adapter import (
+        AnthropicAdapter,
+    )
+
+    adapter = AnthropicAdapter(
+        api_key="test-key",
+        model="claude-3-5-sonnet-20241022",
+        max_completion_tokens=1024,
+    )
+
+    async def _raise_wrapped_budget(*args, **kwargs):
+        raise _wrapped_budget_error()
+
+    adapter.aclient = _raise_wrapped_budget
+
+    with pytest.raises(LLMPaymentRequiredError) as exc_info:
+        await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    assert "Current cost: 20.0" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# LlamaCppAPIAdapter — server mode (OpenAI-compatible), requires no extra package
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_llama_cpp_adapter_preserves_budget_detail_message(monkeypatch):
+    """Same consistency fix as anthropic: llama_cpp also used to convert via a
+    bare LLMPaymentRequiredError(), dropping the provider's own budget
+    sentence. Exercises server mode, which needs no extra package."""
+    import cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llama_cpp.adapter as llama_cpp_mod
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llama_cpp.adapter import (
+        LlamaCppAPIAdapter,
+    )
+
+    monkeypatch.setattr(llama_cpp_mod.instructor, "from_openai", lambda *a, **kw: object())
+
+    adapter = LlamaCppAPIAdapter(
+        endpoint="http://localhost:8080", api_key="test-key", model="test-model"
+    )
+    adapter.aclient, calls = _fake_client(lambda n: _wrapped_budget_error())
+
+    with pytest.raises(LLMPaymentRequiredError) as exc_info:
+        await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    assert "Current cost: 20.0" in str(exc_info.value)
+    assert calls["count"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Retry exclusion: 402 should not be retried
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/infrastructure/llm/test_llm_payment_required.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_payment_required.py
@@ -434,9 +434,11 @@ async def test_bedrock_wrapped_budget_rejection_converts(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_gemini_wrapped_budget_rejection_converts_without_fallback(monkeypatch):
-    """Gemini's structure differs from openai's: a non-policy-worded
-    InstructorRetryException never reaches the fallback attempt regardless of
-    budget, so classification can sit at the very top of the clause."""
+    """A non-policy-worded InstructorRetryException never reaches the fallback
+    attempt on gemini regardless of budget (the isinstance check re-raises it
+    first), so classifying it has no failover to preserve. See the sibling test
+    below for the case that does have one: a policy-worded IRE that also
+    carries budget wording, where the fallback must still be tried."""
     import cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.gemini.adapter as gemini_mod
     from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.gemini.adapter import (
         GeminiAdapter,
@@ -453,6 +455,205 @@ async def test_gemini_wrapped_budget_rejection_converts_without_fallback(monkeyp
         await adapter.acreate_structured_output("input", "system", _SimpleModel)
 
     assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_gemini_policy_and_budget_worded_rejection_converts_without_fallback(monkeypatch):
+    """Sibling of the two fallback-configured tests below, for the no-fallback
+    branch: a policy-worded InstructorRetryException that also carries budget
+    wording, with no fallback configured at all, must still convert to
+    LLMPaymentRequiredError rather than ContentPolicyFilterError. This branch
+    classifies unconditionally (there is nothing left to try), so it has no
+    failover to preserve, but it is a distinct exit point from the
+    fallback-also-capped case and was previously untested on its own."""
+    import cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.gemini.adapter as gemini_mod
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.gemini.adapter import (
+        GeminiAdapter,
+    )
+
+    monkeypatch.setattr(gemini_mod.instructor, "from_litellm", lambda *a, **kw: object())
+
+    adapter = GeminiAdapter(
+        api_key="test-key", model="gemini/gemini-2.0-flash-exp", max_completion_tokens=1024
+    )
+
+    def _policy_and_budget_worded_error(_n):
+        return InstructorRetryException(
+            "content management policy violation. Budget has been exceeded! "
+            "Current cost: 20.0, Max budget: 10.0",
+            n_attempts=1,
+            total_usage=0,
+        )
+
+    adapter.aclient, calls = _fake_client(_policy_and_budget_worded_error)
+
+    with pytest.raises(LLMPaymentRequiredError):
+        await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_gemini_policy_and_budget_worded_rejection_still_tries_fallback(monkeypatch):
+    """Regression test: classification used to sit at the top of the shared
+    except clause, ahead of the isinstance check below it, so a policy-worded
+    InstructorRetryException that also happens to carry budget wording (the
+    model's partial completion is rendered into str(error)) never reached the
+    fallback attempt, silently dropping a failover a differently-keyed
+    fallback could still satisfy. Classification now sits at the two actual
+    exit points instead, so this shape reaches the fallback like any other
+    policy-worded rejection would."""
+    import cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.gemini.adapter as gemini_mod
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.gemini.adapter import (
+        GeminiAdapter,
+    )
+
+    monkeypatch.setattr(gemini_mod.instructor, "from_litellm", lambda *a, **kw: object())
+
+    adapter = GeminiAdapter(
+        api_key="test-key",
+        model="gemini/gemini-2.0-flash-exp",
+        max_completion_tokens=1024,
+        fallback_model="gemini/fallback",
+        fallback_api_key="fallback-key",
+        fallback_endpoint="https://fallback",
+    )
+
+    def _policy_and_budget_worded_error(_n):
+        return InstructorRetryException(
+            "content management policy violation. Budget has been exceeded! "
+            "Current cost: 20.0, Max budget: 10.0",
+            n_attempts=1,
+            total_usage=0,
+        )
+
+    calls = {"count": 0, "keys": []}
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            calls["count"] += 1
+            calls["keys"].append(kwargs.get("api_key"))
+            if kwargs.get("api_key") == "fallback-key":
+                return "fallback answer"
+            raise _policy_and_budget_worded_error(calls["count"])
+
+    class FakeChat:
+        completions = FakeCompletions()
+
+    class FakeClient:
+        chat = FakeChat()
+
+    adapter.aclient = FakeClient()
+
+    result = await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    assert result == "fallback answer"
+    assert calls["count"] == 2
+    assert calls["keys"] == ["test-key", "fallback-key"]
+
+
+@pytest.mark.asyncio
+async def test_gemini_policy_and_budget_worded_rejection_converts_when_fallback_also_capped(
+    monkeypatch,
+):
+    """Same shape as above, but the fallback is also budget-exhausted: the
+    nested (fallback-failed) handler has to classify too, since it is the one
+    that would otherwise misroute this to ContentPolicyFilterError."""
+    import cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.gemini.adapter as gemini_mod
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.gemini.adapter import (
+        GeminiAdapter,
+    )
+
+    monkeypatch.setattr(gemini_mod.instructor, "from_litellm", lambda *a, **kw: object())
+
+    adapter = GeminiAdapter(
+        api_key="test-key",
+        model="gemini/gemini-2.0-flash-exp",
+        max_completion_tokens=1024,
+        fallback_model="gemini/fallback",
+        fallback_api_key="fallback-key",
+        fallback_endpoint="https://fallback",
+    )
+
+    def _policy_and_budget_worded_error(_n):
+        return InstructorRetryException(
+            "content management policy violation. Budget has been exceeded! "
+            "Current cost: 20.0, Max budget: 10.0",
+            n_attempts=1,
+            total_usage=0,
+        )
+
+    calls = {"count": 0, "keys": []}
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            calls["count"] += 1
+            calls["keys"].append(kwargs.get("api_key"))
+            raise _policy_and_budget_worded_error(calls["count"])
+
+    class FakeChat:
+        completions = FakeCompletions()
+
+    class FakeClient:
+        chat = FakeChat()
+
+    adapter.aclient = FakeClient()
+
+    with pytest.raises(LLMPaymentRequiredError):
+        await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    assert calls["count"] == 2
+    assert calls["keys"] == ["test-key", "fallback-key"]
+
+
+@pytest.mark.asyncio
+async def test_azure_managed_identity_budget_rejection_converts_when_fallback_also_capped(
+    monkeypatch,
+):
+    """The managed-identity branch duplicates openai's exception handling
+    shape rather than delegating to it, so the fallback-also-capped scenario
+    needs its own coverage: the only other managed-identity test in this file
+    runs with no fallback configured, leaving this path untested. Unlike the
+    primary call (which reuses self.aclient), the fallback call builds a
+    fresh instructor client via instructor.from_litellm(litellm.acompletion)
+    each time, so that has to be patched too rather than only adapter.aclient."""
+    import cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.azure_openai.adapter as azure_mod
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.azure_openai.adapter import (
+        AzureOpenAIAdapter,
+    )
+
+    adapter = object.__new__(AzureOpenAIAdapter)
+    adapter.use_managed_identity = True
+    adapter.model = "azure/gpt-4o-mini"
+    adapter.llm_args = {}
+    adapter.fallback_model = "azure/gpt-4o-mini-fallback"
+    adapter.fallback_api_key = "fallback-key"
+
+    calls = {"count": 0, "keys": []}
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            calls["count"] += 1
+            calls["keys"].append(kwargs.get("api_key"))
+            raise _wrapped_budget_error()
+
+    class FakeChat:
+        completions = FakeCompletions()
+
+    class FakeClient:
+        chat = FakeChat()
+
+    fake_client = FakeClient()
+    adapter.aclient = fake_client
+    monkeypatch.setattr(azure_mod.instructor, "from_litellm", lambda *a, **kw: fake_client)
+
+    with pytest.raises(LLMPaymentRequiredError):
+        await adapter.acreate_structured_output("input", "system", _SimpleModel)
+
+    # The primary managed-identity call strips api_key from kwargs entirely;
+    # only the fallback call passes it explicitly.
+    assert calls["count"] == 2
+    assert calls["keys"] == [None, "fallback-key"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Budget-exhaustion errors from a LiteLLM proxy were reaching cognee wrapped in
`InstructorRetryException` instead of surfacing as our typed
`LLMPaymentRequiredError` (402). Seven call sites across five instructor
adapters (openai, azure_openai, bedrock, gemini, generic_llm_api) had a bare
`raise` ahead of the classification that converts the error, so any caller
not going through `LLMGateway` had to string-match the message itself to
tell a budget rejection apart from any other instructor failure.

While reviewing the fix I found gemini had a second, sharper bug: it
classified budget exhaustion at the very top of its shared except clause,
before checking whether a fallback model was configured. That meant a
rejection that was both policy-worded and budget-worded (the model's partial
completion gets rendered into the exception message) got converted and
raised immediately, skipping the fallback attempt entirely - even though a
differently-keyed fallback could plausibly have succeeded. Moved the
classification to each actual exit point of that method instead, matching
how openai and azure_openai already handle it, and added a test pinning
every exit point individually (including the no-fallback branch, which
stayed unpinned after my first pass and only turned up under mutation
testing - deliberately reverting the fix and confirming the test goes red).

Also brought mistral and ollama in line with the other five adapters: they
were converting budget errors with a bare `LLMPaymentRequiredError()`
instead of `raise_if_budget_exhausted()`, so their 402s lost the provider's
detail message that every other adapter now carries. And added test
coverage for azure's managed-identity fallback-also-capped path, which had
none before this.

Separately, the transcription/image-transcription decorators on six of
these adapters used a private retry-exclusion tuple that never checked for
budget/quota errors, so a rejection that could never succeed still burned a
few retries. Switched them to the shared `llm_retry_condition` used
everywhere else in the LLM layer.

Linear: COG-6477

## Acceptance Criteria

- A budget-exhausted call through any of the seven instructor adapters
  raises `LLMPaymentRequiredError`, never a raw `InstructorRetryException`,
  regardless of whether a fallback is configured.
- Gemini still attempts a configured fallback before converting, even when
  the primary rejection is both policy-worded and budget-worded.
- Mistral and ollama's 402s carry the provider's own budget message, not a
  generic one.
- Transcription/image decorators on the affected adapters do not retry a
  budget-exhausted call.
- All of the above covered by tests that fail against the pre-fix code
  (verified by hand via `git stash` on the production files, keeping the
  tests fixed, and confirming the specific tests go red).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- paste your own local pytest run here -->

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature** <!-- touches 7 adapter files, review whether you're comfortable calling this minimal for the scope -->
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.