### PR TITLE
fix(neo4j): bind temporal ids as a query parameter

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -8,7 +8,7 @@ from neo4j import AsyncSession
 from neo4j import AsyncGraphDatabase
 from neo4j.exceptions import Neo4jError
 from contextlib import asynccontextmanager, nullcontext
-from typing import Optional, Any, List, Dict, Type, Tuple, Coroutine, Set
+from typing import Optional, Any, List, Dict, Type, Tuple, Coroutine, Set, Union
 from cognee.modules.observability import OtelStatusCode as StatusCode
 from cognee.infrastructure.engine import DataPoint
 from cognee.modules.engine.utils.generate_timestamp_datapoint import date_to_int
@@ -2431,35 +2431,49 @@ class Neo4jAdapter(GraphDBInterface):
         result = await self.query(query)
         return [record["n"] for record in result] if result else []
 
-    async def collect_events(self, ids: List[str]) -> Any:
+    @staticmethod
+    def _normalize_temporal_ids(ids: Union[List[str], str]) -> List[str]:
+        """Accept either a list of ids or the legacy pre-quoted, comma-joined string."""
+        if isinstance(ids, str):
+            return [uid.strip().strip("'\"") for uid in ids.split(",") if uid.strip()]
+
+        return ids
+
+    async def collect_events(self, ids: Union[List[str], str]) -> Any:
         """
         Collect all Event-type nodes reachable within 1..2 hops
         from the given node IDs.
 
         Args:
             graph_engine: Object exposing an async .query(str) -> Any
-            ids: List of node IDs (strings)
+            ids: List of node IDs (strings), or the legacy comma-joined
+                pre-quoted string form.
 
         Returns:
             List of events
         """
 
-        event_collection_cypher = """UNWIND [{quoted}] AS uid
-            MATCH (start {{id: uid}})
+        # Bind the ids as a parameter rather than formatting them into the
+        # query text. The previous `.format(quoted=ids)` only produced valid
+        # Cypher for the pre-quoted string form: a genuine List[str] -- which is
+        # what the signature declared -- rendered its Python repr, so
+        # `UNWIND [['a', 'b']] AS uid` bound uid to the whole list and
+        # `MATCH (start {id: uid})` matched nothing. No error, just zero events.
+        event_collection_cypher = """UNWIND $ids AS uid
+            MATCH (start {id: uid})
             MATCH (start)-[*1..2]-(event)
             WHERE event.type = 'Event'
             WITH DISTINCT event
             RETURN collect(event) AS events;
         """
 
-        query = event_collection_cypher.format(quoted=ids)
-        return await self.query(query)
+        return await self.query(event_collection_cypher, {"ids": self._normalize_temporal_ids(ids)})
 
     async def collect_time_ids(
         self,
         time_from: Optional[Timestamp] = None,
         time_to: Optional[Timestamp] = None,
-    ) -> str:
+    ) -> List[str]:
         """
         Collect IDs of Timestamp nodes between time_from and time_to.
 
@@ -2469,8 +2483,8 @@ class Neo4jAdapter(GraphDBInterface):
             time_to: Upper bound int (inclusive), optional
 
         Returns:
-            A string of quoted IDs:  "'id1', 'id2', 'id3'"
-            (ready for use in a Cypher UNWIND clause).
+            A list of timestamp node IDs, matching the ladybug adapter and the
+            List[str] that collect_events binds as a query parameter.
         """
 
         ids: List[str] = []
@@ -2514,9 +2528,8 @@ class Neo4jAdapter(GraphDBInterface):
             return ids
 
         time_nodes = await self.query(cypher, params)
-        time_ids_list = [item["id"] for item in time_nodes if "id" in item]
 
-        return ", ".join(f"'{uid}'" for uid in time_ids_list)
+        return [item["id"] for item in time_nodes if "id" in item]
 
     async def get_triplets_batch(self, offset: int, limit: int) -> list[dict[str, Any]]:
         """

