### PR TITLE
feat: Add Serply web scraper backend

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -528,11 +528,14 @@ WEB_SCRAPER_TIMEOUT=15.0
 WEB_SCRAPER_MAX_DELAY=10.0
 
 # -- API-based URL fetching. Tavily is used when TAVILY_API_KEY is set,
-#    otherwise Keenable when KEENABLE_API_KEY is set, otherwise the default crawler.
+#    otherwise Keenable when KEENABLE_API_KEY is set, otherwise Serply when
+#    SERPLY_API_KEY is set, otherwise the default crawler.
 #TAVILY_API_KEY=""
 #KEENABLE_API_KEY=""
 #KEENABLE_BASE_URL="https://api.keenable.ai"
 #KEENABLE_LIVE_FETCH="false"
+#SERPLY_API_KEY=""
+#SERPLY_BASE_URL="https://api.serply.io"
 
 ################################################################################
 #  OpenTelemetry / Tracing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ pre-commit install
 - **neptune** - AWS Neptune support
 - **turso** - Turso vector database support
 - **docs** - Document processing (unstructured library)
-- **scraping** - Web scraping (Tavily, BeautifulSoup, Playwright; Keenable needs no extra — it uses the built-in httpx)
+- **scraping** - Web scraping (Tavily, BeautifulSoup, Playwright; Keenable and Serply need no extra; they use the built-in httpx)
 - **langchain** - LangChain integration
 - **llama-index** - LlamaIndex integration
 - **anthropic** - Anthropic Claude models

