### PR TITLE
fix(ci): redact identifiers in telemetry provider aggregates

### DIFF
--- a/.github/scripts/telemetry_aggregate_extract.py
+++ b/.github/scripts/telemetry_aggregate_extract.py
@@ -11,6 +11,8 @@ Hard rules enforced here:
   query strings, error text.
 - Identity columns (user_id, api_key_hash, anonymous_id, persistent_id)
   are used ONLY inside COUNT(DISTINCT ...); their values are never emitted.
+- Identifier-bearing provider/model settings are bucketed as 'redacted'
+  before grouping, so custom deployment names cannot stop the daily export.
 - A post-write guard fails the job if any output header matches the
   denylist or any cell matches identifier patterns (email, UUID, ak_ hash).
 
@@ -31,6 +33,28 @@ import duckdb
 
 WINDOW_DAYS = int(os.getenv("TELEMETRY_WINDOW_DAYS", "70"))
 OUT_DIR = Path(os.getenv("TELEMETRY_OUT_DIR", "telemetry_aggregates"))
+
+# Shared by SQL redaction and the independent post-write guard.
+CELL_PATTERNS = (
+    re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"),  # email
+    re.compile(r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"),  # uuid
+    re.compile(r"\bak_[0-9a-f]{16,}\b"),  # key hash
+)
+_SQL_CELL_PATTERN = "|".join(pattern.pattern for pattern in CELL_PATTERNS).replace("'", "''")
+
+
+def _provider_dimension(property_path: str, *, max_length: int | None = None) -> str:
+    """Bucket identifiers in a fixed provider/model property before aggregation."""
+    value = f"json_extract_string(properties, '$.{property_path}')"
+    identifier_check = f"regexp_matches(lower({value}), '{_SQL_CELL_PATTERN}')"
+    output = value
+    if max_length is not None:
+        output = f"left(lower({value}), {max_length})"
+        # Truncation can hide an identifier or create a word boundary that makes
+        # the shortened value match the guard. Inspect both full and output forms.
+        identifier_check += f" OR regexp_matches({output}, '{_SQL_CELL_PATTERN}')"
+    return f"CASE WHEN {identifier_check} THEN 'redacted' ELSE {output} END"
+
 
 # Events worth analyzing; everything else (internal task/coroutine spam) is skipped.
 EVENT_ALLOWLIST = (
@@ -120,14 +144,15 @@ QUERIES: dict[str, str] = {
               AND endpoint IS NOT NULL
         GROUP BY ALL ORDER BY day, events DESC
     """,
-    # Provider stack correlation (from completed pipeline runs).
+    # Provider/model settings can contain custom deployment identifiers. Redact
+    # before GROUP BY so run and distinct-identity counts cover the whole bucket.
     "provider_stack_daily": f"""
         SELECT ingestion_date AS day,
-               json_extract_string(properties, '$.llm.provider')   AS llm_provider,
-               left(lower(json_extract_string(properties, '$.llm.model')), 60) AS llm_model,
-               json_extract_string(properties, '$.graph.provider') AS graph_provider,
-               json_extract_string(properties, '$.vector.provider') AS vector_provider,
-               json_extract_string(properties, '$.relational.provider') AS relational_provider,
+               {_provider_dimension("llm.provider")} AS llm_provider,
+               {_provider_dimension("llm.model", max_length=60)} AS llm_model,
+               {_provider_dimension("graph.provider")} AS graph_provider,
+               {_provider_dimension("vector.provider")} AS vector_provider,
+               {_provider_dimension("relational.provider")} AS relational_provider,
                {_VERSION} AS version,
                count(*) AS completed_runs,
                count(DISTINCT {_IDENT}) AS distinct_identities
@@ -164,11 +189,6 @@ HEADER_DENYLIST = re.compile(
     r"(search_query|system_prompt|properties|dataset|user_id|api_key|anonymous"
     r"|persistent|tenant|email|error_text|query)",
     re.IGNORECASE,
-)
-CELL_PATTERNS = (
-    re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"),  # email
-    re.compile(r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"),  # uuid
-    re.compile(r"\bak_[0-9a-f]{16,}\b"),  # key hash
 )
 
 

--- a/.github/scripts/telemetry_insights_prompt.md
+++ b/.github/scripts/telemetry_insights_prompt.md
@@ -14,6 +14,8 @@ You are running inside a scheduled GitHub Action for the cognee repository. Your
 - `search_type_daily.csv` — day, SearchType enum, version, events
 - `version_lifecycle.csv` — version, self_hosted, first_seen/last_seen, events, identities
 
+Provider/model values containing identifier-shaped text are grouped into a `redacted` bucket before counting. These rows still contribute to run and distinct-identity totals; treat `redacted` as a mixed set of private configurations, not a specific provider or model.
+
 These are **fully anonymized aggregates**. There are no user identifiers, no query texts, no dataset names — and you must not attempt to obtain any. `distinct_identities` counts deployments (LLM-key hash → machine-stable persistent_id → user_id fallback); note that persistent_id only exists on events from ~April 2026 builds onward, so identity counts on older-version rows skew high — treat cross-version identity comparisons accordingly. You have **no warehouse access and no credentials**; do not try to query MotherDuck or any external data source. Work only from the CSVs and the git history/PRs of this repository.
 
 ## Analyses to run (compute, don't guess)

--- a/.github/workflows/telemetry-insights.yml
+++ b/.github/workflows/telemetry-insights.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install duckdb client
         run: pip install "duckdb>=1.1"
 
+      - name: Test aggregate extraction and privacy guards
+        run: python cognee/tests/unit/test_telemetry_aggregate_extract.py
+
       - name: Extract anonymized aggregates (only step with warehouse access)
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}

--- a/cognee/tests/unit/test_telemetry_aggregate_extract.py
+++ b/cognee/tests/unit/test_telemetry_aggregate_extract.py
@@ -1,0 +1,151 @@
+"""Exercise the telemetry Action's SQL and privacy guard without warehouse access.
+
+Run directly with the Action's DuckDB dependency; no Cognee runtime is needed.
+"""
+
+import csv
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+try:
+    import duckdb
+except ImportError:
+    duckdb = None
+
+
+@unittest.skipIf(duckdb is None, "Requires the telemetry Action's DuckDB dependency")
+class TelemetryAggregateExtractTest(unittest.TestCase):
+    def setUp(self):
+        script = (
+            Path(__file__).resolve().parents[3] / ".github/scripts/telemetry_aggregate_extract.py"
+        )
+        spec = importlib.util.spec_from_file_location("telemetry_aggregate_extract", script)
+        self.extract = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.extract)
+        self.connection = duckdb.connect()
+        self.addCleanup(self.connection.close)
+        self.connection.execute("ATTACH ':memory:' AS analytics")
+        self.connection.execute("""
+            CREATE TABLE analytics.main.pipeline_events (
+                ingestion_date DATE, tracking_event VARCHAR, cognee_version VARCHAR,
+                properties JSON, user_id VARCHAR, endpoint VARCHAR, search_type VARCHAR
+            )
+        """)
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.out_dir = Path(directory.name)
+
+    def _insert(self, model="openai/gpt-5-mini", user="deployment-a", **providers):
+        properties = {
+            "llm": {"provider": "openai", "model": model},
+            "graph": {"provider": "kuzu"},
+            "vector": {"provider": "lancedb"},
+            "relational": {"provider": "sqlite"},
+        }
+        for provider, value in providers.items():
+            properties[provider]["provider"] = value
+        self.connection.execute(
+            """INSERT INTO analytics.main.pipeline_events VALUES
+               (current_date, 'Pipeline Run Completed', '0.5.0-local', ?, ?, NULL, NULL)""",
+            [json.dumps(properties), user],
+        )
+
+    def _provider_rows(self):
+        result = self.connection.execute(self.extract.QUERIES["provider_stack_daily"])
+        columns = [column[0] for column in result.description]
+        return [dict(zip(columns, row)) for row in result.fetchall()]
+
+    def test_redacts_identifiers_in_provider_dimensions(self):
+        for value in (
+            "custom/person@example.com",
+            "custom/12345678-1234-1234-1234-123456789abc",
+            "custom/ak_0123456789abcdef",
+        ):
+            for dimension in ("llm_model", "llm", "graph", "vector", "relational"):
+                with self.subTest(value=value, dimension=dimension):
+                    self.connection.execute("DELETE FROM analytics.main.pipeline_events")
+                    if dimension == "llm_model":
+                        self._insert(model=value)
+                        column = dimension
+                    else:
+                        self._insert(**{dimension: value})
+                        column = f"{dimension}_provider"
+                    row = self._provider_rows()[0]
+                    self.assertEqual(row[column], "redacted")
+                    self.assertEqual(row["completed_runs"], 1)
+
+    def test_redacts_models_when_truncation_changes_identifier_boundaries(self):
+        for model in (
+            "prefix-" * 8 + "12345678-1234-1234-1234-123456789ABC",
+            "prefix-" + "x" * 16 + "/12345678-1234-1234-1234-123456789abcde",
+        ):
+            with self.subTest(model=model):
+                self.connection.execute("DELETE FROM analytics.main.pipeline_events")
+                self._insert(model=model)
+                self.assertEqual(self._provider_rows()[0]["llm_model"], "redacted")
+
+    def test_groups_redacted_models_before_counting_distinct_identities(self):
+        first = "custom/12345678-1234-1234-1234-123456789abc"
+        second = "custom/87654321-4321-4321-4321-cba987654321"
+        self._insert(model=first, user="deployment-a")
+        self._insert(model=second, user="deployment-a")
+        self._insert(model=second, user="deployment-b")
+        rows = self._provider_rows()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["llm_model"], "redacted")
+        self.assertEqual(rows[0]["completed_runs"], 3)
+        self.assertEqual(rows[0]["distinct_identities"], 2)
+
+    def test_preserves_normal_model_normalization_and_missing_values(self):
+        for model in ("OpenAI/GPT-4o-2024-08-06", "model-" * 15, None):
+            with self.subTest(model=model):
+                self.connection.execute("DELETE FROM analytics.main.pipeline_events")
+                self._insert(model=model)
+                row = self._provider_rows()[0]
+                self.assertEqual(row["llm_model"], model.lower()[:60] if model else None)
+                self.assertEqual(row["llm_provider"], "openai")
+                self.assertEqual(row["version"], "0.5.0")
+
+    def test_extracts_all_csvs_with_identifier_bearing_model(self):
+        self._insert(model="custom/person@example.com")
+        with (
+            patch.dict("os.environ", {"MOTHERDUCK_TOKEN": "test-token"}),
+            patch.object(self.extract, "OUT_DIR", self.out_dir),
+            patch.object(self.extract.duckdb, "connect", return_value=self.connection),
+        ):
+            self.extract.main()
+        self.assertEqual(
+            {path.stem for path in self.out_dir.glob("*.csv")}, set(self.extract.QUERIES)
+        )
+        for path in self.out_dir.glob("*.csv"):
+            self.extract._guard(path)
+            self.assertNotIn("person@example.com", path.read_text())
+        self.assertTrue((self.out_dir / "WINDOW.txt").is_file())
+
+    def test_guard_still_rejects_identifiers_without_echoing_them(self):
+        for value in (
+            "person@example.com",
+            "12345678-1234-1234-1234-123456789abc",
+            "ak_0123456789abcdef",
+        ):
+            with self.subTest(value=value):
+                path = self.out_dir / "unsafe.csv"
+                with path.open("w", newline="") as handle:
+                    csv.writer(handle).writerows([["llm_model"], [value]])
+                with self.assertRaisesRegex(SystemExit, "PRIVACY GUARD") as error:
+                    self.extract._guard(path)
+                self.assertNotIn(value, str(error.exception))
+
+    def test_guard_still_rejects_identity_columns(self):
+        path = self.out_dir / "unsafe.csv"
+        path.write_text("user_id\n1\n")
+        with self.assertRaisesRegex(SystemExit, "denylisted column"):
+            self.extract._guard(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

The [September 12 telemetry-insights job](https://github.com/topoteretes/cognee/actions/runs/34675571131/job/103504717288) failed when the privacy guard found an identifier-shaped value in `provider_stack_daily.csv`. Provider and model settings were copied into aggregate keys without sanitization.

Bucket identifier-bearing provider/model values as `redacted` in SQL before grouping. Check the full model name and its normalized, truncated output so truncation cannot hide an identifier or introduce a new guard match. Run and distinct-deployment counts remain correct within each bucket, and the existing output guard continues to reject unsafe exports. The analysis prompt explains how to interpret the mixed `redacted` bucket.

Related: #4941 addresses the same failure with substring replacement. This PR uses whole-value bucketing and includes automated regression coverage executed before the workflow receives warehouse credentials.

Linear: COG-6288 (original telemetry-insights workflow).

The scheduled workflow runs from `main`; this fix takes effect after the dev-to-main sync. No MCP server or UI changes.

## Acceptance Criteria

- Identifier-bearing provider/model settings are redacted before grouping and export.
- Counts are preserved, including distinct deployments shared across redacted model names.
- Normal model names retain existing normalization, truncation, and null handling.
- All seven CSV exports complete for the regression fixture; unsafe cells and identity columns still fail the guard.
- Regression tests run before warehouse access in the daily workflow.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Validation

Passed locally with Python 3.12 and DuckDB 1.5.5:

```sh
uv run --no-project --python 3.12 --with 'duckdb==1.5.5' python cognee/tests/unit/test_telemetry_aggregate_extract.py -v
uvx --from ruff==0.16.6 ruff check .github/scripts/telemetry_aggregate_extract.py cognee/tests/unit/test_telemetry_aggregate_extract.py
uvx --from ruff==0.16.6 ruff format --check .github/scripts/telemetry_aggregate_extract.py cognee/tests/unit/test_telemetry_aggregate_extract.py
git diff --check
```

Seven regression tests pass, including an in-memory DuckDB export through `main()`. The original extractor reproduced the privacy-guard failure against the same fixture. Workflow YAML parsing and `bash -n` validation of every shell step also pass.

Full Cognee unit/integration suites were not run. Full-window warehouse validation timed out, and the production GitHub workflow has not been rerun with this patch.

## Pre-submission Checklist

- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] I have added necessary documentation
- [x] I have searched existing PRs and documented the overlap with #4941
- [x] I have linked relevant context in the description
- [x] My commits have clear and descriptive messages and a DCO sign-off
- [ ] All new and existing tests pass (focused tests pass; full suites not run)

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
