### PR TITLE
fix(forget): raise typed 404 for unknown dataset name instead of NoneType 500

### DIFF
--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -484,7 +484,12 @@ async def _resolve_dataset_id(dataset_ref: str | UUID, user: Any) -> UUID:
             raise ValueError(f"Dataset {dataset_ref} not found or not accessible.")
         return dataset.id
 
+    from cognee.modules.data.exceptions import DatasetNotFoundError
     from cognee.modules.data.methods import get_authorized_dataset_by_name
 
     dataset = await get_authorized_dataset_by_name(dataset_ref, user, "delete")
+    if dataset is None:
+        # Same message for missing and unauthorized: the name lookup returns None
+        # for both, and distinguishing them would leak which dataset names exist.
+        raise DatasetNotFoundError(message=f"Dataset '{dataset_ref}' not found or not accessible.")
     return dataset.id

--- a/cognee/api/v1/forget/routers/get_forget_router.py
+++ b/cognee/api/v1/forget/routers/get_forget_router.py
@@ -6,6 +6,7 @@ from pydantic import ConfigDict, Field
 
 from cognee import __version__ as cognee_version
 from cognee.api.DTO import InDTO
+from cognee.exceptions import CogneeApiError
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
@@ -83,6 +84,8 @@ def get_forget_router() -> APIRouter:
         accepted.
 
         ## Error Codes
+        - **404 Not Found**: Dataset name does not exist or is not accessible
+        - **403 Forbidden**: Caller lacks delete permission on the dataset
         - **422 Unprocessable Entity**: Invalid parameter combination (e.g. both `dataset`
           and `datasetId`, `dataId` without a dataset, or `memoryOnly` without a dataset)
         - **500 Internal Server Error**: Error during deletion
@@ -115,6 +118,11 @@ def get_forget_router() -> APIRouter:
                     "error": "Invalid request parameters. Specify dataset or dataset_id, data_id+dataset, or everything=True."
                 },
             )
+        except CogneeApiError:
+            # Typed errors carry their own status code (DatasetNotFoundError -> 404,
+            # PermissionDeniedError -> 403) and are rendered by the global
+            # CogneeApiError handler; swallowing them here used to turn both into 500s.
+            raise
         except Exception:
             logger = get_logger()
             logger.exception("Forget endpoint error")