--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -183,6 +183,11 @@ async def add(
         (Tavily takes precedence if both keys are set.)
         await cognee.add("https://example.com")
 
+        # Add a single url and serply fetch ingestion method
+        Make sure to set SERPLY_API_KEY = YOUR_SERPLY_API_KEY as a environment variable
+        (Tavily and Keenable take precedence if their keys are set.)
+        await cognee.add("https://example.com")
+
         # Add multiple urls
         await cognee.add(["https://example.com","https://books.toscrape.com"])
         ```
@@ -200,6 +205,7 @@ async def add(
         - GRAPH_DATABASE_PROVIDER: "ladybug" (default), "neo4j"
         - TAVILY_API_KEY: YOUR_TAVILY_API_KEY
         - KEENABLE_API_KEY: YOUR_KEENABLE_API_KEY
+        - SERPLY_API_KEY: YOUR_SERPLY_API_KEY
 
     """
     # Route to remote instance if connected via serve()

--- a/cognee/tasks/web_scraper/README.md
+++ b/cognee/tasks/web_scraper/README.md
@@ -2,13 +2,14 @@
 
 ## Overview
 
-The `web_scraper` module provides tools for scraping web content and storing structured data in cognee's graph database. It supports three scraping backends:
+The `web_scraper` module provides tools for scraping web content and storing structured data in cognee's graph database. It supports four scraping backends:
 
 1. **Default Crawler** - Uses `httpx` for HTTP requests with optional Playwright for JavaScript rendering
 2. **Tavily API** - Uses Tavily for content extraction (requires `TAVILY_API_KEY` environment variable)
 3. **Keenable API** - Uses [Keenable](https://docs.keenable.ai) for clean markdown extraction (requires `KEENABLE_API_KEY` environment variable)
+4. **Serply API** - Uses [Serply](https://serply.io/docs) to fetch pages as markdown or raw HTML (requires `SERPLY_API_KEY` environment variable)
 
-The module automatically selects the backend: Tavily if `TAVILY_API_KEY` is set, otherwise Keenable if `KEENABLE_API_KEY` is set, otherwise the default crawler. Pass `preferred_tool` to `fetch_page_content` to select one explicitly.
+The module automatically selects the backend: Tavily if `TAVILY_API_KEY` is set, otherwise Keenable if `KEENABLE_API_KEY` is set, otherwise Serply if `SERPLY_API_KEY` is set, otherwise the default crawler. Pass `preferred_tool` to `fetch_page_content` to select one explicitly.
 
 ## Components
 
@@ -28,6 +29,7 @@ The module automatically selects the backend: Tavily if `TAVILY_API_KEY` is set,
 | `DefaultCrawlerConfig` | Configuration for default crawler (concurrency, timeouts, Playwright) |
 | `TavilyConfig` | Configuration for Tavily API (API key, extract depth, timeout) |
 | `KeenableConfig` | Configuration for Keenable API (API key, live fetch, extraction prompt, timeout) |
+| `SerplyConfig` | Configuration for Serply API (API key, response type, concurrency, timeout) |
 
 ### Data Models (extend `DataPoint`)
 
@@ -126,6 +128,16 @@ await cognee.cognify()
 | `base_url` | `KEENABLE_BASE_URL` env or `https://api.keenable.ai` | Keenable API base URL |
 | `live` | `KEENABLE_LIVE_FETCH` env or `False` | Fetch the live page instead of Keenable's indexed copy |
 | `prompt` | `None` | Optional LLM extraction instruction (max 2000 chars) |
+| `concurrency` | `5` | Max concurrent fetch requests |
+| `timeout` | `30` | Request timeout (1-120s) |
+
+### SerplyConfig
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `api_key` | `SERPLY_API_KEY` env | Serply API key (required) |
+| `base_url` | `SERPLY_BASE_URL` env or `https://api.serply.io` | Serply API base URL |
+| `response_type` | `"markdown"` | `"markdown"` for converted text or `"full"` for the raw page HTML |
 | `concurrency` | `5` | Max concurrent fetch requests |
 | `timeout` | `30` | Request timeout (1-120s) |
 

--- a/cognee/tasks/web_scraper/__init__.py
+++ b/cognee/tasks/web_scraper/__init__.py
@@ -2,7 +2,7 @@
 
 This module provides tools for scraping web content, managing scraping jobs, and storing
 data in a graph database. It includes classes and functions for crawling web pages using
-BeautifulSoup, Tavily, or Keenable, defining data models, and handling scraping
+BeautifulSoup, Tavily, Keenable, or Serply, defining data models, and handling scraping
 configurations.
 """
 

--- a/cognee/tasks/web_scraper/config.py
+++ b/cognee/tasks/web_scraper/config.py
@@ -20,6 +20,14 @@ class KeenableConfig(BaseModel):
     timeout: int | None = Field(default=30, ge=1, le=120)
 
 
+class SerplyConfig(BaseModel):
+    api_key: str | None = os.getenv("SERPLY_API_KEY")
+    base_url: str = os.getenv("SERPLY_BASE_URL", "https://api.serply.io")
+    response_type: Literal["markdown", "full"] = "markdown"
+    concurrency: int = Field(default=5, ge=1)
+    timeout: int | None = Field(default=30, ge=1, le=120)
+
+
 class DefaultCrawlerConfig(BaseModel):
     concurrency: int = 5
     crawl_delay: float = 0.5

--- a/cognee/tasks/web_scraper/utils.py
+++ b/cognee/tasks/web_scraper/utils.py
@@ -1,7 +1,8 @@
-"""Utilities for fetching web content using BeautifulSoup, Tavily, or Keenable.
+"""Utilities for fetching web content using BeautifulSoup, Tavily, Keenable, or Serply.
 
 This module provides functions to fetch and extract content from web pages, supporting
-BeautifulSoup for custom extraction rules and Tavily or Keenable for API-based scraping.
+BeautifulSoup for custom extraction rules and Tavily, Keenable, or Serply for API-based
+scraping.
 """
 
 import asyncio
@@ -12,7 +13,7 @@ import httpx
 from cognee.shared.logging_utils import get_logger
 from cognee.tasks.web_scraper.types import UrlsToHtmls
 
-from .config import DefaultCrawlerConfig, KeenableConfig, TavilyConfig
+from .config import DefaultCrawlerConfig, KeenableConfig, SerplyConfig, TavilyConfig
 from .default_url_crawler import DefaultUrlCrawler
 
 logger = get_logger(__name__)
@@ -23,24 +24,28 @@ async def fetch_page_content(
     preferred_tool: str | None = None,
     tavily_config: TavilyConfig | None = None,
     keenable_config: KeenableConfig | None = None,
+    serply_config: SerplyConfig | None = None,
     soup_crawler_config: DefaultCrawlerConfig | None = None,
 ) -> UrlsToHtmls:
     """Fetch content from one or more URLs using the specified tool.
 
     This function retrieves web page content using BeautifulSoup (with custom
-    extraction rules), Tavily, or Keenable (API-based scraping). It handles single URLs
-    or lists of URLs and returns a dictionary mapping URLs to their extracted content.
+    extraction rules), Tavily, Keenable, or Serply (API-based scraping). It handles
+    single URLs or lists of URLs and returns a dictionary mapping URLs to their
+    extracted content.
 
     When preferred_tool is not given, the backend is auto-selected from the
     environment: Tavily if TAVILY_API_KEY is set, otherwise Keenable if
-    KEENABLE_API_KEY is set, otherwise the default crawler.
+    KEENABLE_API_KEY is set, otherwise Serply if SERPLY_API_KEY is set, otherwise
+    the default crawler.
 
     Args:
         urls: A single URL (str) or a list of URLs (List[str]) to scrape.
-        preferred_tool: The scraping tool to use ("tavily", "keenable", or
+        preferred_tool: The scraping tool to use ("tavily", "keenable", "serply", or
             "beautifulsoup"). Defaults to environment-based auto-selection.
         tavily_config: Configuration for Tavily API, including API key.
         keenable_config: Configuration for the Keenable API.
+        serply_config: Configuration for the Serply API.
         soup_crawler_config: Configuration for the default (BeautifulSoup) crawler.
 
     Returns:
@@ -57,6 +62,8 @@ async def fetch_page_content(
             preferred_tool = "tavily"
         elif os.getenv("KEENABLE_API_KEY"):
             preferred_tool = "keenable"
+        elif os.getenv("SERPLY_API_KEY"):
+            preferred_tool = "serply"
         else:
             preferred_tool = "beautifulsoup"
 
@@ -66,6 +73,9 @@ async def fetch_page_content(
     elif preferred_tool == "keenable":
         logger.info("Using Keenable API for url fetching")
         return await fetch_with_keenable(urls, keenable_config=keenable_config)
+    elif preferred_tool == "serply":
+        logger.info("Using Serply API for url fetching")
+        return await fetch_with_serply(urls, serply_config=serply_config)
     elif preferred_tool == "beautifulsoup":
         logger.info("Using default crawler for content extraction")
 
@@ -107,7 +117,7 @@ async def fetch_page_content(
     else:
         raise ValueError(
             f"Unknown preferred_tool '{preferred_tool}'. "
-            "Expected 'tavily', 'keenable', or 'beautifulsoup'."
+            "Expected 'tavily', 'keenable', 'serply', or 'beautifulsoup'."
         )
 
 
@@ -251,4 +261,87 @@ async def fetch_with_keenable(
         raise errors[0]
 
     logger.info(f"Successfully fetched content from {len(return_results)} URL(s) via Keenable")
+    return return_results
+
+
+async def fetch_with_serply(
+    urls: str | list[str], serply_config: SerplyConfig | None = None
+) -> UrlsToHtmls:
+    """Fetch content from URLs using the Serply API.
+
+    Uses Serply's /v1/request endpoint (https://serply.io/docs) to fetch each URL and
+    return it as markdown (default) or as the raw HTML of the page. Requires an API key
+    (SERPLY_API_KEY or serply_config.api_key).
+
+    Args:
+        urls: A single URL (str) or a list of URLs (List[str]) to scrape.
+        serply_config: Configuration for the Serply API. Defaults to
+            environment-based configuration (SERPLY_API_KEY, SERPLY_BASE_URL).
+
+    Returns:
+        Dict[str, str]: A dictionary mapping each requested URL to its fetched
+            content. URLs that fail to fetch are omitted with a warning.
+
+    Raises:
+        Exception: If every requested URL fails to fetch (e.g., invalid API key).
+    """
+    serply_config = serply_config or SerplyConfig()
+    url_list = [urls] if isinstance(urls, str) else urls
+
+    headers = {}
+    if serply_config.api_key:
+        headers["X-Api-Key"] = serply_config.api_key
+
+    logger.info(
+        f"Sending fetch requests to Serply API for {len(url_list)} URL(s) "
+        f"(response_type={serply_config.response_type}, timeout={serply_config.timeout}s)"
+    )
+
+    semaphore = asyncio.Semaphore(serply_config.concurrency)
+
+    async with httpx.AsyncClient(
+        base_url=serply_config.base_url,
+        headers=headers,
+        timeout=serply_config.timeout,
+    ) as client:
+
+        async def fetch_one(url: str):
+            payload = {"url": url, "response_type": serply_config.response_type}
+            async with semaphore:
+                response = await client.post("/v1/request", json=payload)
+            response.raise_for_status()
+            if serply_config.response_type == "full":
+                # The "full" response is a JSON envelope with the page HTML under "data".
+                return response.json().get("data") or None
+            # The "markdown" response is the converted page as plain text.
+            return response.text or None
+
+        responses = await asyncio.gather(
+            *(fetch_one(url) for url in url_list), return_exceptions=True
+        )
+
+    return_results = {}
+    errors = []
+    # URLs and error details can embed credentials, so log only positions and
+    # exception class names.
+    for position, (url, result) in enumerate(zip(url_list, responses), start=1):
+        if isinstance(result, BaseException):
+            logger.warning(
+                "Serply API failed to fetch URL %d of %d (%s)",
+                position,
+                len(url_list),
+                type(result).__name__,
+            )
+            errors.append(result)
+        elif result is None:
+            logger.warning(
+                "Serply API returned no content for URL %d of %d", position, len(url_list)
+            )
+        else:
+            return_results[url] = result
+
+    if url_list and not return_results and errors:
+        raise errors[0]
+
+    logger.info(f"Successfully fetched content from {len(return_results)} URL(s) via Serply")
     return return_results

--- a/cognee/tasks/web_scraper/web_scraper_task.py
+++ b/cognee/tasks/web_scraper/web_scraper_task.py
@@ -18,7 +18,7 @@ from cognee.shared.logging_utils import get_logger
 from cognee.tasks.storage.index_data_points import index_data_points
 from cognee.tasks.storage.index_graph_edges import index_graph_edges
 
-from .config import DefaultCrawlerConfig, KeenableConfig, TavilyConfig
+from .config import DefaultCrawlerConfig, KeenableConfig, SerplyConfig, TavilyConfig
 from .models import ScrapingJob, WebPage, WebSite
 from .utils import fetch_page_content
 
@@ -50,6 +50,7 @@ async def cron_web_scraper_task(
     soup_crawler_config: DefaultCrawlerConfig = None,
     tavily_config: TavilyConfig = None,
     keenable_config: KeenableConfig = None,
+    serply_config: SerplyConfig = None,
     job_name: str = "scraping",
     ctx=None,
 ):
@@ -68,6 +69,8 @@ async def cron_web_scraper_task(
         tavily_config: Configuration for Tavily API.
         keenable_config: Configuration for Keenable API. Defaults to KEENABLE_API_KEY
             environment variable when set.
+        serply_config: Configuration for Serply API. Defaults to SERPLY_API_KEY
+            environment variable when set (Tavily and Keenable take precedence).
         job_name: Name of the scraping job. Defaults to "scraping".
 
     Returns:
@@ -96,6 +99,7 @@ async def cron_web_scraper_task(
                 "soup_crawler_config": soup_crawler_config,
                 "tavily_config": tavily_config,
                 "keenable_config": keenable_config,
+                "serply_config": serply_config,
                 "job_name": job_name,
                 "ctx": ctx,
             },
@@ -118,6 +122,7 @@ async def cron_web_scraper_task(
         soup_crawler_config=soup_crawler_config,
         tavily_config=tavily_config,
         keenable_config=keenable_config,
+        serply_config=serply_config,
         job_name=job_name,
         ctx=ctx,
     )
@@ -132,6 +137,7 @@ async def web_scraper_task(
     soup_crawler_config: DefaultCrawlerConfig = None,
     tavily_config: TavilyConfig = None,
     keenable_config: KeenableConfig = None,
+    serply_config: SerplyConfig = None,
     job_name: str | None = None,
     ctx=None,
 ):
@@ -152,6 +158,8 @@ async def web_scraper_task(
         tavily_config: Configuration for Tavily API.
         keenable_config: Configuration for Keenable API. Defaults to KEENABLE_API_KEY
             environment variable when set.
+        serply_config: Configuration for Serply API. Defaults to SERPLY_API_KEY
+            environment variable when set (Tavily and Keenable take precedence).
         job_name: Name of the scraping job. Defaults to a timestamp-based name.
 
     Returns:
@@ -167,8 +175,15 @@ async def web_scraper_task(
     if isinstance(url, str):
         url = [url]
 
-    soup_crawler_config, tavily_config, keenable_config, preferred_tool = check_arguments(
-        tavily_api_key, extraction_rules, tavily_config, soup_crawler_config, keenable_config
+    soup_crawler_config, tavily_config, keenable_config, serply_config, preferred_tool = (
+        check_arguments(
+            tavily_api_key,
+            extraction_rules,
+            tavily_config,
+            soup_crawler_config,
+            keenable_config,
+            serply_config,
+        )
     )
     now = datetime.now(timezone.utc)
     job_name = job_name or f"scrape_{now.strftime('%Y%m%d_%H%M%S')}"
@@ -216,6 +231,7 @@ async def web_scraper_task(
         preferred_tool=preferred_tool,
         tavily_config=tavily_config,
         keenable_config=keenable_config,
+        serply_config=serply_config,
         soup_crawler_config=soup_crawler_config,
     )
     for page_url, content in results.items():
@@ -352,7 +368,12 @@ async def web_scraper_task(
 
 
 def check_arguments(
-    tavily_api_key, extraction_rules, tavily_config, soup_crawler_config, keenable_config=None
+    tavily_api_key,
+    extraction_rules,
+    tavily_config,
+    soup_crawler_config,
+    keenable_config=None,
+    serply_config=None,
 ):
     """Validate and configure arguments for web_scraper_task.
 
@@ -362,11 +383,13 @@ def check_arguments(
         tavily_config: Configuration for Tavily API.
         soup_crawler_config: Configuration for BeautifulSoup crawler.
         keenable_config: Configuration for Keenable API.
+        serply_config: Configuration for Serply API.
 
     Returns:
-        Tuple[DefaultCrawlerConfig, TavilyConfig, KeenableConfig, str]: Configured
-            soup_crawler_config, tavily_config, keenable_config, and preferred_tool
-            ("tavily", "keenable", or "beautifulsoup").
+        Tuple[DefaultCrawlerConfig, TavilyConfig, KeenableConfig, SerplyConfig, str]:
+            Configured soup_crawler_config, tavily_config, keenable_config,
+            serply_config, and preferred_tool ("tavily", "keenable", "serply", or
+            "beautifulsoup").
 
     Raises:
         TypeError: If no scraping configuration is provided.
@@ -390,10 +413,20 @@ def check_arguments(
         if not extraction_rules and not soup_crawler_config:
             preferred_tool = "keenable"
 
-    if not tavily_config and not keenable_config and not soup_crawler_config:
+    if (
+        not tavily_api_key
+        and not keenable_config
+        and (serply_config or os.getenv("SERPLY_API_KEY"))
+    ):
+        if not serply_config:
+            serply_config = SerplyConfig()
+        if not extraction_rules and not soup_crawler_config:
+            preferred_tool = "serply"
+
+    if not tavily_config and not keenable_config and not serply_config and not soup_crawler_config:
         raise TypeError("Make sure you pass arguments for web_scraper_task")
 
-    return soup_crawler_config, tavily_config, keenable_config, preferred_tool
+    return soup_crawler_config, tavily_config, keenable_config, serply_config, preferred_tool
 
 
 def get_path_after_base(base_url: str, url: str) -> str:

--- a/cognee/tests/integration/web_url_crawler/test_serply_crawler.py
+++ b/cognee/tests/integration/web_url_crawler/test_serply_crawler.py
@@ -1,0 +1,27 @@
+import os
+
+import pytest
+
+from cognee.tasks.web_scraper.utils import fetch_with_serply
+
+skip_in_ci = pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") == "true",
+    reason="Skipping in Github for now - before we get SERPLY_API_KEY",
+)
+
+skip_without_key = pytest.mark.skipif(
+    not os.getenv("SERPLY_API_KEY"),
+    reason="SERPLY_API_KEY is not set",
+)
+
+
+@skip_in_ci
+@skip_without_key
+@pytest.mark.asyncio
+async def test_fetch():
+    url = "http://example.com/"
+    results = await fetch_with_serply(url)
+    assert isinstance(results, dict)
+    assert len(results) == 1
+    content = results[url]
+    assert isinstance(content, str)


### PR DESCRIPTION
## Description

This PR adds an additional web scraper backend to cognee for fetching page content. It is a pluggable backend similar to Tavily and Keenable, reached through the same `fetch_page_content` entry point and selected from the environment. It only requires a free account and a `SERPLY_API_KEY`. This is mostly an optional plugin that lets users add a new scraping capability to cognee, with no change in behavior when the key is unset.

Serply slots in as a fourth backend of the same shape as the existing ones:

- `SerplyConfig` in `cognee/tasks/web_scraper/config.py`, alongside `TavilyConfig` and `KeenableConfig`.
- `fetch_with_serply()` in `utils.py`, which POSTs each URL to Serply's `/v1/request` endpoint with the key in an `X-Api-Key` header, bounded by a semaphore, and returns markdown (or full HTML) per URL.
- One line added to the auto-select ladder and one dispatch branch. Precedence is Tavily, then Keenable, then Serply, then the default crawler, so existing setups are unaffected.
- The config is threaded through `web_scraper_task.py`; docs updated in the web scraper `README.md`, `.env.template`, and the `add.py` example.

## Acceptance Criteria

- With `SERPLY_API_KEY` set (and no Tavily/Keenable key), `fetch_page_content` auto-selects the Serply backend and returns page content.
- `preferred_tool="serply"` uses the backend explicitly.
- Behavior is unchanged when `SERPLY_API_KEY` is unset: the existing Tavily/Keenable/BeautifulSoup precedence is preserved.
- A partial failure across a URL list keeps the successful results.
- An invalid key surfaces the upstream HTTP error rather than failing silently.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Screenshots

Local test run (no screenshot; text output):

```
$ ruff check cognee/tasks/web_scraper/ cognee/tests/integration/web_url_crawler/test_serply_crawler.py
All checks passed!

$ SERPLY_API_KEY=... python -m pytest \
    cognee/tests/integration/web_url_crawler/test_serply_crawler.py -q
1 passed
```

Manual checks against the live API (key redacted): all five auto-select precedence cases resolved correctly; `response_type="markdown"` returned page text and `"full"` returned the HTML payload; a two-URL list with one bad URL kept the good result; an invalid key raised `httpx.HTTPStatusError` (401).

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

---

Disclosure: I work with Serply. Happy to adjust scope, naming, or drop this entirely if it isn't a direction you want for the project.