--- a/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_temporal.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_temporal.py
@@ -1,0 +1,75 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognee.infrastructure.databases.graph.neo4j_driver.adapter import Neo4jAdapter
+from cognee.tasks.temporal_graph.models import Timestamp
+
+
+@pytest.mark.asyncio
+async def test_collect_time_ids_returns_list_for_unwind_params():
+    """collect_time_ids returns a list, matching the ladybug adapter.
+
+    It previously returned a pre-quoted, comma-joined string built for string
+    interpolation into the Cypher text.
+    """
+    adapter = Neo4jAdapter.__new__(Neo4jAdapter)
+    adapter.query = AsyncMock(return_value=[{"id": "timestamp-1"}, {"id": "timestamp-2"}])
+
+    ids = await adapter.collect_time_ids(time_to=Timestamp(year=1980))
+
+    assert ids == ["timestamp-1", "timestamp-2"]
+
+
+@pytest.mark.asyncio
+async def test_collect_events_binds_ids_as_list():
+    """A List[str] must reach Cypher as a bound parameter, not as its repr.
+
+    `collect_events` declared `ids: List[str]` but interpolated it with
+    `.format(quoted=ids)`, so a real list rendered its Python repr and produced
+    `UNWIND [['a', 'b']] AS uid`. That binds uid to the whole list, so
+    `MATCH (start {id: uid})` matches nothing and the query returns zero events
+    without raising.
+    """
+    adapter = Neo4jAdapter.__new__(Neo4jAdapter)
+    adapter.query = AsyncMock(return_value=[])
+
+    await adapter.collect_events(ids=["timestamp-1", "timestamp-2"])
+
+    cypher, params = adapter.query.await_args.args
+    assert params == {"ids": ["timestamp-1", "timestamp-2"]}
+    assert "$ids" in cypher, "ids must be bound as a parameter, not interpolated"
+    assert "[['timestamp-1'" not in cypher, "the list must not be rendered as a nested list"
+
+
+@pytest.mark.asyncio
+async def test_collect_events_accepts_legacy_quoted_id_string():
+    """The pre-quoted string form still works, as it does in the ladybug adapter."""
+    adapter = Neo4jAdapter.__new__(Neo4jAdapter)
+    adapter.query = AsyncMock(return_value=[])
+
+    await adapter.collect_events(ids="'timestamp-1', 'timestamp-2'")
+
+    _, params = adapter.query.await_args.args
+    assert params == {"ids": ["timestamp-1", "timestamp-2"]}
+
+
+@pytest.mark.asyncio
+async def test_collect_time_ids_output_feeds_collect_events():
+    """The two halves must compose: whatever one returns, the other must accept.
+
+    This is the path temporal_retriever takes -- collect_time_ids straight into
+    collect_events -- and the shape mismatch between them was the bug.
+    """
+    adapter = Neo4jAdapter.__new__(Neo4jAdapter)
+    adapter.query = AsyncMock(return_value=[{"id": "timestamp-1"}, {"id": "timestamp-2"}])
+
+    ids = await adapter.collect_time_ids(
+        time_from=Timestamp(year=1980), time_to=Timestamp(year=1990)
+    )
+
+    adapter.query = AsyncMock(return_value=[])
+    await adapter.collect_events(ids=ids)
+
+    _, params = adapter.query.await_args.args
+    assert params == {"ids": ["timestamp-1", "timestamp-2"]}


### PR DESCRIPTION
## The bug

`Neo4jAdapter.collect_events` declares `ids: List[str]`, but builds its query by
interpolating that value into the Cypher text:

```python
event_collection_cypher = """UNWIND [{quoted}] AS uid
    MATCH (start {{id: uid}})
    ...
"""
query = event_collection_cypher.format(quoted=ids)
return await self.query(query)
```

`.format()` only produces valid Cypher here if `ids` is already a pre-quoted,
comma-joined string. Passing the `List[str]` the signature promises renders the
list's Python repr:

