### PR TITLE
fix(retrieval): Skip turn prep on raw retrieval (SDK-680)

### DIFF
--- a/cognee/modules/retrieval/chunks_retriever.py
+++ b/cognee/modules/retrieval/chunks_retriever.py
@@ -20,6 +20,11 @@ class ChunksRetriever(BaseRetriever):
     not given.
     """
 
+    # Chunk search returns raw payloads and never calls an LLM, so the conversational
+    # session-turn analysis would add a pre-retrieval LLM round trip to an otherwise
+    # sub-second, deterministic path. Opt out, like the other non-generative retrievers.
+    supports_session_turn_preparation = False
+
     def __init__(
         self,
         top_k: Optional[int] = 5,

--- a/cognee/modules/retrieval/lexical_retriever.py
+++ b/cognee/modules/retrieval/lexical_retriever.py
@@ -24,6 +24,12 @@ def tokenize_words(text: str, stop_words: Optional[set[str]] = None) -> list[str
 
 
 class LexicalRetriever(BaseRetriever):
+    # Lexical search scores chunks locally and never calls an LLM, so the conversational
+    # session-turn analysis would add a pre-retrieval LLM round trip to an otherwise
+    # sub-second, deterministic path. Opt out, like the other non-generative retrievers.
+    # Inherited by BM25ChunksRetriever and JaccardChunksRetriever.
+    supports_session_turn_preparation = False
+
     def __init__(
         self, tokenizer: Callable, scorer: Callable, top_k: int = 15, with_scores: bool = False
     ):

--- a/cognee/modules/retrieval/summaries_retriever.py
+++ b/cognee/modules/retrieval/summaries_retriever.py
@@ -22,6 +22,11 @@ class SummariesRetriever(BaseRetriever):
     - top_k: int - Number of top summaries to retrieve.
     """
 
+    # Summary search returns raw payloads and never calls an LLM, so the conversational
+    # session-turn analysis would add a pre-retrieval LLM round trip to an otherwise
+    # sub-second, deterministic path. Opt out, like the other non-generative retrievers.
+    supports_session_turn_preparation = False
+
     def __init__(self, top_k: int = 5, session_id: Optional[str] = None):
         """Initialize retriever with search parameters."""
         self.top_k = top_k

--- a/cognee/tests/unit/modules/retrieval/test_non_generative_session_preparation.py
+++ b/cognee/tests/unit/modules/retrieval/test_non_generative_session_preparation.py
@@ -1,0 +1,110 @@
+"""Non-generative retrievers must not run a pre-retrieval LLM turn analysis.
+
+`BaseRetriever.supports_session_turn_preparation` exists so that "search types whose
+contract is explicitly non-generative" can skip `prepare_session_turn_for_retrieval`,
+which may call an LLM before retrieval. The retrievers whose own
+`get_completion_from_context` docstring says they "do not generate a completion, we just
+return the payloads" belong in that set; otherwise a sub-second deterministic lookup pays
+for a chat completion whose rewritten query it never benefits from.
+"""
+
+import importlib
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.infrastructure.session.session_manager import SessionTurnPreparation
+from cognee.modules.retrieval.bm25_retriever import BM25ChunksRetriever
+from cognee.modules.retrieval.chunks_retriever import ChunksRetriever
+from cognee.modules.retrieval.completion_retriever import CompletionRetriever
+from cognee.modules.retrieval.jaccard_retrival import JaccardChunksRetriever
+from cognee.modules.retrieval.lexical_retriever import LexicalRetriever
+from cognee.modules.retrieval.summaries_retriever import SummariesRetriever
+from cognee.modules.search.methods.get_retriever_output import get_retriever_output
+from cognee.modules.search.types import SearchType
+
+# The package __init__ re-exports `get_retriever_output` under the same name as the
+# submodule, so a dotted-string patch target resolves to the function. Patch the module
+# object instead, as the sibling test for this path already does.
+get_retriever_output_module = importlib.import_module(
+    "cognee.modules.search.methods.get_retriever_output"
+)
+
+NON_GENERATIVE_RETRIEVERS = [
+    ChunksRetriever,
+    SummariesRetriever,
+    LexicalRetriever,
+    BM25ChunksRetriever,
+    JaccardChunksRetriever,
+]
+
+
+class _FakeGraphEngine:
+    async def is_empty(self):
+        return False
+
+
+@pytest.mark.parametrize("retriever_class", NON_GENERATIVE_RETRIEVERS, ids=lambda c: c.__name__)
+def test_non_generative_retrievers_opt_out_of_session_turn_preparation(retriever_class):
+    assert retriever_class.supports_session_turn_preparation is False
+
+
+def test_generative_retrievers_still_opt_in():
+    assert CompletionRetriever.supports_session_turn_preparation is True
+
+
+async def _search_with(retriever, search_type):
+    """Run a real search through `get_retriever_output`, stubbing only I/O.
+
+    Returns the mock standing in for `prepare_session_turn_for_retrieval`, so a test can
+    assert whether the pre-retrieval LLM analysis ran.
+    """
+    prepare = AsyncMock(
+        return_value=SessionTurnPreparation(should_answer=True, effective_query="q")
+    )
+    with (
+        patch.object(type(retriever), "prepare_session_turn_for_retrieval", prepare),
+        patch.object(type(retriever), "get_retrieved_objects", AsyncMock(return_value=[])),
+        patch.object(type(retriever), "get_context_from_objects", AsyncMock(return_value="")),
+        patch.object(type(retriever), "get_completion_from_context", AsyncMock(return_value=[])),
+        patch.object(
+            get_retriever_output_module,
+            "get_graph_engine",
+            new_callable=AsyncMock,
+            return_value=_FakeGraphEngine(),
+        ),
+        patch.object(
+            get_retriever_output_module,
+            "get_search_type_retriever_instance",
+            new_callable=AsyncMock,
+            return_value=retriever,
+        ),
+    ):
+        await get_retriever_output(search_type, "q")
+    return prepare
+
+
+@pytest.mark.asyncio
+async def test_chunks_search_does_not_prepare_a_session_turn():
+    """The regression from #4439: a CHUNKS recall paid for an LLM call before retrieval."""
+    prepare = await _search_with(ChunksRetriever(), SearchType.CHUNKS)
+    prepare.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_summaries_search_does_not_prepare_a_session_turn():
+    prepare = await _search_with(SummariesRetriever(), SearchType.SUMMARIES)
+    prepare.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_lexical_chunks_search_does_not_prepare_a_session_turn():
+    prepare = await _search_with(BM25ChunksRetriever(), SearchType.CHUNKS_LEXICAL)
+    prepare.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_generative_search_still_prepares_a_session_turn():
+    """Guard the other direction: generative search types keep the conversational turn."""
+    prepare = await _search_with(CompletionRetriever(), SearchType.RAG_COMPLETION)
+    prepare.assert_awaited_once()


