### PR TITLE
fix(mcp): support X-Api-Key authentication scheme in API mode

### DIFF
--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -79,11 +79,21 @@ class CogneeClient:
         If None, uses direct cognee function calls.
     api_token : str, optional
         Authentication token for the API (optional, required if API has authentication enabled).
+    api_auth_scheme : str, optional
+        Authentication scheme: "bearer" (default for non-tenant URLs) or "x-api-key"
+        (required for self-hosted API keys). Can also be set via COGNEE_API_AUTH_SCHEME env var.
     """
 
-    def __init__(self, api_url: str | None = None, api_token: str | None = None):
+    def __init__(
+        self,
+        api_url: str | None = None,
+        api_token: str | None = None,
+        api_auth_scheme: str | None = None,
+    ):
         self.api_url = api_url.rstrip("/") if api_url else None
         self.api_token = api_token
+        resolved_scheme = api_auth_scheme or os.environ.get("COGNEE_API_AUTH_SCHEME")
+        self.api_auth_scheme = resolved_scheme.lower().strip() if resolved_scheme else None
         self.use_api = bool(api_url)
 
         # Extract tenant ID from tenant URL pattern: tenant-<uuid>.*.cognee.ai
@@ -116,16 +126,20 @@ class CogneeClient:
     def _get_headers(self, include_content_type: bool = True) -> dict[str, str]:
         """Get headers for API requests.
 
-        Uses X-Api-Key + X-Tenant-Id for tenant APIs (cloud),
-        falls back to Bearer token for local/self-hosted backends.
+        Uses X-Api-Key (+ optional X-Tenant-Id) when api_auth_scheme is "x-api-key"
+        or for tenant APIs (cloud), and falls back to Bearer token when
+        api_auth_scheme is "bearer" or by default for local/self-hosted backends.
         """
         headers: dict[str, str] = {}
         if include_content_type:
             headers["Content-Type"] = "application/json"
         if self.api_token:
-            if self.tenant_id:
+            if self.api_auth_scheme == "x-api-key" or (
+                self.api_auth_scheme is None and self.tenant_id
+            ):
                 headers["X-Api-Key"] = self.api_token
-                headers["X-Tenant-Id"] = self.tenant_id
+                if self.tenant_id:
+                    headers["X-Tenant-Id"] = self.tenant_id
             else:
                 headers["Authorization"] = f"Bearer {self.api_token}"
         return headers

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -842,6 +842,15 @@ async def main():
         "authentication enabled). Can also be set via the COGNEE_API_KEY env var.",
     )
 
+    parser.add_argument(
+        "--api-auth-scheme",
+        choices=["bearer", "x-api-key"],
+        default=os.getenv("COGNEE_API_AUTH_SCHEME"),
+        help="Authentication scheme for API mode: 'bearer' (default, sends Authorization: Bearer <token>) "
+        "or 'x-api-key' (sends X-Api-Key: <token>, required for self-hosted API keys). "
+        "Can also be set via the COGNEE_API_AUTH_SCHEME env var.",
+    )
+
     # Cognee Cloud connection options
     parser.add_argument(
         "--serve-url",
@@ -860,7 +869,11 @@ async def main():
     args = parser.parse_args()
 
     # Initialize the global CogneeClient
-    cognee_client = CogneeClient(api_url=args.api_url, api_token=args.api_token)
+    cognee_client = CogneeClient(
+        api_url=args.api_url,
+        api_token=args.api_token,
+        api_auth_scheme=args.api_auth_scheme,
+    )
 
     host = args.host
     port = int(args.port)

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -52,6 +52,52 @@ def test_format_recall_results_handles_normalized_rows():
     assert "[graph] graph answer" in rendered
 
 
+def test_cognee_client_auth_schemes():
+    # 1. Default non-tenant URL -> Bearer token
+    client = CogneeClient(api_url="http://localhost:8000", api_token="secret_key")
+    headers = client._get_headers()
+    assert headers["Authorization"] == "Bearer secret_key"
+    assert "X-Api-Key" not in headers
+
+    # 2. Explicit x-api-key scheme -> X-Api-Key header
+    client_key = CogneeClient(
+        api_url="http://localhost:8000",
+        api_token="secret_key",
+        api_auth_scheme="x-api-key",
+    )
+    headers_key = client_key._get_headers()
+    assert headers_key["X-Api-Key"] == "secret_key"
+    assert "Authorization" not in headers_key
+
+    # 3. Explicit bearer scheme -> Bearer token
+    client_bearer = CogneeClient(
+        api_url="http://localhost:8000",
+        api_token="secret_key",
+        api_auth_scheme="bearer",
+    )
+    headers_bearer = client_bearer._get_headers()
+    assert headers_bearer["Authorization"] == "Bearer secret_key"
+    assert "X-Api-Key" not in headers_bearer
+
+    # 4. Cloud tenant URL -> X-Api-Key + X-Tenant-Id
+    tenant_url = "https://tenant-12345678-1234-1234-1234-123456789abc.cognee.ai"
+    client_cloud = CogneeClient(api_url=tenant_url, api_token="secret_key")
+    headers_cloud = client_cloud._get_headers()
+    assert headers_cloud["X-Api-Key"] == "secret_key"
+    assert headers_cloud["X-Tenant-Id"] == "12345678-1234-1234-1234-123456789abc"
+    assert "Authorization" not in headers_cloud
+
+    # 5. COGNEE_API_AUTH_SCHEME environment variable
+    os.environ["COGNEE_API_AUTH_SCHEME"] = "x-api-key"
+    try:
+        client_env = CogneeClient(api_url="http://localhost:8000", api_token="secret_key")
+        headers_env = client_env._get_headers()
+        assert headers_env["X-Api-Key"] == "secret_key"
+        assert "Authorization" not in headers_env
+    finally:
+        os.environ.pop("COGNEE_API_AUTH_SCHEME", None)
+
+
 # Tools that the MCP server is expected to expose. Kept as named groups so the
 # contract documents intent rather than just enumerating names. The hardening
 # rule is that the LLM-direct memory API stays minimal (V2: remember/recall/


### PR DESCRIPTION
## Description
When running `cognee-mcp` in API mode (`--api-url` or `COGNEE_API_URL`) against a self-hosted instance configured with an API key, `CogneeClient` previously hardcoded `Authorization: Bearer <token>` for non-tenant URLs. Self-hosted cognee instances configured with API keys require the `X-Api-Key` header instead of Bearer token authentication.

This change adds an `api_auth_scheme` parameter to `CogneeClient` and a corresponding `--api-auth-scheme` argument in `cognee-mcp/src/server.py`, with support for the `COGNEE_API_AUTH_SCHEME` environment variable (`bearer` or `x-api-key`). When `x-api-key` is configured, outgoing requests use the `X-Api-Key: <token>` header. Existing default behavior is fully preserved (defaults to `Bearer` for regular endpoints, and `X-Api-Key` + `X-Tenant-Id` for cloud tenant URLs).

Closes #5023

## Acceptance Criteria
- [x] Users can configure `x-api-key` auth scheme via `--api-auth-scheme x-api-key` or `COGNEE_API_AUTH_SCHEME=x-api-key`.
- [x] `CogneeClient._get_headers()` attaches `X-Api-Key` header when `api_auth_scheme="x-api-key"`.
- [x] Existing default behavior is preserved for backwards compatibility.
- [x] Unit test `test_cognee_client_auth_schemes` validates default bearer, explicit x-api-key, explicit bearer, cloud tenant URLs, and `COGNEE_API_AUTH_SCHEME` env var.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