```
UNWIND [['timestamp-1', 'timestamp-2']] AS uid
```

That is a list containing one list. `uid` binds to the whole list instead of to
each id, so `MATCH (start {id: uid})` matches nothing. **Nothing raises** — the
temporal retrieval path just returns zero events, and
`TemporalRetriever.get_context` reports "No events identified".

## Reproduced on `main` (`c0d18c80e`)

```python
adapter = Neo4jAdapter.__new__(Neo4jAdapter)
adapter.query = AsyncMock(return_value=[])

await adapter.collect_events(ids=["timestamp-1", "timestamp-2"])
# -> UNWIND [['timestamp-1', 'timestamp-2']] AS uid     (nested; matches nothing)

await adapter.collect_events(ids="'timestamp-1', 'timestamp-2'")
# -> UNWIND ['timestamp-1', 'timestamp-2'] AS uid       (the only shape that works)
```

An empty list — what `collect_time_ids` returns from its `else` branch — yields
`UNWIND [[]] AS uid`.

## The two halves disagreed on the shape they exchange

`collect_time_ids` was annotated `-> str` and returned
`", ".join(f"'{uid}'" for uid in ...)`, while its `else` branch returned `ids`,
an empty **list**. So the declared type was wrong for both paths.

The ladybug adapter had already moved to the other convention:
`collect_time_ids` returns `List[str]`, and `collect_events` accepts
`Union[List[str], str]`, normalizes via `_normalize_temporal_ids`, and binds
`UNWIND $ids`. Its tests pin exactly this:

- `test_collect_time_ids_returns_list_for_unwind_params`
- `test_collect_events_binds_ids_as_list`
- `test_collect_events_accepts_legacy_quoted_id_string`

So the ambiguity in this interface was already known and already handled — on one
adapter. The neo4j side had neither the normalization nor any test.

`temporal_retriever.py:145` calls `collect_events(ids=ids)` with the value from
`collect_time_ids` (`:132`/`:134`/`:136`), so both adapters serve the same
call site through the same shared shape.

## The change

Align neo4j with ladybug:

- `collect_time_ids` returns `List[str]`, and its docstring no longer advertises
  the quoted-string format.
- `collect_events` accepts `Union[List[str], str]` and binds the ids as a query
  parameter (`UNWIND $ids`) after normalizing them.

The legacy pre-quoted string keeps working, so any caller outside this repo
passing the old shape is unaffected. Binding also means ids are no longer
interpolated into query text.

## Tests

New `cognee/tests/unit/infrastructure/databases/graph/test_neo4j_temporal.py`,
mirroring the ladybug file:

- `test_collect_time_ids_returns_list_for_unwind_params`
- `test_collect_events_binds_ids_as_list` — asserts on the bound params, and that
  the nested-list rendering is absent
- `test_collect_events_accepts_legacy_quoted_id_string`
- `test_collect_time_ids_output_feeds_collect_events` — runs the composition
  `collect_time_ids -> collect_events`, which is the path `temporal_retriever`
  takes and where the mismatch lived

The tests assert on the bound parameters rather than on the return value: with
the bug present, the query is well-formed Cypher that simply matches nothing, so
asserting on results would pass either way.

Reverting `adapter.py` alone turns all 4 red. The 3 existing ladybug tests pass
unchanged.

## Verification

- `pytest .../test_neo4j_temporal.py .../test_ladybug_temporal.py` — **7 passed**
- `pytest cognee/tests/unit/infrastructure/databases/graph/` — **126 passed**
- `pytest cognee/tests/unit/modules/retrieval/` — **545 passed, 1 skipped**
- `ruff check` / `ruff format --check` at v0.15.11 (the version pinned in
  `.pre-commit-config.yaml`) — clean on both files

`neo4j_deadlock_test.py` was excluded from the graph run: it needs a live Neo4j,
which is not available here.

I installed the `neo4j` package locally to exercise `Neo4jAdapter` in unit
tests; no dependency changes are included in this PR.