--- a/cognee/tests/unit/api/v1/forget/test_forget_endpoint_not_found.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_endpoint_not_found.py
@@ -1,0 +1,97 @@
+"""Regression tests for typed errors from POST /v1/forget (issue #5013).
+
+Before the fix, an unknown dataset name crashed forget() with
+`AttributeError: 'NoneType' object has no attribute 'id'` and the router's
+catch-all turned every typed error (including PermissionDeniedError, which
+carries status_code=403) into `500 {"error": "An error occurred during deletion."}`.
+Now `_resolve_dataset_id` raises DatasetNotFoundError for an unresolvable name
+and the router re-raises CogneeApiError so the global handler renders its code.
+"""
+
+import importlib
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cognee.api.client import app
+from cognee.modules.data.exceptions import DatasetNotFoundError
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.methods import get_authenticated_user
+
+forget_pkg = importlib.import_module("cognee.api.v1.forget")
+
+
+@pytest.fixture(scope="module")
+def test_client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def client(test_client):
+    async def override_get_authenticated_user():
+        return SimpleNamespace(
+            id=str(uuid.uuid4()),
+            email="test@example.com",
+            is_active=True,
+            tenant_id=str(uuid.uuid4()),
+        )
+
+    app.dependency_overrides[get_authenticated_user] = override_get_authenticated_user
+    yield test_client
+    app.dependency_overrides.pop(get_authenticated_user, None)
+
+
+def test_unknown_dataset_name_returns_404(client):
+    """forget(dataset=<unknown name>) must surface as 404, not a 500 NoneType crash."""
+    with (
+        patch.object(forget_pkg, "forget", new_callable=AsyncMock) as mock_forget,
+        patch("cognee.api.v1.forget.routers.get_forget_router.send_telemetry"),
+    ):
+        mock_forget.side_effect = DatasetNotFoundError(
+            message="Dataset 'does-not-exist' not found or not accessible."
+        )
+
+        response = client.post("/api/v1/forget", json={"dataset": "does-not-exist"})
+
+    assert response.status_code == 404
+    assert "does-not-exist" in response.text
+    assert "DatasetNotFoundError" in response.text
+
+
+def test_permission_denied_no_longer_masked_as_500(client):
+    """PermissionDeniedError carries status_code=403 and must reach the client as 403."""
+    with (
+        patch.object(forget_pkg, "forget", new_callable=AsyncMock) as mock_forget,
+        patch("cognee.api.v1.forget.routers.get_forget_router.send_telemetry"),
+    ):
+        mock_forget.side_effect = PermissionDeniedError(
+            message="You do not have permission to delete this dataset."
+        )
+
+        response = client.post("/api/v1/forget", json={"datasetId": str(uuid.uuid4())})
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_resolve_dataset_id_raises_typed_error_for_unknown_name():
+    """The lookup site itself: a None dataset must raise DatasetNotFoundError, not crash."""
+    from cognee.api.v1.forget.forget import _resolve_dataset_id
+
+    user = SimpleNamespace(id=uuid.uuid4(), email="test@example.com")
+    with (
+        patch(
+            "cognee.modules.data.methods.get_authorized_dataset_by_name",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        pytest.raises(DatasetNotFoundError) as exc_info,
+    ):
+        await _resolve_dataset_id("does-not-exist", user)
+
+    assert "does-not-exist" in str(exc_info.value)
+    assert exc_info.value.status_code == 404


### PR DESCRIPTION
## Description

`cognee.forget(dataset="<name>")` for a name the caller cannot resolve crashed with `AttributeError: 'NoneType' object has no attribute 'id'`, and over HTTP the forget router's `except Exception` catch-all turned that crash, and every other typed error, into `500 {"error": "An error occurred during deletion."}`

two changes:

- `_resolve_dataset_id` in `cognee/api/v1/forget/forget.py`: when `get_authorized_dataset_by_name` returns None, raise `DatasetNotFoundError` (404) with a message that deliberately covers both missing and unauthorized, so dataset names are not leaked. the UUID branch already had a guard; the name branch indexed `dataset.id` unconditionally
- `get_forget_router.py`: re-raise `CogneeApiError` before the catch-all so the global handler at `cognee/api/client.py` renders the error's own status code. `DatasetNotFoundError` now returns 404 and `PermissionDeniedError` returns 403 instead of both becoming 500

## Reasoning

i considered fixing this only in the router by catching AttributeError, but that would leave the SDK, CLI and MCP surfaces with the raw crash. raising at the lookup site fixes all four surfaces at once, and the DatasetNotFoundError + global handler pairing is already the pattern the rest of the API uses (cognify, validate). the no-leak wording matches the existing UUID-path message ("not found or not accessible") so both branches behave the same way

## Acceptance Criteria

- `forget(dataset="does-not-exist")` raises `DatasetNotFoundError` (404) on SDK, CLI, MCP; HTTP returns 404
- `forget(dataset_id=<unknown uuid>)` still raises `PermissionDeniedError` (unchanged no-leak semantics); HTTP returns 403 instead of 500
- existing 422 parameter-validation behavior unchanged

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Screenshots (local tests passing)

```
$ uv run pytest cognee/tests/unit/api/v1/forget/ -q
18 passed, 14 warnings in 1.04s

$ uv run pytest cognee/tests/unit/api/ cognee/tests/unit/exceptions/ -q
688 passed, 2 skipped, 80 warnings in 60.64s

$ uv run pytest cognee/tests/unit/modules/users/ cognee/tests/unit/shared/ -q
121 passed, 13 warnings in 1.21s
```

SDK behavior after the fix (issue #5013 repro):

```
SDK {'dataset': 'does-not-exist'} -> DatasetNotFoundError | DatasetNotFoundError: Dataset 'does-not-exist' not found or not accessible. (Status code: 404)
SDK {'dataset_id': UUID('...')} -> PermissionDeniedError | PermissionDeniedError: Request owner does not have necessary permission: [delete]
```

new regression tests in `cognee/tests/unit/api/v1/forget/test_forget_endpoint_not_found.py`: unknown name returns 404 over HTTP, PermissionDeniedError is no longer masked as 500, and `_resolve_dataset_id` itself raises the typed error

## Pre-submission Checklist

- [x] I have tested these changes thoroughly locally
- [x] My changes are minimal and focused on the described issue
- [x] Code follows the repository's style guidelines (ruff check / ruff format clean)
- [x] I have added tests that prove my fix is effective
- [x] I have updated documentation where applicable (endpoint docstring error codes)
- [x] All local tests pass
- [x] I have searched existing PRs to ensure this is not a duplicate
- [x] I have linked the relevant issue (Fixes #5013)
- [x] My commits have clear messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin