### PR TITLE
fix(retrieval): give each query its own placeholder list on missing collection

### DIFF
--- a/cognee/modules/retrieval/utils/node_edge_vector_search.py
+++ b/cognee/modules/retrieval/utils/node_edge_vector_search.py
@@ -120,7 +120,7 @@ class NodeEdgeVectorSearch:
         """Separates search results into node and edge distances with stable shapes.
 
         Ensures all collections are present in the output, even if empty:
-        - Batch mode: missing/empty collections become [[]] * query_list_length
+        - Batch mode: missing/empty collections become one empty list per query
         - Single mode: missing/empty collections become []
         """
         self.node_distances = {}
@@ -161,7 +161,9 @@ class NodeEdgeVectorSearch:
                 collection_name=collection_name, query_texts=query_batch, limit=None
             )
         except CollectionNotFoundError:
-            return [[]] * len(query_batch)
+            # One list per query, not `[[]] * n`: that repeats a single list
+            # object, so extending one query's results extends every query's.
+            return [[] for _ in range(len(query_batch))]
 
     async def _run_single_search(
         self,

--- a/cognee/tests/unit/modules/retrieval/test_node_edge_vector_search.py
+++ b/cognee/tests/unit/modules/retrieval/test_node_edge_vector_search.py
@@ -271,3 +271,55 @@ async def test_node_edge_vector_search_has_results_batch_edges_only():
     vector_search.node_distances = {}
 
     assert vector_search.has_results() is True
+
+
+@pytest.mark.asyncio
+async def test_missing_collection_placeholder_rows_are_independent():
+    """The CollectionNotFoundError placeholder must not repeat one list object.
+
+    `[[]] * n` repeats a single list, so extending one query's results extends
+    every query's. `brute_force_triplet_search` does exactly that when expanding
+    a neighborhood: `node_distances[collection][qi].extend(per_query)`.
+    """
+    search = NodeEdgeVectorSearch.__new__(NodeEdgeVectorSearch)
+    search.edge_collection = "EdgeType_relationship_name"
+
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.batch_search = AsyncMock(side_effect=CollectionNotFoundError("missing"))
+    search._get_vector_engine = AsyncMock(return_value=mock_vector_engine)
+
+    query_batch = ["query a", "query b", "query c"]
+    placeholder = await search._search_batch_collection("Entity_name", query_batch)
+
+    assert placeholder == [[], [], []]
+    # Distinct objects, so a per-query mutation stays local.
+    assert len({id(row) for row in placeholder}) == len(query_batch)
+
+
+@pytest.mark.asyncio
+async def test_per_query_extend_does_not_leak_across_queries():
+    """Extending one query slot must leave the other queries empty.
+
+    This is the path brute_force_triplet_search takes, so it pins the actual
+    consequence rather than just the placeholder's shape.
+    """
+    search = NodeEdgeVectorSearch.__new__(NodeEdgeVectorSearch)
+    search.edge_collection = "EdgeType_relationship_name"
+
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.batch_search = AsyncMock(side_effect=CollectionNotFoundError("missing"))
+    search._get_vector_engine = AsyncMock(return_value=mock_vector_engine)
+
+    query_batch = ["query a", "query b", "query c"]
+    placeholder = await search._search_batch_collection("Entity_name", query_batch)
+
+    search.set_distances_from_results(
+        ["Entity_name"], [placeholder], query_list_length=len(query_batch)
+    )
+
+    extra = MockScoredResult("node_for_query_a", 0.91)
+    search.node_distances["Entity_name"][0].extend([extra])
+
+    assert search.node_distances["Entity_name"][0] == [extra]
+    assert search.node_distances["Entity_name"][1] == []
+    assert search.node_distances["Entity_name"][2] == []


### PR DESCRIPTION
## The bug

When `batch_search` raises `CollectionNotFoundError`,
`_search_batch_collection` returns a placeholder built with `*`:

```python
except CollectionNotFoundError:
    return [[]] * len(query_batch)
```

`[[]] * n` repeats a **single list object**, so every query slot is the same
list. Mutating one mutates all of them.

## It reaches the mutation site

`set_distances_from_results` does not sanitize it — `[[], [], []]` is truthy, so
`if not result:` never fires and the aliased list is stored as-is.

`brute_force_triplet_search` then extends **per query slot** when expanding a
neighborhood (`brute_force_triplet_search.py:200`):

```python
for qi, per_query in enumerate(extra_scores):
    if qi < len(vector_search.node_distances[collection_name]):
        vector_search.node_distances[collection_name][qi].extend(per_query)
```

So extending `qi=0` extends every query. Queries b and c come back carrying
query a's scores — silently, with no error, and only when a collection is
missing.

## Reproduced on `main` with the real classes

```python
search = NodeEdgeVectorSearch.__new__(NodeEdgeVectorSearch)
search.edge_collection = "EdgeType_relationship_name"
engine = AsyncMock()
engine.batch_search = AsyncMock(side_effect=CollectionNotFoundError("gone"))
search._get_vector_engine = AsyncMock(return_value=engine)

out = await search._search_batch_collection("Entity_name", ["q1", "q2", "q3"])
# out == [[], [], []]      and  out[0] is out[1] is out[2]  ->  True

search.set_distances_from_results(["Entity_name"], [out], query_list_length=3)
search.node_distances["Entity_name"][0].extend(["score_for_q1_only"])
```

```
q1 -> ['score_for_q1_only']
q2 -> ['score_for_q1_only']     <- leaked
q3 -> ['score_for_q1_only']     <- leaked
```

## The convention was already settled elsewhere

`set_distances_from_results` in this same file uses the safe form in all three
places it builds an empty batch shape:

```python
[] if query_list_length is None else [[] for _ in range(query_list_length)]
```

And its docstring described the unsafe form:

```
- Batch mode: missing/empty collections become [[]] * query_list_length
```

while the code beneath it does the opposite. So this line was the only remaining
holdout, and the docstring was pointing the wrong way.

## The change

- Build one list per query in the `CollectionNotFoundError` path.
- Fix that docstring so it matches what the code actually does.

`grep` confirms no other `[[]] * n` (or `[{}] * n`) remains anywhere under
`cognee/`.

## Tests

Two tests appended to the existing
`cognee/tests/unit/modules/retrieval/test_node_edge_vector_search.py`:

- `test_missing_collection_placeholder_rows_are_independent` — asserts the rows
  are distinct objects via `id()`, not merely that the shape is `[[], [], []]`
  (the buggy value has the right shape, so an equality check alone passes either
  way)
- `test_per_query_extend_does_not_leak_across_queries` — runs the mutation
  `brute_force_triplet_search` performs and asserts the other queries stay
  empty, pinning the consequence rather than the placeholder

Reverting the source alone turns both red; the 12 existing tests in the file are
unaffected.

## Verification

- `pytest .../test_node_edge_vector_search.py` — **14 passed**
- `pytest cognee/tests/unit/modules/retrieval/` — **547 passed, 1 skipped**
- `ruff check` / `ruff format --check` at v0.15.11 (the version pinned in
  `.pre-commit-config.yaml`) — clean on both files