### PR DESCRIPTION
## Description

`CHUNKS`, `SUMMARIES` and `CHUNKS_LEXICAL` are non-generative: they return stored payloads and never ask an LLM for an answer. They still ran conversational session-turn analysis before retrieval (`run_sequential_session_turn`, `session_aware_completion.py:419`), which does three things none of them want:

1. **Spends an LLM call ahead of a deterministic lookup.** `analyze_turn_for_session_context` is a structured-output call, plus session reads, in front of a sub-second vector or keyword search.
2. **Replaces the caller's query.** `effective_query=(analysis.query_to_answer or "").strip() or query` — so a lexical/BM25 search silently stops matching the keywords it was handed.
3. **Can return a chat string instead of payloads.** When the analysis sets `should_answer=False`, the path returns `[acknowledgement]` where the caller's contract promises chunk or summary records.

(2) and (3) are correctness, not just latency.

This needs no new mechanism. `BaseRetriever.supports_session_turn_preparation` exists precisely for "search types whose contract is explicitly non-generative", and `CodeRetriever`, `SkillsRetriever` and `GraphReportRetriever` already opt out. This sets it on `ChunksRetriever`, `SummariesRetriever` and `LexicalRetriever` (inherited by BM25 and Jaccard) so the raw search types join them. Generative retrievers are untouched, and `only_context=True` already escaped via the same gate.

**When it bites:** a user in context + `CACHING=true` + `AUTO_FEEDBACK=true` — both defaults. It does *not* need an explicit `session_id`: `resolve_session_id(None)` falls back to the default session, so ordinary authenticated raw searches are affected.

Addresses [SDK-680](https://linear.app/cognee/issue/SDK-680). Fixes #4439.

## Why a new PR

This is #4570 ported to a branch in this repo, keeping @Anai-Guo as author of the fix.

That PR shows 139 red checks, none of them a real failure. It is a fork PR, so it gets no secrets: `Build CI Environment` is skipped and every job depending on it fails before any test runs. The only lane that could execute there was the no-secrets one, which is green — `Community Tests Status`, `Unit Tests (Mocked)`, `CLI Unit Tests (Mocked)`, `Code Quality`, `Lockfile and Pre-commit`, `MCP Tests`. The point of this PR is to get the change through the **full** suite.

## Validation

Merged onto current `dev` (clean), then run both ways to confirm the regression tests actually bite:

| | result |
|---|---|
| The new tests, source reverted to `dev` | **14 failed, 8 passed** |
| The new tests + the fix | **42 passed** |

Full local unit scope for the touched areas:

```
pytest cognee/tests/unit/modules/retrieval/ \
       cognee/tests/unit/modules/search/ \
       cognee/tests/unit/infrastructure/session/ -q
974 passed
```

`pre-commit` clean on all four files.

## Known gaps, deliberately not in this PR

Two retrievers are in the same class and still inherit `True`. Worth their own ticket rather than widening a ported fix:

- **`CypherSearchRetriever`** — the worse case. `get_retrieved_objects` passes `query` straight into `graph_engine.query(query)`, so the query string *is* the Cypher statement. Turn prep can replace a Cypher statement with an LLM-rewritten natural-language question and execute it. It already declares `supports_prompt_preview = False` on the grounds that it never prompts an LLM; the same reasoning applies here.
- **`CodingRulesRetriever`** — ignores `query` in all three methods and just returns stored rules.

Also worth discussing separately: `BaseRetriever.supports_session_turn_preparation` defaults to `True`, so every new non-generative retriever inherits this silently — which is how these five were missed.

## Type of Change

- [x] Bug fix

## Pre-submission Checklist

- [x] Regression tests added, verified to fail without the fix
- [x] Changes follow repository formatting and style
- [x] Linked the relevant issue
- [x] Commits include DCO sign-off